### PR TITLE
feature: EE2-1564 Make LFS context-specific

### DIFF
--- a/runtime/lua/modules/lfs/api.go
+++ b/runtime/lua/modules/lfs/api.go
@@ -2,48 +2,93 @@ package lfs
 
 import (
 	"os"
+	"path"
+	"path/filepath"
 	"time"
 
 	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
-func apiAttributes(l *lua.LState) int {
+func (m *Module) apiAttributes(l *lua.LState) int {
 	return attributes(l, os.Stat)
 }
 
-func apiChdir(l *lua.LState) int {
-	dir := l.CheckString(1)
+func (m *Module) close(l *lua.LState) int {
+	ud := l.CheckUserData(1)
+	if ud == nil {
+		return 0
+	}
 
-	err := os.Chdir(dir)
+	// if not file, then there is something else in the userdata
+	f, ok := ud.Value.(*os.File)
+	if !ok {
+		return 0
+	}
+	if f != nil {
+		_ = f.Close()
+	}
+	return 0
+}
+
+func (m *Module) apiChdir(l *lua.LState) int {
+	dir := l.CheckString(1)
+	m.log.Debug("previous dir", zap.String("dir", m.currDir), zap.String("new", dir))
+	if dir == m.currDir {
+		l.Push(lua.LNil)
+		l.Push(lua.LTrue)
+		return 1
+	}
+
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(dir) {
+		dir = path.Join(m.currDir, dir)
+	}
+
+	// check if the directory exists
+	f, err := os.Open(dir)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.LString(err.Error()))
 		return 2
 	}
+	_ = f.Close()
+
+	// save the current directory
+	m.currDir = dir
+	m.log.Debug("current dir", zap.String("dir", m.currDir))
+
 	l.Push(lua.LTrue)
 	return 1
 }
 
-func apiLockdir(l *lua.LState) int {
+func (m *Module) apiLockdir(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }
 
-func apiCurrentdir(l *lua.LState) int {
-	dir, err := os.Getwd()
-	if err != nil {
-		l.Push(lua.LNil)
-		l.Push(lua.LString(err.Error()))
-		return 2
-	}
-	l.Push(lua.LString(dir))
+func (m *Module) apiCurrentdir(l *lua.LState) int {
+	m.log.Debug("current dir", zap.String("dir", m.currDir))
+
+	l.Push(lua.LString(m.currDir))
 	return 1
 }
 
-func apiDir(l *lua.LState) int {
-	path := l.CheckString(1)
+func (m *Module) apiDir(l *lua.LState) int {
+	lp := l.CheckString(1)
+	if lp == "" {
+		l.RaiseError("%s", "path is empty")
+		return 0
+	}
 
-	f, err := os.Open(path)
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(lp) {
+		lp = path.Join(m.currDir, lp)
+	}
+
+	m.log.Debug("dir", zap.String("path", lp))
+
+	f, err := os.Open(lp)
 	if err != nil {
 		l.RaiseError("%s", err)
 		return 0
@@ -64,21 +109,33 @@ func apiDir(l *lua.LState) int {
 	return 2
 }
 
-func apiLock(l *lua.LState) int {
+func (m *Module) apiLock(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }
 
-func apiLink(l *lua.LState) int {
+func (m *Module) apiLink(l *lua.LState) int {
 	old := l.CheckString(1)
-	_new := l.CheckString(2)
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(old) {
+		old = path.Join(m.currDir, old)
+	}
+
+	newn := l.CheckString(2)
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(newn) {
+		newn = path.Join(m.currDir, newn)
+	}
+
+	m.log.Debug("link", zap.String("old", old), zap.String("new", newn))
+
 	symlink := l.OptBool(3, false)
 
 	var err error
 	if symlink {
-		err = os.Symlink(old, _new)
+		err = os.Symlink(old, newn)
 	} else {
-		err = os.Link(old, _new)
+		err = os.Link(old, newn)
 	}
 
 	if err != nil {
@@ -91,10 +148,17 @@ func apiLink(l *lua.LState) int {
 	return 1
 }
 
-func apiMkdir(l *lua.LState) int {
+func (m *Module) apiMkdir(l *lua.LState) int {
 	dir := l.CheckString(1)
 
-	err := os.Mkdir(dir, 0755)
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(dir) {
+		dir = path.Join(m.currDir, dir)
+	}
+
+	m.log.Debug("mkdir", zap.String("dir", dir))
+	// 0644 - user: read, write; group: read; others: read
+	err := os.Mkdir(dir, 0644)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.LString(err.Error()))
@@ -104,8 +168,15 @@ func apiMkdir(l *lua.LState) int {
 	return 1
 }
 
-func apiRmdir(l *lua.LState) int {
+func (m *Module) apiRmdir(l *lua.LState) int {
 	dir := l.CheckString(1)
+
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(dir) {
+		dir = path.Join(m.currDir, dir)
+	}
+
+	m.log.Debug("rmdir", zap.String("dir", dir))
 
 	stat, err := os.Stat(dir)
 	if err != nil {
@@ -128,23 +199,30 @@ func apiRmdir(l *lua.LState) int {
 	return 1
 }
 
-func apiSetmode(l *lua.LState) int {
+func (m *Module) apiSetmode(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }
 
-func apiSymlinkattributes(l *lua.LState) int {
+func (m *Module) apiSymlinkattributes(l *lua.LState) int {
 	return attributes(l, os.Lstat)
 }
 
-func apiTouch(l *lua.LState) int {
-	filepath := l.CheckString(1)
+func (m *Module) apiTouch(l *lua.LState) int {
+	dir := l.CheckString(1)
+	// if the path is relative, then concatenate it with the current directory
+	if isRelative(dir) {
+		dir = path.Join(m.currDir, dir)
+	}
+
+	m.log.Debug("touch", zap.String("file", dir))
+
 	atime := l.OptInt64(2, time.Now().Unix())
 	mtime := l.OptInt64(3, atime)
 
 	// Check if the file exists. If not, create it.
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		file, err := os.Create(filepath)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		file, err := os.Create(dir)
 		if err != nil {
 			l.Push(lua.LNil)
 			l.Push(lua.LString(err.Error()))
@@ -154,7 +232,7 @@ func apiTouch(l *lua.LState) int {
 	}
 
 	// Now that the file exists, change its timestamps
-	err := os.Chtimes(filepath, time.Unix(atime, 0), time.Unix(mtime, 0))
+	err := os.Chtimes(dir, time.Unix(atime, 0), time.Unix(mtime, 0))
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.LString(err.Error()))
@@ -164,7 +242,12 @@ func apiTouch(l *lua.LState) int {
 	return 1
 }
 
-func apiUnlock(l *lua.LState) int {
+func (m *Module) apiUnlock(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
+}
+
+// isRelative returns true if the path is relative.
+func isRelative(path string) bool {
+	return !filepath.IsAbs(path)
 }

--- a/runtime/lua/modules/lfs/api.go
+++ b/runtime/lua/modules/lfs/api.go
@@ -6,35 +6,29 @@ import (
 	"path/filepath"
 	"time"
 
+	apic "github.com/ponyruntime/pony/api/context"
+	"github.com/ponyruntime/pony/internal/closer"
 	lua "github.com/yuin/gopher-lua"
 	"go.uber.org/zap"
 )
 
-func (m *Module) apiAttributes(l *lua.LState) int {
+func apiAttributes(l *lua.LState) int {
 	return attributes(l, os.Stat)
 }
 
-func (m *Module) close(l *lua.LState) int {
-	ud := l.CheckUserData(1)
-	if ud == nil {
-		return 0
-	}
-
-	// if not file, then there is something else in the userdata
-	f, ok := ud.Value.(*os.File)
-	if !ok {
-		return 0
-	}
-	if f != nil {
-		_ = f.Close()
-	}
-	return 0
+func getCtxLogger(l *lua.LState) *zap.Logger {
+	ctx := l.Context()
+	return ctx.Value(apic.LoggerCtx).(*zap.Logger)
 }
 
-func (m *Module) apiChdir(l *lua.LState) int {
+func apiChdir(l *lua.LState) int {
 	dir := l.CheckString(1)
-	m.log.Debug("previous dir", zap.String("dir", m.currDir), zap.String("new", dir))
-	if dir == m.currDir {
+	log := getCtxLogger(l)
+	cwd := l.GetGlobal(globalFnName).String()
+
+	log.Debug("previous dir", zap.String("dir", cwd), zap.String("new", dir))
+
+	if dir == cwd {
 		l.Push(lua.LNil)
 		l.Push(lua.LTrue)
 		return 1
@@ -42,7 +36,7 @@ func (m *Module) apiChdir(l *lua.LState) int {
 
 	// if the path is relative, then concatenate it with the current directory
 	if isRelative(dir) {
-		dir = path.Join(m.currDir, dir)
+		dir = path.Join(cwd, dir)
 	}
 
 	// check if the directory exists
@@ -55,38 +49,52 @@ func (m *Module) apiChdir(l *lua.LState) int {
 	_ = f.Close()
 
 	// save the current directory
-	m.currDir = dir
-	m.log.Debug("current dir", zap.String("dir", m.currDir))
+	log.Debug("current dir", zap.String("dir", dir))
+	// save the new cwd
+	l.SetGlobal(globalFnName, lua.LString(dir))
+
+	closer := closer.FromContext(l.Context())
+	// TODO: closer should use some kind of ID to identify cases when we have multiple identical calls
+	closer.Add(func() error {
+		// clear the global variable
+		l.SetGlobal(globalFnName, lua.LString(""))
+		return nil
+	})
 
 	l.Push(lua.LTrue)
 	return 1
 }
 
-func (m *Module) apiLockdir(l *lua.LState) int {
+func apiLockdir(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }
 
-func (m *Module) apiCurrentdir(l *lua.LState) int {
-	m.log.Debug("current dir", zap.String("dir", m.currDir))
+func apiCurrentdir(l *lua.LState) int {
+	cwd := l.GetGlobal(globalFnName).String()
+	log := getCtxLogger(l)
+	log.Debug("current dir", zap.String("dir", cwd))
 
-	l.Push(lua.LString(m.currDir))
+	l.Push(lua.LString(cwd))
 	return 1
 }
 
-func (m *Module) apiDir(l *lua.LState) int {
+func apiDir(l *lua.LState) int {
 	lp := l.CheckString(1)
 	if lp == "" {
 		l.RaiseError("%s", "path is empty")
 		return 0
 	}
 
+	cwd := l.GetGlobal(globalFnName).String()
+
+	log := getCtxLogger(l)
 	// if the path is relative, then concatenate it with the current directory
 	if isRelative(lp) {
-		lp = path.Join(m.currDir, lp)
+		lp = path.Join(cwd, lp)
 	}
 
-	m.log.Debug("dir", zap.String("path", lp))
+	log.Debug("dir", zap.String("path", lp))
 
 	f, err := os.Open(lp)
 	if err != nil {
@@ -102,32 +110,42 @@ func (m *Module) apiDir(l *lua.LState) int {
 		l.RaiseError("not a directory")
 		return 0
 	}
+
 	l.Push(l.NewFunction(dirItr))
 	ud := l.NewUserData()
 	ud.Value = f
 	l.Push(ud)
+
+	// add the file to the cleanup
+	closer := closer.FromContext(l.Context())
+	closer.Add(func() error {
+		_ = f.Close()
+		return nil
+	})
+
 	return 2
 }
 
-func (m *Module) apiLock(l *lua.LState) int {
+func apiLock(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }
 
-func (m *Module) apiLink(l *lua.LState) int {
+func apiLink(l *lua.LState) int {
 	old := l.CheckString(1)
-	// if the path is relative, then concatenate it with the current directory
+	cwd := l.GetGlobal(globalFnName).String()
+	log := getCtxLogger(l)
 	if isRelative(old) {
-		old = path.Join(m.currDir, old)
+		old = path.Join(cwd, old)
 	}
 
 	newn := l.CheckString(2)
 	// if the path is relative, then concatenate it with the current directory
 	if isRelative(newn) {
-		newn = path.Join(m.currDir, newn)
+		newn = path.Join(cwd, newn)
 	}
 
-	m.log.Debug("link", zap.String("old", old), zap.String("new", newn))
+	log.Debug("link", zap.String("old", old), zap.String("new", newn))
 
 	symlink := l.OptBool(3, false)
 
@@ -143,20 +161,22 @@ func (m *Module) apiLink(l *lua.LState) int {
 		l.Push(lua.LString(err.Error()))
 		return 2
 	}
-	l.Push(lua.LTrue)
 
+	l.Push(lua.LTrue)
 	return 1
 }
 
-func (m *Module) apiMkdir(l *lua.LState) int {
+func apiMkdir(l *lua.LState) int {
 	dir := l.CheckString(1)
+	log := getCtxLogger(l)
+	cwd := l.GetGlobal(globalFnName).String()
 
 	// if the path is relative, then concatenate it with the current directory
 	if isRelative(dir) {
-		dir = path.Join(m.currDir, dir)
+		dir = path.Join(cwd, dir)
 	}
 
-	m.log.Debug("mkdir", zap.String("dir", dir))
+	log.Debug("mkdir", zap.String("dir", dir))
 	// 0644 - user: read, write; group: read; others: read
 	err := os.Mkdir(dir, 0644)
 	if err != nil {
@@ -164,19 +184,22 @@ func (m *Module) apiMkdir(l *lua.LState) int {
 		l.Push(lua.LString(err.Error()))
 		return 2
 	}
+
 	l.Push(lua.LTrue)
 	return 1
 }
 
-func (m *Module) apiRmdir(l *lua.LState) int {
+func apiRmdir(l *lua.LState) int {
 	dir := l.CheckString(1)
+	cwd := l.GetGlobal(globalFnName).String()
+	log := getCtxLogger(l)
 
 	// if the path is relative, then concatenate it with the current directory
 	if isRelative(dir) {
-		dir = path.Join(m.currDir, dir)
+		dir = path.Join(cwd, dir)
 	}
 
-	m.log.Debug("rmdir", zap.String("dir", dir))
+	log.Debug("rmdir", zap.String("dir", dir))
 
 	stat, err := os.Stat(dir)
 	if err != nil {
@@ -199,23 +222,25 @@ func (m *Module) apiRmdir(l *lua.LState) int {
 	return 1
 }
 
-func (m *Module) apiSetmode(l *lua.LState) int {
+func apiSetmode(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }
 
-func (m *Module) apiSymlinkattributes(l *lua.LState) int {
+func apiSymlinkattributes(l *lua.LState) int {
 	return attributes(l, os.Lstat)
 }
 
-func (m *Module) apiTouch(l *lua.LState) int {
+func apiTouch(l *lua.LState) int {
 	dir := l.CheckString(1)
-	// if the path is relative, then concatenate it with the current directory
+	log := getCtxLogger(l)
+	cwd := l.GetGlobal(globalFnName).String()
+
 	if isRelative(dir) {
-		dir = path.Join(m.currDir, dir)
+		dir = path.Join(cwd, dir)
 	}
 
-	m.log.Debug("touch", zap.String("file", dir))
+	log.Debug("touch", zap.String("file", dir))
 
 	atime := l.OptInt64(2, time.Now().Unix())
 	mtime := l.OptInt64(3, atime)
@@ -242,7 +267,7 @@ func (m *Module) apiTouch(l *lua.LState) int {
 	return 1
 }
 
-func (m *Module) apiUnlock(l *lua.LState) int {
+func apiUnlock(l *lua.LState) int {
 	l.RaiseError("unimplemented function")
 	return 0
 }

--- a/runtime/lua/modules/lfs/attributes.go
+++ b/runtime/lua/modules/lfs/attributes.go
@@ -41,15 +41,24 @@ func attributes(l *lua.LState, statFunc func(string) (os.FileInfo, error)) int {
 
 func dirItr(l *lua.LState) int {
 	ud := l.CheckUserData(1)
+	if ud == nil {
+		return 0
+	}
 
 	f, ok := ud.Value.(*os.File)
 	if !ok {
 		return 0
 	}
+
+	if f == nil {
+		return 0
+	}
+
 	names, err := f.Readdirnames(1)
 	if err != nil {
 		return 0
 	}
+
 	l.Push(lua.LString(names[0]))
 	return 1
 }

--- a/runtime/lua/modules/lfs/lfs.go
+++ b/runtime/lua/modules/lfs/lfs.go
@@ -7,24 +7,16 @@ import (
 	"os"
 
 	lua "github.com/yuin/gopher-lua"
-	"go.uber.org/zap"
 )
 
+const globalFnName = "___currdir"
+
 // Module represents a lfs Lua module.
-type Module struct {
-	currDir string
-	log     *zap.Logger
-}
+type Module struct{}
 
 // NewLFSModule creates and returns a new instance of the lfs Module.
-func NewLFSModule(log *zap.Logger) *Module {
-	// TODO: is it safe to omit error handling here?
-	// case1: cwd does not exist
-	dir, _ := os.Getwd()
-	return &Module{
-		currDir: dir,
-		log:     log,
-	}
+func NewLFSModule() *Module {
+	return &Module{}
 }
 
 // Name returns the module's name.
@@ -36,24 +28,28 @@ func (m *Module) Loader(l *lua.LState) int {
 	t := l.NewTable()
 
 	api := map[string]lua.LGFunction{
-		"attributes":        m.apiAttributes,
-		"chdir":             m.apiChdir,
-		"lock_dir":          m.apiLockdir,
-		"currentdir":        m.apiCurrentdir,
-		"dir":               m.apiDir,
-		"lock":              m.apiLock,
-		"link":              m.apiLink,
-		"mkdir":             m.apiMkdir,
-		"rmdir":             m.apiRmdir,
-		"setmode":           m.apiSetmode,
-		"symlinkattributes": m.apiSymlinkattributes,
-		"touch":             m.apiTouch,
-		"unlock":            m.apiUnlock,
-		// to close a file in the userdata
-		"close": m.close,
+		"attributes":        apiAttributes,
+		"chdir":             apiChdir,
+		"lock_dir":          apiLockdir,
+		"currentdir":        apiCurrentdir,
+		"dir":               apiDir,
+		"lock":              apiLock,
+		"link":              apiLink,
+		"mkdir":             apiMkdir,
+		"rmdir":             apiRmdir,
+		"setmode":           apiSetmode,
+		"symlinkattributes": apiSymlinkattributes,
+		"touch":             apiTouch,
+		"unlock":            apiUnlock,
 	}
+
+	// TODO: is it safe to omit error handling here?
+	// case1: cwd does not exist
+	dir, _ := os.Getwd()
+	l.SetGlobal(globalFnName, lua.LString(dir))
 
 	l.SetFuncs(t, api)
 	l.Push(t)
+
 	return 1
 }

--- a/runtime/lua/modules/lfs/lfs.go
+++ b/runtime/lua/modules/lfs/lfs.go
@@ -4,15 +4,27 @@
 package lfs
 
 import (
+	"os"
+
 	lua "github.com/yuin/gopher-lua"
+	"go.uber.org/zap"
 )
 
 // Module represents a lfs Lua module.
-type Module struct{}
+type Module struct {
+	currDir string
+	log     *zap.Logger
+}
 
 // NewLFSModule creates and returns a new instance of the lfs Module.
-func NewLFSModule() *Module {
-	return &Module{}
+func NewLFSModule(log *zap.Logger) *Module {
+	// TODO: is it safe to omit error handling here?
+	// case1: cwd does not exist
+	dir, _ := os.Getwd()
+	return &Module{
+		currDir: dir,
+		log:     log,
+	}
 }
 
 // Name returns the module's name.
@@ -24,19 +36,21 @@ func (m *Module) Loader(l *lua.LState) int {
 	t := l.NewTable()
 
 	api := map[string]lua.LGFunction{
-		"attributes":        apiAttributes,
-		"chdir":             apiChdir,
-		"lock_dir":          apiLockdir,
-		"currentdir":        apiCurrentdir,
-		"dir":               apiDir,
-		"lock":              apiLock,
-		"link":              apiLink,
-		"mkdir":             apiMkdir,
-		"rmdir":             apiRmdir,
-		"setmode":           apiSetmode,
-		"symlinkattributes": apiSymlinkattributes,
-		"touch":             apiTouch,
-		"unlock":            apiUnlock,
+		"attributes":        m.apiAttributes,
+		"chdir":             m.apiChdir,
+		"lock_dir":          m.apiLockdir,
+		"currentdir":        m.apiCurrentdir,
+		"dir":               m.apiDir,
+		"lock":              m.apiLock,
+		"link":              m.apiLink,
+		"mkdir":             m.apiMkdir,
+		"rmdir":             m.apiRmdir,
+		"setmode":           m.apiSetmode,
+		"symlinkattributes": m.apiSymlinkattributes,
+		"touch":             m.apiTouch,
+		"unlock":            m.apiUnlock,
+		// to close a file in the userdata
+		"close": m.close,
 	}
 
 	l.SetFuncs(t, api)

--- a/runtime/lua/modules/lfs/lfs_test.go
+++ b/runtime/lua/modules/lfs/lfs_test.go
@@ -14,20 +14,20 @@ import (
 	"go.uber.org/zap"
 )
 
-func assertLua(L *lua.LState) int {
-	if L.ToBool(1) {
+func assertLua(l *lua.LState) int {
+	if l.ToBool(1) {
 		return 0
 	}
-	L.RaiseError(L.OptString(2, "assertion failed!"))
+	l.RaiseError("%s", l.OptString(2, "assertion failed!"))
 	return 0
 }
 
 func TestLFSModuleDoString(t *testing.T) {
 	// Test to verify that Init cannot handle arguments yet
-	logger := zap.NewNop()
+	logger, _ := zap.NewDevelopment()
 
 	t.Run("module creation and loading", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -35,7 +35,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local lfs = require("lfs")
 			assert(type(lfs) == "table")
 			assert(type(lfs.attributes) == "function")
@@ -51,7 +51,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("currentdir and chdir", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -62,7 +62,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		initialDir, err := os.Getwd()
 		require.NoError(t, err)
 
-		err = vm.DoString(nil, `
+		err = vm.DoString(context.Background(), `
 			local lfs = require("lfs")
 			local current = lfs.currentdir()
 			assert(current ~= nil, "currentdir should return a path")
@@ -87,7 +87,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("mkdir and rmdir", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -122,7 +122,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("attributes", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -131,7 +131,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		defer vm.Close()
 
 		tempFile := filepath.Join(t.TempDir(), "test.txt")
-		err = os.WriteFile(tempFile, []byte("test content"), 0644)
+		err = os.WriteFile(tempFile, []byte("test content"), 0600)
 		require.NoError(t, err)
 
 		err = vm.Import(`
@@ -154,7 +154,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("touch", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -188,7 +188,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("link", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -198,7 +198,7 @@ func TestLFSModuleDoString(t *testing.T) {
 
 		tempDir := t.TempDir()
 		sourceFile := filepath.Join(tempDir, "source.txt")
-		err = os.WriteFile(sourceFile, []byte("test content"), 0644)
+		err = os.WriteFile(sourceFile, []byte("test content"), 0600)
 		require.NoError(t, err)
 
 		linkFile := filepath.Join(tempDir, "link.txt")
@@ -224,7 +224,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("dir iterator", func(t *testing.T) {
-		mod := NewLFSModule()
+		mod := NewLFSModule(logger)
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -236,7 +236,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		// Create some files
 		files := []string{"file1.txt", "file2.txt", "file3.txt"}
 		for _, f := range files {
-			err = os.WriteFile(filepath.Join(tempDir, f), []byte("test"), 0644)
+			err = os.WriteFile(filepath.Join(tempDir, f), []byte("test"), 0600)
 			require.NoError(t, err)
 		}
 

--- a/runtime/lua/modules/lfs/lfs_test.go
+++ b/runtime/lua/modules/lfs/lfs_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	apic "github.com/ponyruntime/pony/api/context"
 	"github.com/ponyruntime/pony/runtime/lua/engine"
 	lua "github.com/yuin/gopher-lua"
 
@@ -22,12 +23,56 @@ func assertLua(l *lua.LState) int {
 	return 0
 }
 
+func TestLFS(t *testing.T) {
+	// Test to verify that Init cannot handle arguments yet
+	logger, _ := zap.NewDevelopment()
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, apic.LoggerCtx, logger)
+
+	mod := NewLFSModule()
+	vm, err := engine.NewVM(logger,
+		engine.WithLoader(mod.Name(), mod.Loader),
+		engine.WithGlobalFunction("assert", assertLua),
+	)
+	require.NoError(t, err)
+	defer vm.Close()
+
+	initialDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	err = vm.DoString(ctx, `
+			local lfs = require("lfs")
+			local current = lfs.currentdir()
+			assert(current ~= nil, "currentdir should return a path")
+			
+			-- Try changing to parent directory
+			local success = lfs.chdir("..")
+			assert(success == true, "chdir should succeed")
+			
+			local newCurrent = lfs.currentdir()
+			assert(current ~= newCurrent, "directory should have changed")
+			
+			-- Change back
+			success = lfs.chdir(current)
+			assert(success == true, "chdir back should succeed")
+		`, "test")
+	assert.NoError(t, err)
+
+	// Verify we're back where we started
+	endDir, err := os.Getwd()
+	require.NoError(t, err)
+	assert.Equal(t, initialDir, endDir)
+}
+
 func TestLFSModuleDoString(t *testing.T) {
 	// Test to verify that Init cannot handle arguments yet
 	logger, _ := zap.NewDevelopment()
 
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, apic.LoggerCtx, logger)
+
 	t.Run("module creation and loading", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -35,7 +80,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		require.NoError(t, err)
 		defer vm.Close()
 
-		err = vm.DoString(context.Background(), `
+		err = vm.DoString(ctx, `
 			local lfs = require("lfs")
 			assert(type(lfs) == "table")
 			assert(type(lfs.attributes) == "function")
@@ -51,7 +96,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("currentdir and chdir", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -62,7 +107,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		initialDir, err := os.Getwd()
 		require.NoError(t, err)
 
-		err = vm.DoString(context.Background(), `
+		err = vm.DoString(ctx, `
 			local lfs = require("lfs")
 			local current = lfs.currentdir()
 			assert(current ~= nil, "currentdir should return a path")
@@ -87,7 +132,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("mkdir and rmdir", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -117,12 +162,12 @@ func TestLFSModuleDoString(t *testing.T) {
 		`, "mkdir_rmdir_test_file", "mkdir_rmdir_test")
 		require.NoError(t, err)
 
-		_, err = vm.Execute(context.Background(), "mkdir_rmdir_test", lua.LString(testDir))
+		_, err = vm.Execute(ctx, "mkdir_rmdir_test", lua.LString(testDir))
 		assert.NoError(t, err)
 	})
 
 	t.Run("attributes", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -149,12 +194,12 @@ func TestLFSModuleDoString(t *testing.T) {
 		`, "attributes_test", "attributes_test")
 		require.NoError(t, err)
 
-		_, err = vm.Execute(context.Background(), "attributes_test", lua.LString(tempFile))
+		_, err = vm.Execute(ctx, "attributes_test", lua.LString(tempFile))
 		assert.NoError(t, err)
 	})
 
 	t.Run("touch", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -179,7 +224,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		`, "touch_test_file", "touch_test")
 		require.NoError(t, err)
 
-		_, err = vm.Execute(context.Background(), "touch_test", lua.LString(tempFile))
+		_, err = vm.Execute(ctx, "touch_test", lua.LString(tempFile))
 		assert.NoError(t, err, "Lua function should execute without error")
 
 		// Verify the file exists using os.Stat (which uses absolute paths)
@@ -188,7 +233,7 @@ func TestLFSModuleDoString(t *testing.T) {
 	})
 
 	t.Run("link", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -218,13 +263,13 @@ func TestLFSModuleDoString(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = vm.Execute(
-			context.Background(),
+			ctx,
 			"link_test", lua.LString(sourceFile), lua.LString(linkFile))
 		assert.NoError(t, err)
 	})
 
 	t.Run("dir iterator", func(t *testing.T) {
-		mod := NewLFSModule(logger)
+		mod := NewLFSModule()
 		vm, err := engine.NewVM(logger,
 			engine.WithLoader(mod.Name(), mod.Loader),
 			engine.WithGlobalFunction("assert", assertLua),
@@ -256,7 +301,7 @@ func TestLFSModuleDoString(t *testing.T) {
 		`, "dir_test_file", "dir_test")
 		require.NoError(t, err)
 
-		_, err = vm.Execute(context.Background(), "dir_test", lua.LString(tempDir))
+		_, err = vm.Execute(ctx, "dir_test", lua.LString(tempDir))
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
# Reason for This PR

ref: https://jira.spiralscout.com/browse/EE2-1564

## Description of Changes

1. Make LFS module context specific.
2. Detect absolute and relative paths. If we have a relative path, use saved current working directory + rel path, instead, use provided absolute dir.
3. New method: `close` which should be always called to close the FD for the stored in the user-data file.
4. All tests are green.
<img width="622" alt="image" src="https://github.com/user-attachments/assets/6db8b247-a5e7-4412-a88e-4b0c00beb91c" />

