### PR TITLE
- stabilization of lua

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 // replace github.com/ponyruntime/tree-sitter-sql => ../tree-sitter-sql
 
 replace github.com/yuin/gopher-lua => github.com/ponyruntime/go-lua v1.2.6
+
 replace github.com/ponyruntime/go-lua => github.com/wippyai/go-lua v1.2.6
 
 //replace github.com/wippyai/go-lua => ../go-lua

--- a/go.mod
+++ b/go.mod
@@ -63,9 +63,8 @@ require (
 
 // replace github.com/ponyruntime/tree-sitter-sql => ../tree-sitter-sql
 
-replace github.com/yuin/gopher-lua => github.com/ponyruntime/go-lua v1.2.3
-
-replace github.com/ponyruntime/go-lua => github.com/wippyai/go-lua v1.2.5
+replace github.com/yuin/gopher-lua => github.com/ponyruntime/go-lua v1.2.6
+replace github.com/ponyruntime/go-lua => github.com/wippyai/go-lua v1.2.6
 
 //replace github.com/wippyai/go-lua => ../go-lua
 

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAc
 github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ponyruntime/go-lua v1.2.3 h1:e3fYBZ4MHA3fvYE7pcQRphyC93j96bX9O2gv/QRNz/E=
-github.com/ponyruntime/go-lua v1.2.3/go.mod h1:MACtdm8bgMnTf8fdsbl5r+z2FJ3mA0A1mFQaVnQZ0xQ=
+github.com/ponyruntime/go-lua v1.2.6 h1:botDNEZhKEBVe0788j67tDztU5QsFZpctAazgWSd0Ss=
+github.com/ponyruntime/go-lua v1.2.6/go.mod h1:MACtdm8bgMnTf8fdsbl5r+z2FJ3mA0A1mFQaVnQZ0xQ=
 github.com/ponyruntime/tree-sitter-markdown v0.0.2 h1:BrPbu2nTYo75E6POp/mu4ijfwwjYfxGMf8gWBedsKM0=
 github.com/ponyruntime/tree-sitter-markdown v0.0.2/go.mod h1:Eg28LbIWoosBFNXTxws0WZMsXx/rAjN/g1dgHmq7CDI=
 github.com/ponyruntime/tree-sitter-sql v0.0.3 h1:2YO2JIs5OxSjo42lDwuxWdX/yeOwhTVcio+3EmdZhbA=
@@ -339,8 +339,8 @@ github.com/tree-sitter/tree-sitter-rust v0.21.3-0.20240818005432-2b43eafe6447/go
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/wippyai/go-lua v1.2.5 h1:sJLskobs2gkBUsI/y7QbJRG5c+tFVDtjRe++2VgAloM=
-github.com/wippyai/go-lua v1.2.5/go.mod h1:MACtdm8bgMnTf8fdsbl5r+z2FJ3mA0A1mFQaVnQZ0xQ=
+github.com/wippyai/go-lua v1.2.6 h1:yWUChK0rT4CsATHK85YaqFO4pmfSXwepno5MxLJjoOU=
+github.com/wippyai/go-lua v1.2.6/go.mod h1:MACtdm8bgMnTf8fdsbl5r+z2FJ3mA0A1mFQaVnQZ0xQ=
 github.com/wippyai/module-registry-proto-go v0.0.1 h1:EYnW8MTrI/gs7TJ0ilTVgJal3e0NWmXQigeamrXu0mk=
 github.com/wippyai/module-registry-proto-go v0.0.1/go.mod h1:p4ihYQKRQuqRVLxaH1YL0IEnkz4zKdyfVADOwvA5Tno=
 github.com/xuri/efp v0.0.0-20240408161823-9ad904a10d6d h1:llb0neMWDQe87IzJLS4Ci7psK/lVsjIS2otl+1WyRyY=


### PR DESCRIPTION
This pull request updates the replacement directives for Lua dependencies in the `go.mod` file to use the latest patch version. This ensures the project uses the most recent bug fixes and improvements from the upstream repositories.

Dependency updates:

* Updated the replacement for `github.com/yuin/gopher-lua` to point to `github.com/ponyruntime/go-lua v1.2.6` instead of v1.2.3.
* Updated the replacement for `github.com/ponyruntime/go-lua` to point to `github.com/wippyai/go-lua v1.2.6` instead of v1.2.5.