### PR TITLE
EE2-1759 fix panic in http router when adding duplicate route

### DIFF
--- a/service/http/factory.go
+++ b/service/http/factory.go
@@ -192,7 +192,7 @@ func NewServerFactory(middlewareFactory MiddlewareAPI) *ServerFactory {
 
 // CreateServer creates a new HTTP server from the provided configuration
 func (f *ServerFactory) CreateServer(id registry.ID, cfg *config.ServerConfig) (Server, error) {
-	return NewServerService(id, cfg, f.middlewareFactory), nil
+	return NewServerService(id, cfg, f.middlewareFactory)
 }
 
 // wrapWithCacheControl wraps an HTTP handler with Cache-Control header

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -59,6 +59,13 @@ func (rm *RouteManager) AddRouter(id registry.ID, prefix string,
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
+	// Check for duplicate prefixes
+	for _, existingRouter := range rm.routers {
+		if existingRouter.prefix == prefix {
+			return fmt.Errorf("router with prefix %s already exists", prefix)
+		}
+	}
+
 	// Check if the router already exists
 	if existingRouter, exists := rm.routers[id]; exists {
 		// Update existing router instead of returning an error

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -38,14 +38,17 @@ type RouteManager struct {
 }
 
 // NewRouteManager creates a new route manager instance
-func NewRouteManager() *RouteManager {
+func NewRouteManager() (*RouteManager, error) {
 	rm := &RouteManager{
 		routers: make(map[registry.ID]*RouterEntry),
 		mounts:  make(map[string]http.Handler),
 	}
-	rm.Build()
+	err := rm.Build()
+	if err != nil {
+		return nil, err
+	}
 
-	return rm
+	return rm, nil
 }
 
 // AddRouter adds a new router or updates an existing one
@@ -206,12 +209,15 @@ func (rm *RouteManager) Unmount(path string) error {
 }
 
 // Build rebuilds the entire router from the current configuration
-func (rm *RouteManager) Build() {
+func (rm *RouteManager) Build() error {
 	router := chi.NewRouter()
 
 	// Add root mounts first
 	for path, handler := range rm.mounts {
-		router.Mount(path, handler)
+		err := mount(router, path, handler)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Build each router with its middleware and routes
@@ -270,11 +276,28 @@ func (rm *RouteManager) Build() {
 		}
 
 		// Mount subrouter
-		router.Mount(re.prefix, subRouter)
+		err := mount(router, re.prefix, subRouter)
+		if err != nil {
+			return err
+		}
 	}
 
 	var h http.Handler = router
 	rm.router.Store(&h)
+
+	return nil
+}
+
+func mount(router *chi.Mux, pattern string, handler http.Handler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("mount failed for %s", pattern)
+		}
+	}()
+
+	router.Mount(pattern, handler)
+
+	return nil
 }
 
 // createChain creates a middleware chain that will call middlewares in order,

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestRouteManager_BasicOperations(t *testing.T) {
-	rm := NewRouteManager()
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
 
 	t.Run("add and update router", func(t *testing.T) {
 		routerID := registry.ID{NS: "test", Name: "router1"}
@@ -87,11 +88,12 @@ func TestRouteManager_BasicOperations(t *testing.T) {
 }
 
 func TestRouteManager_ServeHTTP(t *testing.T) {
-	rm := NewRouteManager()
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
 
 	// Add test router
 	routerID := registry.ID{NS: "test", Name: "router1"}
-	err := rm.AddRouter(routerID, "/api", nil, nil)
+	err = rm.AddRouter(routerID, "/api", nil, nil)
 	require.NoError(t, err)
 
 	// Add test endpoint
@@ -114,7 +116,8 @@ func TestRouteManager_ServeHTTP(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build the router
-	rm.Build()
+	err = rm.Build()
+	require.NoError(t, err)
 
 	// Create a test server
 	server := httptest.NewServer(rm)
@@ -137,7 +140,8 @@ func TestRouteManager_ServeHTTP(t *testing.T) {
 }
 
 func TestRouteManager_MultipleRouters(t *testing.T) {
-	rm := NewRouteManager()
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
 
 	// Add multiple test routers
 	routerIDs := []struct {
@@ -169,7 +173,8 @@ func TestRouteManager_MultipleRouters(t *testing.T) {
 	}
 
 	// Build the router
-	rm.Build()
+	err = rm.Build()
+	require.NoError(t, err)
 
 	// Create a test server
 	server := httptest.NewServer(rm)
@@ -188,7 +193,8 @@ func TestRouteManager_MultipleRouters(t *testing.T) {
 }
 
 func TestRouteManager_Middleware(t *testing.T) {
-	rm := NewRouteManager()
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
 
 	// Create middleware that adds a header
 	testMiddleware := func(next http.Handler) http.Handler {
@@ -201,7 +207,7 @@ func TestRouteManager_Middleware(t *testing.T) {
 	// Add router with middleware
 	routerID := registry.ID{NS: "test", Name: "router1"}
 	middleware := []func(http.Handler) http.Handler{testMiddleware}
-	err := rm.AddRouter(routerID, "/api", middleware, nil)
+	err = rm.AddRouter(routerID, "/api", middleware, nil)
 	require.NoError(t, err)
 
 	// Add test endpoint
@@ -216,7 +222,8 @@ func TestRouteManager_Middleware(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build the router
-	rm.Build()
+	err = rm.Build()
+	require.NoError(t, err)
 
 	// Create a test server
 	server := httptest.NewServer(rm)
@@ -230,4 +237,38 @@ func TestRouteManager_Middleware(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "applied", resp.Header.Get("X-Test-Middleware"))
 	assert.NoError(t, resp.Body.Close())
+}
+
+func TestRouteManager_DuplicateRoutes(t *testing.T) {
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
+
+	// Add router
+	routerID := registry.ID{NS: "test", Name: "router1"}
+	err = rm.AddRouter(routerID, "/api", nil, nil)
+	require.NoError(t, err)
+
+	// Add first test endpoint
+	funcID1 := registry.ID{NS: "test", Name: "func1"}
+	endpointID1 := registry.ID{NS: "test", Name: "endpoint1"}
+	handler1 := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err = rm.AddRoute(routerID, endpointID1, "GET", "/test", funcID1, handler1)
+	require.NoError(t, err)
+
+	// Add second test endpoint with the same path and method
+	funcID2 := registry.ID{NS: "test", Name: "func2"}
+	endpointID2 := registry.ID{NS: "test", Name: "endpoint2"}
+	handler2 := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err = rm.AddRoute(routerID, endpointID2, "GET", "/test", funcID2, handler2)
+	// AddRoute should fail due to duplicate routes
+	require.ErrorContains(t, err, "route with path /test and method GET already exists in router test:router1")
+
+	err = rm.Build()
+	assert.NoError(t, err)
 }

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -243,31 +243,44 @@ func TestRouteManager_DuplicateRoutes(t *testing.T) {
 	rm, err := NewRouteManager()
 	require.NoError(t, err)
 
-	// Add router
-	routerID := registry.ID{NS: "test", Name: "router1"}
-	err = rm.AddRouter(routerID, "/api", nil, nil)
-	require.NoError(t, err)
+	{
+		// Add router
+		routerID := registry.ID{NS: "test", Name: "router1"}
+		err = rm.AddRouter(routerID, "/api", nil, nil)
+		require.NoError(t, err)
 
-	// Add first test endpoint
-	funcID1 := registry.ID{NS: "test", Name: "func1"}
-	endpointID1 := registry.ID{NS: "test", Name: "endpoint1"}
-	handler1 := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+		// Add first test endpoint
+		funcID1 := registry.ID{NS: "test", Name: "func1"}
+		endpointID1 := registry.ID{NS: "test", Name: "endpoint1"}
+		handler1 := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
 
-	err = rm.AddRoute(routerID, endpointID1, "GET", "/test", funcID1, handler1)
-	require.NoError(t, err)
+		// Add first route
+		err = rm.AddRoute(routerID, endpointID1, "GET", "/test", funcID1, handler1)
+		require.NoError(t, err)
 
-	// Add second test endpoint with the same path and method
-	funcID2 := registry.ID{NS: "test", Name: "func2"}
-	endpointID2 := registry.ID{NS: "test", Name: "endpoint2"}
-	handler2 := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+		// Add duplicate route
+		err = rm.AddRoute(routerID, endpointID1, "GET", "/test", funcID1, handler1)
+		require.ErrorContains(t, err, "route with Source test:endpoint1 already exists in router test:router1")
+	}
 
-	err = rm.AddRoute(routerID, endpointID2, "GET", "/test", funcID2, handler2)
-	// AddRoute should fail due to duplicate routes
-	require.ErrorContains(t, err, "route with path /test and method GET already exists in router test:router1")
+	{
+		// Add router
+		routerID := registry.ID{NS: "test", Name: "router1"}
+		err = rm.AddRouter(routerID, "/api", nil, nil)
+		require.ErrorContains(t, err, "router with prefix /api already exists")
+
+		// Add second test endpoint
+		funcID1 := registry.ID{NS: "test", Name: "func1"}
+		endpointID1 := registry.ID{NS: "test", Name: "endpoint1"}
+		handler1 := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		err = rm.AddRoute(routerID, endpointID1, "GET", "/test", funcID1, handler1)
+		require.ErrorContains(t, err, `route with Source test:endpoint1 already exists in router test:router1`)
+	}
 
 	err = rm.Build()
 	assert.NoError(t, err)

--- a/service/http/server.go
+++ b/service/http/server.go
@@ -53,15 +53,20 @@ type ServerService struct {
 }
 
 // NewServerService creates a new ServerService instance
-func NewServerService(id registry.ID, cfg *config.ServerConfig, middleware MiddlewareAPI) *ServerService {
+func NewServerService(id registry.ID, cfg *config.ServerConfig, middleware MiddlewareAPI) (*ServerService, error) {
+	routeManager, err := NewRouteManager()
+	if err != nil {
+		return nil, err
+	}
+
 	return &ServerService{
 		id:            id,
 		config:        cfg,
-		routeMgr:      NewRouteManager(),
+		routeMgr:      routeManager,
 		statusChan:    make(chan any, StatusBuffer),
 		mountPaths:    make(map[registry.ID]string),
 		middlewareFac: middleware,
-	}
+	}, nil
 }
 
 // UpdateConfig updates the server configuration
@@ -166,7 +171,10 @@ func (s *ServerService) Rebuild(_ context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.routeMgr.Build()
+	err := s.routeMgr.Build()
+	if err != nil {
+		return err
+	}
 
 	// If server is running, we need to update its handler
 	if s.started && s.server != nil {

--- a/service/http/server_test.go
+++ b/service/http/server_test.go
@@ -78,7 +78,8 @@ func TestServerService_Basic(t *testing.T) {
 
 		id := registry.ID{NS: "test", Name: "server1"}
 		middleware := NewDefaultMiddlewareFactory()
-		server := NewServerService(id, cfg, middleware)
+		server, err := NewServerService(id, cfg, middleware)
+		require.NoError(t, err)
 
 		assert.NotNil(t, server)
 		assert.Equal(t, cfg, server.config)
@@ -98,7 +99,8 @@ func TestServerService_Basic(t *testing.T) {
 
 		id := registry.ID{NS: "test", Name: "server1"}
 		middleware := NewDefaultMiddlewareFactory()
-		server := NewServerService(id, cfg, middleware)
+		server, err := NewServerService(id, cfg, middleware)
+		require.NoError(t, err)
 
 		// Update config before starting server
 		newCfg := &config.ServerConfig{
@@ -163,7 +165,8 @@ func TestServerService_RouterOperations(t *testing.T) {
 
 	id := registry.ID{NS: "test", Name: "server1"}
 	middleware := NewDefaultMiddlewareFactory()
-	server := NewServerService(id, cfg, middleware)
+	server, err := NewServerService(id, cfg, middleware)
+	require.NoError(t, err)
 
 	t.Run("add and delete router", func(t *testing.T) {
 		routerID := registry.ID{NS: "test", Name: "router1"}
@@ -288,7 +291,8 @@ func TestServerService_StartStop(t *testing.T) {
 
 	id := registry.ID{NS: "test", Name: "server1"}
 	middleware := NewDefaultMiddlewareFactory()
-	server := NewServerService(id, cfg, middleware)
+	server, err := NewServerService(id, cfg, middleware)
+	require.NoError(t, err)
 
 	// Add router and endpoint
 	routerID := registry.ID{NS: "test", Name: "router4"}
@@ -411,7 +415,8 @@ func TestServerService_Middleware(t *testing.T) {
 		}),
 	)
 
-	server := NewServerService(id, cfg, middlewareFactory)
+	server, err := NewServerService(id, cfg, middlewareFactory)
+	require.NoError(t, err)
 
 	// Add router with middleware
 	routerID := registry.ID{NS: "test", Name: "router5"}
@@ -551,7 +556,8 @@ func TestCreateMiddleware(t *testing.T) {
 		}),
 	)
 
-	server := NewServerService(id, &config.ServerConfig{}, middlewareFactory)
+	server, err := NewServerService(id, &config.ServerConfig{}, middlewareFactory)
+	require.NoError(t, err)
 
 	t.Run("timeout middleware", func(t *testing.T) {
 		options := map[string]string{"timeout": "10s"}
@@ -597,7 +603,8 @@ func TestEnsureRunning(t *testing.T) {
 
 	id := registry.ID{NS: "test", Name: "server1"}
 	middleware := NewDefaultMiddlewareFactory()
-	server := NewServerService(id, cfg, middleware)
+	server, err := NewServerService(id, cfg, middleware)
+	require.NoError(t, err)
 
 	// Serve a separate HTTP server on that port to simulate our server already running
 	httpServer := &http.Server{
@@ -652,7 +659,8 @@ func TestContextListener(t *testing.T) {
 
 	id := registry.ID{NS: "test", Name: "server1"}
 	middleware := NewDefaultMiddlewareFactory()
-	server := NewServerService(id, cfg, middleware)
+	server, err := NewServerService(id, cfg, middleware)
+	require.NoError(t, err)
 
 	// Add a test endpoint that verifies the listener context is set
 	routerID := registry.ID{NS: "test", Name: "router6"}

--- a/service/sql/manager_test.go
+++ b/service/sql/manager_test.go
@@ -241,7 +241,9 @@ func TestNewManagerWithFactory(t *testing.T) {
 	})
 }
 func TestManager_Add(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
 	manager, bus, factory := newTestManager(t)
 
 	// Setup event listener for supervisor and resource events
@@ -359,7 +361,10 @@ func TestManager_Update(t *testing.T) {
 	envContexter.SetValue("POSTGRESQL_DEFAULT_DATABASE", "test-db")
 	envContexter.SetValue("POSTGRESQL_DEFAULT_USERNAME", "test-user")
 	envContexter.SetValue("POSTGRESQL_DEFAULT_PASSWORD", "test-pwd")
-	ctx := context.WithValue(context.Background(), ctxapi.EnvCtx, envContexter)
+
+	rootCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	ctx := context.WithValue(rootCtx, ctxapi.EnvCtx, envContexter)
 
 	// Setup event listener for supervisor events
 	supervisorEvents := make(chan event.Event, 2)
@@ -467,7 +472,10 @@ func TestManager_Delete(t *testing.T) {
 	envContexter.SetValue("POSTGRESQL_DEFAULT_DATABASE", "test-db")
 	envContexter.SetValue("POSTGRESQL_DEFAULT_USERNAME", "test-user")
 	envContexter.SetValue("POSTGRESQL_DEFAULT_PASSWORD", "test-pwd")
-	ctx := context.WithValue(context.Background(), ctxapi.EnvCtx, envContexter)
+
+	rootCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	ctx := context.WithValue(rootCtx, ctxapi.EnvCtx, envContexter)
 
 	// Setup event listeners
 	supervisorEvents := make(chan event.Event, 2)
@@ -507,10 +515,16 @@ func TestManager_Delete(t *testing.T) {
 
 	// Drain events channels
 	for len(supervisorEvents) > 0 {
-		<-supervisorEvents
+		select {
+		case <-supervisorEvents:
+		default:
+		}
 	}
 	for len(resourceEvents) > 0 {
-		<-resourceEvents
+		select {
+		case <-resourceEvents:
+		default:
+		}
 	}
 
 	tests := []struct {


### PR DESCRIPTION
# Reason for This PR
fixes panic of golang application

An error is raised if duplicate routes are detected:
```
2025-05-02 21:26:58     ERROR   registry        failed to apply changes {"error": "operation failed: router with prefix /api/public already exists"}
2025-05-02 21:26:58     FATAL   failed to start application     {"error": "failed to apply initial state: failed to apply changes: operation failed: router with prefix /api/public already exists"}
```
