### PR TITLE
feat(wippy): EE2-1877 add module requirement default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Wippy enables systems that can understand their own structure and adapt over tim
 *   **Concurrency Model:** Utilizes coroutines and Go-inspired channels for efficient, non-blocking concurrency within and between processes.
 *   **Command-Based Interface:** Modern CLI architecture with intuitive commands for dependency management and system operations.
 *   **Module Replacements:** Local development support through module replacement system for faster iteration cycles.
+*   **Default Values for Requirements:** Module requirements can define default values, making the `parameters` section in `ns.dependency` optional and improving developer experience.
 
 ## Architecture Overview
 
@@ -80,6 +81,80 @@ Wippy addresses common challenges in modern software development, especially whe
 *   **Multi-Tenant Processing:** Run isolated, customizable data processing logic for different tenants with resource governance.
 *   **Development Workflow:** Streamlined dependency management with modern CLI commands for rapid iteration and testing.
 *   **Module Development:** Local module development and testing with replacement system for faster development cycles.
+
+## Module Requirements with Default Values
+
+Wippy introduces a powerful feature that simplifies module configuration by allowing requirements to define default values. This enhancement makes the `parameters` section in `ns.dependency` entries **optional** when modules provide sensible defaults.
+
+### Key Benefits
+
+- **Simplified Configuration**: Applications can use modules without specifying parameters when defaults are available
+- **Flexible Override**: Applications can still override defaults when custom values are needed
+- **Backward Compatibility**: Existing applications with parameters continue to work unchanged
+- **Better Developer Experience**: Less boilerplate configuration and more intuitive module usage
+
+### How It Works
+
+**Module Configuration (with defaults):**
+```yaml
+# Module (wippy/llm/_index.yaml)
+version: "1.0"
+namespace: wippy.llm
+
+entries: 
+  - name: application_host
+    kind: ns.requirement
+    meta: 
+      description: "Host ID for the application processes"
+    targets: 
+      - entry: token_refresh
+        path: .meta.default_host
+    default: "app:processes"  # Default value makes parameters optional
+```
+
+**Application Configuration (simplified):**
+```yaml
+# Application (_index.yaml) - Parameters section is now OPTIONAL
+version: "1.0"
+namespace: app.example
+
+entries:
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    component: "wippy/llm"
+    version: ">=v0.0.7"
+    # No parameters section needed when module has defaults!
+```
+
+**Application Configuration (with custom values):**
+```yaml
+# Application (_index.yaml) - Override defaults when needed
+entries:
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    component: "wippy/llm"
+    version: ">=v0.0.7"
+    parameters: 
+      - name: "application_host"
+        value: "system:processes"  # Overrides module default
+```
+
+### Behavior Examples
+
+1. **Application provides parameter**: Uses application value (overrides default)
+2. **Application doesn't provide parameter**: Uses module default value
+3. **Application has no parameters field**: Uses module default value
+4. **Application has malformed parameters**: Gracefully falls back to default
+5. **No parameter and no default**: Requirement is skipped (graceful degradation)
+
+### Validation Rules
+
+- Parameter matching validation with warning logs for mismatches
+- Graceful handling of missing, nil, or malformed parameter fields
+- Requirements without defaults are skipped when no parameter is provided
+- Default values are extracted from requirement entries automatically
+
+This feature significantly improves the developer experience by reducing configuration complexity while maintaining full flexibility for custom scenarios.
 
 ## Getting Started
 

--- a/app/src/demos/requirements_demo/_index.yaml
+++ b/app/src/demos/requirements_demo/_index.yaml
@@ -15,5 +15,6 @@ entries:
     parameters:
       - name: API_ROUTER
         value: "system:api"
-      - name: NAMESPACE
-        value: "ns:system"
+        # used as default value
+#      - name: NAMESPACE
+#        value: "ns:system"

--- a/requirementresolver/README.md
+++ b/requirementresolver/README.md
@@ -1,0 +1,183 @@
+# Default Values for Module Requirements
+
+This document demonstrates the new default value functionality for module requirements in the Wippy system.
+
+## Overview
+
+The default value feature allows module requirements to define fallback values when application dependencies don't provide the required parameters. This improves usability and resilience of the modular system.
+
+**Key Benefit**: When a module requirement has a `default` value, the `parameters` section in `ns.dependency` becomes **optional** in the application configuration.
+
+## How It Works
+
+### Before (Current Behavior)
+- Application **must** pass parameters to dependencies
+- Module requirements consume those parameters
+- If no parameter is provided, the requirement fails
+
+### After (New Behavior)
+- Module requirements can declare default values
+- If application doesn't provide a parameter, the system falls back to the default
+- If application provides a parameter, it overrides the default
+- **The `parameters` section in `ns.dependency` is now optional when defaults are defined**
+
+## Example Usage
+
+### Application Configuration (Simplified - Parameters Optional)
+```yaml
+# Application (_index.yaml) - Parameters section is now OPTIONAL
+version: "1.0"
+namespace: app.example
+
+entries:
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    meta: 
+      description: "LLM component"
+    component: "wippy/llm"
+    version: ">=v0.0.7"
+    # parameters section is OPTIONAL when module has defaults
+    # parameters: 
+    #   - name: "application_host"
+    #     value: "system:processes"
+```
+
+### Application Configuration (With Custom Parameters)
+```yaml
+# Application (_index.yaml) - Override defaults with custom values
+version: "1.0"
+namespace: app.example
+
+entries:
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    meta: 
+      description: "LLM component"
+    component: "wippy/llm"
+    version: ">=v0.0.7"
+    parameters: 
+      - name: "application_host"
+        value: "system:processes"  # Overrides module default
+```
+
+### Module Configuration (With Default Values)
+```yaml
+# Module (wippy/llm/_index.yaml)
+version: "1.0"
+namespace: wippy.llm
+
+entries: 
+  - name: application_host
+    kind: ns.requirement
+    meta: 
+      description: "Host ID for the application processes"
+    targets: 
+      - entry: token_refresh
+        path: .meta.default_host
+      - entry: token_refresh.service
+        path: .host
+      - entry: token_refresh.service
+        path: ".lifecycle.depends_on +="
+    default: "app:processes"  # <-- NEW: Default value (makes parameters optional)
+```
+
+## Behavior Examples
+
+### Case 1: Application Provides Parameter
+- **Application parameter**: `application_host = "system:processes"`
+- **Module default**: `application_host = "app:processes"`
+- **Result**: Uses `"system:processes"` (application value overrides default)
+
+### Case 2: Application Doesn't Provide Parameter
+- **Application parameter**: Not provided
+- **Module default**: `application_host = "app:processes"`
+- **Result**: Uses `"app:processes"` (default value is used)
+
+### Case 3: Application Has No Parameters Field
+- **Application dependency**: No `parameters` field in dependency entry
+- **Module default**: `application_host = "app:processes"`
+- **Result**: Uses `"app:processes"` (default value is used)
+
+### Case 4: Application Has Nil Parameters Field
+- **Application dependency**: `parameters: null` in dependency entry
+- **Module default**: `application_host = "app:processes"`
+- **Result**: Uses `"app:processes"` (default value is used)
+
+### Case 5: Application Has Malformed Parameters Field
+- **Application dependency**: `parameters: "not_an_array"` in dependency entry
+- **Module default**: `application_host = "app:processes"`
+- **Result**: Uses `"app:processes"` (default value is used)
+
+### Case 6: No Parameter and No Default
+- **Application parameter**: Not provided
+- **Module default**: Not defined
+- **Result**: Requirement is skipped (graceful degradation)
+
+## Validation Rules
+
+1. **Parameter Matching**: If `parameters.name` in application doesn't match any requirement name in module → warning logged
+2. **Missing Values**: If `ns.requirement` has no default and application doesn't provide value → requirement is skipped (no fatal error)
+3. **Default Values**: Module requirements can define default values as strings
+4. **Optional Parameters**: When a module requirement has a `default` value, the `parameters` section in `ns.dependency` becomes **optional**
+
+## Implementation Details
+
+The feature is implemented in the `requirementresolver` package:
+
+- `getRequirementDefaultValue()`: Extracts default values from requirement entries
+- `validateParameterMatching()`: Validates parameter-requirement matching
+- Enhanced `ResolveModuleDefinitions()`: Handles default value fallback logic
+- Enhanced `findDependencyByParameterName()`: Robustly handles missing, nil, or malformed parameters fields
+
+## Testing
+
+Comprehensive tests cover:
+- Requirements with default values (no dependency parameter)
+- Requirements with default values (dependency parameter provided)
+- Requirements without default values (no dependency parameter)
+- Requirements with default values (dependency has no parameters field)
+- Requirements with default values (dependency has nil parameters field)
+- Requirements with default values (dependency has malformed parameters field)
+- Default value extraction
+- Parameter matching validation
+- Edge cases for parameter field handling
+
+All tests pass and maintain backward compatibility with existing functionality.
+
+## Key Benefits
+
+### 1. **Simplified Application Configuration**
+When modules define default values, applications can use modules without specifying any parameters:
+
+```yaml
+# Minimal application configuration
+entries:
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    component: "wippy/llm"
+    version: ">=v0.0.7"
+    # No parameters section needed!
+```
+
+### 2. **Flexible Override Capability**
+Applications can still override defaults when needed:
+
+```yaml
+# Custom configuration when needed
+entries:
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    component: "wippy/llm"
+    version: ">=v0.0.7"
+    parameters: 
+      - name: "application_host"
+        value: "custom:host"  # Override default
+```
+
+### 3. **Backward Compatibility**
+Existing applications with parameters continue to work unchanged.
+
+### 4. **Improved Developer Experience**
+- **Less boilerplate**: No need to specify parameters for every module
+- **Sensible defaults**: Modules can provide reasonable default values
+- **Easy customization**: Override only what you need to change

--- a/requirementresolver/resolver.go
+++ b/requirementresolver/resolver.go
@@ -98,7 +98,9 @@ func (r *Resolver) ResolveModuleDefinitions(entries []registry.Entry) ([]registr
 	}
 
 	// Validate that all dependency parameters have corresponding requirements
-	r.validateParameterMatching(nsDependencies, nsRequirements)
+	if err := r.validateParameterMatching(nsDependencies, nsRequirements); err != nil {
+		r.logger.Warn("parameter validation failed", zap.Error(err))
+	}
 
 	return entries, nil
 }
@@ -155,7 +157,7 @@ func ApplyPathValueToEntriesWithGojq(jqQuery string, value string, entries []reg
 				// If Data update failed and it's a meta query, try entire entry
 				err2 := updateEntireEntryWithGojq(entry, jqQuery, value)
 				if err2 != nil {
-					errs = append(errs, fmt.Errorf("failed to update entry with jq query '%s' for entry %s (data error: %v, entire entry error: %v)", jqQuery, entry.ID.Name, err, err2))
+					errs = append(errs, fmt.Errorf("failed to update entry with jq query '%s' for entry %s (data error: %w, entire entry error: %w)", jqQuery, entry.ID.Name, err, err2))
 				}
 			} else if err != nil {
 				errs = append(errs, fmt.Errorf("failed to update entry data with jq query '%s' for entry %s: %w", jqQuery, entry.ID.Name, err))
@@ -588,7 +590,7 @@ func getRequirementDefaultValue(requirement registry.Entry) (string, bool) {
 }
 
 // validateParameterMatching validates that dependency parameters have corresponding requirements
-func (r *Resolver) validateParameterMatching(nsDependencies map[string]registry.Entry, nsRequirements map[string]registry.Entry) {
+func (r *Resolver) validateParameterMatching(nsDependencies map[string]registry.Entry, nsRequirements map[string]registry.Entry) error {
 	// Collect all parameter names from dependencies
 	allParamNames := make(map[string]bool)
 	for _, nsDependency := range nsDependencies {
@@ -607,6 +609,7 @@ func (r *Resolver) validateParameterMatching(nsDependencies map[string]registry.
 	}
 
 	// Check if each parameter has a corresponding requirement
+	var missingRequirements []string
 	for paramName := range allParamNames {
 		found := false
 		for _, nsRequirement := range nsRequirements {
@@ -616,8 +619,13 @@ func (r *Resolver) validateParameterMatching(nsDependencies map[string]registry.
 			}
 		}
 		if !found {
-			r.logger.Warn("dependency parameter has no corresponding requirement",
-				zap.String("parameter_name", paramName))
+			missingRequirements = append(missingRequirements, paramName)
 		}
 	}
+
+	if len(missingRequirements) > 0 {
+		return fmt.Errorf("dependency parameters have no corresponding requirements: %v", missingRequirements)
+	}
+
+	return nil
 }

--- a/requirementresolver/resolver.go
+++ b/requirementresolver/resolver.go
@@ -45,19 +45,14 @@ func (r *Resolver) ResolveModuleDefinitions(entries []registry.Entry) ([]registr
 			zap.String("requirement_name", nsRequirement.ID.Name),
 			zap.String("requirement_namespace", nsRequirement.ID.NS))
 
-		// Find dependency with parameter matching the requirement name
-		nsDependency, paramValue, err := findDependencyByParameterName(nsRequirement.ID.Name, nsDependencies)
+		// Resolve parameter value (from dependency or default)
+		paramValue, err := r.resolveParameterValue(nsRequirement, nsDependencies)
 		if err != nil {
-			r.logger.Warn("failed to find dependency parameter for requirement",
+			r.logger.Warn("failed to resolve parameter value for requirement",
 				zap.String("requirement", nsRequirement.ID.Name),
 				zap.Error(err))
 			continue
 		}
-
-		r.logger.Debug("found dependency parameter for requirement",
-			zap.String("requirement", nsRequirement.ID.String()),
-			zap.String("dependency", nsDependency.ID.Name),
-			zap.String("parameter_value", paramValue))
 
 		// Get requirement targets for value injection
 		requirementTargets, err := getRequirementTargets(nsRequirement)
@@ -102,7 +97,34 @@ func (r *Resolver) ResolveModuleDefinitions(entries []registry.Entry) ([]registr
 		}
 	}
 
+	// Validate that all dependency parameters have corresponding requirements
+	r.validateParameterMatching(nsDependencies, nsRequirements)
+
 	return entries, nil
+}
+
+// resolveParameterValue resolves a parameter value for a requirement from either dependency or default
+func (r *Resolver) resolveParameterValue(requirement registry.Entry, dependencies map[string]registry.Entry) (string, error) {
+	// Try to find parameter in dependencies first
+	_, paramValue, err := findDependencyByParameterName(requirement.ID.Name, dependencies)
+	if err == nil {
+		r.logger.Debug("found dependency parameter for requirement",
+			zap.String("requirement", requirement.ID.Name),
+			zap.String("parameter_value", paramValue))
+		return paramValue, nil
+	}
+
+	// Fall back to default value if available
+	defaultValue, hasDefault := getRequirementDefaultValue(requirement)
+	if hasDefault {
+		r.logger.Debug("using default value for requirement",
+			zap.String("requirement", requirement.ID.Name),
+			zap.String("default_value", defaultValue))
+		return defaultValue, nil
+	}
+
+	// No parameter found and no default available
+	return "", fmt.Errorf("no parameter found and no default value available for requirement %s", requirement.ID.Name)
 }
 
 // ApplyPathValueToEntriesWithGojq applies a value to entries using jq DSL queries
@@ -118,18 +140,24 @@ func ApplyPathValueToEntriesWithGojq(jqQuery string, value string, entries []reg
 			continue
 		}
 
-		// Check if the jqQuery targets kind or meta fields to determine update strategy
+		// Determine update strategy based on query path
 		trimmedQuery := strings.TrimSpace(jqQuery)
-		if trimmedQuery == ".kind" || strings.HasPrefix(trimmedQuery, ".meta") {
-			// Update entire object (including kind and meta fields)
+		if trimmedQuery == ".kind" {
+			// Update entire entry for kind field
 			err := updateEntireEntryWithGojq(entry, jqQuery, value)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to update entire entry with jq query '%s' for entry %s: %w", jqQuery, entry.ID.Name, err))
 			}
 		} else {
-			// Update only the Data field (including .data queries)
+			// Try Data first, fallback to entire entry for meta fields
 			err := updateEntryDataWithGojq(entry, jqQuery, value)
-			if err != nil {
+			if err != nil && strings.HasPrefix(trimmedQuery, ".meta") {
+				// If Data update failed and it's a meta query, try entire entry
+				err2 := updateEntireEntryWithGojq(entry, jqQuery, value)
+				if err2 != nil {
+					errs = append(errs, fmt.Errorf("failed to update entry with jq query '%s' for entry %s (data error: %v, entire entry error: %v)", jqQuery, entry.ID.Name, err, err2))
+				}
+			} else if err != nil {
 				errs = append(errs, fmt.Errorf("failed to update entry data with jq query '%s' for entry %s: %w", jqQuery, entry.ID.Name, err))
 			}
 		}
@@ -336,17 +364,35 @@ func joinErrors(errs []error) error {
 func findDependencyByParameterName(requirementName string, nsDependencies map[string]registry.Entry) (registry.Entry, string, error) {
 	for _, nsDependency := range nsDependencies {
 		data := nsDependency.Data.Data()
-		if depMap, ok := data.(map[string]interface{}); ok {
-			if paramsRaw, ok := depMap["parameters"].([]interface{}); ok {
-				for _, paramRaw := range paramsRaw {
-					if paramMap, ok := paramRaw.(map[string]interface{}); ok {
-						if paramName, ok := paramMap["name"].(string); ok && paramName == requirementName {
-							if paramValue, ok := paramMap["value"].(string); ok {
-								return nsDependency, paramValue, nil
-							}
-						}
-					}
-				}
+		depMap, ok := data.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		paramsRaw, exists := depMap["parameters"]
+		if !exists || paramsRaw == nil {
+			continue
+		}
+
+		paramsArray, ok := paramsRaw.([]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, paramRaw := range paramsArray {
+			paramMap, ok := paramRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			paramName, ok := paramMap["name"].(string)
+			if !ok || paramName != requirementName {
+				continue
+			}
+
+			paramValue, ok := paramMap["value"].(string)
+			if ok {
+				return nsDependency, paramValue, nil
 			}
 		}
 	}
@@ -526,6 +572,52 @@ func (r *Resolver) verifyInjection(entries []registry.Entry, path string, expect
 				zap.String("entry_id", entry.ID.String()),
 				zap.String("path", path),
 				zap.String("value", actualValue))
+		}
+	}
+}
+
+// getRequirementDefaultValue extracts the default value from a requirement entry
+func getRequirementDefaultValue(requirement registry.Entry) (string, bool) {
+	data := requirement.Data.Data()
+	if reqMap, ok := data.(map[string]interface{}); ok {
+		if defaultValue, ok := reqMap["default"].(string); ok {
+			return defaultValue, true
+		}
+	}
+	return "", false
+}
+
+// validateParameterMatching validates that dependency parameters have corresponding requirements
+func (r *Resolver) validateParameterMatching(nsDependencies map[string]registry.Entry, nsRequirements map[string]registry.Entry) {
+	// Collect all parameter names from dependencies
+	allParamNames := make(map[string]bool)
+	for _, nsDependency := range nsDependencies {
+		data := nsDependency.Data.Data()
+		if depMap, ok := data.(map[string]interface{}); ok {
+			if paramsRaw, ok := depMap["parameters"].([]interface{}); ok {
+				for _, paramRaw := range paramsRaw {
+					if paramMap, ok := paramRaw.(map[string]interface{}); ok {
+						if paramName, ok := paramMap["name"].(string); ok {
+							allParamNames[paramName] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Check if each parameter has a corresponding requirement
+	for paramName := range allParamNames {
+		found := false
+		for _, nsRequirement := range nsRequirements {
+			if nsRequirement.ID.Name == paramName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			r.logger.Warn("dependency parameter has no corresponding requirement",
+				zap.String("parameter_name", paramName))
 		}
 	}
 }

--- a/requirementresolver/resolver_test.go
+++ b/requirementresolver/resolver_test.go
@@ -317,6 +317,123 @@ func TestFindDependencyByParameterName(t *testing.T) {
 	}
 }
 
+// TestFindDependencyByParameterNameEdgeCases tests edge cases for findDependencyByParameterName
+func TestFindDependencyByParameterNameEdgeCases(t *testing.T) {
+	testCases := []struct {
+		name            string
+		nsDependencies  map[string]registry.Entry
+		requirementName string
+		shouldFind      bool
+		description     string
+	}{
+		{
+			name: "dependency_without_parameters_field",
+			nsDependencies: map[string]registry.Entry{
+				"dependency1": {
+					ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+					Kind: registry.KindNamespaceDependency,
+					Data: payload.New(map[string]interface{}{
+						"component": "wippy/llm",
+						"version":   ">=v0.0.7",
+						// No parameters field
+					}),
+				},
+			},
+			requirementName: "PARAM1",
+			shouldFind:      false,
+			description:     "Dependency without parameters field",
+		},
+		{
+			name: "dependency_with_nil_parameters_field",
+			nsDependencies: map[string]registry.Entry{
+				"dependency1": {
+					ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+					Kind: registry.KindNamespaceDependency,
+					Data: payload.New(map[string]interface{}{
+						"component":  "wippy/llm",
+						"version":    ">=v0.0.7",
+						"parameters": nil, // nil parameters field
+					}),
+				},
+			},
+			requirementName: "PARAM1",
+			shouldFind:      false,
+			description:     "Dependency with nil parameters field",
+		},
+		{
+			name: "dependency_with_malformed_parameters_field",
+			nsDependencies: map[string]registry.Entry{
+				"dependency1": {
+					ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+					Kind: registry.KindNamespaceDependency,
+					Data: payload.New(map[string]interface{}{
+						"component":  "wippy/llm",
+						"version":    ">=v0.0.7",
+						"parameters": "not_an_array", // malformed parameters field
+					}),
+				},
+			},
+			requirementName: "PARAM1",
+			shouldFind:      false,
+			description:     "Dependency with malformed parameters field",
+		},
+		{
+			name: "dependency_with_empty_parameters_array",
+			nsDependencies: map[string]registry.Entry{
+				"dependency1": {
+					ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+					Kind: registry.KindNamespaceDependency,
+					Data: payload.New(map[string]interface{}{
+						"component":  "wippy/llm",
+						"version":    ">=v0.0.7",
+						"parameters": []interface{}{}, // empty parameters array
+					}),
+				},
+			},
+			requirementName: "PARAM1",
+			shouldFind:      false,
+			description:     "Dependency with empty parameters array",
+		},
+		{
+			name: "dependency_with_valid_parameters",
+			nsDependencies: map[string]registry.Entry{
+				"dependency1": {
+					ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+					Kind: registry.KindNamespaceDependency,
+					Data: payload.New(map[string]interface{}{
+						"component": "wippy/llm",
+						"version":   ">=v0.0.7",
+						"parameters": []interface{}{
+							map[string]interface{}{
+								"name":  "PARAM1",
+								"value": "value1",
+							},
+						},
+					}),
+				},
+			},
+			requirementName: "PARAM1",
+			shouldFind:      true,
+			description:     "Dependency with valid parameters",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			dependency, paramValue, err := findDependencyByParameterName(tc.requirementName, tc.nsDependencies)
+
+			if tc.shouldFind {
+				require.NoError(t, err, "Should find dependency parameter")
+				assert.Equal(t, "dependency1", dependency.ID.Name)
+				assert.Equal(t, "value1", paramValue)
+			} else {
+				require.Error(t, err, "Should not find dependency parameter")
+				assert.Contains(t, err.Error(), "no dependency parameter found")
+			}
+		})
+	}
+}
+
 // ParseEntryReference parses an entry reference string to determine target namespace and name
 // Supports two formats:
 // 1. "entry_name" - resolves to current namespace
@@ -333,4 +450,453 @@ func ParseEntryReference(entryRef string, currentNS string) (targetNS string, ta
 
 	// No namespace prefix, use current namespace
 	return currentNS, entryRef
+}
+
+// TestRequirementDefaultValues tests the new default value functionality
+func TestRequirementDefaultValues(t *testing.T) {
+	logger := zap.NewNop()
+	resolver := NewResolver(logger)
+
+	// Test case 1: Requirement with default value, no dependency parameter provided
+	t.Run("Requirement with default value, no dependency", func(t *testing.T) {
+		entries := []registry.Entry{
+			// Target entry that will receive the default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "target_function"},
+				Kind: "function.lua",
+				Data: payload.New(map[string]interface{}{
+					"meta": map[string]interface{}{
+						"host": "old_value",
+					},
+				}),
+			},
+			// Requirement with default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "app:processes",
+				}),
+			},
+		}
+
+		resolvedEntries, err := resolver.ResolveModuleDefinitions(entries)
+		require.NoError(t, err, "Should resolve requirements without error")
+		assert.Equal(t, len(entries), len(resolvedEntries), "Should return same number of entries")
+
+		// Verify that the default value was applied
+		targetEntry := resolvedEntries[0]
+		data := targetEntry.Data.Data()
+		if meta, ok := data.(map[string]interface{})["meta"].(map[string]interface{}); ok {
+			assert.Equal(t, "app:processes", meta["host"], "Default value should be applied")
+		}
+	})
+
+	// Test case 2: Requirement with default value, but dependency parameter is provided (should use dependency value)
+	t.Run("Requirement with default value, dependency parameter provided", func(t *testing.T) {
+		entries := []registry.Entry{
+			// Target entry that will receive the value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "target_function"},
+				Kind: "function.lua",
+				Data: payload.New(map[string]interface{}{
+					"meta": map[string]interface{}{
+						"host": "old_value",
+					},
+				}),
+			},
+			// Dependency that provides the parameter value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "host_dependency"},
+				Kind: registry.KindNamespaceDependency,
+				Data: payload.New(map[string]interface{}{
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":  "application_host",
+							"value": "system:processes",
+						},
+					},
+				}),
+			},
+			// Requirement with default value (should be overridden by dependency)
+			{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "app:processes",
+				}),
+			},
+		}
+
+		resolvedEntries, err := resolver.ResolveModuleDefinitions(entries)
+		require.NoError(t, err, "Should resolve requirements without error")
+		assert.Equal(t, len(entries), len(resolvedEntries), "Should return same number of entries")
+
+		// Verify that the dependency value was used (not the default)
+		targetEntry := resolvedEntries[0]
+		data := targetEntry.Data.Data()
+		if meta, ok := data.(map[string]interface{})["meta"].(map[string]interface{}); ok {
+			assert.Equal(t, "system:processes", meta["host"], "Dependency value should override default")
+		}
+	})
+
+	// Test case 3: Requirement without default value and no dependency parameter (should fail gracefully)
+	t.Run("Requirement without default value, no dependency", func(t *testing.T) {
+		entries := []registry.Entry{
+			// Target entry
+			{
+				ID:   registry.ID{NS: "app.local", Name: "target_function"},
+				Kind: "function.lua",
+				Data: payload.New(map[string]interface{}{
+					"meta": map[string]interface{}{
+						"host": "old_value",
+					},
+				}),
+			},
+			// Requirement without default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+				}),
+			},
+		}
+
+		resolvedEntries, err := resolver.ResolveModuleDefinitions(entries)
+		require.NoError(t, err, "Should resolve requirements without error")
+		assert.Equal(t, len(entries), len(resolvedEntries), "Should return same number of entries")
+
+		// Verify that the original value was not changed (no injection occurred)
+		targetEntry := resolvedEntries[0]
+		data := targetEntry.Data.Data()
+		if meta, ok := data.(map[string]interface{})["meta"].(map[string]interface{}); ok {
+			assert.Equal(t, "old_value", meta["host"], "Original value should remain unchanged")
+		}
+	})
+
+	// Test case 4: Requirement with default value, dependency has no parameters field
+	t.Run("Requirement with default value, dependency has no parameters field", func(t *testing.T) {
+		entries := []registry.Entry{
+			// Target entry that will receive the default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "target_function"},
+				Kind: "function.lua",
+				Data: payload.New(map[string]interface{}{
+					"meta": map[string]interface{}{
+						"host": "old_value",
+					},
+				}),
+			},
+			// Dependency without parameters field
+			{
+				ID:   registry.ID{NS: "app.local", Name: "host_dependency"},
+				Kind: registry.KindNamespaceDependency,
+				Data: payload.New(map[string]interface{}{
+					"component": "wippy/llm",
+					"version":   ">=v0.0.7",
+					// No parameters field
+				}),
+			},
+			// Requirement with default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "app:processes",
+				}),
+			},
+		}
+
+		resolvedEntries, err := resolver.ResolveModuleDefinitions(entries)
+		require.NoError(t, err, "Should resolve requirements without error")
+		assert.Equal(t, len(entries), len(resolvedEntries), "Should return same number of entries")
+
+		// Verify that the default value was applied
+		targetEntry := resolvedEntries[0]
+		data := targetEntry.Data.Data()
+		if meta, ok := data.(map[string]interface{})["meta"].(map[string]interface{}); ok {
+			assert.Equal(t, "app:processes", meta["host"], "Default value should be applied when parameters field is missing")
+		}
+	})
+
+	// Test case 5: Requirement with default value, dependency has nil parameters field
+	t.Run("Requirement with default value, dependency has nil parameters field", func(t *testing.T) {
+		entries := []registry.Entry{
+			// Target entry that will receive the default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "target_function"},
+				Kind: "function.lua",
+				Data: payload.New(map[string]interface{}{
+					"meta": map[string]interface{}{
+						"host": "old_value",
+					},
+				}),
+			},
+			// Dependency with nil parameters field
+			{
+				ID:   registry.ID{NS: "app.local", Name: "host_dependency"},
+				Kind: registry.KindNamespaceDependency,
+				Data: payload.New(map[string]interface{}{
+					"component":  "wippy/llm",
+					"version":    ">=v0.0.7",
+					"parameters": nil, // nil parameters field
+				}),
+			},
+			// Requirement with default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "app:processes",
+				}),
+			},
+		}
+
+		resolvedEntries, err := resolver.ResolveModuleDefinitions(entries)
+		require.NoError(t, err, "Should resolve requirements without error")
+		assert.Equal(t, len(entries), len(resolvedEntries), "Should return same number of entries")
+
+		// Verify that the default value was applied
+		targetEntry := resolvedEntries[0]
+		data := targetEntry.Data.Data()
+		if meta, ok := data.(map[string]interface{})["meta"].(map[string]interface{}); ok {
+			assert.Equal(t, "app:processes", meta["host"], "Default value should be applied when parameters field is nil")
+		}
+	})
+
+	// Test case 6: Requirement with default value, dependency has malformed parameters field
+	t.Run("Requirement with default value, dependency has malformed parameters field", func(t *testing.T) {
+		entries := []registry.Entry{
+			// Target entry that will receive the default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "target_function"},
+				Kind: "function.lua",
+				Data: payload.New(map[string]interface{}{
+					"meta": map[string]interface{}{
+						"host": "old_value",
+					},
+				}),
+			},
+			// Dependency with malformed parameters field (not an array)
+			{
+				ID:   registry.ID{NS: "app.local", Name: "host_dependency"},
+				Kind: registry.KindNamespaceDependency,
+				Data: payload.New(map[string]interface{}{
+					"component":  "wippy/llm",
+					"version":    ">=v0.0.7",
+					"parameters": "not_an_array", // malformed parameters field
+				}),
+			},
+			// Requirement with default value
+			{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "app:processes",
+				}),
+			},
+		}
+
+		resolvedEntries, err := resolver.ResolveModuleDefinitions(entries)
+		require.NoError(t, err, "Should resolve requirements without error")
+		assert.Equal(t, len(entries), len(resolvedEntries), "Should return same number of entries")
+
+		// Verify that the default value was applied
+		targetEntry := resolvedEntries[0]
+		data := targetEntry.Data.Data()
+		if meta, ok := data.(map[string]interface{})["meta"].(map[string]interface{}); ok {
+			assert.Equal(t, "app:processes", meta["host"], "Default value should be applied when parameters field is malformed")
+		}
+	})
+}
+
+// TestGetRequirementDefaultValue tests the getRequirementDefaultValue function
+func TestGetRequirementDefaultValue(t *testing.T) {
+	testCases := []struct {
+		name          string
+		requirement   registry.Entry
+		expectedValue string
+		expectedFound bool
+		description   string
+	}{
+		{
+			name: "requirement_with_default",
+			requirement: registry.Entry{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "app:processes",
+				}),
+			},
+			expectedValue: "app:processes",
+			expectedFound: true,
+			description:   "Requirement with default value",
+		},
+		{
+			name: "requirement_without_default",
+			requirement: registry.Entry{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+				}),
+			},
+			expectedValue: "",
+			expectedFound: false,
+			description:   "Requirement without default value",
+		},
+		{
+			name: "requirement_with_empty_default",
+			requirement: registry.Entry{
+				ID:   registry.ID{NS: "app.local", Name: "application_host"},
+				Kind: registry.KindNamespaceRequirement,
+				Data: payload.New(map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"entry": "target_function",
+							"path":  ".meta.host",
+						},
+					},
+					"default": "",
+				}),
+			},
+			expectedValue: "",
+			expectedFound: true,
+			description:   "Requirement with empty default value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			value, found := getRequirementDefaultValue(tc.requirement)
+			assert.Equal(t, tc.expectedValue, value, "Default value should match")
+			assert.Equal(t, tc.expectedFound, found, "Found flag should match")
+		})
+	}
+}
+
+// TestValidateParameterMatching tests the validateParameterMatching function
+func TestValidateParameterMatching(t *testing.T) {
+	logger := zap.NewNop()
+	resolver := NewResolver(logger)
+
+	// Test case 1: All parameters have corresponding requirements
+	t.Run("All parameters have requirements", func(t *testing.T) {
+		nsDependencies := map[string]registry.Entry{
+			"dependency1": {
+				ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+				Kind: registry.KindNamespaceDependency,
+				Data: payload.New(map[string]interface{}{
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":  "PARAM1",
+							"value": "value1",
+						},
+						map[string]interface{}{
+							"name":  "PARAM2",
+							"value": "value2",
+						},
+					},
+				}),
+			},
+		}
+
+		nsRequirements := map[string]registry.Entry{
+			"requirement1": {
+				ID:   registry.ID{NS: "app.local", Name: "PARAM1"},
+				Kind: registry.KindNamespaceRequirement,
+			},
+			"requirement2": {
+				ID:   registry.ID{NS: "app.local", Name: "PARAM2"},
+				Kind: registry.KindNamespaceRequirement,
+			},
+		}
+
+		// This should not panic or error
+		resolver.validateParameterMatching(nsDependencies, nsRequirements)
+	})
+
+	// Test case 2: Some parameters don't have corresponding requirements
+	t.Run("Some parameters missing requirements", func(t *testing.T) {
+		nsDependencies := map[string]registry.Entry{
+			"dependency1": {
+				ID:   registry.ID{NS: "app.local", Name: "dependency1"},
+				Kind: registry.KindNamespaceDependency,
+				Data: payload.New(map[string]interface{}{
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":  "PARAM1",
+							"value": "value1",
+						},
+						map[string]interface{}{
+							"name":  "PARAM2",
+							"value": "value2",
+						},
+						map[string]interface{}{
+							"name":  "PARAM3",
+							"value": "value3",
+						},
+					},
+				}),
+			},
+		}
+
+		nsRequirements := map[string]registry.Entry{
+			"requirement1": {
+				ID:   registry.ID{NS: "app.local", Name: "PARAM1"},
+				Kind: registry.KindNamespaceRequirement,
+			},
+			// PARAM2 and PARAM3 are missing requirements
+		}
+
+		// This should not panic or error, but should log warnings
+		resolver.validateParameterMatching(nsDependencies, nsRequirements)
+	})
 }

--- a/requirementresolver/resolver_test.go
+++ b/requirementresolver/resolver_test.go
@@ -859,8 +859,11 @@ func TestValidateParameterMatching(t *testing.T) {
 			},
 		}
 
-		// This should not panic or error
-		resolver.validateParameterMatching(nsDependencies, nsRequirements)
+		// This should not return an error
+		err := resolver.validateParameterMatching(nsDependencies, nsRequirements)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
 	})
 
 	// Test case 2: Some parameters don't have corresponding requirements
@@ -896,7 +899,16 @@ func TestValidateParameterMatching(t *testing.T) {
 			// PARAM2 and PARAM3 are missing requirements
 		}
 
-		// This should not panic or error, but should log warnings
-		resolver.validateParameterMatching(nsDependencies, nsRequirements)
+		// This should return an error with missing parameter names
+		err := resolver.validateParameterMatching(nsDependencies, nsRequirements)
+		if err == nil {
+			t.Error("Expected error for missing requirements, got nil")
+		}
+
+		// Check that the error contains the missing parameter names
+		errorMsg := err.Error()
+		if !strings.Contains(errorMsg, "PARAM2") || !strings.Contains(errorMsg, "PARAM3") {
+			t.Errorf("Expected error to contain missing parameter names, got: %s", errorMsg)
+		}
 	})
 }

--- a/tests/replacements/hello/module_example.yaml
+++ b/tests/replacements/hello/module_example.yaml
@@ -8,6 +8,7 @@ entries:
       description: "Target namespace for module dependency"
     targets:
       - path: ".meta.depends_on +="
+    default: "ns:system"
 
   - name: API_ROUTER
     kind: ns.requirement


### PR DESCRIPTION
## 🚀 Feature: Module Requirements with Default Values (EE2-1877)

### Overview
Adds default value support for module requirements, making the `parameters` section in `ns.dependency` entries **optional** when modules provide sensible defaults.

### Key Changes
- **Default Value Support**: Module requirements can declare `default` values
- **Optional Parameters**: `parameters` section becomes optional when defaults exist
- **Graceful Fallback**: Handles missing/malformed parameters by falling back to defaults
- **Enhanced Validation**: Parameter-requirement matching with warning logs

### Implementation
- Added `resolveParameterValue()` method with dependency → default fallback logic
- Added `getRequirementDefaultValue()` and `validateParameterMatching()` helpers
- Enhanced `ResolveModuleDefinitions()` with default value support
- Comprehensive test suite (566+ new test lines)

### Usage Example
```yaml
# Module with default
- name: application_host
  kind: ns.requirement
  default: "app:processes"  # Makes parameters optional

# Application (simplified)
- name: __dependency.wippy.llm
  kind: "ns.dependency"
  component: "wippy/llm"
  # No parameters section needed!
```

### Benefits
- **Simplified Configuration**: Less boilerplate when using modules
- **Flexible Override**: Still can override defaults when needed
- **Backward Compatible**: Existing apps work unchanged
- **Better DX**: More intuitive module usage
