### PR TITLE
feature: EE2-1570: markdown and sql modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,4 @@ test-service:
 
 debug_vm:
 	dlv test -- test.v -test.run="^TestVM\$"
+

--- a/__redo/sql/db.go
+++ b/__redo/sql/db.go
@@ -5,7 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	// SQLite3 driver
 	_ "github.com/mattn/go-sqlite3"
 )

--- a/__redo/sql/execute.go
+++ b/__redo/sql/execute.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/__redo/sql/loader.go
+++ b/__redo/sql/loader.go
@@ -1,6 +1,6 @@
 package sql
 
-import "github.com/yuin/gopher-lua"
+import lua "github.com/yuin/gopher-lua"
 
 func (m *Module) Loader(l *lua.LState) int {
 	// Create the SQL module table

--- a/__redo/sql/module.go
+++ b/__redo/sql/module.go
@@ -1,10 +1,10 @@
 package sql
 
 import (
-	"github.com/yuin/gopher-lua"
 
 	// PQ Driver
 	_ "github.com/lib/pq"
+	lua "github.com/yuin/gopher-lua"
 	// SQLite3 driver
 	_ "github.com/mattn/go-sqlite3"
 

--- a/__redo/sql/prepare.go
+++ b/__redo/sql/prepare.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/__redo/sql/query.go
+++ b/__redo/sql/query.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/__redo/sql/sql_test.go
+++ b/__redo/sql/sql_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	lengine "github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 
 	_ "github.com/mattn/go-sqlite3"

--- a/__redo/sql/transaction.go
+++ b/__redo/sql/transaction.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"
 )

--- a/api/runtime/executor.go
+++ b/api/runtime/executor.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"

--- a/api/runtime/lua/api.go
+++ b/api/runtime/lua/api.go
@@ -2,7 +2,8 @@ package lua
 
 import (
 	"context"
-	"github.com/yuin/gopher-lua"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 type (

--- a/api/runtime/lua/config.go
+++ b/api/runtime/lua/config.go
@@ -2,6 +2,7 @@ package lua
 
 import (
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/registry"
 )
 

--- a/api/service/http/config.go
+++ b/api/service/http/config.go
@@ -3,11 +3,12 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ponyruntime/pony/api/registry"
-	"github.com/ponyruntime/pony/api/supervisor"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/ponyruntime/pony/api/registry"
+	"github.com/ponyruntime/pony/api/supervisor"
 )
 
 const (

--- a/api/service/http/context.go
+++ b/api/service/http/context.go
@@ -1,8 +1,9 @@
 package http
 
 import (
-	"github.com/ponyruntime/pony/api/context"
 	"net/http"
+
+	"github.com/ponyruntime/pony/api/context"
 )
 
 var (

--- a/api/supervisor/service.go
+++ b/api/supervisor/service.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/ponyruntime/pony/api/events"
 	"time"
+
+	"github.com/ponyruntime/pony/api/events"
 )
 
 const (

--- a/cmd/entity-dump/main.go
+++ b/cmd/entity-dump/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/ponyruntime/pony/pkg/payload/lua"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/ponyruntime/pony/pkg/payload/lua"
+	"go.uber.org/zap/zapcore"
 
 	"go.uber.org/zap"
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -4,6 +4,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"hash/fnv"
+	httpbase "net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
 	contextapi "github.com/ponyruntime/pony/api/context"
 	regapi "github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/pkg/eventbus"
@@ -28,13 +36,6 @@ import (
 	"github.com/ponyruntime/pony/service/http"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"hash/fnv"
-	httpbase "net/http"
-	"os"
-	"os/signal"
-	"strings"
-	"syscall"
-	"time"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/ponyruntime/pony
 
-go 1.23.2
+go 1.23
+
+toolchain go1.23.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/google/uuid v1.6.0
+	github.com/ponyruntime/tree-sitter-markdown v0.0.2
 	github.com/stretchr/testify v1.10.0
 	github.com/tree-sitter-grammars/tree-sitter-lua v0.2.0
 	github.com/tree-sitter/go-tree-sitter v0.24.0
@@ -20,6 +23,8 @@ require (
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+// replace github.com/ponyruntime/tree-sitter-markdown v0.0.1 => ../tree-sitter-markdown
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/google/uuid v1.6.0
 	github.com/ponyruntime/tree-sitter-markdown v0.0.2
+	github.com/ponyruntime/tree-sitter-sql v0.0.3
 	github.com/stretchr/testify v1.10.0
 	github.com/tree-sitter-grammars/tree-sitter-lua v0.2.0
 	github.com/tree-sitter/go-tree-sitter v0.24.0
@@ -24,13 +25,13 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-// replace github.com/ponyruntime/tree-sitter-markdown v0.0.1 => ../tree-sitter-markdown
+// replace github.com/ponyruntime/tree-sitter-sql => ../tree-sitter-sql
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ponyruntime/tree-sitter-markdown v0.0.2 h1:BrPbu2nTYo75E6POp/mu4ijfwwjYfxGMf8gWBedsKM0=
 github.com/ponyruntime/tree-sitter-markdown v0.0.2/go.mod h1:Eg28LbIWoosBFNXTxws0WZMsXx/rAjN/g1dgHmq7CDI=
+github.com/ponyruntime/tree-sitter-sql v0.0.3 h1:2YO2JIs5OxSjo42lDwuxWdX/yeOwhTVcio+3EmdZhbA=
+github.com/ponyruntime/tree-sitter-sql v0.0.3/go.mod h1:ca8Mg8NbumykCBrKCX4VULdA20VZkHM46udVNIpe6jU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
@@ -47,8 +49,9 @@ github.com/tree-sitter/tree-sitter-rust v0.21.3-0.20240818005432-2b43eafe6447 h1
 github.com/tree-sitter/tree-sitter-rust v0.21.3-0.20240818005432-2b43eafe6447/go.mod h1:1Oh95COkkTn6Ezp0vcMbvfhRP5gLeqqljR0BYnBzWvc=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ponyruntime/tree-sitter-markdown v0.0.2 h1:BrPbu2nTYo75E6POp/mu4ijfwwjYfxGMf8gWBedsKM0=
+github.com/ponyruntime/tree-sitter-markdown v0.0.2/go.mod h1:Eg28LbIWoosBFNXTxws0WZMsXx/rAjN/g1dgHmq7CDI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/internal/closer/closer.go
+++ b/internal/closer/closer.go
@@ -2,8 +2,9 @@ package closer
 
 import (
 	"context"
-	ctxapi "github.com/ponyruntime/pony/api/context"
 	"sync"
+
+	ctxapi "github.com/ponyruntime/pony/api/context"
 )
 
 type Cleanup struct {

--- a/internal/version/map.go
+++ b/internal/version/map.go
@@ -2,9 +2,10 @@ package version
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/graph"
-	"sort"
 )
 
 type (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/registry"
 )
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,8 +1,9 @@
 package version
 
 import (
-	"github.com/ponyruntime/pony/api/registry"
 	"testing"
+
+	"github.com/ponyruntime/pony/api/registry"
 )
 
 func TestVersion(t *testing.T) {

--- a/pkg/eventbus/bus.go
+++ b/pkg/eventbus/bus.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/internal/wildcard"
 	"go.uber.org/zap"
-	"sync"
-	"sync/atomic"
 )
 
 type actionType int

--- a/pkg/eventbus/bus_test.go
+++ b/pkg/eventbus/bus_test.go
@@ -2,15 +2,16 @@ package eventbus
 
 import (
 	"context"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
-	"sync"
-	"testing"
-	"time"
 )
 
 // Helper function to create a new Bus with an observed logger for testing

--- a/pkg/eventbus/subscriber.go
+++ b/pkg/eventbus/subscriber.go
@@ -2,8 +2,9 @@ package eventbus
 
 import (
 	"context"
-	"github.com/ponyruntime/pony/api/events"
 	"sync"
+
+	"github.com/ponyruntime/pony/api/events"
 )
 
 // Subscriber is a helper struct that simplifies subscribing to and handling events from an event bus.

--- a/pkg/payload/json/json.go
+++ b/pkg/payload/json/json.go
@@ -3,6 +3,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/payload"
 )
 

--- a/pkg/payload/json/json_test.go
+++ b/pkg/payload/json/json_test.go
@@ -1,9 +1,10 @@
 package json
 
 import (
-	"github.com/ponyruntime/pony/api/payload"
 	"reflect"
 	"testing"
+
+	"github.com/ponyruntime/pony/api/payload"
 )
 
 func TestJsonToGolangTranscoder_Transcode(t *testing.T) {

--- a/pkg/payload/lua/func.go
+++ b/pkg/payload/lua/func.go
@@ -1,7 +1,7 @@
 package lua
 
 import (
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Helper functions for Lua transcoding

--- a/pkg/payload/lua/func_test.go
+++ b/pkg/payload/lua/func_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func TestToGoAny(t *testing.T) {

--- a/pkg/payload/lua/json.go
+++ b/pkg/payload/lua/json.go
@@ -2,9 +2,10 @@ package lua
 
 import (
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/runtime/lua/modules/json"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // RegisterJson registers JSON<->Lua transcoders

--- a/pkg/payload/lua/json_test.go
+++ b/pkg/payload/lua/json_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/stretchr/testify/assert"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func TestJsonLuaTranscoders(t *testing.T) {

--- a/pkg/payload/lua/lua.go
+++ b/pkg/payload/lua/lua.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/ponyruntime/pony/api/payload"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func Register(transcoder payload.TranscoderRegister) {

--- a/pkg/payload/lua/lua_test.go
+++ b/pkg/payload/lua/lua_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/ponyruntime/pony/api/payload"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // MockTranscoder is a mock implementation of payload.Transcoder for testing.

--- a/pkg/payload/yaml/yaml.go
+++ b/pkg/payload/yaml/yaml.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/payload"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/registry/loader/change_set.go
+++ b/pkg/registry/loader/change_set.go
@@ -1,9 +1,10 @@
 package loader
 
 import (
+	"sort"
+
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/graph"
-	"sort"
 )
 
 // SortEntriesByDependency sorts entries based on their dependencies.

--- a/pkg/registry/loader/folder_loader.go
+++ b/pkg/registry/loader/folder_loader.go
@@ -2,9 +2,10 @@ package loader
 
 import (
 	"fmt"
-	"github.com/ponyruntime/pony/internal/interpolator"
 	"path/filepath"
 	"strings"
+
+	"github.com/ponyruntime/pony/internal/interpolator"
 
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"

--- a/pkg/registry/loader/folder_loader_test.go
+++ b/pkg/registry/loader/folder_loader_test.go
@@ -1,6 +1,9 @@
 package loader
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/utils"
@@ -10,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"strings"
-	"testing"
 )
 
 func TestFolderLoader_Load_MultipleFiles_Interpolation(t *testing.T) {

--- a/pkg/registry/loader/interpolators_test.go
+++ b/pkg/registry/loader/interpolators_test.go
@@ -2,11 +2,12 @@ package loader
 
 import (
 	"fmt"
-	"github.com/ponyruntime/pony/internal/utils"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ponyruntime/pony/internal/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadVars(t *testing.T) {

--- a/pkg/registry/meta_test.go
+++ b/pkg/registry/meta_test.go
@@ -1,9 +1,10 @@
 package registry
 
 import (
-	"github.com/ponyruntime/pony/api/registry"
 	"reflect"
 	"testing"
+
+	"github.com/ponyruntime/pony/api/registry"
 )
 
 func TestMetadata_StringValue(t *testing.T) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -3,8 +3,9 @@ package registry
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"sync"
+
+	"go.uber.org/zap"
 
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/version"

--- a/pkg/registry/router/router.go
+++ b/pkg/registry/router/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/wildcard"

--- a/pkg/registry/runner/bus_runner.go
+++ b/pkg/registry/runner/bus_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/registry"
 	"go.uber.org/zap"

--- a/pkg/registry/runner/bus_runner_test.go
+++ b/pkg/registry/runner/bus_runner_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"

--- a/pkg/registry/state_builder.go
+++ b/pkg/registry/state_builder.go
@@ -2,12 +2,13 @@ package registry
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
+
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/version"
 	"github.com/ponyruntime/pony/pkg/registry/loader"
 	"go.uber.org/zap"
-	"reflect"
-	"sort"
 )
 
 type StateBuilder struct {

--- a/pkg/registry/state_builder_test.go
+++ b/pkg/registry/state_builder_test.go
@@ -2,13 +2,14 @@ package registry
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/internal/version"
 	"go.uber.org/zap"
-	"reflect"
-	"strings"
-	"testing"
 )
 
 // MockHistory is a mock implementation of the registry.History interface for testing.

--- a/pkg/supervisor/controller.go
+++ b/pkg/supervisor/controller.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ponyruntime/pony/api/supervisor"
 	"sync"
 	"time"
+
+	"github.com/ponyruntime/pony/api/supervisor"
 )
 
 type State struct {

--- a/pkg/supervisor/controller_test.go
+++ b/pkg/supervisor/controller_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ponyruntime/pony/api/supervisor"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ponyruntime/pony/api/supervisor"
 )
 
 // mockService implements supervisor.Lifecycle for testing

--- a/pkg/supervisor/helpers.go
+++ b/pkg/supervisor/helpers.go
@@ -3,10 +3,11 @@ package supervisor
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/api/supervisor"
-	"go.uber.org/zap"
 	"sync"
 	"time"
+
+	"github.com/ponyruntime/pony/api/supervisor"
+	"go.uber.org/zap"
 )
 
 type internalState struct {

--- a/runtime/executor_test.go
+++ b/runtime/executor_test.go
@@ -3,6 +3,10 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"
@@ -11,9 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"sync"
-	"testing"
-	"time"
 )
 
 func setupTest(t *testing.T) (*Executor, events.Bus) {

--- a/runtime/lua/engine/channel/channel.go
+++ b/runtime/lua/engine/channel/channel.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"container/list"
 	"errors"
+
 	lua "github.com/yuin/gopher-lua"
 )
 

--- a/runtime/lua/engine/channel/channel_test.go
+++ b/runtime/lua/engine/channel/channel_test.go
@@ -1,8 +1,9 @@
 package channel
 
 import (
-	lua "github.com/yuin/gopher-lua"
 	"testing"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func TestChannelBasicOperations(t *testing.T) {

--- a/runtime/lua/engine/channel/module.go
+++ b/runtime/lua/engine/channel/module.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"fmt"
+
 	lua "github.com/yuin/gopher-lua"
 )
 

--- a/runtime/lua/engine/channel/named_test.go
+++ b/runtime/lua/engine/channel/named_test.go
@@ -2,12 +2,13 @@ package channel
 
 import (
 	"context"
+	"strings"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
-	"strings"
-	"testing"
 )
 
 func TestNamedChannelVisibility(t *testing.T) {

--- a/runtime/lua/engine/channel/passing_test.go
+++ b/runtime/lua/engine/channel/passing_test.go
@@ -2,10 +2,11 @@ package channel
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestChannelPassingSimple(t *testing.T) {

--- a/runtime/lua/engine/channel/runtime.go
+++ b/runtime/lua/engine/channel/runtime.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"fmt"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	lua "github.com/yuin/gopher-lua"
 )

--- a/runtime/lua/engine/channel/runtime_test.go
+++ b/runtime/lua/engine/channel/runtime_test.go
@@ -3,11 +3,12 @@ package channel
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"strings"
-	"testing"
 )
 
 func TestUnbufferedChannelOperations(t *testing.T) {

--- a/runtime/lua/engine/channel/select_test.go
+++ b/runtime/lua/engine/channel/select_test.go
@@ -2,10 +2,11 @@ package channel
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestSelectImmediate(t *testing.T) {

--- a/runtime/lua/engine/core_libs.go
+++ b/runtime/lua/engine/core_libs.go
@@ -1,7 +1,7 @@
 package engine
 
 import (
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // CoreLib represents a core Lua library

--- a/runtime/lua/engine/cvm.go
+++ b/runtime/lua/engine/cvm.go
@@ -4,9 +4,10 @@ import (
 	"container/list"
 	"context"
 	"fmt"
+	"strings"
+
 	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
-	"strings"
 )
 
 // TaskKey is the key used to store the current task in the Lua state specific to thread

--- a/runtime/lua/engine/cvm_test.go
+++ b/runtime/lua/engine/cvm_test.go
@@ -3,10 +3,11 @@ package engine
 import (
 	"context"
 	"fmt"
-	lua "github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"strings"
 	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 func TestCoroutineVM_Basic(t *testing.T) {

--- a/runtime/lua/engine/options.go
+++ b/runtime/lua/engine/options.go
@@ -2,8 +2,9 @@ package engine
 
 import (
 	"fmt"
-	"github.com/yuin/gopher-lua"
 	"strings"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 // WithLibrary adds a library from source code to the VM

--- a/runtime/lua/engine/vm.go
+++ b/runtime/lua/engine/vm.go
@@ -3,10 +3,11 @@ package engine
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/internal/closer"
 	"strings"
 
-	"github.com/yuin/gopher-lua"
+	"github.com/ponyruntime/pony/internal/closer"
+
+	lua "github.com/yuin/gopher-lua"
 	"github.com/yuin/gopher-lua/parse"
 	"go.uber.org/zap"
 )

--- a/runtime/lua/engine/vm_test.go
+++ b/runtime/lua/engine/vm_test.go
@@ -2,10 +2,11 @@ package engine
 
 import (
 	"context"
-	"github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"strings"
 	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 func TestVM_Basic(t *testing.T) {

--- a/runtime/lua/lua.go
+++ b/runtime/lua/lua.go
@@ -3,12 +3,13 @@ package lua
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	contextapi "github.com/ponyruntime/pony/api/context"
 	"github.com/ponyruntime/pony/api/runtime"
 	config "github.com/ponyruntime/pony/api/runtime/lua"
 	"github.com/ponyruntime/pony/runtime/lua/pool"
-	"github.com/yuin/gopher-lua"
-	"sync"
+	lua "github.com/yuin/gopher-lua"
 
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"
@@ -130,7 +131,9 @@ func (m *RuntimeManager) Execute(task runtime.Task) (chan *runtime.Result, error
 
 	// to clean up all dangling references
 	ctx, cancel := context.WithCancel(
-		context.WithValue(task.Context, "function", task.Target),
+		// TODO: should not use string
+		// TODO where is that key used?
+		context.WithValue(task.Context, "function", task.Target), //nolint:revive,staticcheck
 	)
 	defer cancel()
 

--- a/runtime/lua/modules/base64/base64.go
+++ b/runtime/lua/modules/base64/base64.go
@@ -3,7 +3,7 @@ package base64
 import (
 	"encoding/base64"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Module represents a base64 Lua module.

--- a/runtime/lua/modules/ctx/ctx.go
+++ b/runtime/lua/modules/ctx/ctx.go
@@ -3,7 +3,7 @@ package ctx
 import (
 	ctxapi "github.com/ponyruntime/pony/api/context" // Make sure this import path is correct
 	transcoder "github.com/ponyruntime/pony/pkg/payload/lua"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/ctx/ctx_test.go
+++ b/runtime/lua/modules/ctx/ctx_test.go
@@ -2,8 +2,9 @@ package ctx
 
 import (
 	"context"
-	ctxapi "github.com/ponyruntime/pony/api/context"
 	"testing"
+
+	ctxapi "github.com/ponyruntime/pony/api/context"
 
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"

--- a/runtime/lua/modules/exec/executor.go
+++ b/runtime/lua/modules/exec/executor.go
@@ -3,12 +3,13 @@ package exec
 import (
 	"context"
 	"errors"
+
 	contextapi "github.com/ponyruntime/pony/api/context"
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/api/runtime"
 	transcode "github.com/ponyruntime/pony/pkg/payload/lua"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // todo: we might need some whitelist of what can actually be called from Lua

--- a/runtime/lua/modules/exec/executor_test.go
+++ b/runtime/lua/modules/exec/executor_test.go
@@ -3,6 +3,8 @@ package exec
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	contextapi "github.com/ponyruntime/pony/api/context"
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/runtime"
@@ -14,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 type mockExecutor struct {

--- a/runtime/lua/modules/hash/hash.go
+++ b/runtime/lua/modules/hash/hash.go
@@ -9,7 +9,7 @@ import (
 	"hash"
 	"hash/fnv"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Module represents a hash Lua module.

--- a/runtime/lua/modules/http/helpers.go
+++ b/runtime/lua/modules/http/helpers.go
@@ -2,9 +2,10 @@ package http
 
 import (
 	"errors"
-	"github.com/yuin/gopher-lua"
 	"net/url"
 	"strings"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func encodeURI(l *lua.LState) int {

--- a/runtime/lua/modules/http/helpers_test.go
+++ b/runtime/lua/modules/http/helpers_test.go
@@ -1,13 +1,14 @@
 package http
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
-	"net/http"
-	"testing"
 )
 
 func TestEncodeURI(t *testing.T) {

--- a/runtime/lua/modules/http/http.go
+++ b/runtime/lua/modules/http/http.go
@@ -3,13 +3,14 @@ package http
 import (
 	"context"
 	"errors"
-	"github.com/ponyruntime/pony/internal/closer"
 	"io"
 	"net/http"
 	"time"
 
+	"github.com/ponyruntime/pony/internal/closer"
+
 	"github.com/ponyruntime/pony/runtime/lua/modules/stream"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/http/options.go
+++ b/runtime/lua/modules/http/options.go
@@ -2,12 +2,13 @@ package http
 
 import (
 	"errors"
-	"github.com/ponyruntime/pony/runtime/lua/modules/stream"
-	"github.com/yuin/gopher-lua"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/ponyruntime/pony/runtime/lua/modules/stream"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // requestOptions holds parsed request options

--- a/runtime/lua/modules/http/options_test.go
+++ b/runtime/lua/modules/http/options_test.go
@@ -1,11 +1,12 @@
 package http
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/yuin/gopher-lua"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func TestParseOptions(t *testing.T) {

--- a/runtime/lua/modules/http/response.go
+++ b/runtime/lua/modules/http/response.go
@@ -3,7 +3,7 @@ package http
 import (
 	"net/http"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // luaHTTPResponseTypeName is the type name for HTTP response userdata in Lua

--- a/runtime/lua/modules/http/response_test.go
+++ b/runtime/lua/modules/http/response_test.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"io"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ponyruntime/pony/runtime/lua/engine"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/runtime/lua/modules/httpctx/httpctx.go
+++ b/runtime/lua/modules/httpctx/httpctx.go
@@ -2,7 +2,7 @@ package httpctx
 
 import (
 	"github.com/ponyruntime/pony/runtime/lua/modules/stream"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/httpctx/httpctx_test.go
+++ b/runtime/lua/modules/httpctx/httpctx_test.go
@@ -2,11 +2,12 @@ package httpctx
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestHttpContextConstants(t *testing.T) {

--- a/runtime/lua/modules/httpctx/integration_test.go
+++ b/runtime/lua/modules/httpctx/integration_test.go
@@ -3,15 +3,16 @@ package httpctx
 import (
 	"context"
 	"encoding/json"
+	httpbase "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/ponyruntime/pony/api/service/http"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	httpbase "net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
 )
 
 func TestHttpHandler_Integration(t *testing.T) {

--- a/runtime/lua/modules/httpctx/request.go
+++ b/runtime/lua/modules/httpctx/request.go
@@ -3,15 +3,16 @@ package httpctx
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/api/service/http"
-	"github.com/ponyruntime/pony/internal/closer"
-	"github.com/ponyruntime/pony/runtime/lua/modules/json"
-	"github.com/ponyruntime/pony/runtime/lua/modules/stream"
-	"github.com/yuin/gopher-lua"
 	"io"
 	basehttp "net/http"
 	"strings"
 	"time"
+
+	"github.com/ponyruntime/pony/api/service/http"
+	"github.com/ponyruntime/pony/internal/closer"
+	"github.com/ponyruntime/pony/runtime/lua/modules/json"
+	"github.com/ponyruntime/pony/runtime/lua/modules/stream"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Request represents a Lua userdata object wrapping http.Request

--- a/runtime/lua/modules/httpctx/request_stream_test.go
+++ b/runtime/lua/modules/httpctx/request_stream_test.go
@@ -2,12 +2,13 @@ package httpctx
 
 import (
 	"context"
-	"github.com/ponyruntime/pony/api/service/http"
-	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"go.uber.org/zap"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ponyruntime/pony/api/service/http"
+	"github.com/ponyruntime/pony/runtime/lua/engine"
+	"go.uber.org/zap"
 )
 
 func TestRequest_StreamBody_Simple(t *testing.T) {

--- a/runtime/lua/modules/httpctx/request_test.go
+++ b/runtime/lua/modules/httpctx/request_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ponyruntime/pony/api/service/http"
-	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ponyruntime/pony/api/service/http"
+	"github.com/ponyruntime/pony/runtime/lua/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 type delayReader struct {

--- a/runtime/lua/modules/httpctx/response.go
+++ b/runtime/lua/modules/httpctx/response.go
@@ -2,10 +2,11 @@ package httpctx
 
 import (
 	"fmt"
+	basehttp "net/http"
+
 	"github.com/ponyruntime/pony/api/service/http"
 	"github.com/ponyruntime/pony/runtime/lua/modules/json"
-	"github.com/yuin/gopher-lua"
-	basehttp "net/http"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Response represents a Lua userdata object wrapping http.ResponseWriter

--- a/runtime/lua/modules/httpctx/response_test.go
+++ b/runtime/lua/modules/httpctx/response_test.go
@@ -3,14 +3,15 @@ package httpctx
 import (
 	"context"
 	"encoding/json"
+	basehttp "net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/ponyruntime/pony/api/service/http"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	basehttp "net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 // mockResponseWriter wraps httptest.ResponseRecorder to track header sent state

--- a/runtime/lua/modules/json/json.go
+++ b/runtime/lua/modules/json/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 var (

--- a/runtime/lua/modules/lfs/api.go
+++ b/runtime/lua/modules/lfs/api.go
@@ -1,9 +1,10 @@
 package lfs
 
 import (
-	"github.com/yuin/gopher-lua"
 	"os"
 	"time"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func apiAttributes(l *lua.LState) int {

--- a/runtime/lua/modules/lfs/api_darwin.go
+++ b/runtime/lua/modules/lfs/api_darwin.go
@@ -3,9 +3,10 @@
 package lfs
 
 import (
-	"github.com/yuin/gopher-lua"
 	"os"
 	"syscall"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func attributesFill(tbl *lua.LTable, stat os.FileInfo) error {

--- a/runtime/lua/modules/lfs/api_linux.go
+++ b/runtime/lua/modules/lfs/api_linux.go
@@ -3,9 +3,10 @@
 package lfs
 
 import (
-	"github.com/yuin/gopher-lua"
 	"os"
 	"syscall"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func attributesFill(tbl *lua.LTable, stat os.FileInfo) error {

--- a/runtime/lua/modules/lfs/api_windows.go
+++ b/runtime/lua/modules/lfs/api_windows.go
@@ -3,10 +3,11 @@
 package lfs
 
 import (
-	"github.com/yuin/gopher-lua"
 	"os"
 	"syscall"
 	"time"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func attributesFill(tbl *lua.LTable, stat os.FileInfo) error {

--- a/runtime/lua/modules/lfs/attributes.go
+++ b/runtime/lua/modules/lfs/attributes.go
@@ -1,9 +1,10 @@
 package lfs
 
 import (
-	"github.com/yuin/gopher-lua"
 	"os"
 	"path/filepath"
+
+	lua "github.com/yuin/gopher-lua"
 )
 
 func attributes(l *lua.LState, statFunc func(string) (os.FileInfo, error)) int {

--- a/runtime/lua/modules/lfs/lfs.go
+++ b/runtime/lua/modules/lfs/lfs.go
@@ -4,7 +4,7 @@
 package lfs
 
 import (
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Module represents a lfs Lua module.

--- a/runtime/lua/modules/logger/logger.go
+++ b/runtime/lua/modules/logger/logger.go
@@ -2,8 +2,9 @@ package logger
 
 import (
 	"errors"
+
 	transcoder "github.com/ponyruntime/pony/pkg/payload/lua"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/stream/lua_stream.go
+++ b/runtime/lua/modules/stream/lua_stream.go
@@ -2,9 +2,10 @@ package stream
 
 import (
 	"fmt"
-	"github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"io"
+
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 // LuaStream wraps Stream for Lua

--- a/runtime/lua/modules/stream/stream_test.go
+++ b/runtime/lua/modules/stream/stream_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"io"
 	"sync"
 	"testing"
+
+	"github.com/ponyruntime/pony/runtime/lua/engine"
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/runtime/lua/modules/time/coroutine_test.go
+++ b/runtime/lua/modules/time/coroutine_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/time/duration.go
+++ b/runtime/lua/modules/time/duration.go
@@ -3,7 +3,7 @@ package time
 import (
 	"time"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Module represents a time Lua module

--- a/runtime/lua/modules/time/location.go
+++ b/runtime/lua/modules/time/location.go
@@ -3,7 +3,7 @@ package time
 import (
 	"time"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Location represents a Lua userdata object wrapping time.Location

--- a/runtime/lua/modules/time/location_test.go
+++ b/runtime/lua/modules/time/location_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/time/module.go
+++ b/runtime/lua/modules/time/module.go
@@ -1,6 +1,6 @@
 package time
 
-import "github.com/yuin/gopher-lua"
+import lua "github.com/yuin/gopher-lua"
 
 // Duration constants in nanoseconds
 const (

--- a/runtime/lua/modules/time/time.go
+++ b/runtime/lua/modules/time/time.go
@@ -3,7 +3,7 @@ package time
 import (
 	"time"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Time represents a Lua userdata object wrapping time.Time

--- a/runtime/lua/modules/time/time_test.go
+++ b/runtime/lua/modules/time/time_test.go
@@ -2,13 +2,13 @@ package time
 
 import (
 	"context"
-	"github.com/yuin/gopher-lua"
 	"testing"
 	"time"
 
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/modules/treesitter/Makefile
+++ b/runtime/lua/modules/treesitter/Makefile
@@ -1,0 +1,3 @@
+debug_test:
+	dlv test -- test.v -test.run="^TestSQLQueries\\$\\"
+

--- a/runtime/lua/modules/treesitter/cursor.go
+++ b/runtime/lua/modules/treesitter/cursor.go
@@ -2,7 +2,7 @@ package treesitter
 
 import (
 	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 type CursorWrapper struct {
@@ -11,148 +11,146 @@ type CursorWrapper struct {
 }
 
 // Register the Cursor type to Lua
-func registerCursor(L *lua.LState) {
-	mt := L.NewTypeMetatable("treesitter.Cursor")
-	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), cursorMethods))
+func registerCursor(l *lua.LState) {
+	mt := l.NewTypeMetatable("treesitter.Cursor")
+	l.SetField(mt, "__index", l.SetFuncs(l.NewTable(), map[string]lua.LGFunction{
+		"current_node":               cursorCurrentNode,
+		"current_field_id":           cursorCurrentFieldID,
+		"current_field_name":         cursorCurrentFieldName,
+		"current_depth":              cursorCurrentDepth,
+		"current_descendant_index":   cursorCurrentDescendantIndex,
+		"goto_parent":                cursorGotoParent,
+		"goto_first_child":           cursorGotoFirstChild,
+		"goto_last_child":            cursorGotoLastChild,
+		"goto_next_sibling":          cursorGotoNextSibling,
+		"goto_previous_sibling":      cursorGotoPreviousSibling,
+		"goto_descendant":            cursorGotoDescendant,
+		"goto_first_child_for_byte":  cursorGotoFirstChildForByte,
+		"goto_first_child_for_point": cursorGotoFirstChildForPoint,
+		"reset":                      cursorReset,
+		"reset_to":                   cursorResetTo,
+		"copy":                       cursorCopy,
+		"close":                      cursorClose,
+	}))
 }
 
-var cursorMethods = map[string]lua.LGFunction{
-	"current_node":               cursorCurrentNode,
-	"current_field_id":           cursorCurrentFieldId,
-	"current_field_name":         cursorCurrentFieldName,
-	"current_depth":              cursorCurrentDepth,
-	"current_descendant_index":   cursorCurrentDescendantIndex,
-	"goto_parent":                cursorGotoParent,
-	"goto_first_child":           cursorGotoFirstChild,
-	"goto_last_child":            cursorGotoLastChild,
-	"goto_next_sibling":          cursorGotoNextSibling,
-	"goto_previous_sibling":      cursorGotoPreviousSibling,
-	"goto_descendant":            cursorGotoDescendant,
-	"goto_first_child_for_byte":  cursorGotoFirstChildForByte,
-	"goto_first_child_for_point": cursorGotoFirstChildForPoint,
-	"reset":                      cursorReset,
-	"reset_to":                   cursorResetTo,
-	"copy":                       cursorCopy,
-	"close":                      cursorClose,
-}
-
-func cursorCurrentNode(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorCurrentNode(l *lua.LState) int {
+	cursor := checkCursor(l)
 	node := cursor.cursor.Node()
 	if node == nil {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 		return 1
 	}
 
-	ud := L.NewUserData()
+	ud := l.NewUserData()
 	ud.Value = &NodeWrapper{node: node, source: cursor.source}
-	L.SetMetatable(ud, L.GetTypeMetatable("treesitter.Node"))
-	L.Push(ud)
+	l.SetMetatable(ud, l.GetTypeMetatable("treesitter.Node"))
+	l.Push(ud)
 	return 1
 }
 
-func cursorCurrentFieldId(L *lua.LState) int {
-	cursor := checkCursor(L)
-	L.Push(lua.LNumber(cursor.cursor.FieldId()))
+func cursorCurrentFieldID(l *lua.LState) int {
+	cursor := checkCursor(l)
+	l.Push(lua.LNumber(cursor.cursor.FieldId()))
 	return 1
 }
 
-func cursorCurrentFieldName(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorCurrentFieldName(l *lua.LState) int {
+	cursor := checkCursor(l)
 	fieldName := cursor.cursor.FieldName()
 	if fieldName == "" {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 		return 1
 	}
-	L.Push(lua.LString(fieldName))
+	l.Push(lua.LString(fieldName))
 	return 1
 }
 
-func cursorCurrentDepth(L *lua.LState) int {
-	cursor := checkCursor(L)
-	L.Push(lua.LNumber(cursor.cursor.Depth()))
+func cursorCurrentDepth(l *lua.LState) int {
+	cursor := checkCursor(l)
+	l.Push(lua.LNumber(cursor.cursor.Depth()))
 	return 1
 }
 
-func cursorCurrentDescendantIndex(L *lua.LState) int {
-	cursor := checkCursor(L)
-	L.Push(lua.LNumber(cursor.cursor.DescendantIndex()))
+func cursorCurrentDescendantIndex(l *lua.LState) int {
+	cursor := checkCursor(l)
+	l.Push(lua.LNumber(cursor.cursor.DescendantIndex()))
 	return 1
 }
 
-func cursorGotoParent(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorGotoParent(l *lua.LState) int {
+	cursor := checkCursor(l)
 	success := cursor.cursor.GotoParent()
-	L.Push(lua.LBool(success))
+	l.Push(lua.LBool(success))
 	return 1
 }
 
-func cursorGotoFirstChild(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorGotoFirstChild(l *lua.LState) int {
+	cursor := checkCursor(l)
 	success := cursor.cursor.GotoFirstChild()
-	L.Push(lua.LBool(success))
+	l.Push(lua.LBool(success))
 	return 1
 }
 
-func cursorGotoLastChild(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorGotoLastChild(l *lua.LState) int {
+	cursor := checkCursor(l)
 	success := cursor.cursor.GotoLastChild()
-	L.Push(lua.LBool(success))
+	l.Push(lua.LBool(success))
 	return 1
 }
 
-func cursorGotoNextSibling(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorGotoNextSibling(l *lua.LState) int {
+	cursor := checkCursor(l)
 	success := cursor.cursor.GotoNextSibling()
-	L.Push(lua.LBool(success))
+	l.Push(lua.LBool(success))
 	return 1
 }
 
-func cursorGotoPreviousSibling(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorGotoPreviousSibling(l *lua.LState) int {
+	cursor := checkCursor(l)
 	success := cursor.cursor.GotoPreviousSibling()
-	L.Push(lua.LBool(success))
+	l.Push(lua.LBool(success))
 	return 1
 }
 
-func cursorGotoDescendant(L *lua.LState) int {
-	cursor := checkCursor(L)
-	index := uint32(L.CheckNumber(2))
+func cursorGotoDescendant(l *lua.LState) int {
+	cursor := checkCursor(l)
+	index := uint32(l.CheckNumber(2))
 	cursor.cursor.GotoDescendant(index)
 	return 0
 }
 
-func cursorGotoFirstChildForByte(L *lua.LState) int {
-	cursor := checkCursor(L)
-	byteIndex := uint32(L.CheckNumber(2))
+func cursorGotoFirstChildForByte(l *lua.LState) int {
+	cursor := checkCursor(l)
+	byteIndex := uint32(l.CheckNumber(2))
 	if index := cursor.cursor.GotoFirstChildForByte(byteIndex); index != nil {
-		L.Push(lua.LNumber(*index))
+		l.Push(lua.LNumber(*index))
 	} else {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 	}
 	return 1
 }
 
-func cursorGotoFirstChildForPoint(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorGotoFirstChildForPoint(l *lua.LState) int {
+	cursor := checkCursor(l)
 
 	// Get point table argument
-	pointTbl := L.CheckTable(2)
+	pointTbl := l.CheckTable(2)
 	row := uint(pointTbl.RawGetString("row").(lua.LNumber))
 	col := uint(pointTbl.RawGetString("column").(lua.LNumber))
 
 	point := treesitter.Point{Row: row, Column: col}
 	if index := cursor.cursor.GotoFirstChildForPoint(point); index != nil {
-		L.Push(lua.LNumber(*index))
+		l.Push(lua.LNumber(*index))
 	} else {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 	}
 	return 1
 }
 
-func cursorReset(L *lua.LState) int {
-	cursor := checkCursor(L)
-	ud := L.CheckUserData(2)
+func cursorReset(l *lua.LState) int {
+	cursor := checkCursor(l)
+	ud := l.CheckUserData(2)
 	if node, ok := ud.Value.(*NodeWrapper); ok {
 		cursor.cursor.Reset(*node.node)
 		return 0
@@ -160,30 +158,30 @@ func cursorReset(L *lua.LState) int {
 	return 0
 }
 
-func cursorResetTo(L *lua.LState) int {
-	cursor := checkCursor(L)
-	ud := L.CheckUserData(2)
+func cursorResetTo(l *lua.LState) int {
+	cursor := checkCursor(l)
+	ud := l.CheckUserData(2)
 	if otherCursor, ok := ud.Value.(*CursorWrapper); ok {
 		cursor.cursor.ResetTo(otherCursor.cursor)
 		return 0
 	}
-	L.ArgError(2, "TreeCursor expected")
+	l.ArgError(2, "TreeCursor expected")
 	return 0
 }
 
-func cursorCopy(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorCopy(l *lua.LState) int {
+	cursor := checkCursor(l)
 	copied := cursor.cursor.Copy()
 
-	ud := L.NewUserData()
+	ud := l.NewUserData()
 	ud.Value = &CursorWrapper{cursor: copied, source: cursor.source}
-	L.SetMetatable(ud, L.GetTypeMetatable("treesitter.Cursor"))
-	L.Push(ud)
+	l.SetMetatable(ud, l.GetTypeMetatable("treesitter.Cursor"))
+	l.Push(ud)
 	return 1
 }
 
-func cursorClose(L *lua.LState) int {
-	cursor := checkCursor(L)
+func cursorClose(l *lua.LState) int {
+	cursor := checkCursor(l)
 	if cursor != nil {
 		cursor.cursor.Close()
 	}
@@ -191,11 +189,11 @@ func cursorClose(L *lua.LState) int {
 }
 
 // Helper functions
-func checkCursor(L *lua.LState) *CursorWrapper {
-	ud := L.CheckUserData(1)
+func checkCursor(l *lua.LState) *CursorWrapper {
+	ud := l.CheckUserData(1)
 	if v, ok := ud.Value.(*CursorWrapper); ok {
 		return v
 	}
-	L.ArgError(1, "TreeCursor expected")
+	l.ArgError(1, "TreeCursor expected")
 	return nil
 }

--- a/runtime/lua/modules/treesitter/cursor_test.go
+++ b/runtime/lua/modules/treesitter/cursor_test.go
@@ -1,11 +1,13 @@
 package treesitter
 
 import (
+	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestCursorMethods(t *testing.T) {
@@ -20,7 +22,7 @@ func TestCursorMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -61,7 +63,7 @@ func TestCursorMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -102,7 +104,7 @@ func TestCursorMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -146,7 +148,7 @@ func TestCursorMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -187,7 +189,7 @@ func TestCursorAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				type Person struct {
@@ -217,7 +219,7 @@ func TestCursorAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -255,7 +257,7 @@ func TestCursorAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -281,7 +283,7 @@ func TestCursorImplementation(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             local code = "package main\n\nfunc test() {}\n"
             local tree = treesitter.parse("go", code)
@@ -315,7 +317,7 @@ func TestCursorImplementation(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             local code = "package main\n\nfunc test() {}\n"
             local tree = treesitter.parse("go", code)

--- a/runtime/lua/modules/treesitter/grammars.go
+++ b/runtime/lua/modules/treesitter/grammars.go
@@ -1,7 +1,6 @@
 package treesitter
 
 import (
-	_ "embed"
 	"unsafe"
 
 	tslua "github.com/tree-sitter-grammars/tree-sitter-lua/bindings/go"
@@ -21,99 +20,106 @@ type LanguageInfo struct {
 	Language func() unsafe.Pointer // Function to get the Tree-sitter language object
 }
 
-// languageDefinitions contains the core language definitions
-var languageDefinitions = []LanguageInfo{
-	{
-		Name:     "lua",
-		Aliases:  []string{"lua"},
-		Language: tslua.Language,
-	},
-	{
-		Name:     "php",
-		Aliases:  []string{"php"},
-		Language: tsphp.LanguagePHP,
-	},
-	{
-		Name:     "go",
-		Aliases:  []string{"go", "golang"},
-		Language: tsgo.Language,
-	},
-	{
-		Name:     "javascript",
-		Aliases:  []string{"js", "javascript"},
-		Language: tsjs.Language,
-	},
-	{
-		Name:     "typescript+jsx",
-		Aliases:  []string{"tsx"},
-		Language: tsts.LanguageTSX,
-	},
-	{
-		Name:     "typescript",
-		Aliases:  []string{"ts", "typescript"},
-		Language: tsts.LanguageTypescript,
-	},
-	{
-		Name:     "python",
-		Aliases:  []string{"python", "py"},
-		Language: tspython.Language,
-	},
-	{
-		Name:     "c#",
-		Aliases:  []string{"csharp", "c#", "cs"},
-		Language: cscsharp.Language,
-	},
-	{
-		Name:     "html",
-		Aliases:  []string{"html", "html5"},
-		Language: tshtml.Language,
-	},
-	{
-		Name:     "markdown",
-		Aliases:  []string{"markdown", "md"},
-		Language: nil, // todo: find and fix me
-	},
-	{
-		Name:     "sql",
-		Aliases:  []string{"sql"},
-		Language: nil, // todo: find and fix me
-	},
+type Languages struct {
+	li        []*LanguageInfo
+	supported map[string]*LanguageInfo
 }
 
-// supportedLanguages is a map of all language aliases to their LanguageInfo
-var supportedLanguages map[string]*LanguageInfo
+func NewLanguages() *Languages {
+	li := []*LanguageInfo{
+		{
+			Name:     "lua",
+			Aliases:  []string{"lua"},
+			Language: tslua.Language,
+		},
+		{
+			Name:     "php",
+			Aliases:  []string{"php"},
+			Language: tsphp.LanguagePHP,
+		},
+		{
+			Name:     "go",
+			Aliases:  []string{"go", "golang"},
+			Language: tsgo.Language,
+		},
+		{
+			Name:     "javascript",
+			Aliases:  []string{"js", "javascript"},
+			Language: tsjs.Language,
+		},
+		{
+			Name:     "typescript+jsx",
+			Aliases:  []string{"tsx"},
+			Language: tsts.LanguageTSX,
+		},
+		{
+			Name:     "typescript",
+			Aliases:  []string{"ts", "typescript"},
+			Language: tsts.LanguageTypescript,
+		},
+		{
+			Name:     "python",
+			Aliases:  []string{"python", "py"},
+			Language: tspython.Language,
+		},
+		{
+			Name:     "c#",
+			Aliases:  []string{"csharp", "c#", "cs"},
+			Language: cscsharp.Language,
+		},
+		{
+			Name:     "html",
+			Aliases:  []string{"html", "html5"},
+			Language: tshtml.Language,
+		},
+		{
+			Name:     "markdown",
+			Aliases:  []string{"markdown", "md"},
+			Language: nil, // todo: find and fix me
+		},
+		{
+			Name:     "sql",
+			Aliases:  []string{"sql"},
+			Language: nil, // todo: find and fix me
+		},
+	}
 
-func init() {
 	// Initialize the map with enough capacity for all aliases
 	totalAliases := 0
-	for _, lang := range languageDefinitions {
+	for _, lang := range li {
 		totalAliases += len(lang.Aliases)
 	}
-	supportedLanguages = make(map[string]*LanguageInfo, totalAliases)
+
+	supportedLanguages := make(map[string]*LanguageInfo, totalAliases)
 
 	// Map all aliases to their language info
-	for i := range languageDefinitions {
-		langInfo := &languageDefinitions[i]
+	for i := range li {
+		langInfo := li[i]
 		for _, alias := range langInfo.Aliases {
 			supportedLanguages[alias] = langInfo
 		}
 	}
+
+	return &Languages{
+		li:        li,
+		supported: supportedLanguages,
+	}
 }
 
-// GetLanguageInfo returns the LanguageInfo for a given language alias.
-func GetLanguageInfo(alias string) *LanguageInfo {
-	return supportedLanguages[alias]
+// GetLanguageInfo returns the LanguageInfo for a given language alias or nil
+func (l *Languages) GetLanguageInfo(alias string) *LanguageInfo {
+	return l.supported[alias]
 }
 
-// GetSupportedLanguages returns a list of supported language names.
-func GetSupportedLanguages() []string {
+func (l *Languages) GetSupportedLanguages() []string {
 	seen := make(map[string]bool)
-	names := make([]string, 0, len(languageDefinitions))
-	for _, langInfo := range languageDefinitions {
+	names := make([]string, 0, 10)
+	for _, langInfo := range l.li {
 		if !seen[langInfo.Name] {
 			names = append(names, langInfo.Name)
 			seen[langInfo.Name] = true
 		}
 	}
+
 	return names
 }

--- a/runtime/lua/modules/treesitter/grammars.go
+++ b/runtime/lua/modules/treesitter/grammars.go
@@ -3,6 +3,7 @@ package treesitter
 import (
 	"unsafe"
 
+	tsmd "github.com/ponyruntime/tree-sitter-markdown/bindings/go"
 	tslua "github.com/tree-sitter-grammars/tree-sitter-lua/bindings/go"
 	cscsharp "github.com/tree-sitter/tree-sitter-c-sharp/bindings/go"
 	tsgo "github.com/tree-sitter/tree-sitter-go/bindings/go"
@@ -75,7 +76,7 @@ func NewLanguages() *Languages {
 		{
 			Name:     "markdown",
 			Aliases:  []string{"markdown", "md"},
-			Language: nil, // todo: find and fix me
+			Language: tsmd.Language,
 		},
 		{
 			Name:     "sql",

--- a/runtime/lua/modules/treesitter/grammars.go
+++ b/runtime/lua/modules/treesitter/grammars.go
@@ -4,6 +4,7 @@ import (
 	"unsafe"
 
 	tsmd "github.com/ponyruntime/tree-sitter-markdown/bindings/go"
+	tssql "github.com/ponyruntime/tree-sitter-sql/bindings/go"
 	tslua "github.com/tree-sitter-grammars/tree-sitter-lua/bindings/go"
 	cscsharp "github.com/tree-sitter/tree-sitter-c-sharp/bindings/go"
 	tsgo "github.com/tree-sitter/tree-sitter-go/bindings/go"
@@ -81,7 +82,7 @@ func NewLanguages() *Languages {
 		{
 			Name:     "sql",
 			Aliases:  []string{"sql"},
-			Language: nil, // todo: find and fix me
+			Language: tssql.Language,
 		},
 	}
 

--- a/runtime/lua/modules/treesitter/grammars_test.go
+++ b/runtime/lua/modules/treesitter/grammars_test.go
@@ -48,10 +48,10 @@ func TestGetLanguageInfo(t *testing.T) {
 		},
 		{
 			name:  "Get language with nil Language function",
-			alias: "markdown",
+			alias: "foo",
 			want: &LanguageInfo{
-				Name:     "markdown",
-				Aliases:  []string{"markdown", "md"},
+				Name:     "bar",
+				Aliases:  []string{"foobar", "bar"},
 				Language: nil,
 			},
 			wantFound: true,

--- a/runtime/lua/modules/treesitter/grammars_test.go
+++ b/runtime/lua/modules/treesitter/grammars_test.go
@@ -1,14 +1,16 @@
 package treesitter
 
 import (
+	"context"
+	"reflect"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	treesittergo "github.com/tree-sitter/tree-sitter-go/bindings/go"
 	treesitterjs "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
 	"go.uber.org/zap"
-	"reflect"
-	"testing"
 )
 
 func TestGetLanguageInfo(t *testing.T) {
@@ -55,9 +57,11 @@ func TestGetLanguageInfo(t *testing.T) {
 			wantFound: true,
 		},
 	}
+
+	langs := NewLanguages()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetLanguageInfo(tt.alias)
+			got := langs.GetLanguageInfo(tt.alias)
 			if (got != nil) != tt.wantFound {
 				t.Errorf("GetLanguageInfo() found = %v, wantFound %v", got != nil, tt.wantFound)
 				return
@@ -85,7 +89,8 @@ func TestGetLanguageInfo(t *testing.T) {
 
 // TestLanguageFunctions checks if the Language functions return non-nil values.
 func TestLanguageFunctions(t *testing.T) {
-	for alias, info := range supportedLanguages {
+	langs := NewLanguages()
+	for alias, info := range langs.supported {
 		// Skip languages without a Language function (like Markdown)
 		if info.Language == nil {
 			continue
@@ -97,18 +102,6 @@ func TestLanguageFunctions(t *testing.T) {
 			}
 		})
 	}
-}
-
-// copyLangInfo creates a copy of a LanguageInfo value.
-func copyLangInfo(info LanguageInfo) *LanguageInfo {
-	// Create a new LanguageInfo with copies of the values
-	newInfo := &LanguageInfo{
-		Name:     info.Name,
-		Aliases:  make([]string, len(info.Aliases)), // Copy the slice
-		Language: info.Language,
-	}
-	copy(newInfo.Aliases, info.Aliases) // Copy the slice contents
-	return newInfo
 }
 
 func TestGrammarSupport(t *testing.T) {
@@ -123,7 +116,7 @@ func TestGrammarSupport(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local langs = treesitter.supported_languages()
 			assert(type(langs) == "table", "supported_languages should return a table")
@@ -149,7 +142,7 @@ func TestGrammarSupport(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test various language aliases
@@ -200,7 +193,7 @@ func TestGrammarSupport(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			local function test_invalid_parse(alias)

--- a/runtime/lua/modules/treesitter/language.go
+++ b/runtime/lua/modules/treesitter/language.go
@@ -3,7 +3,7 @@ package treesitter
 import "C"
 import (
 	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // LanguageWrapper wraps a tree-sitter Language for Lua integration

--- a/runtime/lua/modules/treesitter/language_test.go
+++ b/runtime/lua/modules/treesitter/language_test.go
@@ -1,11 +1,13 @@
 package treesitter
 
 import (
+	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestLanguageMethods(t *testing.T) {
@@ -20,7 +22,7 @@ func TestLanguageMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -43,7 +45,7 @@ func TestLanguageMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -66,7 +68,7 @@ func TestLanguageMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -101,7 +103,7 @@ func TestLanguageMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -132,7 +134,7 @@ func TestLanguageMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -159,7 +161,7 @@ func TestLanguageEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test with invalid language
@@ -191,7 +193,7 @@ func TestLanguageEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -221,7 +223,7 @@ func TestLanguageEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test with different languages

--- a/runtime/lua/modules/treesitter/node.go
+++ b/runtime/lua/modules/treesitter/node.go
@@ -2,7 +2,7 @@ package treesitter
 
 import (
 	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // NodeWrapper wraps a tree-sitter Node for Lua integration
@@ -14,48 +14,47 @@ type NodeWrapper struct {
 // Register the Node type to Lua
 func registerNode(L *lua.LState) {
 	mt := L.NewTypeMetatable("treesitter.Node")
-	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), nodeMethods))
-}
 
-var nodeMethods = map[string]lua.LGFunction{
-	// Navigation methods
-	"parent":                           nodeParent,
-	"child":                            nodeChild,
-	"child_count":                      nodeChildCount,
-	"next_sibling":                     nodeNextSibling,
-	"prev_sibling":                     nodePrevSibling,
-	"next_named_sibling":               nodeNextNamedSibling,
-	"prev_named_sibling":               nodePrevNamedSibling,
-	"named_child":                      nodeNamedChild,
-	"named_child_count":                nodeNamedChildCount,
-	"named_descendant_for_point_range": nodeNamedDescendantForPointRange,
-	"descendant_count":                 nodeDescendantCount,
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		// Navigation methods
+		"parent":                           nodeParent,
+		"child":                            nodeChild,
+		"child_count":                      nodeChildCount,
+		"next_sibling":                     nodeNextSibling,
+		"prev_sibling":                     nodePrevSibling,
+		"next_named_sibling":               nodeNextNamedSibling,
+		"prev_named_sibling":               nodePrevNamedSibling,
+		"named_child":                      nodeNamedChild,
+		"named_child_count":                nodeNamedChildCount,
+		"named_descendant_for_point_range": nodeNamedDescendantForPointRange,
+		"descendant_count":                 nodeDescendantCount,
 
-	// Field-related methods
-	"child_by_field_name":  nodeChildByFieldName,
-	"field_name_for_child": nodeFieldNameForChild,
+		// Field-related methods
+		"child_by_field_name":  nodeChildByFieldName,
+		"field_name_for_child": nodeFieldNameForChild,
 
-	// Inspection methods
-	"kind": nodeKind,
-	"type": nodeKind, // alias for AI
+		// Inspection methods
+		"kind": nodeKind,
+		"type": nodeKind, // alias for AI
 
-	"is_named":     nodeIsNamed,
-	"grammar_name": nodeGrammarName,
-	"is_extra":     nodeIsExtra,
-	"is_missing":   nodeIsMissing,
+		"is_named":     nodeIsNamed,
+		"grammar_name": nodeGrammarName,
+		"is_extra":     nodeIsExtra,
+		"is_missing":   nodeIsMissing,
 
-	"has_error": nodeHasError,
-	"is_error":  nodeIsError,
+		"has_error": nodeHasError,
+		"is_error":  nodeIsError,
 
-	// Position methods
-	"start_byte":  nodeStartByte,
-	"end_byte":    nodeEndByte,
-	"start_point": nodeStartPoint,
-	"end_point":   nodeEndPoint,
+		// Position methods
+		"start_byte":  nodeStartByte,
+		"end_byte":    nodeEndByte,
+		"start_point": nodeStartPoint,
+		"end_point":   nodeEndPoint,
 
-	// Text and source methods
-	"text":    nodeText,
-	"to_sexp": nodeToSexp,
+		// Text and source methods
+		"text":    nodeText,
+		"to_sexp": nodeToSexp,
+	}))
 }
 
 // Navigation methods implementation
@@ -280,15 +279,15 @@ func nodeText(L *lua.LState) int {
 	}
 
 	// Get byte positions
+	// start and end can't be < 0
 	start := node.node.StartByte()
 	end := node.node.EndByte()
 
-	// Bounds checking with uint32 for safe comparisons
-	sourceLen := uint32(len(code))
-	startPos := uint32(start)
-	endPos := uint32(end)
+	sourceLen := len(code)
+	startPos := start
+	endPos := end
 
-	if start < 0 || end < 0 || startPos > endPos || endPos > sourceLen {
+	if startPos > endPos || endPos > uint(sourceLen) {
 		// Instead of just returning nil, raise an error
 		L.RaiseError("invalid byte range")
 		return 0 // This line won't be reached due to RaiseError

--- a/runtime/lua/modules/treesitter/node_test.go
+++ b/runtime/lua/modules/treesitter/node_test.go
@@ -1,12 +1,14 @@
 package treesitter
 
 import (
+	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestNodeMethods(t *testing.T) {
@@ -21,7 +23,7 @@ func TestNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -59,7 +61,7 @@ func TestNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -95,7 +97,7 @@ func TestNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -130,7 +132,7 @@ func TestNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -168,7 +170,7 @@ func TestNodeAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				type Person struct {
@@ -201,7 +203,7 @@ func TestNodeAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "func main() { invalid syntax }"
 			local tree = treesitter.parse("go", code)
@@ -233,7 +235,7 @@ func TestNodeAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -280,7 +282,7 @@ func TestNodeTextMethod(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             local code = [[package main
 
@@ -342,7 +344,7 @@ func TestNodeChildText(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             local code = "func test() { return 42 }"
             
@@ -380,7 +382,7 @@ func TestOtherNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -421,7 +423,7 @@ func TestOtherNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "func main() { x = "  -- Missing expression and closing brace
 			local tree = treesitter.parse("go", code)
@@ -458,7 +460,7 @@ func TestOtherNodeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[package main
 			
@@ -487,7 +489,7 @@ func hello() {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[package main
 
@@ -533,7 +535,7 @@ func TestCodeValidation(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test case 1: Missing closing brace
@@ -615,7 +617,7 @@ func TestNodeSiblingNavigation(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             local code = [[
                 package main
@@ -716,7 +718,7 @@ func TestNodeSiblingNavigation(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             -- Use a simpler code sample for edge cases
             local code = [[

--- a/runtime/lua/modules/treesitter/parser.go
+++ b/runtime/lua/modules/treesitter/parser.go
@@ -3,11 +3,12 @@ package treesitter
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/internal/closer"
 	"time"
 
+	"github.com/ponyruntime/pony/internal/closer"
+
 	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 type ParserWrapper struct {
@@ -17,40 +18,38 @@ type ParserWrapper struct {
 
 func registerParser(L *lua.LState) {
 	mt := L.NewTypeMetatable("treesitter.Parser")
-	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), parserMethods))
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"parse":        parserParse,
+		"set_language": parserSetLanguage,
+		"get_language": parserGetLanguage,
+		"reset":        parserReset,
+		"close":        parserClose,
+		"set_timeout":  parserSetTimeout,
+		"set_ranges":   parserSetRanges,
+	}))
 }
 
-var parserMethods = map[string]lua.LGFunction{
-	"parse":        parserParse,
-	"set_language": parserSetLanguage,
-	"get_language": parserGetLanguage,
-	"reset":        parserReset,
-	"close":        parserClose,
-	"set_timeout":  parserSetTimeout,
-	"set_ranges":   parserSetRanges,
-}
-
-func newParser(L *lua.LState) int {
+func newParser(l *lua.LState) int {
 	parser := treesitter.NewParser()
 
-	if L.Context() != nil {
-		cleanup := closer.FromContext(L.Context())
+	if l.Context() != nil {
+		cleanup := closer.FromContext(l.Context())
 		if cleanup != nil {
 			cleanup.Add(func() error { parser.Close(); return nil })
 		}
 	}
 
-	ud := L.NewUserData()
+	ud := l.NewUserData()
 	ud.Value = &ParserWrapper{parser: parser}
-	L.SetMetatable(ud, L.GetTypeMetatable("treesitter.Parser"))
-	L.Push(ud)
+	l.SetMetatable(ud, l.GetTypeMetatable("treesitter.Parser"))
+	l.Push(ud)
 	return 1
 }
 
-func (p *ParserWrapper) parseWithContext(code []byte, oldTree *TreeWrapper, ctx context.Context) (*treesitter.Tree, error) {
+func (p *ParserWrapper) parseWithContext(ctx context.Context, code []byte, oldTree *TreeWrapper) (*treesitter.Tree, error) {
 	if deadline, ok := ctx.Deadline(); ok {
 		timeout := time.Until(deadline)
-		p.parser.SetTimeoutMicros(uint64(timeout.Microseconds()))
+		p.parser.SetTimeoutMicros(uint64(timeout.Microseconds())) //nolint:gosec
 	}
 
 	var cflag uintptr
@@ -76,14 +75,14 @@ func parserSetLanguage(L *lua.LState) int {
 	p := checkParser(L)
 	langAlias := L.CheckString(2)
 
-	langInfo := GetLanguageInfo(langAlias)
+	langInfo := NewLanguages().GetLanguageInfo(langAlias)
 	if langInfo == nil {
-		L.RaiseError("language '" + langAlias + "' not found")
+		L.RaiseError("language %s is not found", langAlias)
 		return 0
 	}
 
 	if langInfo.Language == nil {
-		L.RaiseError("language '" + langAlias + "' does not have a Tree-sitter language binding")
+		L.RaiseError("language %s does not have a Tree-sitter language binding", langAlias)
 		return 0
 	}
 
@@ -141,7 +140,7 @@ func parserParse(L *lua.LState) int {
 	}
 
 	// Parse with context handling
-	tree, err := parser.parseWithContext([]byte(code), oldTree, ctx)
+	tree, err := parser.parseWithContext(ctx, []byte(code), oldTree)
 	if err != nil {
 		L.Push(lua.LNil)
 		L.Push(lua.LString(err.Error()))

--- a/runtime/lua/modules/treesitter/parser_test.go
+++ b/runtime/lua/modules/treesitter/parser_test.go
@@ -2,14 +2,15 @@ package treesitter
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	ctxapi "github.com/ponyruntime/pony/api/context"
 	"github.com/ponyruntime/pony/internal/closer"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
-	"time"
 )
 
 func TestParser(t *testing.T) {
@@ -24,7 +25,7 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test parser creation
@@ -54,7 +55,7 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local parser = treesitter.parser()
 			parser:set_language("go")
@@ -76,7 +77,7 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local parser = treesitter.parser()
 			parser:set_language("go")
@@ -124,7 +125,7 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local parser = treesitter.parser()
 
@@ -165,7 +166,7 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local parser = treesitter.parser()
 			parser:set_language("go")
@@ -214,7 +215,7 @@ func TestParser(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
         local parser = treesitter.parser()
         
@@ -253,7 +254,7 @@ func TestParserWithRangesForNestedCode(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
         local parser = treesitter.parser()
         
@@ -394,7 +395,7 @@ func TestParserLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             
             -- Create parser and parse some code
@@ -444,7 +445,7 @@ func TestParserLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             
             -- Test parser memory handling during edits
@@ -497,7 +498,7 @@ func TestParserResetAndClose(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Get a parser and parse some code
@@ -542,7 +543,7 @@ func TestParserResetAndClose(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local parser = treesitter.parser()
 			assert(parser:set_language("go"), "should set language")
@@ -581,7 +582,7 @@ func TestParserResetAndClose(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local parser = treesitter.parser()
 			

--- a/runtime/lua/modules/treesitter/query.go
+++ b/runtime/lua/modules/treesitter/query.go
@@ -3,10 +3,11 @@ package treesitter
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/ponyruntime/pony/internal/closer"
 	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
-	"regexp"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // QueryWrapper wraps a tree-sitter Query and QueryCursor for Lua integration
@@ -17,71 +18,69 @@ type QueryWrapper struct {
 }
 
 // Register the Query type to Lua
-func registerQuery(L *lua.LState) {
-	mt := L.NewTypeMetatable("treesitter.Query")
-	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), queryMethods))
-}
+func registerQuery(l *lua.LState) {
+	mt := l.NewTypeMetatable("treesitter.Query")
+	l.SetField(mt, "__index", l.SetFuncs(l.NewTable(), map[string]lua.LGFunction{
+		// Core functionality
+		"close":                  queryClose,
+		"matches":                queryMatches,
+		"captures":               queryCaptures,
+		"pattern_count":          queryPatternCount,
+		"capture_count":          queryCaptureCount,
+		"string_count":           queryStringCount,
+		"start_byte_for_pattern": queryStartByteForPattern,
 
-var queryMethods = map[string]lua.LGFunction{
-	// Core functionality
-	"close":                  queryClose,
-	"matches":                queryMatches,
-	"captures":               queryCaptures,
-	"pattern_count":          queryPatternCount,
-	"capture_count":          queryCaptureCount,
-	"string_count":           queryStringCount,
-	"start_byte_for_pattern": queryStartByteForPattern,
+		// Cursor control
+		"set_byte_range":         querySetByteRange,
+		"set_point_range":        querySetPointRange,
+		"set_match_limit":        querySetMatchLimit,
+		"get_match_limit":        queryGetMatchLimit,
+		"did_exceed_match_limit": queryDidExceedMatchLimit,
+		"set_timeout":            querySetTimeout,
+		"get_timeout":            queryGetTimeout,
 
-	// Cursor control
-	"set_byte_range":         querySetByteRange,
-	"set_point_range":        querySetPointRange,
-	"set_match_limit":        querySetMatchLimit,
-	"get_match_limit":        queryGetMatchLimit,
-	"did_exceed_match_limit": queryDidExceedMatchLimit,
-	"set_timeout":            querySetTimeout,
-	"get_timeout":            queryGetTimeout,
+		// Pattern/capture control
+		"disable_pattern":      queryDisablePattern,
+		"disable_capture":      queryDisableCapture,
+		"is_pattern_rooted":    queryIsPatternRooted,
+		"is_pattern_non_local": queryIsPatternNonLocal,
+		"capture_name_for_id":  queryCaptureNameForID,
+		"capture_quantifier":   queryCaptureQuantifier,
 
-	// Pattern/capture control
-	"disable_pattern":      queryDisablePattern,
-	"disable_capture":      queryDisableCapture,
-	"is_pattern_rooted":    queryIsPatternRooted,
-	"is_pattern_non_local": queryIsPatternNonLocal,
-	"capture_name_for_id":  queryCaptureNameForId,
-	"capture_quantifier":   queryCaptureQuantifier,
-
-	"set_max_start_depth":     querySetMaxStartDepth,
-	"get_property_predicates": queryGetPropertyPredicates,
-	"get_property_settings":   queryGetPropertySettings,
-	"is_pattern_guaranteed":   queryIsPatternGuaranteed,
-	"capture_index_for_name":  queryCaptureIndexForName,
-	"end_byte_for_pattern":    queryEndByteForPattern,
-	"get_text_predicates":     queryGetTextPredicates,
+		"set_max_start_depth":     querySetMaxStartDepth,
+		"get_property_predicates": queryGetPropertyPredicates,
+		"get_property_settings":   queryGetPropertySettings,
+		"is_pattern_guaranteed":   queryIsPatternGuaranteed,
+		"capture_index_for_name":  queryCaptureIndexForName,
+		"end_byte_for_pattern":    queryEndByteForPattern,
+		"get_text_predicates":     queryGetTextPredicates,
+	}))
 }
 
 // Create a new Query
-func newQuery(L *lua.LState) int {
-	languageStr := L.CheckString(1)
-	pattern := L.CheckString(2)
+func newQuery(l *lua.LState) int {
+	languageStr := l.CheckString(1)
+	pattern := l.CheckString(2)
 
 	// Get language from string
-	langInfo := GetLanguageInfo(languageStr)
+	langInfo := NewLanguages().GetLanguageInfo(languageStr)
 	if langInfo == nil {
-		L.Push(lua.LNil)
-		L.Push(lua.LString(fmt.Sprintf("unsupported language: %s", languageStr)))
+		l.Push(lua.LNil)
+		l.Push(lua.LString(fmt.Sprintf("unsupported language: %s", languageStr)))
 		return 2
 	}
 
 	if langInfo.Language == nil {
-		L.Push(lua.LNil)
-		L.Push(lua.LString(fmt.Sprintf("language '%s' does not have a Tree-sitter language binding", languageStr)))
+		l.Push(lua.LNil)
+		l.Push(lua.LString(fmt.Sprintf("language '%s' does not have a Tree-sitter language binding", languageStr)))
 		return 2
 	}
 
 	lang := treesitter.NewLanguage(langInfo.Language())
 	query, err := treesitter.NewQuery(lang, pattern)
 	if err != nil {
-		L.Push(lua.LNil)
-		L.Push(lua.LString(formatQueryError(err)))
+		l.Push(lua.LNil)
+		l.Push(lua.LString(formatQueryError(err)))
 		return 2
 	}
 
@@ -91,8 +90,8 @@ func newQuery(L *lua.LState) int {
 		cursor: treesitter.NewQueryCursor(),
 	}
 
-	if L.Context() != nil {
-		cleanup := closer.FromContext(L.Context())
+	if l.Context() != nil {
+		cleanup := closer.FromContext(l.Context())
 		if cleanup != nil {
 			cleanup.Add(func() error {
 				if wrapper.cursor != nil {
@@ -109,26 +108,26 @@ func newQuery(L *lua.LState) int {
 		}
 	}
 
-	ud := L.NewUserData()
+	ud := l.NewUserData()
 	ud.Value = wrapper
-	L.SetMetatable(ud, L.GetTypeMetatable("treesitter.Query"))
-	L.Push(ud)
+	l.SetMetatable(ud, l.GetTypeMetatable("treesitter.Query"))
+	l.Push(ud)
 	return 1
 }
 
-func matchToLuaTable(L *lua.LState, query *treesitter.Query, match *treesitter.QueryMatch, source string) *lua.LTable {
-	matchTable := L.NewTable()
+func matchToLuaTable(l *lua.LState, query *treesitter.Query, match *treesitter.QueryMatch, source string) *lua.LTable {
+	matchTable := l.NewTable()
 	matchTable.RawSetString("id", lua.LNumber(match.Id()))
 	matchTable.RawSetString("pattern", lua.LNumber(match.PatternIndex))
 
-	capturesTable := L.NewTable()
+	capturesTable := l.NewTable()
 	for _, capture := range match.Captures {
-		captureTable := L.NewTable()
+		captureTable := l.NewTable()
 
 		// Create Node wrapper for the specific capture's node
-		nodeUD := L.NewUserData()
+		nodeUD := l.NewUserData()
 		nodeUD.Value = &NodeWrapper{node: &capture.Node, source: &source}
-		L.SetMetatable(nodeUD, L.GetTypeMetatable("treesitter.Node"))
+		l.SetMetatable(nodeUD, l.GetTypeMetatable("treesitter.Node"))
 
 		captureTable.RawSetString("node", nodeUD)
 		captureTable.RawSetString("index", lua.LNumber(capture.Index))
@@ -146,59 +145,59 @@ func matchToLuaTable(L *lua.LState, query *treesitter.Query, match *treesitter.Q
 	return matchTable
 }
 
-func queryMatches(L *lua.LState) int {
-	query := checkQuery(L)
-	nodeUD := L.CheckUserData(2)
-	source := L.CheckString(3)
+func queryMatches(l *lua.LState) int {
+	query := checkQuery(l)
+	nodeUD := l.CheckUserData(2)
+	source := l.CheckString(3)
 
 	node, ok := nodeUD.Value.(*NodeWrapper)
 	if !ok {
-		L.ArgError(2, "Node expected")
+		l.ArgError(2, "Node expected")
 		return 0
 	}
 
 	query.source = source
 	matches := query.cursor.Matches(query.query, node.node, []byte(source))
 
-	matchesTable := L.NewTable()
+	matchesTable := l.NewTable()
 	for match := matches.Next(); match != nil; match = matches.Next() {
 		if match.SatisfiesTextPredicate(query.query, nil, nil, []byte(source)) {
-			matchTable := matchToLuaTable(L, query.query, match, source)
+			matchTable := matchToLuaTable(l, query.query, match, source)
 			matchesTable.Append(matchTable)
 		}
 	}
 
-	L.Push(matchesTable)
+	l.Push(matchesTable)
 	return 1
 }
 
-func queryCaptures(L *lua.LState) int {
-	query := checkQuery(L)
-	nodeUD := L.CheckUserData(2)
-	source := L.CheckString(3)
+func queryCaptures(l *lua.LState) int {
+	query := checkQuery(l)
+	nodeUD := l.CheckUserData(2)
+	source := l.CheckString(3)
 
 	node, ok := nodeUD.Value.(*NodeWrapper)
 	if !ok {
-		L.ArgError(2, "Node expected")
+		l.ArgError(2, "Node expected")
 		return 0
 	}
 
 	query.source = source
 	captures := query.cursor.Captures(query.query, node.node, []byte(source))
 
-	capturesTable := L.NewTable()
+	capturesTable := l.NewTable()
 	for match, index := captures.Next(); match != nil; match, index = captures.Next() {
 		if !match.SatisfiesTextPredicate(query.query, nil, nil, []byte(source)) {
 			continue
 		}
 
 		capture := match.Captures[index]
-		captureTable := L.NewTable()
+		captureTable := l.NewTable()
 
 		// Create Node wrapper
-		nodeUD := L.NewUserData()
+		nodeUD := l.NewUserData()
 		nodeUD.Value = &NodeWrapper{node: &capture.Node, source: &source}
-		L.SetMetatable(nodeUD, L.GetTypeMetatable("treesitter.Node"))
+		l.SetMetatable(nodeUD, l.GetTypeMetatable("treesitter.Node"))
 
 		captureTable.RawSetString("node", nodeUD)
 		captureTable.RawSetString("index", lua.LNumber(capture.Index))
@@ -212,35 +211,35 @@ func queryCaptures(L *lua.LState) int {
 		// Get the text of the captured node
 		start := capture.Node.StartByte()
 		end := capture.Node.EndByte()
-		if start >= 0 && end >= 0 && uint32(end) <= uint32(len(source)) {
+		if end <= uint(len(source)) {
 			captureTable.RawSetString("text", lua.LString(source[start:end]))
 		}
 
 		capturesTable.Append(captureTable)
 	}
 
-	L.Push(capturesTable)
+	l.Push(capturesTable)
 	return 1
 }
 
 // Cursor control methods
 
-func querySetByteRange(L *lua.LState) int {
-	query := checkQuery(L)
-	startByte := uint(L.CheckNumber(2))
-	endByte := uint(L.CheckNumber(3))
+func querySetByteRange(l *lua.LState) int {
+	query := checkQuery(l)
+	startByte := uint(l.CheckNumber(2))
+	endByte := uint(l.CheckNumber(3))
 	query.cursor.SetByteRange(startByte, endByte)
 	return 0
 }
 
-func querySetPointRange(L *lua.LState) int {
-	query := checkQuery(L)
+func querySetPointRange(l *lua.LState) int {
+	query := checkQuery(l)
 
-	startPointTbl := L.CheckTable(2)
+	startPointTbl := l.CheckTable(2)
 	startRow := uint(startPointTbl.RawGetString("row").(lua.LNumber))
 	startCol := uint(startPointTbl.RawGetString("column").(lua.LNumber))
 
-	endPointTbl := L.CheckTable(3)
+	endPointTbl := l.CheckTable(3)
 	endRow := uint(endPointTbl.RawGetString("row").(lua.LNumber))
 	endCol := uint(endPointTbl.RawGetString("column").(lua.LNumber))
 
@@ -251,90 +250,90 @@ func querySetPointRange(L *lua.LState) int {
 	return 0
 }
 
-func querySetMatchLimit(L *lua.LState) int {
-	query := checkQuery(L)
-	limit := uint(L.CheckNumber(2))
+func querySetMatchLimit(l *lua.LState) int {
+	query := checkQuery(l)
+	limit := uint(l.CheckNumber(2))
 	query.cursor.SetMatchLimit(limit)
 	return 0
 }
 
-func queryGetMatchLimit(L *lua.LState) int {
-	query := checkQuery(L)
-	L.Push(lua.LNumber(query.cursor.MatchLimit()))
+func queryGetMatchLimit(l *lua.LState) int {
+	query := checkQuery(l)
+	l.Push(lua.LNumber(query.cursor.MatchLimit()))
 	return 1
 }
 
-func queryDidExceedMatchLimit(L *lua.LState) int {
-	query := checkQuery(L)
-	L.Push(lua.LBool(query.cursor.DidExceedMatchLimit()))
+func queryDidExceedMatchLimit(l *lua.LState) int {
+	query := checkQuery(l)
+	l.Push(lua.LBool(query.cursor.DidExceedMatchLimit()))
 	return 1
 }
 
-func querySetTimeout(L *lua.LState) int {
-	query := checkQuery(L)
-	timeout := uint64(L.CheckNumber(2))
+func querySetTimeout(l *lua.LState) int {
+	query := checkQuery(l)
+	timeout := uint64(l.CheckNumber(2))
 	query.cursor.SetTimeoutMicros(timeout)
 	return 0
 }
 
-func queryGetTimeout(L *lua.LState) int {
-	query := checkQuery(L)
-	L.Push(lua.LNumber(query.cursor.TimeoutMicros()))
+func queryGetTimeout(l *lua.LState) int {
+	query := checkQuery(l)
+	l.Push(lua.LNumber(query.cursor.TimeoutMicros()))
 	return 1
 }
 
 // Pattern and capture control methods
 
-func queryDisablePattern(L *lua.LState) int {
-	query := checkQuery(L)
-	pattern := uint(L.CheckNumber(2))
+func queryDisablePattern(l *lua.LState) int {
+	query := checkQuery(l)
+	pattern := uint(l.CheckNumber(2))
 	query.query.DisablePattern(pattern)
 	return 0
 }
 
-func queryDisableCapture(L *lua.LState) int {
-	query := checkQuery(L)
-	name := L.CheckString(2)
+func queryDisableCapture(l *lua.LState) int {
+	query := checkQuery(l)
+	name := l.CheckString(2)
 	query.query.DisableCapture(name)
 	return 0
 }
 
-func queryIsPatternRooted(L *lua.LState) int {
-	query := checkQuery(L)
-	pattern := uint(L.CheckNumber(2))
-	L.Push(lua.LBool(query.query.IsPatternRooted(pattern)))
+func queryIsPatternRooted(l *lua.LState) int {
+	query := checkQuery(l)
+	pattern := uint(l.CheckNumber(2))
+	l.Push(lua.LBool(query.query.IsPatternRooted(pattern)))
 	return 1
 }
 
-func queryIsPatternNonLocal(L *lua.LState) int {
-	query := checkQuery(L)
-	pattern := uint(L.CheckNumber(2))
-	L.Push(lua.LBool(query.query.IsPatternNonLocal(pattern)))
+func queryIsPatternNonLocal(l *lua.LState) int {
+	query := checkQuery(l)
+	pattern := uint(l.CheckNumber(2))
+	l.Push(lua.LBool(query.query.IsPatternNonLocal(pattern)))
 	return 1
 }
 
-func queryCaptureNameForId(L *lua.LState) int {
-	query := checkQuery(L)
-	id := uint(L.CheckNumber(2))
+func queryCaptureNameForID(l *lua.LState) int {
+	query := checkQuery(l)
+	id := uint(l.CheckNumber(2))
 	names := query.query.CaptureNames()
 	if id < uint(len(names)) {
-		L.Push(lua.LString(names[id]))
+		l.Push(lua.LString(names[id]))
 	} else {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 	}
 	return 1
 }
 
-func queryCaptureQuantifier(L *lua.LState) int {
-	query := checkQuery(L)
-	pattern := uint(L.CheckNumber(2))
-	id := uint(L.CheckNumber(3))
+func queryCaptureQuantifier(l *lua.LState) int {
+	query := checkQuery(l)
+	pattern := uint(l.CheckNumber(2))
+	id := uint(l.CheckNumber(3))
 
 	quantifiers := query.query.CaptureQuantifiers(pattern)
 	if id < uint(len(quantifiers)) {
-		L.Push(lua.LNumber(quantifiers[id]))
+		l.Push(lua.LNumber(quantifiers[id]))
 	} else {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 	}
 	return 1
 }

--- a/runtime/lua/modules/treesitter/query_test.go
+++ b/runtime/lua/modules/treesitter/query_test.go
@@ -1,12 +1,14 @@
 package treesitter
 
 import (
+	"context"
+	"os"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func TestBasicQuery(t *testing.T) {
@@ -20,7 +22,7 @@ func TestBasicQuery(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 		
 		-- Simple test code with a function
@@ -80,7 +82,7 @@ func TestQueryMultipleCaptures(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 		
 		-- Test code with multiple functions and parameters
@@ -148,7 +150,7 @@ func TestQueryFunctionDetails(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
         
         local code = [[
@@ -258,7 +260,7 @@ func TestQueryParamDebug(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
 
 local code = [[
@@ -378,7 +380,7 @@ func TestQueryAdvancedFeatures(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
         
         local code = [[
@@ -489,7 +491,7 @@ func TestQueryOperations(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 
 -- Test code with rich syntax for comprehensive query testing
@@ -629,7 +631,7 @@ func TestQueryErrorCases(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 
 -- Test different query error types
@@ -702,7 +704,7 @@ func TestQueryTextPredicates(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 
 -- Test code with various matches for predicates
@@ -800,7 +802,7 @@ func TestQueryNestedGrammars(t *testing.T) {
 	code, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	err = vm.DoString(nil, string(code), "test")
+	err = vm.DoString(context.Background(), string(code), "test")
 	assert.NoError(t, err)
 }
 
@@ -820,7 +822,7 @@ func TestQueryLuaInLua(t *testing.T) {
 	code, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	err = vm.DoString(nil, string(code), "test")
+	err = vm.DoString(context.Background(), string(code), "test")
 	assert.NoError(t, err)
 }
 
@@ -840,6 +842,6 @@ func TestQueryLuaFileStruct(t *testing.T) {
 	code, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	err = vm.DoString(nil, string(code), "test")
+	err = vm.DoString(context.Background(), string(code), "test")
 	assert.NoError(t, err)
 }

--- a/runtime/lua/modules/treesitter/query_test.go
+++ b/runtime/lua/modules/treesitter/query_test.go
@@ -11,7 +11,65 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestBasicQuery(t *testing.T) {
+func TestSQLQueries(t *testing.T) {
+	logger := zap.NewNop()
+	mod := NewTreeSitterModule(logger)
+
+	vm, err := engine.NewVM(logger,
+		engine.WithLoader(mod.Name(), mod.Loader),
+		engine.WithGlobalFunction("assert", assertLua),
+	)
+	require.NoError(t, err)
+	defer vm.Close()
+
+	err = vm.DoString(context.Background(), `
+	local treesitter = require("treesitter")
+
+	-- Test SQL query parsing
+	local sql_code = [[
+/*
+This is a query
+With a multiline comment
+*/
+SELECT id
+/*
+SELECT id FROM my_table;
+*/
+FROM my_table;
+        ]]
+
+	-- Parse SQL code
+	local tree = treesitter.parse("sql", sql_code)
+	assert(tree ~= nil, "tree should not be nil")
+
+    local root = tree:root_node()
+	assert(root ~= nil, "root should not be nil")
+
+	local create_table_query = treesitter.query("sql", [[
+(program
+  (marginalia)
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            name: (identifier)))))
+    (marginalia)
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier))))))
+	]])
+	-- Execute query
+	local matches = create_table_query:matches(root, sql_code)
+	assert(matches ~= nil, "matches should not be nil")
+	`, "test")
+	assert.NoError(t, err)
+}
+
+func TestMarkdownQueries(t *testing.T) {
 	logger := zap.NewNop()
 	mod := NewTreeSitterModule(logger)
 
@@ -25,33 +83,99 @@ func TestBasicQuery(t *testing.T) {
 	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 		
+		-- Test Markdown parsing
+		local md_code = [[
+- [x] foo
+  - [ ] bar
+  - [x] baz
+- [ ] bim
+
+]]
+		
+		-- Parse Markdown code
+		local tree = treesitter.parse("markdown", md_code)
+		assert(tree ~= nil, "tree should not be nil")
+		
+		local root = tree:root_node()
+		assert(root ~= nil, "root should not be nil")
+		
+		-- Query for headers
+		local header_query = treesitter.query("markdown", [[
+			(document
+  (section
+    (list
+      (list_item
+        (list_marker_minus)
+        (task_list_marker_checked)
+        (paragraph
+          (inline)
+          (block_continuation))
+        (list
+          (list_item
+            (list_marker_minus)
+            (task_list_marker_unchecked)
+            (paragraph
+              (inline)
+              (block_continuation)))
+          (list_item
+            (list_marker_minus)
+            (task_list_marker_checked)
+            (paragraph
+              (inline)))))
+      (list_item
+        (list_marker_minus)
+        (task_list_marker_unchecked)
+        (paragraph
+          (inline))))))
+		]])
+		
+		local matches = header_query:matches(root, md_code)
+		assert(matches ~= nil, "matches should not be nil")
+	`, "test")
+	assert.NoError(t, err)
+}
+
+func TestBasicQuery(t *testing.T) {
+	logger := zap.NewNop()
+	mod := NewTreeSitterModule(logger)
+
+	vm, err := engine.NewVM(logger,
+		engine.WithLoader(mod.Name(), mod.Loader),
+		engine.WithGlobalFunction("assert", assertLua),
+	)
+	require.NoError(t, err)
+	defer vm.Close()
+
+	err = vm.DoString(context.Background(), `
+		local treesitter = require("treesitter")
+
 		-- Simple test code with a function
 		local code = [[
 			func hello() {
 				println("world")
 			}
 		]]
-		
+
 		-- Parse the code
 		local tree = treesitter.parse("go", code)
 		assert(tree ~= nil, "tree should not be nil")
-		
+
 		local root = tree:root_node()
 		assert(root ~= nil, "root should not be nil")
-		
+
 		-- Create a simple query to find the function
 		local query = treesitter.query("go", "(function_declaration) @function")
 		assert(query ~= nil, "query should not be nil")
-		
+
 		-- Execute query
 		local matches = query:matches(root, code)
 		assert(matches ~= nil, "matches should not be nil")
-		
+
 		-- Should find exactly one function
 		local match_count = 0
 		for _, match in pairs(matches) do
 			match_count = match_count + 1
-			
+
 			-- Verify the match has captures
 			assert(match.captures ~= nil, "match should have captures")
 			assert(#match.captures > 0, "should have at least one capture")
@@ -59,13 +183,13 @@ func TestBasicQuery(t *testing.T) {
 			-- Verify the captured node
 			local capture = match.captures[1]
 			assert(capture.node ~= nil, "capture should have node")
-			
+
 			-- Get the text of the captured node
 			local text = capture.node:text(code)
 
 			assert(text:match("^func hello"), "captured text should start with 'func hello'")
 		end
-		
+
 		assert(match_count == 1, "should find exactly one function")
 	`, "test")
 	assert.NoError(t, err)
@@ -84,7 +208,7 @@ func TestQueryMultipleCaptures(t *testing.T) {
 
 	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
-		
+
 		-- Test code with multiple functions and parameters
 		local code = [[
 func add(x int, y int) int {
@@ -95,36 +219,36 @@ func greet(name string) {
 	println("Hello, " .. name)
 }
 ]]
-		
+
 		-- Parse the code
 		local tree = treesitter.parse("go", code)
 		assert(tree ~= nil, "tree should not be nil")
-		
+
 		local root = tree:root_node()
 		assert(root ~= nil, "root should not be nil")
-		
+
 		-- Create query to capture function name and parameters
 		local query = treesitter.query("go", [[
 (function_declaration
   name: (identifier) @func_name)
 ]])
-		
+
 		-- Execute query and debug output
 		local matches = query:matches(root, code)
 		assert(matches ~= nil, "matches should not be nil")
-		
+
 		-- Verify matches
 		local found_add = false
 		local found_greet = false
-		
+
 		for i, match in ipairs(matches) do
 			assert(match.captures ~= nil, "match should have captures")
-			
+
 			for j, capture in ipairs(match.captures) do
 				assert(capture.node ~= nil, "capture should have node")
-				
+
 				local text = capture.node:text(code)
-				
+
 				if text == "add" then
 					found_add = true
 				elseif text == "greet" then
@@ -132,7 +256,7 @@ func greet(name string) {
 				end
 			end
 		end
-		
+
 		assert(found_add, "should find 'add' function")
 		assert(found_greet, "should find 'greet' function")
 	`, "test")
@@ -152,7 +276,7 @@ func TestQueryFunctionDetails(t *testing.T) {
 
 	err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
-        
+
         local code = [[
 func add(x int, y int) int {
     return x + y
@@ -166,33 +290,33 @@ func log(msg string) {
     println(msg)
 }
 ]]
-        
+
         local tree = treesitter.parse("go", code)
         local root = tree:root_node()
-        
+
         -- First get functions and their names
         local func_query = treesitter.query("go", [[
-(function_declaration 
+(function_declaration
   name: (identifier) @func_name
   parameters: (parameter_list) @params
   result: (type_identifier)? @return_type)
 ]])
 
         local param_query = treesitter.query("go", [[
-(parameter_list 
+(parameter_list
   (parameter_declaration
     name: (identifier) @param_name
     type: (type_identifier) @param_type))
 ]])
 
         local func_matches = func_query:matches(root, code)
-        
+
         local functions = {}
-        
+
         -- Process each function declaration
         for _, match in ipairs(func_matches) do
             local func = { name = nil, params = {}, return_type = nil }
-            
+
             -- Find the function name and parameter list node
             for _, capture in ipairs(match.captures) do
                 if capture.name == "func_name" then
@@ -219,10 +343,10 @@ func log(msg string) {
             end
             table.insert(functions, func)
         end
-        
+
         -- Verification phase
         for _, func in ipairs(functions) do
-            
+
             -- Verify the function details
             if func.name == "add" then
                 assert(#func.params == 2, "add should have 2 parameters")
@@ -292,8 +416,8 @@ local func_query = treesitter.query("go", [[
 -- Query for parameters within a parameter list
 local param_query = treesitter.query("go", [[
 (parameter_list
-  (parameter_declaration 
-    name: (identifier) @param_name 
+  (parameter_declaration
+    name: (identifier) @param_name
     type: (type_identifier) @param_type))
 ]])
 
@@ -303,46 +427,46 @@ local functions = {}
 
 -- Process function matches
 for i, match in ipairs(func_matches) do
-    
+
     local func = { name = nil, params = {}, return_type = nil }
-    
+
     for j, capture in ipairs(match.captures) do
         local text = capture.node:text(code)
-        
+
         if capture.name == "func_name" then
             func.name = text
         elseif capture.name == "return_type" then
             func.return_type = text
         elseif capture.name == "params" then
             local param_matches = param_query:matches(capture.node, code)
-            
+
             -- Process parameter matches
             for k, param_match in ipairs(param_matches) do
                 local param = {}
-                
+
                 for l, param_capture in ipairs(param_match.captures) do
                     local param_text = param_capture.node:text(code)
-                    
+
                     if param_capture.name == "param_name" then
                         param.name = param_text
                     elseif param_capture.name == "param_type" then
                         param.type = param_text
                     end
                 end
-                
+
                 if param.name and param.type then
                     table.insert(func.params, param)
                 end
             end
         end
     end
-    
+
     table.insert(functions, func)
 end
 
 -- Verification phase
 for _, func in ipairs(functions) do
-    
+
     -- Assertions
     if func.name == "add" then
         assert(#func.params == 2, "add should have 2 parameters")
@@ -382,7 +506,7 @@ func TestQueryAdvancedFeatures(t *testing.T) {
 
 	err = vm.DoString(context.Background(), `
         local treesitter = require("treesitter")
-        
+
         local code = [[
 func example(x int, y string) int {
     if x > 0 {
@@ -392,24 +516,24 @@ func example(x int, y string) int {
     return 0
 }
 ]]
-        
+
         local tree = treesitter.parse("go", code)
         local root = tree:root_node()
-        
+
         -- Create query with multiple patterns
         local query = treesitter.query("go", [[
           (function_declaration) @func
-          (parameter_declaration name: (identifier) @param_name type: (type_identifier) @param_type) 
+          (parameter_declaration name: (identifier) @param_name type: (type_identifier) @param_type)
           (if_statement condition: (binary_expression) @condition)
         ]])
 
         -- Test pattern count and capture count
         local pattern_count = query:pattern_count()
         assert(pattern_count == 3, "should have 3 patterns")
-        
+
         local capture_count = query:capture_count()
         assert(capture_count == 4, "should have 4 captures") -- func, param_name, param_type, condition
-        
+
         -- Get all capture names
         local capture_names = {}
         for i = 0, capture_count-1 do
@@ -422,12 +546,12 @@ func example(x int, y string) int {
         assert(capture_names["param_name"], "should have param_name capture")
         assert(capture_names["param_type"], "should have param_type capture")
         assert(capture_names["condition"], "should have condition capture")
-        
+
         -- Test match limit and timeout
         query:set_match_limit(1000)
         local limit = query:get_match_limit()
         assert(limit == 1000, "match limit should be set")
-        
+
         query:set_timeout(5000)
         local timeout = query:get_timeout()
         assert(timeout == 5000, "timeout should be set")
@@ -438,7 +562,7 @@ func example(x int, y string) int {
 
         -- Test matches
         local matches = query:matches(root, code)
-        
+
         local found_func = false
         local found_param = false
         local found_condition = false
@@ -530,14 +654,14 @@ local query = treesitter.query("go", [[
         parameters: (parameter_list) @params
         result: [(type_identifier) (ERROR)]? @return_type) @function
 
-    (if_statement 
+    (if_statement
         condition: (_) @if_condition) @if
-    
+
     (binary_expression
         left: (_) @left
         operator: (_) @op
         right: (_) @right) @binary
-    
+
     ((identifier) @id
      (#match? @id "^process"))
 ]])
@@ -664,16 +788,16 @@ local error_cases = {
 
 for _, case in ipairs(error_cases) do
     local query, err = treesitter.query("go", case.query)
-    
+
     -- Should not create a valid query
     assert(query == nil, "invalid query '" .. case.query .. "' should return nil")
-    
+
     -- Should have an error message
     assert(err ~= nil, "should have error message for query: " .. case.query)
-    
+
     -- Error message should match expected pattern
-    assert(err:match(case.expected), 
-           string.format("\nError message did not match pattern.\nGot: '%s'\nExpected to match: '%s'", 
+    assert(err:match(case.expected),
+           string.format("\nError message did not match pattern.\nGot: '%s'\nExpected to match: '%s'",
                         err, case.expected))
 end
 
@@ -736,7 +860,7 @@ local query = treesitter.query("go", [[
   name: (identifier) @func
   (#match? @func "^[A-Z]"))
 
-(field_declaration 
+(field_declaration
   name: (field_identifier) @field
   type: (type_identifier) @type
   (#eq? @type "string"))

--- a/runtime/lua/modules/treesitter/tree.go
+++ b/runtime/lua/modules/treesitter/tree.go
@@ -18,44 +18,40 @@ type TreeWrapper struct {
 }
 
 // Register the Tree type to Lua
-func registerTree(L *lua.LState) {
-	mt := L.NewTypeMetatable("treesitter.Tree")
-	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), treeMethods))
+func registerTree(l *lua.LState) {
+	mt := l.NewTypeMetatable("treesitter.Tree")
+	l.SetField(mt, "__index", l.SetFuncs(l.NewTable(), map[string]lua.LGFunction{
+		"root_node":             treeRootNode,
+		"root_node_with_offset": treeRootNodeWithOffset,
+		"language":              treeLanguage,
+		"copy":                  treeCopy,
+		"walk":                  treeWalk,
+		"edit":                  treeEdit,
+		"close":                 treeClose,
+		"changed_ranges":        treeChangedRanges,
+		"included_ranges":       treeIncludedRanges,
+		"dot_graph":             treePrintDotGraph,
+	}))
 }
 
-var treeMethods = map[string]lua.LGFunction{
-	"root_node":             treeRootNode,
-	"root_node_with_offset": treeRootNodeWithOffset,
-	"language":              treeLanguage,
-	"copy":                  treeCopy,
-	"walk":                  treeWalk,
-	"edit":                  treeEdit,
-	"close":                 treeClose,
-	"changed_ranges":        treeChangedRanges,
-	"included_ranges":       treeIncludedRanges,
-	"dot_graph":             treePrintDotGraph,
-}
-
-// Tree methods implementation
-
-func treeRootNode(L *lua.LState) int {
-	tree := checkTree(L)
+func treeRootNode(l *lua.LState) int {
+	tree := checkTree(l)
 	if tree.tree == nil {
-		L.RaiseError("tree is closed")
+		l.RaiseError("tree is closed")
 		return 0
 	}
 
 	root := tree.tree.RootNode()
 	if root == nil {
-		L.Push(lua.LNil)
+		l.Push(lua.LNil)
 		return 1
 	}
 
 	// Create and push new Node userdata
-	ud := L.NewUserData()
+	ud := l.NewUserData()
 	ud.Value = &NodeWrapper{node: root, source: &tree.source}
-	L.SetMetatable(ud, L.GetTypeMetatable("treesitter.Node"))
-	L.Push(ud)
+	l.SetMetatable(ud, l.GetTypeMetatable("treesitter.Node"))
+	l.Push(ud)
 	return 1
 }
 
@@ -177,9 +173,9 @@ func treeEdit(L *lua.LState) int {
 	editTable := L.CheckTable(2)
 
 	// Validate edit parameters
-	startByte := int32(editTable.RawGetString("start_byte").(lua.LNumber))
-	oldEndByte := int32(editTable.RawGetString("old_end_byte").(lua.LNumber))
-	newEndByte := int32(editTable.RawGetString("new_end_byte").(lua.LNumber))
+	startByte := editTable.RawGetString("start_byte").(lua.LNumber)
+	oldEndByte := editTable.RawGetString("old_end_byte").(lua.LNumber)
+	newEndByte := editTable.RawGetString("new_end_byte").(lua.LNumber)
 
 	// Basic validation of byte positions
 	if startByte < 0 || oldEndByte < startByte || newEndByte < 0 {
@@ -189,12 +185,13 @@ func treeEdit(L *lua.LState) int {
 	}
 
 	// Validate row/column positions
-	startRow := int32(editTable.RawGetString("start_row").(lua.LNumber))
-	startCol := int32(editTable.RawGetString("start_column").(lua.LNumber))
-	oldEndRow := int32(editTable.RawGetString("old_end_row").(lua.LNumber))
-	oldEndCol := int32(editTable.RawGetString("old_end_column").(lua.LNumber))
-	newEndRow := int32(editTable.RawGetString("new_end_row").(lua.LNumber))
-	newEndCol := int32(editTable.RawGetString("new_end_column").(lua.LNumber))
+	// TODO: potentially dangerous type assertion
+	startRow := editTable.RawGetString("start_row").(lua.LNumber)
+	startCol := editTable.RawGetString("start_column").(lua.LNumber)
+	oldEndRow := editTable.RawGetString("old_end_row").(lua.LNumber)
+	oldEndCol := editTable.RawGetString("old_end_column").(lua.LNumber)
+	newEndRow := editTable.RawGetString("new_end_row").(lua.LNumber)
+	newEndCol := editTable.RawGetString("new_end_column").(lua.LNumber)
 
 	if startRow < 0 || startCol < 0 || oldEndRow < startRow ||
 		(oldEndRow == startRow && oldEndCol < startCol) ||

--- a/runtime/lua/modules/treesitter/tree.go
+++ b/runtime/lua/modules/treesitter/tree.go
@@ -3,11 +3,12 @@ package treesitter
 import (
 	"bytes"
 	"fmt"
-	"github.com/ponyruntime/pony/internal/closer"
-	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
 	"os"
 	"sync"
+
+	"github.com/ponyruntime/pony/internal/closer"
+	treesitter "github.com/tree-sitter/go-tree-sitter"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // TreeWrapper wraps a tree-sitter Tree for Lua integration

--- a/runtime/lua/modules/treesitter/tree_test.go
+++ b/runtime/lua/modules/treesitter/tree_test.go
@@ -1,13 +1,15 @@
 package treesitter
 
 import (
+	"context"
+	"os"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func TestTreeMethods(t *testing.T) {
@@ -22,7 +24,7 @@ func TestTreeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -57,7 +59,7 @@ func TestTreeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -86,7 +88,7 @@ func TestTreeMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -119,7 +121,7 @@ func TestTreeAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test invalid language
@@ -152,7 +154,7 @@ func TestTreeAdditionalMethods(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -184,7 +186,7 @@ func TestTreeTraversal(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -309,7 +311,7 @@ func TestTreeEditOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "func main() {\n\tprint(42)\n}"
 			local tree = treesitter.parse("go", code)
@@ -364,7 +366,7 @@ func TestTreeEditOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local tree = treesitter.parse("go", "package main")
 			
@@ -393,7 +395,7 @@ func TestTreeEditOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Create and manipulate multiple trees
@@ -450,7 +452,7 @@ func TestComplexTreeOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				package main
@@ -495,7 +497,7 @@ func TestComplexTreeOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = [[
 				func main() {
@@ -623,7 +625,7 @@ func TestTreeWalking(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
             local treesitter = require("treesitter")
             
             -- Create a slightly complex tree
@@ -726,6 +728,6 @@ func TestTreeEditAndReparse(t *testing.T) {
 	code, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	err = vm.DoString(nil, string(code), "test")
+	err = vm.DoString(context.Background(), string(code), "test")
 	assert.NoError(t, err)
 }

--- a/runtime/lua/modules/treesitter/treesitter.go
+++ b/runtime/lua/modules/treesitter/treesitter.go
@@ -62,34 +62,36 @@ func (m *Module) supportedLanguages(l *lua.LState) int {
 	return 1
 }
 
-func (m *Module) language(L *lua.LState) int {
-	languageAlias := L.CheckString(1)
+func (m *Module) language(l *lua.LState) int {
+	languageAlias := l.CheckString(1)
 
 	langInfo := m.languages.GetLanguageInfo(languageAlias)
 	if langInfo == nil {
-		L.Push(lua.LNil)
-		L.Push(lua.LString(fmt.Sprintf("unsupported language: %s", languageAlias)))
+		l.Push(lua.LNil)
+		l.Push(lua.LString(fmt.Sprintf("unsupported language: %s", languageAlias)))
 		return 2
 	}
 
 	if langInfo.Language == nil {
-		L.Push(lua.LNil)
-		L.Push(lua.LString(fmt.Sprintf("language '%s' does not have a Tree-sitter language binding", languageAlias)))
+		l.Push(lua.LNil)
+		l.Push(lua.LString(fmt.Sprintf("language '%s' does not have a Tree-sitter language binding", languageAlias)))
 		return 2
 	}
 
 	lang := treesitter.NewLanguage(langInfo.Language())
 
 	// Create and return Language userdata
-	ud := L.NewUserData()
+	ud := l.NewUserData()
 	ud.Value = &LanguageWrapper{lang: lang}
-	L.SetMetatable(ud, L.GetTypeMetatable("treesitter.Language"))
-	L.Push(ud)
+	l.SetMetatable(ud, l.GetTypeMetatable("treesitter.Language"))
+	l.Push(ud)
 	return 1
 }
 
 // parse parses the text into a Tree object.
 func (m *Module) parse(l *lua.LState) int {
+	m.log.Debug("parse called")
+
 	if l.GetTop() != 2 {
 		l.ArgError(1, "expected 2 arguments: language, code")
 		return 0

--- a/runtime/lua/modules/treesitter/treesitter.go
+++ b/runtime/lua/modules/treesitter/treesitter.go
@@ -3,19 +3,22 @@ package treesitter
 import (
 	"context"
 	"fmt"
+
 	treesitter "github.com/tree-sitter/go-tree-sitter"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 
 // todo: a good chunk of memory optimizations is needed here, but no rush
 type Module struct {
-	log *zap.Logger
+	languages *Languages
+	log       *zap.Logger
 }
 
 func NewTreeSitterModule(log *zap.Logger) *Module {
 	return &Module{
-		log: log,
+		languages: NewLanguages(),
+		log:       log,
 	}
 }
 
@@ -50,7 +53,7 @@ func (m *Module) Loader(l *lua.LState) int {
 
 // supportedLanguages returns a table of supported languages.
 func (m *Module) supportedLanguages(l *lua.LState) int {
-	langs := GetSupportedLanguages()
+	langs := m.languages.GetSupportedLanguages()
 	table := l.NewTable()
 	for _, lang := range langs {
 		table.RawSetString(lang, lua.LTrue)
@@ -62,7 +65,7 @@ func (m *Module) supportedLanguages(l *lua.LState) int {
 func (m *Module) language(L *lua.LState) int {
 	languageAlias := L.CheckString(1)
 
-	langInfo := GetLanguageInfo(languageAlias)
+	langInfo := m.languages.GetLanguageInfo(languageAlias)
 	if langInfo == nil {
 		L.Push(lua.LNil)
 		L.Push(lua.LString(fmt.Sprintf("unsupported language: %s", languageAlias)))
@@ -99,7 +102,7 @@ func (m *Module) parse(l *lua.LState) int {
 	parser := treesitter.NewParser()
 	defer parser.Close()
 
-	langInfo := GetLanguageInfo(languageAlias)
+	langInfo := m.languages.GetLanguageInfo(languageAlias)
 	if langInfo == nil {
 		l.ArgError(1, fmt.Sprintf("unsupported language: %s", languageAlias))
 		return 0

--- a/runtime/lua/modules/treesitter/treesitter_test.go
+++ b/runtime/lua/modules/treesitter/treesitter_test.go
@@ -1,19 +1,21 @@
 package treesitter
 
 import (
+	"context"
+	"testing"
+
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func assertLua(L *lua.LState) int {
 	if L.ToBool(1) {
 		return 0
 	}
-	L.RaiseError(L.OptString(2, "assertion failed!"))
+	L.RaiseError("%s", L.OptString(2, "assertion failed!"))
 	return 0
 }
 
@@ -29,7 +31,7 @@ func TestTreeSitterModule_Parse(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local code = "package main"
 			local tree = treesitter.parse("go", code)
@@ -52,7 +54,7 @@ func TestLanguageOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			
 			-- Test supported languages
@@ -117,7 +119,7 @@ func TestLanguageOperations(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local treesitter = require("treesitter")
 			local lang = treesitter.language("go")
 			
@@ -161,7 +163,7 @@ func TestLuaSupport(t *testing.T) {
 	require.NoError(t, err)
 	defer vm.Close()
 
-	err = vm.DoString(nil, `
+	err = vm.DoString(context.Background(), `
 		local treesitter = require("treesitter")
 
 		-- Simple Lua code with a function

--- a/runtime/lua/pool/config.go
+++ b/runtime/lua/pool/config.go
@@ -2,9 +2,10 @@ package pool
 
 import (
 	"fmt"
+
 	api "github.com/ponyruntime/pony/api/runtime/lua"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/pool/config_test.go
+++ b/runtime/lua/pool/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/pool/queued/queued_pool.go
+++ b/runtime/lua/pool/queued/queued_pool.go
@@ -3,11 +3,12 @@ package queued
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/runtime/lua/pool"
-	"github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
+
+	"github.com/ponyruntime/pony/runtime/lua/pool"
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 type taskResult struct {

--- a/runtime/lua/pool/queued/queued_test.go
+++ b/runtime/lua/pool/queued/queued_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ponyruntime/pony/runtime/lua/pool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/lua/pool/sync/sync_pool.go
+++ b/runtime/lua/pool/sync/sync_pool.go
@@ -3,12 +3,13 @@ package sync
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/runtime/lua/engine"
-	"github.com/ponyruntime/pony/runtime/lua/pool"
-	"github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
+
+	"github.com/ponyruntime/pony/runtime/lua/engine"
+	"github.com/ponyruntime/pony/runtime/lua/pool"
+	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 // Option represents a pool configuration option

--- a/runtime/lua/pool/sync/sync_pool.go
+++ b/runtime/lua/pool/sync/sync_pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	"github.com/ponyruntime/pony/runtime/lua/pool"
@@ -39,7 +38,6 @@ type Pool struct {
 	logger    *zap.Logger
 	vmConfig  *pool.VMConfig
 	vms       chan *engine.VM
-	closed    atomic.Bool
 	closeOnce sync.Once
 	done      chan struct{} // opChan for signaling shutdown
 }

--- a/runtime/lua/pool/sync/sync_pool_test.go
+++ b/runtime/lua/pool/sync/sync_pool_test.go
@@ -3,17 +3,18 @@ package sync
 import (
 	"context"
 	"fmt"
-	time2 "github.com/ponyruntime/pony/runtime/lua/modules/time"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	time2 "github.com/ponyruntime/pony/runtime/lua/modules/time"
+
 	cfg "github.com/ponyruntime/pony/runtime/lua/pool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 

--- a/runtime/noop/noop.go
+++ b/runtime/noop/noop.go
@@ -3,6 +3,7 @@ package noop
 import (
 	"context"
 	"fmt"
+
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"

--- a/service/http/handler/endpoint_handler.go
+++ b/service/http/handler/endpoint_handler.go
@@ -3,13 +3,14 @@ package handler
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/api/runtime"
 	config "github.com/ponyruntime/pony/api/service/http"
 	"go.uber.org/zap"
-	"io"
-	"net/http"
 )
 
 // EndpointHandler processes HTTP requests for specific endpoints.

--- a/service/http/handler/endpoint_handler_test.go
+++ b/service/http/handler/endpoint_handler_test.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/ponyruntime/pony/api/payload"
-	"github.com/ponyruntime/pony/api/runtime"
-	config "github.com/ponyruntime/pony/api/service/http"
-	"go.uber.org/zap"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ponyruntime/pony/api/payload"
+	"github.com/ponyruntime/pony/api/runtime"
+	config "github.com/ponyruntime/pony/api/service/http"
+	"go.uber.org/zap"
 )
 
 // MockExecutor is a simple mock implementation of runtime.Executor

--- a/service/http/handler/json_validator.go
+++ b/service/http/handler/json_validator.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/xeipuuv/gojsonschema"
 	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
 )
 
 // ValidationError represents a JSON schema validation error

--- a/service/http/http.go
+++ b/service/http/http.go
@@ -3,10 +3,11 @@ package http
 import (
 	"context"
 	"fmt"
-	"github.com/ponyruntime/pony/api/runtime"
-	"github.com/ponyruntime/pony/service/http/handler"
 	"net/http"
 	"sync"
+
+	"github.com/ponyruntime/pony/api/runtime"
+	"github.com/ponyruntime/pony/service/http/handler"
 
 	"github.com/ponyruntime/pony/api/events"
 	"github.com/ponyruntime/pony/api/payload"

--- a/service/http/http_test.go
+++ b/service/http/http_test.go
@@ -2,11 +2,12 @@ package http
 
 import (
 	"context"
+	httpbase "net/http"
+	"testing"
+
 	"github.com/ponyruntime/pony/api/payload"
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/api/service/http"
-	httpbase "net/http"
-	"testing"
 
 	"github.com/ponyruntime/pony/pkg/eventbus"
 	transcoder "github.com/ponyruntime/pony/pkg/payload"

--- a/service/http/router/chi.go
+++ b/service/http/router/chi.go
@@ -3,12 +3,13 @@ package router
 import (
 	"context"
 	"fmt"
-	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
-	config "github.com/ponyruntime/pony/api/service/http"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	config "github.com/ponyruntime/pony/api/service/http"
 )
 
 // ChiRouter manages router configuration and endpoints

--- a/service/http/router/chi_test.go
+++ b/service/http/router/chi_test.go
@@ -1,12 +1,13 @@
 package router
 
 import (
-	config "github.com/ponyruntime/pony/api/service/http"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	config "github.com/ponyruntime/pony/api/service/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewChiRouter(t *testing.T) {

--- a/service/http/router/router_test.go
+++ b/service/http/router/router_test.go
@@ -2,15 +2,16 @@ package router
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/ponyruntime/pony/api/registry"
 	config "github.com/ponyruntime/pony/api/service/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"sync"
-	"testing"
 )
 
 func TestRouterComposition(t *testing.T) {

--- a/service/http/server_test.go
+++ b/service/http/server_test.go
@@ -2,12 +2,13 @@ package http
 
 import (
 	"context"
-	"github.com/ponyruntime/pony/api/supervisor"
-	sup "github.com/ponyruntime/pony/pkg/supervisor"
 	"io"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/ponyruntime/pony/api/supervisor"
+	sup "github.com/ponyruntime/pony/pkg/supervisor"
 
 	config "github.com/ponyruntime/pony/api/service/http"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
# Reason for This PR

ref: https://jira.spiralscout.com/browse/EE2-1570

## Description of Changes

- Rewrote `LanguagesInfo`.
- Eliminate globals (only in the treesitter module), which should not be ever used in Go.
- Fix ton of errors in tests, especially nil context.
- TODO: many values in ctx passed as strings, which should not be done, since strings are the basic types and easily might be overwritten.
- Linters should work for that module now + tests.
- Query tests for sql and markdown modules.
