### PR TITLE
- adds support for expr

### DIFF
--- a/cmd/runner/app/services.go
+++ b/cmd/runner/app/services.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/ponyruntime/pony/runtime/lua/modules/expr"
 	"github.com/ponyruntime/pony/runtime/noop"
 
 	"github.com/ponyruntime/pony/runtime/lua/modules/html"
@@ -402,6 +403,7 @@ func withLuaRuntime(a *App) []eventbus.EventHandler {
 				system.NewSystemModule(),
 				contractmod.NewContractModule(a.logger.Named("contract")),
 				otelmod.NewOTelModule(),
+				expr.NewExprModule(expr.WithCapacity(1000)),
 				html.NewHTMLModule(),
 			},
 			ProtoCacheSize: 60000,

--- a/cmd/runner/app/services.go
+++ b/cmd/runner/app/services.go
@@ -403,7 +403,7 @@ func withLuaRuntime(a *App) []eventbus.EventHandler {
 				system.NewSystemModule(),
 				contractmod.NewContractModule(a.logger.Named("contract")),
 				otelmod.NewOTelModule(),
-				expr.NewExprModule(expr.WithCapacity(1000)),
+				expr.NewExprModule(expr.WithCapacity(5000)),
 				html.NewHTMLModule(),
 			},
 			ProtoCacheSize: 60000,

--- a/deps/requirementresolver/resolver.go
+++ b/deps/requirementresolver/resolver.go
@@ -298,12 +298,39 @@ func updateEntryFromRawJSONMap(entry *registry.Entry, m map[string]interface{}) 
 	return nil
 }
 
-// setValueWithGojqReturnMap is like setValueWithGojq but returns the updated map
+// setValueWithGojqReturnMap with deduplication for depends_on arrays
 func setValueWithGojqReturnMap(data interface{}, path string, value string) (map[string]interface{}, error) {
 	trimmedPath := strings.TrimSpace(path)
 
 	var jqQuery string
 	if strings.Contains(trimmedPath, "+=") {
+		// Special handling for depends_on to avoid duplicates
+		if strings.Contains(trimmedPath, "depends_on") {
+			// First check if value already exists
+			checkQuery := strings.ReplaceAll(trimmedPath, "+=", "")
+			checkQuery = strings.TrimSpace(checkQuery)
+
+			// Try to get existing array
+			query, err := gojq.Parse(checkQuery)
+			if err == nil {
+				iter := query.Run(data)
+				if v, ok := iter.Next(); ok {
+					if existingArray, isArray := v.([]interface{}); isArray {
+						// Check if value already exists
+						for _, existing := range existingArray {
+							if existing == value {
+								// Value already exists, return data unchanged
+								if resultMap, ok := data.(map[string]interface{}); ok {
+									return resultMap, nil
+								}
+								return nil, fmt.Errorf("data is not a map")
+							}
+						}
+					}
+				}
+			}
+		}
+
 		jqQuery = fmt.Sprintf("%s [\"%s\"]", trimmedPath, value)
 	} else {
 		// For simple assignment, check if the path already has an assignment operator

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/expr-lang/expr v1.17.6 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/expr-lang/expr v1.17.6 h1:1h6i8ONk9cexhDmowO/A64VPxHScu7qfSl2k8OlINec=
+github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=

--- a/runtime/lua/modules/expr/module.go
+++ b/runtime/lua/modules/expr/module.go
@@ -122,7 +122,7 @@ func (m *Module) luaCompile(l *luavm.LState) int {
 	}
 
 	// Get optional environment
-	var env interface{}
+	var env any
 	if l.GetTop() >= 2 && l.Get(2) != luavm.LNil {
 		env = lua.ToGoAny(l.Get(2))
 	}
@@ -154,7 +154,7 @@ func (m *Module) luaEval(l *luavm.LState) int {
 	}
 
 	// Get optional environment
-	var env interface{}
+	var env any
 	if l.GetTop() >= 2 && l.Get(2) != luavm.LNil {
 		env = lua.ToGoAny(l.Get(2))
 	}
@@ -197,7 +197,7 @@ func (m *Module) programRun(l *luavm.LState) int {
 	}
 
 	// Get optional environment
-	var env interface{}
+	var env any
 	if l.GetTop() >= 2 && l.Get(2) != luavm.LNil {
 		env = lua.ToGoAny(l.Get(2))
 	}
@@ -242,7 +242,7 @@ func (m *Module) getCachedProgram(expression string) (*vm.Program, error) {
 }
 
 // compileExpression compiles an expression (only built-ins supported)
-func (m *Module) compileExpression(expression string, env interface{}) (*vm.Program, error) {
+func (m *Module) compileExpression(expression string, env any) (*vm.Program, error) {
 	// Build options
 	var options []expr.Option
 	if env != nil {

--- a/runtime/lua/modules/expr/module.go
+++ b/runtime/lua/modules/expr/module.go
@@ -1,0 +1,261 @@
+package expr
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+	lru "github.com/ponyruntime/pony/internal/cache"
+	"github.com/ponyruntime/pony/runtime/lua/engine/value"
+	"github.com/ponyruntime/pony/system/payload/lua"
+	luavm "github.com/yuin/gopher-lua"
+)
+
+// Option defines a functional option for configuring the expr module
+type Option func(*config)
+
+// config holds the configuration for the expr module
+type config struct {
+	capacity int
+}
+
+// WithCapacity sets the LRU cache capacity
+func WithCapacity(capacity int) Option {
+	return func(c *config) {
+		c.capacity = capacity
+	}
+}
+
+// Module represents the expr Lua module
+type Module struct {
+	cache       *lru.Cache[string, *vm.Program]
+	moduleTable *luavm.LTable
+	once        sync.Once
+}
+
+// Program wraps a compiled expr program
+type Program struct {
+	program *vm.Program
+}
+
+// NewExprModule creates a new expr module with LRU cache
+func NewExprModule(opts ...Option) *Module {
+	cfg := &config{
+		capacity: 1000, // default capacity
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	cache := lru.New[string, *vm.Program](
+		lru.WithCapacity(cfg.capacity),
+	)
+
+	return &Module{
+		cache: cache,
+	}
+}
+
+// Name returns the module's name
+func (m *Module) Name() string {
+	return "expr"
+}
+
+// Loader loads the module into the given Lua state
+func (m *Module) Loader(l *luavm.LState) int {
+	m.once.Do(func() {
+		m.initModuleTable(l)
+	})
+
+	l.Push(m.moduleTable)
+	return 1
+}
+
+// initModuleTable creates and initializes the module table once
+func (m *Module) initModuleTable(l *luavm.LState) {
+	// Register the Program type methods
+	value.RegisterMethods(l, "expr.Program", map[string]luavm.LGFunction{
+		"run": m.programRun,
+	})
+
+	// Create module table
+	t := l.CreateTable(0, 2) // 2 functions: compile, eval
+
+	t.RawSetString("compile", l.NewFunction(m.luaCompile))
+	t.RawSetString("eval", l.NewFunction(m.luaEval))
+
+	// Make the table immutable so it can be safely reused
+	t.Immutable = true
+
+	m.moduleTable = t
+}
+
+// CheckProgram checks if the first argument is a Program and returns it
+func CheckProgram(l *luavm.LState) *Program {
+	ud := l.CheckUserData(1)
+	if program, ok := ud.Value.(*Program); ok {
+		return program
+	}
+	l.ArgError(1, "expected expr.Program")
+	return nil
+}
+
+// WrapProgram wraps a Program as a Lua userdata
+func WrapProgram(l *luavm.LState, program *Program) *luavm.LUserData {
+	ud := l.NewUserData()
+	ud.Value = program
+	ud.Metatable = value.GetTypeMetatable(l, "expr.Program")
+	return ud
+}
+
+// luaCompile compiles an expression without caching
+func (m *Module) luaCompile(l *luavm.LState) int {
+	// Get expression string
+	expression := l.CheckString(1)
+	if expression == "" {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString("expression cannot be empty"))
+		return 2
+	}
+
+	// Get optional environment
+	var env interface{}
+	if l.GetTop() >= 2 && l.Get(2) != luavm.LNil {
+		env = lua.ToGoAny(l.Get(2))
+	}
+
+	// Compile expression
+	program, err := m.compileExpression(expression, env)
+	if err != nil {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString(err.Error()))
+		return 2
+	}
+
+	// Wrap program in our Program type
+	wrappedProgram := &Program{program: program}
+	ud := WrapProgram(l, wrappedProgram)
+	l.Push(ud)
+	l.Push(luavm.LNil)
+	return 2
+}
+
+// luaEval evaluates an expression with caching
+func (m *Module) luaEval(l *luavm.LState) int {
+	// Get expression string
+	expression := l.CheckString(1)
+	if expression == "" {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString("expression cannot be empty"))
+		return 2
+	}
+
+	// Get optional environment
+	var env interface{}
+	if l.GetTop() >= 2 && l.Get(2) != luavm.LNil {
+		env = lua.ToGoAny(l.Get(2))
+	}
+
+	// Get or compile program from cache
+	program, err := m.getCachedProgram(expression)
+	if err != nil {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString(err.Error()))
+		return 2
+	}
+
+	// Run program
+	result, err := expr.Run(program, env)
+	if err != nil {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString(err.Error()))
+		return 2
+	}
+
+	// Convert result back to Lua
+	luaResult, err := lua.GoToLua(result)
+	if err != nil {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString(fmt.Sprintf("failed to convert result: %s", err.Error())))
+		return 2
+	}
+
+	l.Push(luaResult)
+	l.Push(luavm.LNil)
+	return 2
+}
+
+// programRun runs a compiled program with environment
+func (m *Module) programRun(l *luavm.LState) int {
+	// Check and get program
+	program := CheckProgram(l)
+	if program == nil {
+		return 0
+	}
+
+	// Get optional environment
+	var env interface{}
+	if l.GetTop() >= 2 && l.Get(2) != luavm.LNil {
+		env = lua.ToGoAny(l.Get(2))
+	}
+
+	// Run program
+	result, err := expr.Run(program.program, env)
+	if err != nil {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString(err.Error()))
+		return 2
+	}
+
+	// Convert result back to Lua
+	luaResult, err := lua.GoToLua(result)
+	if err != nil {
+		l.Push(luavm.LNil)
+		l.Push(luavm.LString(fmt.Sprintf("failed to convert result: %s", err.Error())))
+		return 2
+	}
+
+	l.Push(luaResult)
+	l.Push(luavm.LNil)
+	return 2
+}
+
+// getCachedProgram gets a compiled program from cache or compiles and caches it
+func (m *Module) getCachedProgram(expression string) (*vm.Program, error) {
+	// Try to get from cache first
+	if program, found := m.cache.Get(expression); found {
+		return program, nil
+	}
+
+	// Compile and cache
+	program, err := m.compileExpression(expression, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the compiled program
+	m.cache.Set(expression, program)
+	return program, nil
+}
+
+// compileExpression compiles an expression (only built-ins supported)
+func (m *Module) compileExpression(expression string, env interface{}) (*vm.Program, error) {
+	// Build options
+	var options []expr.Option
+	if env != nil {
+		options = append(options, expr.Env(env))
+	}
+
+	// Compile expression (only built-in functions available)
+	return expr.Compile(expression, options...)
+}
+
+// Close cleans up the module resources
+func (m *Module) Close() {
+	if m.cache != nil {
+		m.cache.Close()
+	}
+}

--- a/runtime/lua/modules/expr/module_test.go
+++ b/runtime/lua/modules/expr/module_test.go
@@ -1,0 +1,488 @@
+package expr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ponyruntime/pony/runtime/lua/engine"
+	"github.com/ponyruntime/pony/runtime/lua/engine/coroutine"
+	"github.com/ponyruntime/pony/system/payload/lua"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	luavm "github.com/yuin/gopher-lua"
+	"go.uber.org/zap/zaptest"
+)
+
+// setupTestEnvironment creates a test environment with expr module
+func setupTestEnvironment(t *testing.T, opts ...Option) (*engine.CoroutineVM, *luavm.LState, engine.UnitOfWork, *engine.Runner) {
+	logger := zaptest.NewLogger(t)
+
+	// Create the expr module with options
+	module := NewExprModule(opts...)
+
+	// Create a VM with coroutine support
+	vm, err := engine.NewCVM(logger)
+	require.NoError(t, err)
+
+	// Get the Lua state
+	L := vm.State()
+
+	// Register the expr module
+	L.PreloadModule(module.Name(), module.Loader)
+
+	// Create a runner with the coroutine layer
+	runner := engine.NewRunner(vm, engine.WithLayer(coroutine.NewCoroutineLayer()))
+
+	// Create a UOW for resource management
+	uw, ctx := runner.InitUnitOfWork(context.Background())
+
+	// Set the context in the Lua state
+	L.SetContext(ctx)
+
+	return vm, L, uw, runner
+}
+
+func TestExprModule_CompileAndRun(t *testing.T) {
+	vm, L, uw, runner := setupTestEnvironment(t)
+	defer vm.Close()
+	defer func() {
+		err := uw.Close()
+		assert.NoError(t, err, "Unit of work cleanup failed")
+	}()
+
+	// Import test function for compile and run
+	err := vm.Import(`
+		function test_compile_and_run()
+			local expr = require("expr")
+			
+			-- Test basic compile
+			local program, err = expr.compile("2 + 3 * 4")
+			if err then error(err) end
+			assert(program ~= nil, "Program should not be nil")
+			assert(type(program) == "userdata", "Program should be userdata")
+			
+			-- Test program:run() method
+			local result1, err1 = program:run()
+			if err1 then error(err1) end
+			assert(result1 == 14, "2 + 3 * 4 should equal 14, got: " .. tostring(result1))
+			
+			-- Test running same program multiple times
+			local result2, err2 = program:run()
+			if err2 then error(err2) end
+			assert(result2 == 14, "Second run should also equal 14")
+			
+			-- Test program with environment
+			local program_env, err3 = expr.compile("price * quantity")
+			if err3 then error(err3) end
+			
+			local result3, err4 = program_env:run({price = 10, quantity = 3})
+			if err4 then error(err4) end
+			assert(result3 == 30, "10 * 3 should equal 30, got: " .. tostring(result3))
+			
+			-- Test same program with different environments
+			local result4, err5 = program_env:run({price = 5, quantity = 4})
+			if err5 then error(err5) end
+			assert(result4 == 20, "5 * 4 should equal 20, got: " .. tostring(result4))
+			
+			return {
+				basic = result1,
+				with_env1 = result3,
+				with_env2 = result4,
+				success = true
+			}
+		end
+	`, "test", "test_compile_and_run")
+	require.NoError(t, err, "Failed to import test function")
+
+	// Execute the function
+	result, err := runner.Execute(L.Context(), "test_compile_and_run")
+	require.NoError(t, err, "Lua execution failed")
+
+	resultMap := lua.ToGoAny(result).(map[string]interface{})
+
+	assert.Equal(t, true, resultMap["success"], "Test should succeed")
+	assert.Equal(t, float64(14), resultMap["basic"], "Basic arithmetic should work")
+	assert.Equal(t, float64(30), resultMap["with_env1"], "First environment should work")
+	assert.Equal(t, float64(20), resultMap["with_env2"], "Second environment should work")
+}
+
+func TestExprModule_ProgramBuiltinFunctions(t *testing.T) {
+	vm, L, uw, runner := setupTestEnvironment(t)
+	defer vm.Close()
+	defer func() {
+		err := uw.Close()
+		assert.NoError(t, err, "Unit of work cleanup failed")
+	}()
+
+	// Import test function for built-in functions with programs
+	err := vm.Import(`
+		function test_program_builtins()
+			local expr = require("expr")
+			
+			-- Compile programs with built-in functions
+			local all_prog, err1 = expr.compile("all(numbers, {# > 0})")
+			if err1 then error(err1) end
+			
+			local filter_prog, err2 = expr.compile("filter(numbers, {# > 3})")
+			if err2 then error(err2) end
+			
+			local map_prog, err3 = expr.compile("map(numbers, {# * 2})")
+			if err3 then error(err3) end
+			
+			local max_prog, err4 = expr.compile("max(a, b)")
+			if err4 then error(err4) end
+			
+			-- Test with different data sets
+			local env1 = {numbers = {1, 2, 3, 4, 5}}
+			local env2 = {numbers = {-1, 0, 1}}
+			local env3 = {a = 10, b = 5}
+			local env4 = {a = 3, b = 8}
+			
+			-- Run tests
+			local all_result1, err5 = all_prog:run(env1)
+			if err5 then error(err5) end
+			
+			local all_result2, err6 = all_prog:run(env2)
+			if err6 then error(err6) end
+			
+			local filter_result, err7 = filter_prog:run(env1)
+			if err7 then error(err7) end
+			
+			local map_result, err8 = map_prog:run(env1)
+			if err8 then error(err8) end
+			
+			local max_result1, err9 = max_prog:run(env3)
+			if err9 then error(err9) end
+			
+			local max_result2, err10 = max_prog:run(env4)
+			if err10 then error(err10) end
+			
+			return {
+				all_positive = all_result1,
+				all_mixed = all_result2,
+				filtered = filter_result,
+				mapped = map_result,
+				max1 = max_result1,
+				max2 = max_result2
+			}
+		end
+	`, "test", "test_program_builtins")
+	require.NoError(t, err, "Failed to import test function")
+
+	// Execute the function
+	result, err := runner.Execute(L.Context(), "test_program_builtins")
+	require.NoError(t, err, "Lua execution failed")
+
+	resultMap := lua.ToGoAny(result).(map[string]interface{})
+
+	assert.Equal(t, true, resultMap["all_positive"], "All positive numbers should be > 0")
+	assert.Equal(t, false, resultMap["all_mixed"], "Mixed numbers should not all be > 0")
+	assert.Equal(t, []interface{}{float64(4), float64(5)}, resultMap["filtered"], "Filter should return [4, 5]")
+	assert.Equal(t, []interface{}{float64(2), float64(4), float64(6), float64(8), float64(10)}, resultMap["mapped"], "Map should double all numbers")
+	assert.Equal(t, float64(10), resultMap["max1"], "Max of 10 and 5 should be 10")
+	assert.Equal(t, float64(8), resultMap["max2"], "Max of 3 and 8 should be 8")
+}
+
+func TestExprModule_ErrorHandling(t *testing.T) {
+	vm, L, uw, runner := setupTestEnvironment(t)
+	defer vm.Close()
+	defer func() {
+		err := uw.Close()
+		assert.NoError(t, err, "Unit of work cleanup failed")
+	}()
+
+	// Import test function for error handling
+	err := vm.Import(`
+		function test_error_handling()
+			local expr = require("expr")
+			
+			-- Test empty expression compile
+			local program1, err1 = expr.compile("")
+			assert(program1 == nil, "Empty expression should return nil")
+			assert(err1 ~= nil, "Empty expression should return error")
+			
+			-- Test invalid syntax compile
+			local program2, err2 = expr.compile("2 +")
+			assert(program2 == nil, "Invalid syntax should return nil")
+			assert(err2 ~= nil, "Invalid syntax should return error")
+			
+			-- Test valid compile but runtime error
+			local program3, err3 = expr.compile("undefined_var")
+			assert(program3 ~= nil, "Valid syntax should compile")
+			assert(err3 == nil, "Valid syntax should not error on compile")
+			
+			-- Test runtime error
+			local result3, err4 = program3:run()
+			assert(result3 == nil, "Undefined variable should return nil")
+			assert(err4 ~= nil, "Undefined variable should return runtime error")
+			
+			-- Test type mismatch at runtime
+			local program4, err5 = expr.compile("x + y")
+			assert(program4 ~= nil, "Valid syntax should compile")
+			assert(err5 == nil, "Valid syntax should not error on compile")
+			
+			local result4, err6 = program4:run({x = "string", y = 42})
+			assert(result4 == nil, "Type mismatch should return nil")
+			assert(err6 ~= nil, "Type mismatch should return error")
+			
+			-- Test invalid program object (can't test easily, but verify method exists)
+			-- This would test CheckProgram validation in real scenarios
+			
+			return {success = true}
+		end
+	`, "test", "test_error_handling")
+	require.NoError(t, err, "Failed to import test function")
+
+	// Execute the function
+	result, err := runner.Execute(L.Context(), "test_error_handling")
+	require.NoError(t, err, "Lua execution failed")
+
+	resultMap := lua.ToGoAny(result).(map[string]interface{})
+	assert.Equal(t, true, resultMap["success"], "Error handling test should succeed")
+}
+
+func TestExprModule_CachingBehavior(t *testing.T) {
+	vm, L, uw, runner := setupTestEnvironment(t, WithCapacity(100))
+	defer vm.Close()
+	defer func() {
+		err := uw.Close()
+		assert.NoError(t, err, "Unit of work cleanup failed")
+	}()
+
+	// Import test function that compares eval vs compile caching
+	err := vm.Import(`
+		function test_caching_behavior()
+			local expr = require("expr")
+			
+			-- Test eval caching (should cache)
+			local expr_text = "a + b * c"
+			local env = {a = 1, b = 2, c = 3}
+			
+			local eval_results = {}
+			for i = 1, 5 do
+				local result, err = expr.eval(expr_text, env)
+				if err then error(err) end
+				table.insert(eval_results, result)
+			end
+			
+			-- Test compile (should not cache, each compile is independent)
+			local compile_results = {}
+			for i = 1, 3 do
+				local program, err = expr.compile(expr_text)
+				if err then error(err) end
+				
+				local result, err2 = program:run(env)
+				if err2 then error(err2) end
+				table.insert(compile_results, result)
+			end
+			
+			-- All results should be the same regardless of method
+			for i = 2, #eval_results do
+				assert(eval_results[i] == eval_results[1], "All eval results should be equal")
+			end
+			
+			for i = 2, #compile_results do
+				assert(compile_results[i] == compile_results[1], "All compile results should be equal")
+			end
+			
+			assert(eval_results[1] == compile_results[1], "Eval and compile should give same result")
+			
+			-- Test that compile allows different programs with same expression
+			local program1, err1 = expr.compile("x * 2")
+			if err1 then error(err1) end
+			
+			local program2, err2 = expr.compile("x * 2")
+			if err2 then error(err2) end
+			
+			-- Both should work independently
+			local result1, err3 = program1:run({x = 5})
+			if err3 then error(err3) end
+			
+			local result2, err4 = program2:run({x = 10})
+			if err4 then error(err4) end
+			
+			return {
+				eval_result = eval_results[1],
+				compile_result = compile_results[1],
+				independent1 = result1,
+				independent2 = result2,
+				success = true
+			}
+		end
+	`, "test", "test_caching_behavior")
+	require.NoError(t, err, "Failed to import test function")
+
+	// Execute the function
+	result, err := runner.Execute(L.Context(), "test_caching_behavior")
+	require.NoError(t, err, "Lua execution failed")
+
+	resultMap := lua.ToGoAny(result).(map[string]interface{})
+	assert.Equal(t, true, resultMap["success"], "Caching behavior test should succeed")
+	assert.Equal(t, float64(7), resultMap["eval_result"], "1 + 2 * 3 should equal 7")
+	assert.Equal(t, float64(7), resultMap["compile_result"], "Compile should give same result as eval")
+	assert.Equal(t, float64(10), resultMap["independent1"], "5 * 2 should equal 10")
+	assert.Equal(t, float64(20), resultMap["independent2"], "10 * 2 should equal 20")
+}
+
+func TestExprModule_ComplexProgramUsage(t *testing.T) {
+	vm, L, uw, runner := setupTestEnvironment(t)
+	defer vm.Close()
+	defer func() {
+		err := uw.Close()
+		assert.NoError(t, err, "Unit of work cleanup failed")
+	}()
+
+	// Import test function for complex usage patterns
+	err := vm.Import(`
+		function test_complex_usage()
+			local expr = require("expr")
+			
+			-- Test nested objects with programs
+			local user_check, err1 = expr.compile("user.profile.age >= min_age && user.active")
+			if err1 then error(err1) end
+			
+			local users = {
+				{profile = {age = 25}, active = true},
+				{profile = {age = 17}, active = true},
+				{profile = {age = 30}, active = false}
+			}
+			
+			local results = {}
+			for i, user in ipairs(users) do
+				local result, err = user_check:run({user = user, min_age = 18})
+				if err then error(err) end
+				table.insert(results, result)
+			end
+			
+			-- Test array processing with programs
+			local discount_calc, err2 = expr.compile("map(items, {.price * (1 - discount)})")
+			if err2 then error(err2) end
+			
+			local order1 = {
+				items = {{price = 100}, {price = 50}, {price = 75}},
+				discount = 0.1
+			}
+			
+			local order2 = {
+				items = {{price = 200}, {price = 80}},
+				discount = 0.2
+			}
+			
+			local discounted1, err3 = discount_calc:run(order1)
+			if err3 then error(err3) end
+			
+			local discounted2, err4 = discount_calc:run(order2)
+			if err4 then error(err4) end
+			
+			-- Test string operations
+			local name_formatter, err5 = expr.compile('upper(firstName) + " " + upper(lastName)')
+			if err5 then error(err5) end
+			
+			local name1, err6 = name_formatter:run({firstName = "john", lastName = "doe"})
+			if err6 then error(err6) end
+			
+			local name2, err7 = name_formatter:run({firstName = "jane", lastName = "smith"})
+			if err7 then error(err7) end
+			
+			return {
+				user_results = results,
+				discounted1 = discounted1,
+				discounted2 = discounted2,
+				name1 = name1,
+				name2 = name2
+			}
+		end
+	`, "test", "test_complex_usage")
+	require.NoError(t, err, "Failed to import test function")
+
+	// Execute the function
+	result, err := runner.Execute(L.Context(), "test_complex_usage")
+	require.NoError(t, err, "Lua execution failed")
+
+	resultMap := lua.ToGoAny(result).(map[string]interface{})
+
+	// Check user validation results
+	userResults := resultMap["user_results"].([]interface{})
+	assert.Equal(t, true, userResults[0], "First user should pass (age 25, active)")
+	assert.Equal(t, false, userResults[1], "Second user should fail (age 17)")
+	assert.Equal(t, false, userResults[2], "Third user should fail (not active)")
+
+	// Check discount calculations
+	discounted1 := resultMap["discounted1"].([]interface{})
+	assert.Equal(t, float64(90), discounted1[0], "100 * 0.9 = 90")
+	assert.Equal(t, float64(45), discounted1[1], "50 * 0.9 = 45")
+	assert.Equal(t, float64(67.5), discounted1[2], "75 * 0.9 = 67.5")
+
+	discounted2 := resultMap["discounted2"].([]interface{})
+	assert.Equal(t, float64(160), discounted2[0], "200 * 0.8 = 160")
+	assert.Equal(t, float64(64), discounted2[1], "80 * 0.8 = 64")
+
+	// Check string formatting
+	assert.Equal(t, "JOHN DOE", resultMap["name1"], "Name formatting should work")
+	assert.Equal(t, "JANE SMITH", resultMap["name2"], "Name formatting should work")
+}
+
+func TestExprModule_EvalStillWorks(t *testing.T) {
+	vm, L, uw, runner := setupTestEnvironment(t)
+	defer vm.Close()
+	defer func() {
+		err := uw.Close()
+		assert.NoError(t, err, "Unit of work cleanup failed")
+	}()
+
+	// Import test function to ensure eval still works as before
+	err := vm.Import(`
+		function test_eval_compatibility()
+			local expr = require("expr")
+			
+			-- Test basic eval (should still work)
+			local result1, err1 = expr.eval("2 + 3 * 4")
+			if err1 then error(err1) end
+			
+			-- Test eval with environment
+			local result2, err2 = expr.eval("price * quantity", {
+				price = 10.5,
+				quantity = 3
+			})
+			if err2 then error(err2) end
+			
+			-- Test eval with built-ins
+			local result3, err3 = expr.eval("all(numbers, {# > 0})", {
+				numbers = {1, 2, 3, 4, 5}
+			})
+			if err3 then error(err3) end
+			
+			return {
+				arithmetic = result1,
+				variables = result2,
+				builtin = result3
+			}
+		end
+	`, "test", "test_eval_compatibility")
+	require.NoError(t, err, "Failed to import test function")
+
+	// Execute the function
+	result, err := runner.Execute(L.Context(), "test_eval_compatibility")
+	require.NoError(t, err, "Lua execution failed")
+
+	resultMap := lua.ToGoAny(result).(map[string]interface{})
+
+	assert.Equal(t, float64(14), resultMap["arithmetic"], "2 + 3 * 4 should equal 14")
+	assert.Equal(t, float64(31.5), resultMap["variables"], "10.5 * 3 should equal 31.5")
+	assert.Equal(t, true, resultMap["builtin"], "All numbers should be > 0")
+}
+
+func TestExprModule_CustomCapacity(t *testing.T) {
+	// Test that custom capacity option works
+	module := NewExprModule(WithCapacity(50))
+	assert.NotNil(t, module, "Module should be created successfully")
+	assert.NotNil(t, module.cache, "Cache should be initialized")
+
+	// Verify module can be closed
+	module.Close()
+}
+
+func TestExprModule_ModuleName(t *testing.T) {
+	module := NewExprModule()
+	assert.Equal(t, "expr", module.Name(), "Module name should be 'expr'")
+}

--- a/runtime/lua/modules/expr/spec.md
+++ b/runtime/lua/modules/expr/spec.md
@@ -1,0 +1,245 @@
+# Lua Expr Module Specification
+
+## Overview
+
+The Expr module provides dynamic expression compilation and evaluation capabilities for Lua, based on the expr-lang/expr Go library. Supports compile-once-run-many pattern for optimal performance with caching, type safety, and extensive built-in functionality.
+
+## Module Interface
+
+### Module Loading
+```lua
+local expr = require("expr")
+```
+
+### Methods
+
+#### eval(expression, environment)
+Direct expression evaluation with automatic caching.
+
+```lua
+local result, err = expr.eval("2 + 3 * 4")                    -- 14
+local result, err = expr.eval("price * quantity", {price = 10, quantity = 3})  -- 30
+local result, err = expr.eval("all(items, {.price > 0})", {items = products})
+```
+
+Parameters:
+- `expression`: String containing the expression to evaluate
+- `environment`: Optional table containing variables accessible in expression
+
+Returns:
+- `result`: Evaluated result or nil on error
+- `err`: Error message string or nil on success
+
+Caching: Expressions are automatically cached by string content for performance
+
+#### compile(expression)
+Compile expression into reusable program object.
+
+```lua
+local program, err = expr.compile("price * (1 - discount)")
+local result1, err1 = program:run({price = 100, discount = 0.1})  -- 90
+local result2, err2 = program:run({price = 50, discount = 0.2})   -- 40
+```
+
+Parameters:
+- `expression`: String containing the expression to compile
+
+Returns:
+- `program`: Program userdata object or nil on error
+- `err`: Error message string or nil on success
+
+Performance: Programs can be reused multiple times with different environments
+
+Compiled applications not cached by default. Use `eval()` for automatic caching.
+
+## Program Object
+
+Compiled expression program providing efficient repeated evaluation.
+
+### Methods
+
+#### run(environment)
+Execute compiled program with given environment.
+
+```lua
+local result, err = program:run({x = 10, y = 20})
+```
+
+Parameters:
+- `environment`: Optional table containing variables accessible during execution
+
+Returns:
+- `result`: Execution result or nil on error
+- `err`: Error message string or nil on success
+
+## Expression Syntax
+
+### Literals
+- **Numbers**: `42`, `3.14`, `1e-5`, `0x1A`, `0b1010`, `0o755`
+- **Strings**: `"hello"`, `'world'`, `"multi\nline"`
+- **Booleans**: `true`, `false`
+- **Arrays**: `[1, 2, 3]`, `["a", "b", "c"]`
+- **Objects**: Access with dot notation `user.profile.age`
+
+### Arithmetic Operators
+- **Addition**: `a + b`
+- **Subtraction**: `a - b`
+- **Multiplication**: `a * b`
+- **Division**: `a / b`
+- **Modulo**: `a % b`
+- **Power**: `a ** b`
+- **Unary minus**: `-a`
+- **Unary plus**: `+a`
+
+### Comparison Operators
+- **Equal**: `a == b`
+- **Not equal**: `a != b`
+- **Less than**: `a < b`
+- **Less than or equal**: `a <= b`
+- **Greater than**: `a > b`
+- **Greater than or equal**: `a >= b`
+- **In operator**: `item in array`
+- **Matches operator**: `string matches "regex"`
+
+### Logical Operators
+- **Logical AND**: `a && b`
+- **Logical OR**: `a || b`
+- **Logical NOT**: `!a`
+
+### Bitwise Operators
+- **Bitwise AND**: `a & b`
+- **Bitwise OR**: `a | b`
+- **Bitwise XOR**: `a ^ b`
+- **Left shift**: `a << b`
+- **Right shift**: `a >> b`
+
+### Ternary Operator
+```expr
+condition ? true_value : false_value
+age >= 18 ? "adult" : "minor"
+```
+
+### String Operations
+- **Concatenation**: `"hello" + " " + "world"`
+- **Contains**: `"hello world" contains "world"`
+- **Starts with**: `"hello" startsWith "hel"`
+- **Ends with**: `"world" endsWith "rld"`
+
+### Array/Slice Operations
+- **Indexing**: `array[0]`, `array[-1]` (negative indexing)
+- **Slicing**: `array[1:3]`, `array[:5]`, `array[2:]`
+- **Range**: `1..10`, `0..len(array)-1`
+
+### Member Access
+- **Property access**: `user.name`, `config.database.host`
+- **Optional chaining**: `user?.profile?.age` (returns nil if any part is nil)
+- **Array element**: `items[0].price`
+- **Dynamic access**: `object[key]`
+
+## Built-in Functions
+
+### Array Functions
+- **all(array, predicate)**: `all(numbers, {# > 0})` - All elements match predicate
+- **any(array, predicate)**: `any(numbers, {# > 10})` - Any element matches predicate
+- **none(array, predicate)**: `none(numbers, {# < 0})` - No elements match predicate
+- **one(array, predicate)**: `one(numbers, {# == 5})` - Exactly one element matches
+- **filter(array, predicate)**: `filter(numbers, {# > 5})` - Filter elements
+- **map(array, transform)**: `map(numbers, {# * 2})` - Transform elements
+- **count(array, predicate)**: `count(numbers, {# > 5})` - Count matching elements
+- **len(array)**: `len([1, 2, 3])` - Array length
+- **first(array)**: `first([1, 2, 3])` - First element
+- **last(array)**: `last([1, 2, 3])` - Last element
+
+### Closure Syntax
+- **Predicate**: `{# > 5}` where `#` represents current element
+- **Transform**: `{# * 2}` where `#` represents current element
+- **Property access**: `{.price > 100}` where `.` accesses element properties
+
+### Math Functions
+- **max(a, b, ...)**: `max(1, 2, 3)` - Maximum value
+- **min(a, b, ...)**: `min(1, 2, 3)` - Minimum value
+- **abs(x)**: `abs(-5)` - Absolute value
+- **ceil(x)**: `ceil(3.2)` - Ceiling
+- **floor(x)**: `floor(3.8)` - Floor
+- **round(x)**: `round(3.6)` - Round to nearest integer
+- **sqrt(x)**: `sqrt(16)` - Square root
+- **pow(x, y)**: `pow(2, 8)` - Power function
+
+### String Functions
+- **len(string)**: `len("hello")` - String length
+- **upper(string)**: `upper("hello")` - Uppercase
+- **lower(string)**: `lower("HELLO")` - Lowercase
+- **trim(string)**: `trim(" hello ")` - Remove whitespace
+- **contains(string, substr)**: `contains("hello", "ell")` - Contains substring
+- **startsWith(string, prefix)**: `startsWith("hello", "hel")` - Starts with prefix
+- **endsWith(string, suffix)**: `endsWith("hello", "llo")` - Ends with suffix
+- **split(string, separator)**: `split("a,b,c", ",")` - Split string
+- **join(array, separator)**: `join(["a", "b"], ",")` - Join array elements
+
+### Type Functions
+- **type(value)**: `type(42)` - Returns type name ("int", "float", "string", "bool", "array", "map")
+- **int(value)**: `int("42")` - Convert to integer
+- **float(value)**: `float("3.14")` - Convert to float
+- **string(value)**: `string(42)` - Convert to string
+
+### Date/Time Functions
+- **now()**: `now()` - Current timestamp
+- **date(format)**: `date("2006-01-02")` - Parse date
+- **duration(string)**: `duration("1h30m")` - Parse duration
+
+## Environment Variables
+
+Variables accessible within expressions through the environment parameter.
+
+### Variable Access
+```lua
+-- Simple variables
+{price = 100, quantity = 3}
+-- Expression: price * quantity
+
+-- Nested objects  
+{user = {profile = {age = 25, active = true}}}
+-- Expression: user.profile.age >= 18 && user.profile.active
+
+-- Arrays
+{items = {{price = 100}, {price = 50}}}
+-- Expression: all(items, {.price > 0})
+```
+
+### Special Variables
+- **#**: Current element in array iteration contexts
+- **.**: Property accessor for current element
+- **$**: Root context (implementation dependent)
+
+## Error Handling
+
+### Compile-time Errors
+- **Syntax errors**: Invalid expression syntax
+- **Type errors**: Incompatible operations
+- **Undefined functions**: Unknown function calls
+- **Invalid operations**: Type mismatches
+
+### Runtime Errors
+- **Division by zero**: `5 / 0`
+- **Index out of bounds**: `array[100]`
+- **Null access**: `nil.property`
+- **Type conversion**: Cannot convert incompatible types
+- **Undefined variables**: Variable not in environment
+
+### Error Messages
+```lua
+local program, err = expr.compile("2 +")
+-- err: "unexpected end of expression"
+
+local result, err = program:run({})  
+-- err: "undefined variable: x"
+```
+
+### Safety Features
+- **Side-effect free**: Expressions cannot modify state
+- **Always terminating**: No infinite loops possible
+- **Sandboxed**: No access to system functions
+- **Type safe**: Runtime type checking prevents errors
+
+### Permissions
+Expression evaluation requires no special permissions. All operations are read-only on provided environment data.


### PR DESCRIPTION
This pull request introduces a new Lua module for expression evaluation using the `expr` Go library, and integrates it into the application. The main focus is to provide Lua scripts with the ability to compile and evaluate expressions efficiently, with caching support for performance. The most important changes are summarized below:

**New Lua Expression Module:**

* Added a new `expr` module at `runtime/lua/modules/expr/module.go`, which provides Lua bindings to the `expr` Go library, allowing Lua scripts to compile and evaluate expressions. The module includes LRU caching for compiled expressions, and exposes `compile`, `eval`, and `Program:run` methods to Lua.

**Integration and Dependency Updates:**

* Registered the new `expr` module in the application by updating the Lua runtime initialization in `cmd/runner/app/services.go`, and set the cache capacity to 1000 entries. [[1]](diffhunk://#diff-bfcaa284a9b2b9816b62bdf1433ee2e2034052cb61d5abc08a1bda097bb6606eR10) [[2]](diffhunk://#diff-bfcaa284a9b2b9816b62bdf1433ee2e2034052cb61d5abc08a1bda097bb6606eR406)
* Added the `github.com/expr-lang/expr` dependency to `go.mod` to support expression evaluation.