### PR TITLE
EE2-1867 wippy is unable to start when a lock file is present on windows

### DIFF
--- a/cmd/runner/app.go
+++ b/cmd/runner/app.go
@@ -791,8 +791,10 @@ func loadEntriesFromLoadedModules(
 
 	for _, module := range loadResult.Modules {
 		// Create a sub-filesystem for this specific module from the root filesystem
+		// Convert Windows backslashes to forward slashes for cross-platform compatibility
+		modulePath := filepath.ToSlash(module.Path)
 
-		moduleFS, err := iofs.Sub(rootFS, module.Path)
+		moduleFS, err := iofs.Sub(rootFS, modulePath)
 		if err != nil {
 			return nil, fmt.Errorf("create sub-filesystem for module %s: %w", module.Path, err)
 		}

--- a/cmd/runner/deps.go
+++ b/cmd/runner/deps.go
@@ -43,6 +43,11 @@ func (dm *DependencyManager) InstallDependencies(ctx context.Context) error {
 		return fmt.Errorf("find lock file: %w", err)
 	}
 
+	// Check if lock file exists
+	if lockPath == "" {
+		return fmt.Errorf("no lock file found in project directory: %s", dm.config.FolderPath)
+	}
+
 	// Load lock file
 	lockFile, err := moduleloader.LoadLockFile(lockPath)
 	if err != nil {


### PR DESCRIPTION
# Reason for This PR
EE2-1867

## Description of Changes
wippy is unable to start when a lock file is present on windows