### PR TITLE
feat(wippy): EE2-1885 implement meta.parent assignment for ns.require…

### DIFF
--- a/cmd/runner/app/app.go
+++ b/cmd/runner/app/app.go
@@ -60,7 +60,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/go-sql-driver/mysql" // MySQL driver for database connections
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -88,9 +88,9 @@ type appConfig struct {
 	clusterAdvertise  string
 }
 
-type AppOption func(*appConfig)
+type Option func(*appConfig)
 
-func WithCluster(enabled bool, name, bind string, port int, join, secret, secretFile, advertise string) AppOption {
+func WithCluster(enabled bool, name, bind string, port int, join, secret, secretFile, advertise string) Option {
 	return func(c *appConfig) {
 		c.clusterEnabled = enabled
 		c.clusterName = name
@@ -103,7 +103,7 @@ func WithCluster(enabled bool, name, bind string, port int, join, secret, secret
 	}
 }
 
-func WithPaths(folderPath, lockFilePath, modulesDirPath, lockFileDir string, useEmbed bool) AppOption {
+func WithPaths(folderPath, lockFilePath, modulesDirPath, lockFileDir string, useEmbed bool) Option {
 	return func(c *appConfig) {
 		c.folderPath = folderPath
 		c.lockFilePath = lockFilePath
@@ -113,7 +113,7 @@ func WithPaths(folderPath, lockFilePath, modulesDirPath, lockFileDir string, use
 	}
 }
 
-func WithLogging(consoleLogging, eventStreaming bool, minLevel zapcore.Level) AppOption {
+func WithLogging(consoleLogging, eventStreaming bool, minLevel zapcore.Level) Option {
 	return func(c *appConfig) {
 		c.consoleLogging = consoleLogging
 		c.eventStreaming = eventStreaming
@@ -121,7 +121,7 @@ func WithLogging(consoleLogging, eventStreaming bool, minLevel zapcore.Level) Ap
 	}
 }
 
-func WithProfiling(enabled bool) AppOption {
+func WithProfiling(enabled bool) Option {
 	return func(c *appConfig) {
 		c.enableProfiling = enabled
 	}
@@ -168,7 +168,7 @@ type App struct {
 	otelCleanup   func()
 }
 
-func NewApp(logger *zap.Logger, opts ...AppOption) (*App, error) {
+func NewApp(logger *zap.Logger, opts ...Option) (*App, error) {
 	if os.Getenv("GOMEMLIMIT") == "" {
 		debug.SetMemoryLimit(1 * 1024 * 1024 * 1024)
 	}
@@ -605,7 +605,15 @@ func (a *App) loadApplicationState(ctx context.Context, appFS iofs.FS) (regapi.C
 			return nil, nil, fmt.Errorf("create project root filesystem: %w", err)
 		}
 
-		dependencyEntries, err := loadEntriesFromLoadedModules(ctx, folderLoader, loadResult, projectRootFS, a.logger)
+		// Create mapping from module names to their parent dependency entry IDs
+		parentDependencyMap := deps.CreateParentDependencyMap(entries, loadResult, a.logger)
+
+		// Validate that there are no conflicts in parent dependency assignments
+		if err := deps.ValidateParentDependencyConflicts(parentDependencyMap, a.logger); err != nil {
+			return nil, nil, fmt.Errorf("parent dependency conflicts detected: %w", err)
+		}
+
+		dependencyEntries, err := loadEntriesFromLoadedModules(ctx, folderLoader, loadResult, projectRootFS, a.logger, parentDependencyMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("load dependencies: %w", err)
 		}
@@ -733,7 +741,14 @@ func (a *App) StartProfiler() {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
-		if err := httpbase.ListenAndServe(profilerAddr, mux); err != nil {
+		server := &httpbase.Server{
+			Addr:         profilerAddr,
+			Handler:      mux,
+			ReadTimeout:  15 * time.Second,
+			WriteTimeout: 15 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		}
+		if err := server.ListenAndServe(); err != nil {
 			if !errors.Is(err, httpbase.ErrServerClosed) {
 				a.logger.Error("pprof server failed", zap.Error(err))
 			}
@@ -816,6 +831,7 @@ func loadEntriesFromLoadedModules(
 	loadResult *deps.LoadResult,
 	rootFS iofs.FS,
 	mainLogger *zap.Logger,
+	parentDependencyMap map[string][]deps.ParentDependencyInfo, // Maps module name (vendor/name) to parent dependency entries with parameters
 ) ([]regapi.Entry, error) {
 	if loadResult == nil || len(loadResult.Modules) == 0 {
 		return nil, nil
@@ -837,6 +853,27 @@ func loadEntriesFromLoadedModules(
 		moduleEntries, err := folderLoader.LoadFS(ctx, moduleFS)
 		if err != nil {
 			return nil, fmt.Errorf("load entries from module %s: %w", module.Path, err)
+		}
+
+		// Set meta.parent for ns.requirement entries
+		moduleName := module.Name.String() // Format: "vendor/name"
+		if parentDependencies, exists := parentDependencyMap[moduleName]; exists {
+			for i := range moduleEntries {
+				if moduleEntries[i].Kind == regapi.KindNamespaceRequirement {
+					// Find the best parent dependency based on parameter matching
+					bestParentID := deps.SelectBestParentDependency(moduleEntries[i], parentDependencies, mainLogger)
+					if bestParentID != "" {
+						if moduleEntries[i].Meta == nil {
+							moduleEntries[i].Meta = make(regapi.Metadata)
+						}
+						moduleEntries[i].Meta["parent"] = bestParentID
+						mainLogger.Debug("set meta.parent for ns.requirement",
+							zap.String("requirement_id", moduleEntries[i].ID.String()),
+							zap.String("parent_dependency_id", bestParentID),
+							zap.String("module_name", moduleName))
+					}
+				}
+			}
 		}
 
 		allEntries = append(allEntries, moduleEntries...)

--- a/cmd/runner/cmd/init.go
+++ b/cmd/runner/cmd/init.go
@@ -13,7 +13,7 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new lock file",
 	Long:  "Initialize a new lock file with the specified directory structure.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger, err := createLogger()
 		if err != nil {
 			return fmt.Errorf("failed to create logger: %w", err)

--- a/cmd/runner/cmd/replace.go
+++ b/cmd/runner/cmd/replace.go
@@ -140,7 +140,7 @@ var replaceRemoveCmd = &cobra.Command{
 var replaceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all replacements",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		lockFile, _ := cmd.Flags().GetString("lock-file")
 		folderPath := "."
 

--- a/cmd/runner/cmd/run.go
+++ b/cmd/runner/cmd/run.go
@@ -19,7 +19,7 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run the application",
 	Long:  "Run the smart application runtime using paths from the lock file.",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger, err := createLogger()
 		if err != nil {
 			return fmt.Errorf("failed to create logger: %w", err)

--- a/cmd/runner/cmd/update.go
+++ b/cmd/runner/cmd/update.go
@@ -23,7 +23,7 @@ var updateCmd = &cobra.Command{
 	},
 }
 
-func runUpdate(cmd *cobra.Command, args []string, logger *zap.Logger) error {
+func runUpdate(cmd *cobra.Command, _ []string, logger *zap.Logger) error {
 	lockFile, _ := cmd.Flags().GetString("lock-file")
 	folderPath := "."
 

--- a/deps/manifest.go
+++ b/deps/manifest.go
@@ -61,6 +61,8 @@ type LoadedModule struct {
 	Path         string `json:"path"`
 	Organization string `json:"organization"`
 	Module       string `json:"module"`
+	// ParentDependencyID is the ID of the ns.dependency entry that caused this module to be loaded
+	ParentDependencyID string `json:"parent_dependency_id,omitempty"`
 }
 
 // LoadResult represents the result of loading modules from the registry.

--- a/deps/parent_manager.go
+++ b/deps/parent_manager.go
@@ -1,0 +1,198 @@
+package deps
+
+import (
+	"fmt"
+
+	"github.com/ponyruntime/pony/api/registry"
+	"go.uber.org/zap"
+)
+
+// ParentDependencyInfo contains information about a parent dependency
+type ParentDependencyInfo struct {
+	EntryID    string
+	Parameters map[string]string // parameter name -> parameter value
+}
+
+// CreateParentDependencyMap creates a map of module names to their parent dependency information
+func CreateParentDependencyMap(entries []registry.Entry, loadResult *LoadResult, logger *zap.Logger) map[string][]ParentDependencyInfo {
+	parentMap := make(map[string][]ParentDependencyInfo)
+
+	if loadResult == nil {
+		return parentMap
+	}
+
+	// Create a set of loaded module names for quick lookup
+	loadedModuleNames := make(map[string]bool)
+	for _, module := range loadResult.Modules {
+		loadedModuleNames[module.Name.String()] = true
+	}
+
+	// Find ns.dependency entries that match loaded modules
+	for _, entry := range entries {
+		if entry.Kind != registry.KindNamespaceDependency {
+			continue
+		}
+
+		componentStr, err := extractComponentFromDependency(entry)
+		if err != nil {
+			logger.Debug("failed to extract component from dependency",
+				zap.String("entry_id", entry.ID.String()),
+				zap.Error(err))
+			continue
+		}
+
+		// Check if this component matches any loaded module
+		if !loadedModuleNames[componentStr] {
+			continue
+		}
+
+		// Extract parameters from the dependency entry
+		parameters := extractParametersFromDependency(entry)
+
+		parentInfo := ParentDependencyInfo{
+			EntryID:    entry.ID.String(),
+			Parameters: parameters,
+		}
+
+		parentMap[componentStr] = append(parentMap[componentStr], parentInfo)
+		logger.Debug("mapped module to parent dependency",
+			zap.String("module_name", componentStr),
+			zap.String("parent_dependency_id", entry.ID.String()),
+			zap.Any("parameters", parameters))
+	}
+
+	return parentMap
+}
+
+// extractComponentFromDependency extracts component from a ns.dependency entry
+func extractComponentFromDependency(entry registry.Entry) (string, error) {
+	if entry.Data == nil {
+		return "", fmt.Errorf("entry data is nil")
+	}
+
+	data := entry.Data.Data()
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("entry data is not a map")
+	}
+
+	component, exists := dataMap["component"]
+	if !exists {
+		return "", fmt.Errorf("component field not found")
+	}
+
+	componentStr, ok := component.(string)
+	if !ok {
+		return "", fmt.Errorf("component is not a string")
+	}
+
+	return componentStr, nil
+}
+
+// extractParametersFromDependency extracts parameters from a ns.dependency entry
+func extractParametersFromDependency(entry registry.Entry) map[string]string {
+	parameters := make(map[string]string)
+
+	if entry.Data == nil {
+		return parameters
+	}
+
+	data := entry.Data.Data()
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return parameters
+	}
+
+	paramsRaw, exists := dataMap["parameters"]
+	if !exists {
+		return parameters
+	}
+
+	paramsArray, ok := paramsRaw.([]interface{})
+	if !ok {
+		return parameters
+	}
+
+	for _, paramRaw := range paramsArray {
+		paramMap, ok := paramRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		paramName, ok := paramMap["name"].(string)
+		if !ok {
+			continue
+		}
+
+		paramValue, ok := paramMap["value"].(string)
+		if !ok {
+			continue
+		}
+
+		parameters[paramName] = paramValue
+	}
+
+	return parameters
+}
+
+// SelectBestParentDependency selects the best parent dependency for a requirement based on parameter matching
+func SelectBestParentDependency(requirement registry.Entry, parentDependencies []ParentDependencyInfo, logger *zap.Logger) string {
+	if len(parentDependencies) == 0 {
+		return ""
+	}
+	if len(parentDependencies) == 1 {
+		return parentDependencies[0].EntryID
+	}
+
+	requirementName := requirement.ID.Name
+	for _, parentDep := range parentDependencies {
+		if _, hasParameter := parentDep.Parameters[requirementName]; hasParameter {
+			logger.Debug("selected parent dependency based on parameter match",
+				zap.String("requirement_name", requirementName),
+				zap.String("parent_dependency_id", parentDep.EntryID),
+				zap.String("parameter_value", parentDep.Parameters[requirementName]))
+			return parentDep.EntryID
+		}
+	}
+
+	// Fallback to first available parent dependency
+	if len(parentDependencies) > 0 {
+		logger.Debug("no parameter match found, using first available parent dependency",
+			zap.String("requirement_name", requirementName),
+			zap.String("selected_parent_dependency_id", parentDependencies[0].EntryID))
+		return parentDependencies[0].EntryID
+	}
+
+	return ""
+}
+
+// ValidateParentDependencyConflicts validates that there are no conflicts in parent dependency assignments
+func ValidateParentDependencyConflicts(parentDependencyMap map[string][]ParentDependencyInfo, logger *zap.Logger) error {
+	for moduleName, parentDeps := range parentDependencyMap {
+		if len(parentDeps) <= 1 {
+			continue
+		}
+
+		// Check for conflicts: multiple parent dependencies defining the same parameter
+		parameterToParents := make(map[string][]string)
+		for _, parentDep := range parentDeps {
+			for paramName := range parentDep.Parameters {
+				parameterToParents[paramName] = append(parameterToParents[paramName], parentDep.EntryID)
+			}
+		}
+
+		// Report conflicts
+		for paramName, parentIDs := range parameterToParents {
+			if len(parentIDs) > 1 {
+				logger.Error("conflict detected: multiple parent dependencies define the same parameter",
+					zap.String("module_name", moduleName),
+					zap.String("parameter_name", paramName),
+					zap.Strings("conflicting_parent_ids", parentIDs))
+				return fmt.Errorf("conflict: multiple parent dependencies for module %s define parameter %s: %v",
+					moduleName, paramName, parentIDs)
+			}
+		}
+	}
+
+	return nil
+}

--- a/deps/parent_manager_test.go
+++ b/deps/parent_manager_test.go
@@ -1,0 +1,633 @@
+package deps
+
+import (
+	"testing"
+
+	"github.com/ponyruntime/pony/api/payload"
+	"github.com/ponyruntime/pony/api/registry"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// TestPayload is a test implementation of registry.Payload
+type TestPayload struct {
+	data interface{}
+}
+
+func (p *TestPayload) Data() interface{} {
+	return p.data
+}
+
+func (p *TestPayload) Format() payload.Format {
+	return payload.Golang
+}
+
+func TestCreateParentDependencyMap(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("empty entries and load result", func(t *testing.T) {
+		entries := []registry.Entry{}
+		loadResult := &LoadResult{Modules: []LoadedModule{}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Empty(t, parentMap)
+	})
+
+	t.Run("nil load result", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_dependency"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "igor-test-3/test-2",
+				}},
+			},
+		}
+
+		parentMap := CreateParentDependencyMap(entries, nil, logger)
+		assert.Empty(t, parentMap)
+	})
+
+	t.Run("no matching dependency entries", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_dependency"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "igor-test-3/test-2",
+				}},
+			},
+		}
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "igor-test-3", Module: "test-1"}},
+		}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Empty(t, parentMap)
+	})
+
+	t.Run("matching dependency entries with parameters", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_dependency"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "igor-test-3/test-2",
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":  "API_ROUTER",
+							"value": "http://localhost:8080",
+						},
+					},
+				}},
+			},
+		}
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "igor-test-3", Module: "test-2"}},
+		}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Len(t, parentMap, 1)
+		assert.Contains(t, parentMap, "igor-test-3/test-2")
+		assert.Len(t, parentMap["igor-test-3/test-2"], 1)
+		assert.Equal(t, "app:test_dependency", parentMap["igor-test-3/test-2"][0].EntryID)
+		assert.Equal(t, map[string]string{"API_ROUTER": "http://localhost:8080"}, parentMap["igor-test-3/test-2"][0].Parameters)
+	})
+
+	t.Run("multiple dependencies for same module", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_dependency1"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "igor-test-3/test-2",
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":  "API_ROUTER",
+							"value": "http://localhost:8080",
+						},
+					},
+				}},
+			},
+			{
+				ID:   registry.ParseID("app:test_dependency2"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "igor-test-3/test-2",
+					"parameters": []interface{}{
+						map[string]interface{}{
+							"name":  "NAMESPACE",
+							"value": "test-namespace",
+						},
+					},
+				}},
+			},
+		}
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "igor-test-3", Module: "test-2"}},
+		}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Len(t, parentMap, 1)
+		assert.Contains(t, parentMap, "igor-test-3/test-2")
+		assert.Len(t, parentMap["igor-test-3/test-2"], 2)
+	})
+
+	t.Run("non-dependency entries are ignored", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_requirement"),
+				Kind: registry.KindNamespaceRequirement,
+				Data: &TestPayload{data: map[string]interface{}{
+					"name": "API_ROUTER",
+				}},
+			},
+		}
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "igor-test-3", Module: "test-2"}},
+		}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Empty(t, parentMap)
+	})
+
+	t.Run("entries without component field are ignored", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_dependency"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"name": "test",
+				}},
+			},
+		}
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "igor-test-3", Module: "test-2"}},
+		}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Empty(t, parentMap)
+	})
+
+	t.Run("entries with non-string component are ignored", func(t *testing.T) {
+		entries := []registry.Entry{
+			{
+				ID:   registry.ParseID("app:test_dependency"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": 123,
+				}},
+			},
+		}
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "igor-test-3", Module: "test-2"}},
+		}}
+
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+		assert.Empty(t, parentMap)
+	})
+}
+
+func TestSelectBestParentDependency(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("no parent dependencies", func(t *testing.T) {
+		requirement := registry.Entry{
+			ID:   registry.ParseID("app:API_ROUTER"),
+			Kind: registry.KindNamespaceRequirement,
+		}
+		parentDeps := []ParentDependencyInfo{}
+
+		result := SelectBestParentDependency(requirement, parentDeps, logger)
+		assert.Empty(t, result)
+	})
+
+	t.Run("single parent dependency", func(t *testing.T) {
+		requirement := registry.Entry{
+			ID:   registry.ParseID("app:API_ROUTER"),
+			Kind: registry.KindNamespaceRequirement,
+		}
+		parentDeps := []ParentDependencyInfo{
+			{
+				EntryID:    "app:test_dependency",
+				Parameters: map[string]string{"API_ROUTER": "http://localhost:8080"},
+			},
+		}
+
+		result := SelectBestParentDependency(requirement, parentDeps, logger)
+		assert.Equal(t, "app:test_dependency", result)
+	})
+
+	t.Run("multiple parent dependencies with parameter match", func(t *testing.T) {
+		requirement := registry.Entry{
+			ID:   registry.ParseID("app:API_ROUTER"),
+			Kind: registry.KindNamespaceRequirement,
+		}
+		parentDeps := []ParentDependencyInfo{
+			{
+				EntryID:    "app:test_dependency1",
+				Parameters: map[string]string{"NAMESPACE": "test-namespace"},
+			},
+			{
+				EntryID:    "app:test_dependency2",
+				Parameters: map[string]string{"API_ROUTER": "http://localhost:8080"},
+			},
+		}
+
+		result := SelectBestParentDependency(requirement, parentDeps, logger)
+		assert.Equal(t, "app:test_dependency2", result)
+	})
+
+	t.Run("multiple parent dependencies without parameter match", func(t *testing.T) {
+		requirement := registry.Entry{
+			ID:   registry.ParseID("app:API_ROUTER"),
+			Kind: registry.KindNamespaceRequirement,
+		}
+		parentDeps := []ParentDependencyInfo{
+			{
+				EntryID:    "app:test_dependency1",
+				Parameters: map[string]string{"NAMESPACE": "test-namespace"},
+			},
+			{
+				EntryID:    "app:test_dependency2",
+				Parameters: map[string]string{"DATABASE": "postgresql"},
+			},
+		}
+
+		result := SelectBestParentDependency(requirement, parentDeps, logger)
+		assert.Equal(t, "app:test_dependency1", result) // Should return first available
+	})
+}
+
+func TestValidateParentDependencyConflicts(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("no conflicts with single parent", func(t *testing.T) {
+		parentMap := map[string][]ParentDependencyInfo{
+			"igor-test-3/test-2": {
+				{
+					EntryID:    "app:test_dependency1",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:8080"},
+				},
+			},
+		}
+
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("no conflicts with multiple parents but different parameters", func(t *testing.T) {
+		parentMap := map[string][]ParentDependencyInfo{
+			"igor-test-3/test-2": {
+				{
+					EntryID:    "app:test_dependency1",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:8080"},
+				},
+				{
+					EntryID:    "app:test_dependency2",
+					Parameters: map[string]string{"NAMESPACE": "test-namespace"},
+				},
+			},
+		}
+
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("conflict detected with same parameter", func(t *testing.T) {
+		parentMap := map[string][]ParentDependencyInfo{
+			"igor-test-3/test-2": {
+				{
+					EntryID:    "app:test_dependency1",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:8080"},
+				},
+				{
+					EntryID:    "app:test_dependency2",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:9090"},
+				},
+			},
+		}
+
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "conflict: multiple parent dependencies for module igor-test-3/test-2 define parameter API_ROUTER")
+	})
+
+	t.Run("conflict detected with multiple parameters", func(t *testing.T) {
+		parentMap := map[string][]ParentDependencyInfo{
+			"igor-test-3/test-2": {
+				{
+					EntryID:    "app:test_dependency1",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:8080", "NAMESPACE": "ns1"},
+				},
+				{
+					EntryID:    "app:test_dependency2",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:9090", "NAMESPACE": "ns2"},
+				},
+			},
+		}
+
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "conflict: multiple parent dependencies for module igor-test-3/test-2 define parameter")
+	})
+
+	t.Run("multiple modules with conflicts", func(t *testing.T) {
+		parentMap := map[string][]ParentDependencyInfo{
+			"igor-test-3/test-1": {
+				{
+					EntryID:    "app:test_dependency1",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:8080"},
+				},
+				{
+					EntryID:    "app:test_dependency2",
+					Parameters: map[string]string{"API_ROUTER": "http://localhost:9090"},
+				},
+			},
+			"igor-test-3/test-2": {
+				{
+					EntryID:    "app:test_dependency3",
+					Parameters: map[string]string{"NAMESPACE": "ns1"},
+				},
+			},
+		}
+
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "conflict: multiple parent dependencies for module igor-test-3/test-1 define parameter API_ROUTER")
+	})
+
+	t.Run("empty parent map", func(t *testing.T) {
+		parentMap := map[string][]ParentDependencyInfo{}
+
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.NoError(t, err)
+	})
+}
+
+func TestComplexIntegrationScenario(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("complex scenario with 10 dependencies and 5 requirements", func(t *testing.T) {
+		// Create 10 different dependency entries with various parameters
+		entries := []registry.Entry{
+			// Module 1: web-service
+			{
+				ID:   registry.ParseID("app:web_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/web-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "API_ROUTER", "value": "http://localhost:8080"},
+						map[string]interface{}{"name": "DATABASE_URL", "value": "postgres://localhost:5432/webdb"},
+					},
+				}},
+			},
+			{
+				ID:   registry.ParseID("app:web_service_alt_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/web-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "CACHE_URL", "value": "redis://localhost:6379"},
+					},
+				}},
+			},
+			// Module 2: auth-service
+			{
+				ID:   registry.ParseID("app:auth_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/auth-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "JWT_SECRET", "value": "super-secret-key"},
+						map[string]interface{}{"name": "AUTH_DB", "value": "postgres://localhost:5432/authdb"},
+					},
+				}},
+			},
+			// Module 3: payment-service
+			{
+				ID:   registry.ParseID("app:payment_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/payment-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "STRIPE_KEY", "value": "sk_test_123456789"},
+						map[string]interface{}{"name": "PAYMENT_DB", "value": "postgres://localhost:5432/paymentdb"},
+					},
+				}},
+			},
+			{
+				ID:   registry.ParseID("app:payment_service_alt_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/payment-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "WEBHOOK_URL", "value": "https://api.company.com/webhooks"},
+					},
+				}},
+			},
+			// Module 4: notification-service
+			{
+				ID:   registry.ParseID("app:notification_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/notification-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "SMTP_HOST", "value": "smtp.company.com"},
+						map[string]interface{}{"name": "SMS_API_KEY", "value": "sms_api_key_123"},
+					},
+				}},
+			},
+			// Module 5: analytics-service
+			{
+				ID:   registry.ParseID("app:analytics_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/analytics-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "ANALYTICS_DB", "value": "postgres://localhost:5432/analyticsdb"},
+						map[string]interface{}{"name": "KAFKA_BROKERS", "value": "localhost:9092"},
+					},
+				}},
+			},
+			// Module 6: file-service
+			{
+				ID:   registry.ParseID("app:file_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/file-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "S3_BUCKET", "value": "company-files"},
+						map[string]interface{}{"name": "S3_REGION", "value": "us-east-1"},
+					},
+				}},
+			},
+			// Module 7: search-service
+			{
+				ID:   registry.ParseID("app:search_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/search-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "ELASTICSEARCH_URL", "value": "http://localhost:9200"},
+					},
+				}},
+			},
+			// Module 8: monitoring-service
+			{
+				ID:   registry.ParseID("app:monitoring_service_dep"),
+				Kind: registry.KindNamespaceDependency,
+				Data: &TestPayload{data: map[string]interface{}{
+					"component": "company/monitoring-service",
+					"parameters": []interface{}{
+						map[string]interface{}{"name": "PROMETHEUS_URL", "value": "http://localhost:9090"},
+						map[string]interface{}{"name": "GRAFANA_URL", "value": "http://localhost:3000"},
+					},
+				}},
+			},
+		}
+
+		// Create load result with 8 loaded modules
+		loadResult := &LoadResult{Modules: []LoadedModule{
+			{Name: Name{Organization: "company", Module: "web-service"}},
+			{Name: Name{Organization: "company", Module: "auth-service"}},
+			{Name: Name{Organization: "company", Module: "payment-service"}},
+			{Name: Name{Organization: "company", Module: "notification-service"}},
+			{Name: Name{Organization: "company", Module: "analytics-service"}},
+			{Name: Name{Organization: "company", Module: "file-service"}},
+			{Name: Name{Organization: "company", Module: "search-service"}},
+			{Name: Name{Organization: "company", Module: "monitoring-service"}},
+		}}
+
+		// Create parent dependency map
+		parentMap := CreateParentDependencyMap(entries, loadResult, logger)
+
+		// Verify all modules are mapped
+		expectedModules := []string{
+			"company/web-service",
+			"company/auth-service",
+			"company/payment-service",
+			"company/notification-service",
+			"company/analytics-service",
+			"company/file-service",
+			"company/search-service",
+			"company/monitoring-service",
+		}
+
+		for _, module := range expectedModules {
+			assert.Contains(t, parentMap, module, "Module %s should be in parent map", module)
+		}
+
+		// Verify specific mappings
+		assert.Len(t, parentMap["company/web-service"], 2, "web-service should have 2 dependencies")
+		assert.Len(t, parentMap["company/payment-service"], 2, "payment-service should have 2 dependencies")
+		assert.Len(t, parentMap["company/auth-service"], 1, "auth-service should have 1 dependency")
+
+		// Verify parameters are correctly extracted
+		webServiceDeps := parentMap["company/web-service"]
+		apiRouterFound := false
+		databaseURLFound := false
+		cacheURLFound := false
+
+		for _, dep := range webServiceDeps {
+			if dep.EntryID == "app:web_service_dep" {
+				assert.Equal(t, "http://localhost:8080", dep.Parameters["API_ROUTER"])
+				assert.Equal(t, "postgres://localhost:5432/webdb", dep.Parameters["DATABASE_URL"])
+				apiRouterFound = true
+				databaseURLFound = true
+			}
+			if dep.EntryID == "app:web_service_alt_dep" {
+				assert.Equal(t, "redis://localhost:6379", dep.Parameters["CACHE_URL"])
+				cacheURLFound = true
+			}
+		}
+
+		assert.True(t, apiRouterFound, "API_ROUTER parameter should be found")
+		assert.True(t, databaseURLFound, "DATABASE_URL parameter should be found")
+		assert.True(t, cacheURLFound, "CACHE_URL parameter should be found")
+
+		// Test requirement selection with 5 different requirements
+		requirements := []registry.Entry{
+			{ID: registry.ParseID("app:API_ROUTER"), Kind: registry.KindNamespaceRequirement},
+			{ID: registry.ParseID("app:JWT_SECRET"), Kind: registry.KindNamespaceRequirement},
+			{ID: registry.ParseID("app:STRIPE_KEY"), Kind: registry.KindNamespaceRequirement},
+			{ID: registry.ParseID("app:ELASTICSEARCH_URL"), Kind: registry.KindNamespaceRequirement},
+			{ID: registry.ParseID("app:PROMETHEUS_URL"), Kind: registry.KindNamespaceRequirement},
+		}
+
+		// Test API_ROUTER requirement (should match web_service_dep)
+		apiRouterParent := SelectBestParentDependency(requirements[0], parentMap["company/web-service"], logger)
+		assert.Equal(t, "app:web_service_dep", apiRouterParent, "API_ROUTER should match web_service_dep")
+
+		// Test JWT_SECRET requirement (should match auth_service_dep)
+		jwtSecretParent := SelectBestParentDependency(requirements[1], parentMap["company/auth-service"], logger)
+		assert.Equal(t, "app:auth_service_dep", jwtSecretParent, "JWT_SECRET should match auth_service_dep")
+
+		// Test STRIPE_KEY requirement (should match payment_service_dep)
+		stripeKeyParent := SelectBestParentDependency(requirements[2], parentMap["company/payment-service"], logger)
+		assert.Equal(t, "app:payment_service_dep", stripeKeyParent, "STRIPE_KEY should match payment_service_dep")
+
+		// Test ELASTICSEARCH_URL requirement (should match search_service_dep)
+		elasticsearchParent := SelectBestParentDependency(requirements[3], parentMap["company/search-service"], logger)
+		assert.Equal(t, "app:search_service_dep", elasticsearchParent, "ELASTICSEARCH_URL should match search_service_dep")
+
+		// Test PROMETHEUS_URL requirement (should match monitoring_service_dep)
+		prometheusParent := SelectBestParentDependency(requirements[4], parentMap["company/monitoring-service"], logger)
+		assert.Equal(t, "app:monitoring_service_dep", prometheusParent, "PROMETHEUS_URL should match monitoring_service_dep")
+
+		// Test conflict validation - should pass since no conflicts exist
+		err := ValidateParentDependencyConflicts(parentMap, logger)
+		assert.NoError(t, err, "No conflicts should be detected")
+
+		// Test a requirement that doesn't match any parameter (should fallback to first dependency)
+		unknownRequirement := registry.Entry{ID: registry.ParseID("app:UNKNOWN_PARAM"), Kind: registry.KindNamespaceRequirement}
+		unknownParent := SelectBestParentDependency(unknownRequirement, parentMap["company/web-service"], logger)
+		assert.Equal(t, "app:web_service_dep", unknownParent, "Unknown parameter should fallback to first dependency")
+
+		// Verify total count of dependencies
+		totalDependencies := 0
+		for _, deps := range parentMap {
+			totalDependencies += len(deps)
+		}
+		assert.Equal(t, 10, totalDependencies, "Should have exactly 10 total dependencies")
+
+		// Verify all expected parameters are present
+		allParameters := make(map[string]string)
+		for _, deps := range parentMap {
+			for _, dep := range deps {
+				for paramName, paramValue := range dep.Parameters {
+					allParameters[paramName] = paramValue
+				}
+			}
+		}
+
+		expectedParameters := map[string]string{
+			"API_ROUTER":        "http://localhost:8080",
+			"DATABASE_URL":      "postgres://localhost:5432/webdb",
+			"CACHE_URL":         "redis://localhost:6379",
+			"JWT_SECRET":        "super-secret-key",
+			"AUTH_DB":           "postgres://localhost:5432/authdb",
+			"STRIPE_KEY":        "sk_test_123456789",
+			"PAYMENT_DB":        "postgres://localhost:5432/paymentdb",
+			"WEBHOOK_URL":       "https://api.company.com/webhooks",
+			"SMTP_HOST":         "smtp.company.com",
+			"SMS_API_KEY":       "sms_api_key_123",
+			"ANALYTICS_DB":      "postgres://localhost:5432/analyticsdb",
+			"KAFKA_BROKERS":     "localhost:9092",
+			"S3_BUCKET":         "company-files",
+			"S3_REGION":         "us-east-1",
+			"ELASTICSEARCH_URL": "http://localhost:9200",
+			"PROMETHEUS_URL":    "http://localhost:9090",
+			"GRAFANA_URL":       "http://localhost:3000",
+		}
+
+		for paramName, expectedValue := range expectedParameters {
+			actualValue, exists := allParameters[paramName]
+			assert.True(t, exists, "Parameter %s should exist", paramName)
+			assert.Equal(t, expectedValue, actualValue, "Parameter %s should have correct value", paramName)
+		}
+
+		assert.Equal(t, len(expectedParameters), len(allParameters), "Should have exactly %d parameters", len(expectedParameters))
+	})
+}


### PR DESCRIPTION
Problem
ns.requirement entries lacked proper parent tracking when loaded via ns.dependency entries, making parameter injection impossible.

Solution
- Parameter-based parent selection: Selects dependency that declares matching parameter name
- Conflict validation: Prevents ambiguous assignments when multiple dependencies define same parameter
- Refactored to moduleloader package: Better separation of concerns

Example
# ns.dependency
hello_world_dependency:
  kind: ns.dependency
  component: igor-test-3/test-2
  parameters:
    - name: API_ROUTER
      value: http://localhost:8080

# ns.requirement (gets meta.parent = "hello_world_dependency")
API_ROUTER:
  kind: ns.requirement
  # meta.parent automatically set