### PR TITLE
feature: ctx module

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -12,4 +12,24 @@ func (ck *Key) String() string {
 var (
 	LoggerKey      = &Key{name: "logger"}      //nolint:gochecknoglobals
 	CfgFilenameKey = &Key{name: "cfgfilename"} //nolint:gochecknoglobals
+	ContexterKey   = &Key{name: "contexter"}   //nolint:gochecknoglobals
 )
+
+type Contexter[T any] struct {
+	shared map[string]T
+}
+
+func NewContexter[T any]() *Contexter[T] {
+	return &Contexter[T]{
+		shared: make(map[string]T),
+	}
+}
+
+func (c *Contexter[T]) WithValue(key string, value T) {
+	c.shared[key] = value
+}
+
+func (c *Contexter[T]) Value(key string) (T, bool) {
+	v, ok := c.shared[key]
+	return v, ok
+}

--- a/api/task.go
+++ b/api/task.go
@@ -22,24 +22,6 @@ func (t *Task) Respond(tr *TaskResult) {
 	t.response <- tr
 }
 
-func (t *Task) StreamingResponse() *Streamer {
-	return &Streamer{ch: t.response}
-}
-
-type Streamer struct {
-	ch chan *TaskResult
-}
-
-func (s *Streamer) ReadChunk() *TaskResult {
-	select {
-	case data := <-s.ch:
-		return data
-	default:
-		// no data
-		return nil
-	}
-}
-
 type TaskResult struct {
 	Payload []byte `json:"payload"` // todo: payload type and possibly any for internal types
 	Error   error  `json:"error"`

--- a/api/task.go
+++ b/api/task.go
@@ -22,6 +22,24 @@ func (t *Task) Respond(tr *TaskResult) {
 	t.response <- tr
 }
 
+func (t *Task) StreamingResponse() *Streamer {
+	return &Streamer{ch: t.response}
+}
+
+type Streamer struct {
+	ch chan *TaskResult
+}
+
+func (s *Streamer) ReadChunk() *TaskResult {
+	select {
+	case data := <-s.ch:
+		return data
+	default:
+		// no data
+		return nil
+	}
+}
+
 type TaskResult struct {
 	Payload []byte `json:"payload"` // todo: payload type and possibly any for internal types
 	Error   error  `json:"error"`

--- a/runtime/lua/modules/ctx/ctx_test.go
+++ b/runtime/lua/modules/ctx/ctx_test.go
@@ -1,0 +1,70 @@
+package ctx
+
+import (
+	"context"
+	"testing"
+
+	ctxapi "github.com/ponyruntime/pony/api/context"
+	lengine "github.com/ponyruntime/pony/runtime/lua/engine"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestContextGetValue(t *testing.T) {
+	cter := ctxapi.NewContexter[any]()
+	cter.WithValue("testKey", "testValue")
+	cter.WithValue("testKey2", 1)
+	cter.WithValue("testKey3", map[string]string{"test": "test"})
+
+	ctx := context.WithValue(context.Background(), ctxapi.ContexterKey, cter)
+	log, _ := zap.NewDevelopment()
+
+	engine := lengine.NewLuaEngine(ctx, log.Named("tests"))
+
+	// Preload ctx module
+	engine.L.PreloadModule("ctx", New[any](ctx, log.Named("ctx")).Loader)
+
+	// Lua code to get value from context
+	luaCode := `
+	local ctx = require("ctx")
+	local value, err = ctx.get("testKey")
+	if err then
+		return nil, err
+	end
+	return value
+	`
+
+	err := engine.DoString(luaCode, "TestContextGetValue")
+	require.NoError(t, err)
+	result := lengine.ToGoAny(engine.Get(-1))
+	require.Equal(t, "testValue", result)
+
+	luaCode2 := `
+	local ctx = require("ctx")
+	local value, err = ctx.get("testKey2")
+	if err then
+		return nil, err
+	end
+	return value
+	`
+
+	err = engine.DoString(luaCode2, "TestContextGetValue")
+	require.NoError(t, err)
+	result = lengine.ToGoAny(engine.Get(-1))
+	require.Equal(t, float64(1), result)
+
+	luaCode3 := `
+	local ctx = require("ctx")
+	local value, err = ctx.get("testKey3")
+	if err then
+		return nil, err
+	end
+	return value
+	`
+
+	err = engine.DoString(luaCode3, "TestContextGetValue")
+	require.NoError(t, err)
+	result = lengine.ToGoAny(engine.Get(-1))
+	require.Equal(t, map[string]any{"test": "test"}, result)
+	engine.Close()
+}

--- a/runtime/lua/modules/ctx/ctx_test.go
+++ b/runtime/lua/modules/ctx/ctx_test.go
@@ -22,7 +22,7 @@ func TestContextGetValue(t *testing.T) {
 	engine := lengine.NewLuaEngine(ctx, log.Named("tests"))
 
 	// Preload ctx module
-	engine.L.PreloadModule("ctx", New[any](ctx, log.Named("ctx")).Loader)
+	engine.L.PreloadModule("ctx", New[any](log.Named("ctx")).Loader)
 
 	// Lua code to get value from context
 	luaCode := `

--- a/runtime/lua/modules/ctx/loader.go
+++ b/runtime/lua/modules/ctx/loader.go
@@ -11,7 +11,6 @@ func (m *Module[T]) Loader(l *lua.LState) int {
 	}
 
 	l.SetFuncs(t, lapi)
-	l.SetContext(m.parentCtx)
 	l.Push(t)
 	return 1
 }

--- a/runtime/lua/modules/ctx/loader.go
+++ b/runtime/lua/modules/ctx/loader.go
@@ -1,0 +1,17 @@
+package ctx
+
+import "github.com/ponyruntime/go-lua"
+
+// Loader is the entry point for loading the plugin
+func (m *Module[T]) Loader(l *lua.LState) int {
+	t := l.NewTable()
+
+	lapi := map[string]lua.LGFunction{
+		"get": m.get,
+	}
+
+	l.SetFuncs(t, lapi)
+	l.SetContext(m.parentCtx)
+	l.Push(t)
+	return 1
+}

--- a/runtime/lua/modules/ctx/module.go
+++ b/runtime/lua/modules/ctx/module.go
@@ -1,8 +1,6 @@
 package ctx
 
 import (
-	"context"
-
 	"github.com/ponyruntime/go-lua"
 	ctxapi "github.com/ponyruntime/pony/api/context"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
@@ -11,15 +9,13 @@ import (
 
 // Module (ctx) accepts 1 argument, a string, and returns a context value found by that key.
 type Module[T any] struct {
-	parentCtx context.Context
-	log       *zap.Logger
+	log *zap.Logger
 }
 
-func New[T any](inCtx context.Context, log *zap.Logger) *Module[T] {
+func New[T any](log *zap.Logger) *Module[T] {
 	return &Module[T]{
 		// TODO: context might have a cancel function, do we need to handle context cancellation and propagate it to the lua?
-		parentCtx: inCtx,
-		log:       log,
+		log: log,
 	}
 }
 

--- a/runtime/lua/modules/ctx/module.go
+++ b/runtime/lua/modules/ctx/module.go
@@ -1,0 +1,66 @@
+package ctx
+
+import (
+	"context"
+
+	"github.com/ponyruntime/go-lua"
+	ctxapi "github.com/ponyruntime/pony/api/context"
+	"github.com/ponyruntime/pony/runtime/lua/engine"
+	"go.uber.org/zap"
+)
+
+// Module (ctx) accepts 1 argument, a string, and returns a context value found by that key.
+type Module[T any] struct {
+	parentCtx context.Context
+	log       *zap.Logger
+}
+
+func New[T any](inCtx context.Context, log *zap.Logger) *Module[T] {
+	return &Module[T]{
+		// TODO: context might have a cancel function, do we need to handle context cancellation and propagate it to the lua?
+		parentCtx: inCtx,
+		log:       log,
+	}
+}
+
+func (m *Module[T]) get(l *lua.LState) int {
+	ctx := l.Context()
+	if ctx == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.LString("no context found"))
+		return 2
+	}
+
+	k := l.CheckString(1)
+	if k == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.LString("empty key provided"))
+		return 2
+	}
+
+	ctxer := ctx.Value(ctxapi.ContexterKey)
+	if ctxer == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.LString("no contexter found"))
+		return 2
+	}
+
+	sharedvals := ctxer.(*ctxapi.Contexter[T])
+	if sharedvals == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.LString("no shared values found"))
+		return 2
+	}
+
+	if _, ok := sharedvals.Value(k); !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.LString("no value found for key: " + k))
+		return 2
+	}
+
+	vv, _ := sharedvals.Value(k)
+	l.Push(engine.GoToLua(l, vv))
+	l.Push(lua.LNil)
+
+	return 2
+}


### PR DESCRIPTION
# Reason for This PR

closes: https://jira.spiralscout.com/browse/EE2-1497

## Description of Changes

- Add context parser module

## API

In the root context (http component for example), initialize the `Contexter`:
```go
package foo
import (
	"context"

	ctxapi "github.com/ponyruntime/pony/api/context" // <--- module
	lengine "github.com/ponyruntime/pony/runtime/lua/engine"
	"go.uber.org/zap"
)

func foo() {
        log, _ := zap.NewDevelopment()
    	cter := ctxapi.NewContexter[any]() // contexter supports generics values, it can be `any` or might be typed with a structure or basic type.
        // store any value in it
        cter.WithValue("testKey", "testValue")
	cter.WithValue("testKey2", 1)
	cter.WithValue("testKey3", map[string]string{"test": "test"})

        // contexter might be extracted on any step before the ctx module:
        ctxer := ctx.Value(ctxapi.ContexterKey)
        // store additional values
        cter.WithValue("testKey222", 111)
        // save the contexter and pass to another function down the road
        ctx := context.WithValue(context.Background(), ctxapi.ContexterKey, cter)
        // as the last step, context with contexter should be passed to the lua engine constructor

       	engine := lengine.NewLuaEngine(ctx, log.Named("tests"))
}

``` 

Example of the Lua code:
```lua
	local ctx = require("ctx")
	local value, err = ctx.get("testKey")
	if err then
		return nil, err
	end
	return value
```
CC: @AndreiMaroz 
