### PR TITLE
feat(wippy): EE2-1878 fix wippy update command to load packages from src directory and restore verbose logging

### DIFF
--- a/cmd/runner/cli.go
+++ b/cmd/runner/cli.go
@@ -114,12 +114,14 @@ func (cr *CLIRunner) showHelp() error {
 	fmt.Println()
 	fmt.Println("Options:")
 	fmt.Println("  --lock-file <path>  - Path to lock file (default: wippy.lock)")
+	fmt.Println("  -v, --verbose       - Enable verbose debug logging")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  wippy init --lock-file=\"./wippy.lock\" --src-dir=\".\" --modules-dir=\".wippy\" --")
 	fmt.Println("  wippy install --lock-file=\"./wippy.lock\" --")
 	fmt.Println("  wippy update --lock-file=\"./wippy.lock\" --")
 	fmt.Println("  wippy run --lock-file=\"./wippy.lock\" --")
+	fmt.Println("  wippy update -v --lock-file=\"./wippy.lock\" --")
 	fmt.Println()
 	fmt.Println("Use 'wippy <command> --help' for command-specific help")
 	return nil
@@ -134,13 +136,27 @@ func (ic *InitCommand) Execute(_ context.Context, flags []string, _ []string) er
 	// Parse init-specific flags
 	flagSet := flag.NewFlagSet("init", flag.ExitOnError)
 	var srcDir, modulesDir, lockFilePath string
+	var verbose bool
 	flagSet.StringVar(&srcDir, "src-dir", ".", "source directory path")
 	flagSet.StringVar(&modulesDir, "modules-dir", ".wippy", "modules directory path")
 	flagSet.StringVar(&lockFilePath, "lock-file", "wippy.lock", "path to lock file")
+	flagSet.BoolVar(&verbose, "v", false, "enable verbose debug logging")
+	flagSet.BoolVar(&verbose, "verbose", false, "enable verbose debug logging")
 
 	// Parse flags (before --)
 	if err := flagSet.Parse(flags); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	// Update logger if verbose flag is set
+	if verbose {
+		ic.runner.config.Verbose = true
+		// Reinitialize logger with verbose settings
+		logger, err := initMainLogger(true, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize verbose logger: %w", err)
+		}
+		ic.runner.logger = logger
 	}
 
 	// Update config with parsed lock file
@@ -198,9 +214,23 @@ func (ic *InstallCommand) Execute(ctx context.Context, flags []string, args []st
 	// Parse common flags
 	flagSet := flag.NewFlagSet("install", flag.ExitOnError)
 	var lockFilePath string
+	var verbose bool
 	flagSet.StringVar(&lockFilePath, "lock-file", "wippy.lock", "path to lock file")
+	flagSet.BoolVar(&verbose, "v", false, "enable verbose debug logging")
+	flagSet.BoolVar(&verbose, "verbose", false, "enable verbose debug logging")
 	if err := flagSet.Parse(flags); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	// Update logger if verbose flag is set
+	if verbose {
+		ic.runner.config.Verbose = true
+		// Reinitialize logger with verbose settings
+		logger, err := initMainLogger(true, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize verbose logger: %w", err)
+		}
+		ic.runner.logger = logger
 	}
 
 	// Update config with parsed lock file
@@ -305,9 +335,23 @@ func (ic *UpdateCommand) Execute(ctx context.Context, flags []string, args []str
 	// Parse common flags
 	flagSet := flag.NewFlagSet("update", flag.ExitOnError)
 	var lockFilePath string
+	var verbose bool
 	flagSet.StringVar(&lockFilePath, "lock-file", "wippy.lock", "path to lock file")
+	flagSet.BoolVar(&verbose, "v", false, "enable verbose debug logging")
+	flagSet.BoolVar(&verbose, "verbose", false, "enable verbose debug logging")
 	if err := flagSet.Parse(flags); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	// Update logger if verbose flag is set
+	if verbose {
+		ic.runner.config.Verbose = true
+		// Reinitialize logger with verbose settings
+		logger, err := initMainLogger(true, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize verbose logger: %w", err)
+		}
+		ic.runner.logger = logger
 	}
 
 	// Update config with parsed lock file
@@ -359,9 +403,23 @@ func (ic *RunCommand) Execute(_ context.Context, flags []string, args []string) 
 	// Parse common flags
 	flagSet := flag.NewFlagSet("run", flag.ExitOnError)
 	var lockFilePath string
+	var verbose bool
 	flagSet.StringVar(&lockFilePath, "lock-file", "wippy.lock", "path to lock file")
+	flagSet.BoolVar(&verbose, "v", false, "enable verbose debug logging")
+	flagSet.BoolVar(&verbose, "verbose", false, "enable verbose debug logging")
 	if err := flagSet.Parse(flags); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	// Update logger if verbose flag is set
+	if verbose {
+		ic.runner.config.Verbose = true
+		// Reinitialize logger with verbose settings
+		logger, err := initMainLogger(true, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize verbose logger: %w", err)
+		}
+		ic.runner.logger = logger
 	}
 
 	// Update config with parsed lock file

--- a/cmd/runner/cli_test.go
+++ b/cmd/runner/cli_test.go
@@ -172,3 +172,189 @@ func TestInitCommandWithCustomPaths(t *testing.T) {
 		}
 	})
 }
+
+func TestVerboseFlag(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "wippy-test-verbose")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to the temporary directory for testing
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("Failed to restore original directory: %v", err)
+		}
+	}()
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Create test config
+	config := &Config{
+		FolderPath: tempDir,
+		LockFile:   "wippy.lock",
+	}
+
+	// Create logger
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+
+	// Create CLI runner
+	runner := NewCLIRunner(config, logger)
+
+	// Test verbose flag for init command
+	t.Run("InitCommandVerbose", func(t *testing.T) {
+		initCmd := &InitCommand{runner: runner}
+
+		// Test with verbose flag
+		flags := []string{"-v"}
+		err := initCmd.Execute(context.Background(), flags, []string{})
+		if err != nil {
+			t.Fatalf("Init command with verbose flag failed: %v", err)
+		}
+
+		// Verify that verbose mode was enabled
+		if !runner.config.Verbose {
+			t.Error("Expected verbose mode to be enabled")
+		}
+	})
+
+	// Test verbose flag for install command
+	t.Run("InstallCommandVerbose", func(t *testing.T) {
+		installCmd := &InstallCommand{runner: runner}
+
+		// Test with verbose flag
+		flags := []string{"-v"}
+		err := installCmd.Execute(context.Background(), flags, []string{})
+		if err != nil {
+			t.Fatalf("Install command with verbose flag failed: %v", err)
+		}
+
+		// Verify that verbose mode was enabled
+		if !runner.config.Verbose {
+			t.Error("Expected verbose mode to be enabled")
+		}
+	})
+
+	// Test verbose flag for update command
+	t.Run("UpdateCommandVerbose", func(t *testing.T) {
+		updateCmd := &UpdateCommand{runner: runner}
+
+		// Test with verbose flag
+		flags := []string{"-v"}
+		err := updateCmd.Execute(context.Background(), flags, []string{})
+		if err != nil {
+			t.Fatalf("Update command with verbose flag failed: %v", err)
+		}
+
+		// Verify that verbose mode was enabled
+		if !runner.config.Verbose {
+			t.Error("Expected verbose mode to be enabled")
+		}
+	})
+
+	// Test verbose flag for run command
+	t.Run("RunCommandVerbose", func(t *testing.T) {
+		runCmd := &RunCommand{runner: runner}
+
+		// Test with verbose flag
+		flags := []string{"-v"}
+		err := runCmd.Execute(context.Background(), flags, []string{})
+		if err != nil {
+			t.Fatalf("Run command with verbose flag failed: %v", err)
+		}
+
+		// Verify that verbose mode was enabled
+		if !runner.config.Verbose {
+			t.Error("Expected verbose mode to be enabled")
+		}
+	})
+}
+
+func TestUpdateCommandWithSrcDirectory(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "wippy-test-src")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to the temporary directory for testing
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Errorf("Failed to restore original directory: %v", err)
+		}
+	}()
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Create test config
+	config := &Config{
+		FolderPath: tempDir,
+		LockFile:   "wippy.lock",
+	}
+
+	// Create logger
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+
+	// Create CLI runner
+	runner := NewCLIRunner(config, logger)
+
+	// First create a lock file with src directory
+	t.Run("CreateLockFileWithSrcDir", func(t *testing.T) {
+		initCmd := &InitCommand{runner: runner}
+
+		// Create lock file with custom src directory
+		flags := []string{"--src-dir", "app", "--modules-dir", ".wippy"}
+		err := initCmd.Execute(context.Background(), flags, []string{})
+		if err != nil {
+			t.Fatalf("Init command failed: %v", err)
+		}
+
+		// Verify lock file was created with correct src directory
+		lockPath := filepath.Join(tempDir, "wippy.lock")
+		lockFile, err := moduleloader.LoadLockFile(lockPath)
+		if err != nil {
+			t.Fatalf("Failed to load lock file: %v", err)
+		}
+
+		if lockFile.Directories.Src != "app" {
+			t.Errorf("Expected src dir to be 'app', got '%s'", lockFile.Directories.Src)
+		}
+	})
+
+	// Test update command with existing lock file
+	t.Run("UpdateCommandWithExistingLockFile", func(t *testing.T) {
+		updateCmd := &UpdateCommand{runner: runner}
+
+		// Test update command - it should use src directory from lock file
+		flags := []string{"-v"}
+		err := updateCmd.Execute(context.Background(), flags, []string{})
+		if err != nil {
+			t.Fatalf("Update command failed: %v", err)
+		}
+
+		// Verify that verbose mode was enabled
+		if !runner.config.Verbose {
+			t.Error("Expected verbose mode to be enabled")
+		}
+	})
+}

--- a/cmd/runner/deps.go
+++ b/cmd/runner/deps.go
@@ -69,20 +69,37 @@ func (dm *DependencyManager) InstallDependencies(ctx context.Context) error {
 func (dm *DependencyManager) UpdateDependencies(ctx context.Context) error {
 	dm.logger.Info("Updating dependencies")
 
-	// Load entries from the application directory
-	entries, err := dm.loadRegistryEntries(ctx)
+	// First, try to load existing lock file to get src directory
+	var srcDir string
+	existingLockPath := filepath.Join(dm.config.FolderPath, dm.config.LockFile)
+	if existingLock, err := moduleloader.LoadLockFile(existingLockPath); err == nil {
+		srcDir = existingLock.Directories.Src
+		dm.logger.Debug("Using src directory from lock file", zap.String("src_dir", srcDir))
+	} else {
+		// Use default src directory if no existing lock file
+		srcDir = "."
+		dm.logger.Debug("Using default src directory", zap.String("src_dir", srcDir))
+	}
+
+	// Load entries from the src directory (not root directory)
+	entries, err := dm.loadRegistryEntries(ctx, srcDir)
 	if err != nil {
 		return fmt.Errorf("load registry entries: %w", err)
 	}
 
 	// Create module loader manager with loaded entries
+	dm.logger.Debug("Creating module loader manager with entries", zap.Int("entries_count", len(entries)))
 	registryLoader := dm.createModuleLoaderManagerWithEntries(entries)
 
 	// Load dependencies with latest versions
+	dm.logger.Debug("Loading dependencies with registry loader")
 	loadResult, err := registryLoader.Load(ctx)
 	if err != nil {
 		return fmt.Errorf("load dependencies: %w", err)
 	}
+
+	dm.logger.Debug("Registry loader completed",
+		zap.Int("modules_count", len(loadResult.Modules)))
 
 	// Display package operations
 	dm.displayPackageOperations(loadResult, "update")
@@ -105,20 +122,17 @@ func (dm *DependencyManager) UpdateDependencies(ctx context.Context) error {
 			zap.String("path", module.Path))
 	}
 
-	// Try to load existing lock file to get directory structure and preserve replacements
-	var modulesDir, srcDir string
+	// Get directory structure and preserve replacements from existing lock file
+	var modulesDir string
 	var existingReplacements []moduleloader.Replacement
-	existingLockPath := filepath.Join(dm.config.FolderPath, dm.config.LockFile)
 	if existingLock, err := moduleloader.LoadLockFile(existingLockPath); err == nil {
 		modulesDir = existingLock.Directories.Modules
-		srcDir = existingLock.Directories.Src
 		existingReplacements = existingLock.Replacements
 		dm.logger.Debug("Preserving existing replacements",
 			zap.Int("count", len(existingReplacements)))
 	} else {
-		// Use default directories if no existing lock file
+		// Use default modules directory if no existing lock file
 		modulesDir = ".wippy"
-		srcDir = "."
 	}
 
 	lockFile := moduleloader.ConvertToLockFile(loadResult, modulesDir, srcDir)
@@ -153,8 +167,8 @@ func (dm *DependencyManager) UpdateDependencies(ctx context.Context) error {
 	return nil
 }
 
-// loadRegistryEntries loads registry entries from the application directory
-func (dm *DependencyManager) loadRegistryEntries(ctx context.Context) ([]regapi.Entry, error) {
+// loadRegistryEntries loads registry entries from the specified directory
+func (dm *DependencyManager) loadRegistryEntries(ctx context.Context, srcDir string) ([]regapi.Entry, error) {
 	// For testing purposes, create mock entries if no real entries are loaded
 	dtt := transcoder.GlobalTranscoder()
 	json.Register(dtt)
@@ -165,18 +179,32 @@ func (dm *DependencyManager) loadRegistryEntries(ctx context.Context) ([]regapi.
 		interpolate.WithInterpolator(interpolate.LoadFile),
 	))
 
-	// Create filesystem from the application directory
-	fsys := os.DirFS(dm.config.FolderPath)
+	// Resolve the full path to the src directory
+	srcPath := filepath.Join(dm.config.FolderPath, srcDir)
+
+	// Create filesystem from the src directory
+	fsys := os.DirFS(srcPath)
 
 	// Load entries from the filesystem
 	entries, err := folderLoader.LoadFS(ctx, fsys)
 	if err != nil {
-		return nil, fmt.Errorf("load entries from directory: %w", err)
+		return nil, fmt.Errorf("load entries from directory %s: %w", srcPath, err)
 	}
 
 	dm.logger.Debug("Loaded entries from directory",
-		zap.String("directory", dm.config.FolderPath),
+		zap.String("directory", srcPath),
+		zap.String("src_dir", srcDir),
 		zap.Int("count", len(entries)))
+
+	// Log some sample entries for debugging
+	for i, entry := range entries {
+		if i < 5 { // Log first 5 entries
+			dm.logger.Debug("Sample entry",
+				zap.Int("index", i),
+				zap.String("id", entry.ID.String()),
+				zap.String("kind", entry.Kind))
+		}
+	}
 
 	return entries, nil
 }
@@ -188,6 +216,10 @@ func (dm *DependencyManager) createModuleLoaderManagerWithEntries(entries []rega
 		baseURL = modulesURL
 	}
 
+	dm.logger.Debug("Creating registry loader with entries",
+		zap.String("base_url", baseURL),
+		zap.Int("entries_count", len(entries)))
+
 	client := &http.Client{}
 	organizationClient := identityv1connect.NewOrganizationServiceClient(client, baseURL)
 	moduleClient := modulev1connect.NewModuleServiceClient(client, baseURL)
@@ -196,6 +228,8 @@ func (dm *DependencyManager) createModuleLoaderManagerWithEntries(entries []rega
 	downloadClient := modulev1connect.NewDownloadServiceClient(client, baseURL)
 
 	registryLoader := moduleloader.NewEntryLoader(entries, dm.logger)
+
+	dm.logger.Debug("Created entry loader, creating manager")
 
 	return moduleloader.NewManager(
 		organizationClient,

--- a/moduleloader/registry_loader.go
+++ b/moduleloader/registry_loader.go
@@ -31,6 +31,11 @@ func (r *EntryLoader) LoadManifest(_ context.Context) (*Manifest, error) {
 		}
 	}
 
+	r.logger.Debug("Found dependency entries",
+		zap.Int("total_entries", len(r.entries)),
+		zap.Int("dependency_entries", len(entries)),
+		zap.String("dependency_kind", regapi.KindNamespaceDependency))
+
 	// Convert registry entries to ManifestDependency format
 	dependencies := make([]ManifestDependency, 0, len(entries))
 

--- a/wippy.lock
+++ b/wippy.lock
@@ -6,14 +6,14 @@ modules:
   version: v1.0.10
   hash: 0198604c-3e58-7f01-904e-395a037a4e1a
 - name: wippy/llm
-  version: v0.0.12
-  hash: 0198804f-dfb2-7197-b156-98315cb39ed5
+  version: v0.2.3
+  hash: 01991a0d-cf24-70fc-ae81-4b4bfacaa577
 - name: wippy/security
   version: v0.0.7
   hash: 01978c92-7d02-7b4a-95df-55b57cfe80b7
 - name: wippy/test
-  version: v0.0.8
-  hash: 0197e530-927f-75f5-995c-b6f5e0dd32f9
+  version: v0.2.0
+  hash: 01991006-a0de-77c0-a0db-8de881e5f0a4
 replacements:
 - from: igor-test-3/test-2
   to: ./tests/replacements/hello/


### PR DESCRIPTION
# Fix wippy update command to load packages from src directory and restore verbose logging

## Issues
- `wippy update` was loading packages from root directory instead of `src` directory from lock file
- `-v` flag was not working in new CLI commands

## Solution
- Fixed package loading logic to use `src` directory from lock file
- Restored verbose logging support (`-v`/`--verbose`) across all CLI commands
- Added comprehensive debug logging and tests
