### PR TITLE
EE2-1861 add comprehensive env.storage.os demo implementation

### DIFF
--- a/app/src/demos/env_demo/README.md
+++ b/app/src/demos/env_demo/README.md
@@ -1,0 +1,118 @@
+# Environment Storage Demo
+
+This demo showcases different types of environment variable storage backends available in the runtime system.
+
+## Storage Types
+
+### 1. Memory Storage (`env.storage.memory`)
+- **Type**: Read-write
+- **Persistence**: In-memory only (lost on restart)
+- **Use case**: Temporary variables, caching, testing
+
+### 2. File Storage (`env.storage.file`)
+- **Type**: Read-write
+- **Persistence**: File-based (survives restarts)
+- **Use case**: Configuration files, persistent settings
+
+### 3. OS Storage (`env.storage.os`) - NEW!
+- **Type**: Read-only
+- **Persistence**: System environment variables
+- **Use case**: Accessing system environment variables
+
+## OS Storage Feature
+
+The new `env.storage.os` feature allows you to access operating system environment variables in a read-only manner. This is useful for:
+
+- Accessing system configuration (PATH, HOME, USER, etc.)
+- Reading environment variables set by the system or container
+- Integrating with external tools that rely on environment variables
+
+### Configuration
+
+The OS storage is configured in `system.yaml`:
+
+```yaml
+- name: envos
+  kind: env.storage.os
+  meta:
+    type: envstorage
+    comment: OS storage for environment variables (read-only)
+```
+
+### Usage Examples
+
+```yaml
+# Access system PATH variable
+- name: path_env
+  kind: env.variable
+  meta:
+    type: secret_key
+    depends_on:
+      - system:envos
+  variable: PATH
+  storage: system:envos
+  default:
+  readonly: true
+
+# Access user home directory
+- name: home_env
+  kind: env.variable
+  meta:
+    type: secret_key
+    depends_on:
+      - system:envos
+  variable: HOME
+  storage: system:envos
+  default:
+  readonly: true
+```
+
+### Lua API Usage
+
+```lua
+local env = require("env")
+
+-- Get system environment variables
+local path = env.get('path_env')        -- Gets PATH
+local home = env.get('home_env')        -- Gets HOME
+local user = env.get('user_env')        -- Gets USER
+
+-- Try to set (will fail - read-only)
+local success = env.set('path_env', 'new_path')  -- Returns false
+```
+
+## Testing the Demo
+
+1. Start the runtime system
+2. Navigate to `/env/demo` endpoint
+3. View the test results showing:
+   - Memory storage operations
+   - File storage operations
+   - OS storage operations (new!)
+
+## Key Features of OS Storage
+
+- **Read-only**: Cannot modify system environment variables
+- **System integration**: Accesses actual OS environment variables
+- **Cross-platform**: Works on Linux, Windows, macOS
+- **Container-friendly**: Works in Docker containers
+- **Security**: Respects system permissions and security policies
+
+## Test Cases
+
+The demo includes tests for:
+
+1. **Basic OS variable access**: Reading system environment variables
+2. **Full name access**: Using namespace-qualified variable names
+3. **ENV_NAME access**: Using environment variable names directly
+4. **Read-only enforcement**: Attempting to set OS variables (should fail)
+5. **Common system variables**: PATH, HOME, USER
+6. **Non-existent variables**: Handling missing environment variables
+
+## Benefits
+
+- **System integration**: Access real system environment variables
+- **Security**: Read-only access prevents accidental modifications
+- **Compatibility**: Works with existing system tools and scripts
+- **Containerization**: Supports Docker and other container environments
+- **Cross-platform**: Works across different operating systems 

--- a/app/src/demos/env_demo/_index.yaml
+++ b/app/src/demos/env_demo/_index.yaml
@@ -68,3 +68,58 @@ entries:
     storage: system:envfile
     default:
     readonly: true
+
+  - name: path_env
+    kind: env.variable
+    meta:
+      type: secret_key
+      depends_on:
+        - system:envos
+    variable: PATH
+    storage: system:envos
+    default:
+    readonly: true
+
+  - name: home_env
+    kind: env.variable
+    meta:
+      type: secret_key
+      depends_on:
+        - system:envos
+    variable: HOME
+    storage: system:envos
+    default:
+    readonly: true
+
+  - name: user_env
+    kind: env.variable
+    meta:
+      type: secret_key
+      depends_on:
+        - system:envos
+    variable: USER
+    storage: system:envos
+    default:
+    readonly: true
+
+  - name: pwd_env
+    kind: env.variable
+    meta:
+      type: secret_key
+      depends_on:
+        - system:envos
+    variable: PWD
+    storage: system:envos
+    default:
+    readonly: true
+
+  - name: shell_env
+    kind: env.variable
+    meta:
+      type: secret_key
+      depends_on:
+        - system:envos
+    variable: SHELL
+    storage: system:envos
+    default:
+    readonly: true

--- a/app/src/demos/env_demo/env.lua
+++ b/app/src/demos/env_demo/env.lua
@@ -139,6 +139,64 @@ local function handler()
                 result = (not env.set('FILE_TEST_ENV_READONLY', 'new_value') and env.get('FILE_TEST_ENV_READONLY') == "file_value_readonly") and "success" or "failed",
                 stored_value = env.get('FILE_TEST_ENV_READONLY')
             },
+        },
+        os_variables = {
+            {
+                operation = "Get PATH Environment Variable",
+                variable = "path_env",
+                expected_value = "exists",
+                result = (env.get('path_env') ~= nil and env.get('path_env') ~= "") and "success" or "failed",
+                stored_value = env.get('path_env')
+            },
+            {
+                operation = "Get PATH by Full Name",
+                variable = "app.env.demo:path_env",
+                expected_value = "exists",
+                result = (env.get('app.env.demo:path_env') ~= nil and env.get('app.env.demo:path_env') ~= "") and "success" or "failed",
+                stored_value = env.get('app.env.demo:path_env')
+            },
+            {
+                operation = "Get HOME Environment Variable",
+                variable = "home_env",
+                expected_value = "exists",
+                result = (env.get('home_env') ~= nil and env.get('home_env') ~= "") and "success" or "failed",
+                stored_value = env.get('home_env')
+            },
+            {
+                operation = "Get USER Environment Variable",
+                variable = "user_env",
+                expected_value = "exists",
+                result = (env.get('user_env') ~= nil and env.get('user_env') ~= "") and "success" or "failed",
+                stored_value = env.get('user_env')
+            },
+            {
+                operation = "Get PWD Environment Variable",
+                variable = "pwd_env",
+                expected_value = "exists",
+                result = (env.get('pwd_env') ~= nil and env.get('pwd_env') ~= "") and "success" or "failed",
+                stored_value = env.get('pwd_env')
+            },
+            {
+                operation = "Get SHELL Environment Variable",
+                variable = "shell_env",
+                expected_value = "exists",
+                result = (env.get('shell_env') ~= nil and env.get('shell_env') ~= "") and "success" or "failed",
+                stored_value = env.get('shell_env')
+            },
+            {
+                operation = "Set PATH Variable (Should Fail)",
+                variable = "path_env",
+                expected_value = "readonly",
+                result = (not env.set('path_env', 'new_path')) and "success" or "failed",
+                stored_value = env.get('path_env')
+            },
+            {
+                operation = "Get Non-existent OS Variable",
+                variable = "NON_EXISTENT_VAR",
+                expected_value = "nil",
+                result = (env.get('NON_EXISTENT_VAR') == nil) and "success" or "failed",
+                stored_value = env.get('NON_EXISTENT_VAR')
+            },
         }
     }
 
@@ -178,6 +236,13 @@ local function handler()
     -- Add file variables section
     ascii_response = ascii_response .. create_header("FILE VARIABLES")
     for _, test in ipairs(test_results.file_variables) do
+        ascii_response = ascii_response .. create_row(test.operation, test.variable, test.expected_value, test.stored_value, test.result)
+    end
+    ascii_response = ascii_response .. create_separator()
+
+    -- Add OS variables section
+    ascii_response = ascii_response .. create_header("OS VARIABLES (env.storage.os)")
+    for _, test in ipairs(test_results.os_variables) do
         ascii_response = ascii_response .. create_row(test.operation, test.variable, test.expected_value, test.stored_value, test.result)
     end
     ascii_response = ascii_response .. create_separator()

--- a/app/system.yaml
+++ b/app/system.yaml
@@ -120,6 +120,19 @@ entries:
       type: envstorage
       comment: Memory storage for environment variables
 
+  - name: envos
+    kind: env.storage.os
+    meta:
+      type: envstorage
+      comment: OS storage for environment variables (read-only)
+
+  - name: envfile
+    kind: env.storage.file
+    meta:
+      type: envstorage
+      comment: File storage for environment variables
+    file_path: "./app/env/.env.sample"
+
   - name: file_test_env2
     kind: env.variable
     meta:
@@ -144,13 +157,6 @@ entries:
     region: us-east-1
     access_key_id_env: ACCESS_KEY_ID_CUSTOM
 
-  - name: envfile
-    kind: env.storage.file
-    meta:
-      type: envstorage
-      comment: File storage for environment variables
-    file_path: "./app/env/.env.sample"
-
   - name: test_s3
     kind: cloudstorage.s3
     meta:
@@ -159,7 +165,6 @@ entries:
         - aws_config
     bucket: mybucket
     config: system:aws_config
-
 #  - name: db_postgres
 #    kind: db.sql.postgres
 #    meta:

--- a/cmd/runner/services.go
+++ b/cmd/runner/services.go
@@ -219,6 +219,7 @@ func withEphemeralHost(a *App) eventbus.EventHandler {
 	))
 }
 
+//nolint:unused // it breaks runtime. use only for dev purpose
 func withNoopRuntime(a *App) eventbus.EventHandler {
 	return reghandler.NewRegistryHandler("(function|workflow|process|library).*", noop.NewNoopRuntime(
 		a.eventBus,


### PR DESCRIPTION
# Reason for This PR
EE2-1861

## Description of Changes
- Add OS storage configuration to system.yaml (envos)
- Enhance env_demo with 5 real system environment variables:
  * path_env (PATH)
  * home_env (HOME)
  * user_env (USER)
  * pwd_env (PWD)
  * shell_env (SHELL)
- Add 8 comprehensive OS storage tests in env.lua:
  * Reading real system environment variables
  * Full namespace access patterns
  * Read-only enforcement verification
  * Non-existent variable handling
- Add complete documentation in README.md:
  * OS storage feature overview
  * Configuration examples
  * Lua API usage patterns
  * Testing instructions
- Fix linter warning in services.go with nolint comment

All tests now pass successfully at /api/v1/env/demo endpoint. Demonstrates read-only access to system environment variables with proper error handling and comprehensive test coverage.
