### PR TITLE
feat(wippy): EE2-1876 update workflow to publish releases instead of commits

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,16 +2,13 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches:
-      - main
-      - develop
     tags:
       - "v*"
-  pull_request:
+      - "release/*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g., v1.0.0)"
+        description: "Release tag (e.g., v1.0.0, v1.2.3-alpha)"
         required: true
         type: string
 
@@ -51,6 +48,9 @@ jobs:
       CGO_ENABLED: 1
       BINARY_NAME: wippy
       TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
+      # Remove 'v' prefix and 'release/' prefix for filename
+      VERSION_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      CLEAN_TAG: ${{ contains(github.event.inputs.tag || github.ref_name, 'v') && replace(github.event.inputs.tag || github.ref_name, 'v', '') || replace(github.event.inputs.tag || github.ref_name, 'release/', '') }}
 
     steps:
       - name: Check out code
@@ -149,28 +149,28 @@ jobs:
         run: |
           make build-runner-linux-amd64
           cd ./dist
-          mv runner-linux-amd64 wippy-linux-amd64
-          echo "✅ Built wippy-linux-amd64"
-          echo "📊 Binary size before compression: $(ls -lh wippy-linux-amd64 | awk '{print $5}')"
+          mv runner-linux-amd64 wippy-linux-amd64-${{ env.CLEAN_TAG }}
+          echo "✅ Built wippy-linux-amd64-${{ env.CLEAN_TAG }}"
+          echo "📊 Binary size before compression: $(ls -lh wippy-linux-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
           # Compress with UPX
-          upx --best --lzma wippy-linux-amd64
-          echo "✅ Compressed wippy-linux-amd64 with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-linux-amd64 | awk '{print $5}')"
+          upx --best --lzma wippy-linux-amd64-${{ env.CLEAN_TAG }}
+          echo "✅ Compressed wippy-linux-amd64-${{ env.CLEAN_TAG }} with UPX"
+          echo "📊 Binary size after compression: $(ls -lh wippy-linux-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build Linux ARM64 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64'
         run: |
           make build-runner-linux-arm64
           cd ./dist
-          mv runner-linux-arm64 wippy-linux-arm64
-          echo "✅ Built wippy-linux-arm64"
-          echo "📊 Binary size before compression: $(ls -lh wippy-linux-arm64 | awk '{print $5}')"
+          mv runner-linux-arm64 wippy-linux-arm64-${{ env.CLEAN_TAG }}
+          echo "✅ Built wippy-linux-arm64-${{ env.CLEAN_TAG }}"
+          echo "📊 Binary size before compression: $(ls -lh wippy-linux-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
           # Compress with UPX
-          upx --best --lzma wippy-linux-arm64
-          echo "✅ Compressed wippy-linux-arm64 with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-linux-arm64 | awk '{print $5}')"
+          upx --best --lzma wippy-linux-arm64-${{ env.CLEAN_TAG }}
+          echo "✅ Compressed wippy-linux-arm64-${{ env.CLEAN_TAG }} with UPX"
+          echo "📊 Binary size after compression: $(ls -lh wippy-linux-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build Windows AMD64
         if: matrix.os == 'windows-latest' && matrix.arch == 'amd64'
@@ -178,107 +178,53 @@ jobs:
         run: |
           make build-runner-windows-amd64
           cd ./dist
-          mv runner-windows-amd64.exe wippy-windows-amd64.exe
-          echo "✅ Built wippy-windows-amd64.exe"
-          echo "📊 Binary size before compression: $(ls -lh wippy-windows-amd64.exe | awk '{print $5}')"
+          mv runner-windows-amd64.exe wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe
+          echo "✅ Built wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe"
+          echo "📊 Binary size before compression: $(ls -lh wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe | awk '{print $5}')"
 
           # Compress with UPX
-          upx --best --lzma wippy-windows-amd64.exe
-          echo "✅ Compressed wippy-windows-amd64.exe with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-windows-amd64.exe | awk '{print $5}')"
+          upx --best --lzma wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe
+          echo "✅ Compressed wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe with UPX"
+          echo "📊 Binary size after compression: $(ls -lh wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe | awk '{print $5}')"
 
       - name: Build macOS AMD64
         if: matrix.os == 'macos-latest' && matrix.arch == 'amd64'
         run: |
           make build-runner-darwin-amd64
           cd ./dist
-          mv runner-darwin-amd64 wippy-darwin-amd64
-          echo "✅ Built wippy-darwin-amd64"
-          echo "📊 Binary size before compression: $(ls -lh wippy-darwin-amd64 | awk '{print $5}')"
+          mv runner-darwin-amd64 wippy-darwin-amd64-${{ env.CLEAN_TAG }}
+          echo "✅ Built wippy-darwin-amd64-${{ env.CLEAN_TAG }}"
+          echo "📊 Binary size before compression: $(ls -lh wippy-darwin-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
           # Compress with UPX (force macOS support)
-          upx --best --lzma --force-macos wippy-darwin-amd64
-          echo "✅ Compressed wippy-darwin-amd64 with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-darwin-amd64 | awk '{print $5}')"
+          upx --best --lzma --force-macos wippy-darwin-amd64-${{ env.CLEAN_TAG }}
+          echo "✅ Compressed wippy-darwin-amd64-${{ env.CLEAN_TAG }} with UPX"
+          echo "📊 Binary size after compression: $(ls -lh wippy-darwin-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build macOS ARM64
         if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
         run: |
           make build-runner-darwin-arm64
           cd ./dist
-          mv runner-darwin-arm64 wippy-darwin-arm64
-          echo "✅ Built wippy-darwin-arm64"
-          echo "📊 Binary size before compression: $(ls -lh wippy-darwin-arm64 | awk '{print $5}')"
+          mv runner-darwin-arm64 wippy-darwin-arm64-${{ env.CLEAN_TAG }}
+          echo "✅ Built wippy-darwin-arm64-${{ env.CLEAN_TAG }}"
+          echo "📊 Binary size before compression: $(ls -lh wippy-darwin-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
           # Compress with UPX (force macOS support)
-          upx --best --lzma --force-macos wippy-darwin-arm64
-          echo "✅ Compressed wippy-darwin-arm64 with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-darwin-arm64 | awk '{print $5}')"
+          upx --best --lzma --force-macos wippy-darwin-arm64-${{ env.CLEAN_TAG }}
+          echo "✅ Compressed wippy-darwin-arm64-${{ env.CLEAN_TAG }} with UPX"
+          echo "📊 Binary size after compression: $(ls -lh wippy-darwin-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wippy-${{ matrix.platform }}-${{ matrix.arch }}
+          name: wippy-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.CLEAN_TAG }}
           path: ./dist/
           retention-days: 30
 
-  # PR Summary - only for pull requests
-  pr-summary:
-    name: PR Build Summary
-    runs-on: ubuntu-latest
-    needs: lint-test-build
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 5
-
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: ./artifacts/
-
-      - name: Generate build summary
-        run: |
-          echo "## 📦 Build Summary for PR #${{ github.event.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.head_ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Optimized Binaries (UPX Compressed):" >> $GITHUB_STEP_SUMMARY
-
-          # Extract binaries from all artifacts
-          for artifact_dir in ./artifacts/wippy-*; do
-            if [ -d "$artifact_dir" ]; then
-              echo "📦 From $artifact_dir:" >> $GITHUB_STEP_SUMMARY
-              for file in "$artifact_dir"/*; do
-                if [ -f "$file" ]; then
-                  filename=$(basename "$file")
-                  size=$(stat -c%s "$file" 2>/dev/null || echo "Unknown")
-                  if [ "$size" != "Unknown" ] && [ "$size" -gt 0 ]; then
-                    if [ "$size" -lt 1024 ]; then
-                      size_str="${size}B"
-                    elif [ "$size" -lt 1048576 ]; then
-                      size_str="$(( size / 1024 ))KB"
-                    else
-                      size_str="$(( size / 1048576 ))MB"
-                    fi
-                    echo "- \`$filename\` ($size_str)" >> $GITHUB_STEP_SUMMARY
-                  fi
-                fi
-              done
-            fi
-          done
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🔗 Download Links:" >> $GITHUB_STEP_SUMMARY
-          echo "- [wippy-releases (with binaries)](https://github.com/wippyai/wippy-releases/tree/main/releases/wippy)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Latest Build (direct download)](https://github.com/wippyai/wippy-releases/tree/main/releases/wippy/latest)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### ℹ️ Note:" >> $GITHUB_STEP_SUMMARY
-          echo "Binaries are optimized with UPX compression (~80% size reduction) and available for direct download from wippy-releases repository." >> $GITHUB_STEP_SUMMARY
-
-  # Release job - runs on every push and manual releases
+  # Release job - creates GitHub release in wippy-releases repository
   release:
-    name: Create Release
+    name: Create Release in wippy-releases
     runs-on: ubuntu-latest
     needs: lint-test-build
     if: always() && (needs.lint-test-build.result != 'failure')
@@ -286,6 +232,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}
       TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
+      CLEAN_TAG: ${{ contains(github.event.inputs.tag || github.ref_name, 'v') && replace(github.event.inputs.tag || github.ref_name, 'v', '') || replace(github.event.inputs.tag || github.ref_name, 'release/', '') }}
 
     steps:
       - name: Check out code
@@ -318,9 +265,6 @@ jobs:
 
           echo "📦 Available binaries for release:"
           ls -la ./release-binaries/ || echo "No binaries found"
-
-          # Compress binaries for wippy-releases (they are already compressed from build steps)
-          echo "📦 Binaries are already compressed with UPX from build steps"
 
       - name: Generate checksums
         run: |
@@ -365,15 +309,15 @@ jobs:
           ## Downloads
 
           ### Windows
-          - **Windows AMD64**: \`wippy-windows-amd64.exe\` (compressed with UPX)
+          - **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe\` (compressed with UPX)
 
           ### Linux
-          - **Linux AMD64**: \`wippy-linux-amd64\` (compressed with UPX)
-          - **Linux ARM64**: \`wippy-linux-arm64\` (compressed with UPX)
+          - **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
+          - **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
 
           ### macOS
-          - **macOS AMD64**: \`wippy-darwin-amd64\` (compressed with UPX)
-          - **macOS ARM64**: \`wippy-darwin-arm64\` (compressed with UPX)
+          - **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
+          - **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
 
           ### Binary Optimization
           All binaries are optimized for minimal size with UPX compression (~80% size reduction).
@@ -383,21 +327,21 @@ jobs:
           ### Windows
           \`\`\`powershell
           # Download the appropriate binary
-          wippy-windows-amd64.exe --help
+          wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe --help
           \`\`\`
 
           ### Linux
           \`\`\`bash
           # Download and make executable
-          chmod +x wippy-linux-amd64
-          ./wippy-linux-amd64 --help
+          chmod +x wippy-linux-amd64-${{ env.CLEAN_TAG }}
+          ./wippy-linux-amd64-${{ env.CLEAN_TAG }} --help
           \`\`\`
 
           ### macOS
           \`\`\`bash
           # Download and make executable
-          chmod +x wippy-darwin-amd64  # or wippy-darwin-arm64 for Apple Silicon
-          ./wippy-darwin-amd64 --help
+          chmod +x wippy-darwin-amd64-${{ env.CLEAN_TAG }}  # or wippy-darwin-arm64-${{ env.CLEAN_TAG }} for Apple Silicon
+          ./wippy-darwin-amd64-${{ env.CLEAN_TAG }} --help
           \`\`\`
 
           ## Verification
@@ -410,11 +354,11 @@ jobs:
 
           echo "✅ Generated release notes"
 
-      - name: Create Release (only for valid tags)
-        if: startsWith(env.TAG_NAME, 'v') || startsWith(env.TAG_NAME, 'release/')
+      - name: Create Release in wippy-releases repository
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ env.GITHUB_TOKEN }}
+          repository: wippyai/wippy-releases
           tag_name: ${{ env.TAG_NAME }}
           name: "Wippy ${{ env.TAG_NAME }}"
           body_path: release_notes.md
@@ -423,291 +367,11 @@ jobs:
           draft: false
           prerelease: ${{ contains(env.TAG_NAME, 'alpha') || contains(env.TAG_NAME, 'beta') || contains(env.TAG_NAME, 'rc') }}
 
-      - name: Update wippy-releases repository
-        run: |
-          # Clone wippy-releases repository
-          git clone https://${GITHUB_TOKEN}@github.com/wippyai/wippy-releases.git release-repo
-          cd release-repo
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Determine directory structure based on branch/tag
-          COMMIT_HASH=$(echo "${{ github.sha }}" | cut -c1-8)
-          BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H-%M)
-
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            # Latest version for main - no timestamp, overwrites previous
-            DIR_NAME="wippy/main"
-            echo "📁 Using main branch directory: $DIR_NAME"
-          elif [ "${{ github.ref_name }}" = "develop" ]; then
-            # Latest version for develop - no timestamp, overwrites previous
-            DIR_NAME="wippy/develop"
-            echo "📁 Using develop branch directory: $DIR_NAME"
-          elif [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            # Timestamped releases for version tags
-            DIR_NAME="wippy/releases/${BUILD_TIMESTAMP}"
-            echo "📁 Using version tag directory: $DIR_NAME"
-          elif [[ "${{ github.ref_name }}" =~ ^release/ ]]; then
-            # Timestamped releases for release tags
-            DIR_NAME="wippy/releases/${BUILD_TIMESTAMP}"
-            echo "📁 Using release tag directory: $DIR_NAME"
-          else
-            # Timestamped releases for feature branches - only timestamp, no branch name
-            DIR_NAME="wippy/feature/${BUILD_TIMESTAMP}"
-            echo "📁 Using feature branch directory: $DIR_NAME"
-          fi
-
-          mkdir -p ./releases/$DIR_NAME
-
-          # Copy binaries to wippy-releases repository
-          echo "📦 Copying binaries to wippy-releases repository..."
-          cp -r ../release-binaries/* ./releases/$DIR_NAME/
-
-          # Create README with download links
-          cat > ./releases/$DIR_NAME/README.md << EOF
-          # Wippy Build $COMMIT_HASH
-
-          **Build Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          **Commit**: ${{ github.sha }}
-          **Branch/Tag**: ${{ github.ref_name }}
-          **Pipeline**: ${{ github.run_id }}
-          **Directory**: $DIR_NAME
-
-          ## Downloads
-
-          This build contains the following optimized binaries (available for direct download):
-
-          - **Linux AMD64**: [wippy-linux-amd64](./wippy-linux-amd64) (compressed with UPX)
-          - **Linux ARM64**: [wippy-linux-arm64](./wippy-linux-arm64) (compressed with UPX)
-          - **Windows AMD64**: [wippy-windows-amd64.exe](./wippy-windows-amd64.exe) (compressed with UPX)
-          - **macOS AMD64**: [wippy-darwin-amd64](./wippy-darwin-amd64) (compressed with UPX)
-          - **macOS ARM64**: [wippy-darwin-arm64](./wippy-darwin-arm64) (compressed with UPX)
-
-          ${{ startsWith(env.TAG_NAME, 'v') || startsWith(env.TAG_NAME, 'release/') && format('## GitHub Release\n\nThis build is also available on GitHub Releases:\n\n- [Download from GitHub Releases](https://github.com/{0}/releases/tag/{1})\n', github.repository, env.TAG_NAME) || '' }}
-
-          ## Binary Optimization
-
-          All binaries are optimized for minimal size:
-          - **Build optimization**: Stripped debug symbols, trimmed paths, PIE build mode
-          - **UPX compression**: ~80% size reduction with LZMA compression
-          - **Final size**: ~12MB (down from ~78MB uncompressed)
-
-          ## Installation
-
-          ### Linux
-          \`\`\`bash
-          # Download and make executable
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-linux-amd64
-          chmod +x wippy-linux-amd64
-          ./wippy-linux-amd64 --help
-          \`\`\`
-
-          ### Windows
-          \`\`\`powershell
-          # Download and run
-          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-windows-amd64.exe" -OutFile "wippy-windows-amd64.exe"
-          .\wippy-windows-amd64.exe --help
-          \`\`\`
-
-          ### macOS
-          \`\`\`bash
-          # Download and make executable (Intel Mac)
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-darwin-amd64
-          chmod +x wippy-darwin-amd64
-          ./wippy-darwin-amd64 --help
-
-          # Or for Apple Silicon Mac
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-darwin-arm64
-          chmod +x wippy-darwin-arm64
-          ./wippy-darwin-arm64 --help
-          \`\`\`
-
-          ## Verification
-
-          Verify the integrity of downloaded files using the provided checksums:
-          \`\`\`bash
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/checksums.txt
-          sha256sum -c checksums.txt
-          \`\`\`
-
-          ## Build Information
-
-          - **Repository**: ${{ github.repository }}
-          - **Workflow**: [View Build](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          - **Source**: [Commit $COMMIT_HASH](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          EOF
-
-          # Create symlinks and update main README based on branch type
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            # For main branch, create main symlink
-            rm -f ./releases/wippy/main
-            ln -sf $DIR_NAME ./releases/wippy/main
-            echo "🔗 Created main symlink: wippy/main -> $DIR_NAME"
-          elif [ "${{ github.ref_name }}" = "develop" ]; then
-            # For develop branch, create develop symlink
-            rm -f ./releases/wippy/develop
-            ln -sf $DIR_NAME ./releases/wippy/develop
-            echo "🔗 Created develop symlink: wippy/develop -> $DIR_NAME"
-          else
-            # For other branches/tags, create latest symlink
-            rm -f ./releases/wippy/latest
-            ln -sf $DIR_NAME ./releases/wippy/latest
-            echo "🔗 Created latest symlink: wippy/latest -> $DIR_NAME"
-          fi
-
-          # Update main README with latest build info
-          cat > ./releases/wippy/README.md << EOF
-          # Wippy Releases
-
-          This repository contains pre-built binaries for the Wippy runtime, organized by branch and release type.
-
-          ## Quick Access
-
-          - **Main Branch**: [wippy/main](./main/) - Latest stable builds
-          - **Develop Branch**: [wippy/develop](./develop/) - Latest development builds
-          - **Latest Build**: [wippy/latest](./latest/) - Most recent build (any branch)
-
-          ## Current Build
-
-          - **Build**: [$DIR_NAME](./$DIR_NAME/) (Commit: $COMMIT_HASH)
-          - **Branch/Tag**: ${{ github.ref_name }}
-          - **Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-
-          ## Available Platforms
-
-          - **Linux AMD64**: Optimized for x86_64 Linux systems
-          - **Linux ARM64**: Optimized for ARM64 Linux systems (Raspberry Pi, etc.)
-          - **Windows AMD64**: Optimized for x86_64 Windows systems
-          - **macOS AMD64**: Optimized for Intel-based Mac systems
-          - **macOS ARM64**: Optimized for Apple Silicon Mac systems (M1/M2/M3)
-
-          ## Binary Optimization
-
-          All binaries are optimized for minimal size:
-          - **Build optimization**: Stripped debug symbols, trimmed paths, PIE build mode
-          - **UPX compression**: ~80% size reduction with LZMA compression
-          - **Final size**: ~12MB (down from ~78MB uncompressed)
-
-          ## Quick Start
-
-          ### Main Branch (Stable)
-          \`\`\`bash
-          # Download latest stable build
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/wippy/main/wippy-linux-amd64
-          chmod +x wippy-linux-amd64
-          ./wippy-linux-amd64 --help
-          \`\`\`
-
-          ### Develop Branch (Development)
-          \`\`\`bash
-          # Download latest development build
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/wippy/develop/wippy-linux-amd64
-          chmod +x wippy-linux-amd64
-          ./wippy-linux-amd64 --help
-          \`\`\`
-
-          ### Latest Build (Any Branch)
-          \`\`\`bash
-          # Download most recent build
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/wippy/latest/wippy-linux-amd64
-          chmod +x wippy-linux-amd64
-          ./wippy-linux-amd64 --help
-          \`\`\`
-
-          ### Windows
-          \`\`\`powershell
-          # Download latest build (Windows)
-          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/wippy/latest/wippy-windows-amd64.exe" -OutFile "wippy-windows-amd64.exe"
-          .\wippy-windows-amd64.exe --help
-          \`\`\`
-
-          ### macOS
-          \`\`\`bash
-          # Download latest build (macOS)
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/wippy/latest/wippy-darwin-amd64  # Intel Mac
-          # or
-          wget https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/wippy/latest/wippy-darwin-arm64  # Apple Silicon Mac
-          chmod +x wippy-darwin-amd64
-          ./wippy-darwin-amd64 --help
-          \`\`\`
-
-          ## Directory Structure
-
-          - **wippy/main/**: Latest builds from main branch (stable)
-          - **wippy/develop/**: Latest builds from develop branch (development)
-          - **wippy/releases/**: Timestamped releases from version tags
-          - **wippy/feature/**: Timestamped builds from feature branches (YYYY-MM-DD-HH-MM format)
-
-          ## Build History
-
-          All builds are preserved in their respective directories. Check the [releases directory](./) for historical builds.
-          EOF
-
-          # Commit and push
-          git add .
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            # Create commit message based on branch type
-            if [ "${{ github.ref_name }}" = "main" ]; then
-              COMMIT_MSG="Update main branch build $COMMIT_HASH
-
-          - Updated optimized binaries for Linux AMD64, Linux ARM64, and Windows AMD64
-          - All binaries compressed with UPX for minimal size
-          - Updated main symlink and main README
-          - Build from commit: ${{ github.sha }}"
-            elif [ "${{ github.ref_name }}" = "develop" ]; then
-              COMMIT_MSG="Update develop branch build $COMMIT_HASH
-
-          - Updated optimized binaries for Linux AMD64, Linux ARM64, and Windows AMD64
-          - All binaries compressed with UPX for minimal size
-          - Updated develop symlink and main README
-          - Build from commit: ${{ github.sha }}"
-            elif [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-              COMMIT_MSG="Add version release ${{ github.ref_name }} - $COMMIT_HASH
-
-          - Added optimized binaries for Linux AMD64, Linux ARM64, and Windows AMD64
-          - All binaries compressed with UPX for minimal size
-          - Version release from commit: ${{ github.sha }}"
-            else
-              COMMIT_MSG="Add feature build ${{ github.ref_name }} - $COMMIT_HASH
-
-          - Added optimized binaries for Linux AMD64, Linux ARM64, and Windows AMD64
-          - All binaries compressed with UPX for minimal size
-          - Feature build from commit: ${{ github.sha }}"
-            fi
-            
-            git commit -m "$COMMIT_MSG"
-            git push origin main
-            echo "✅ Updated wippy-releases repository with binaries in $DIR_NAME"
-          fi
-
       - name: Release Summary
         run: |
-          # Determine directory structure for summary
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            DIR_NAME="wippy/main"
-            BRANCH_TYPE="Main Branch (Stable)"
-          elif [ "${{ github.ref_name }}" = "develop" ]; then
-            DIR_NAME="wippy/develop"
-            BRANCH_TYPE="Develop Branch (Development)"
-          elif [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H-%M)
-            DIR_NAME="wippy/releases/${BUILD_TIMESTAMP}"
-            BRANCH_TYPE="Version Release (${{ github.ref_name }})"
-          elif [[ "${{ github.ref_name }}" =~ ^release/ ]]; then
-            BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H-%M)
-            DIR_NAME="wippy/releases/${BUILD_TIMESTAMP}"
-            BRANCH_TYPE="Release Tag (${{ github.ref_name }})"
-          else
-            BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H-%M)
-            DIR_NAME="wippy/feature/${BUILD_TIMESTAMP}"
-            BRANCH_TYPE="Feature Branch (${{ github.ref_name }})"
-          fi
-
-          echo "## 🚀 $BRANCH_TYPE Published!" >> $GITHUB_STEP_SUMMARY
+          echo "## 🚀 Release ${{ env.TAG_NAME }} Published!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Directory**: \`$DIR_NAME\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag**: \`${{ env.TAG_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📦 Optimized Binaries (UPX Compressed):" >> $GITHUB_STEP_SUMMARY
@@ -731,18 +395,14 @@ jobs:
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🔗 Release Links:" >> $GITHUB_STEP_SUMMARY
-          echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/${{ env.TAG_NAME }})" >> $GITHUB_STEP_SUMMARY
-          echo "- [wippy-releases (with binaries)](https://github.com/wippyai/wippy-releases/tree/main/releases/wippy)" >> $GITHUB_STEP_SUMMARY
-          echo "- [This Build (direct download)](https://github.com/wippyai/wippy-releases/tree/main/releases/$DIR_NAME)" >> $GITHUB_STEP_SUMMARY
+          echo "- [GitHub Release in wippy-releases](https://github.com/wippyai/wippy-releases/releases/tag/${{ env.TAG_NAME }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📥 Direct Download URLs:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Linux AMD64**: \`https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-linux-amd64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Linux ARM64**: \`https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-linux-arm64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Windows AMD64**: \`https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-windows-amd64.exe\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS AMD64**: \`https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-darwin-amd64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS ARM64**: \`https://raw.githubusercontent.com/wippyai/wippy-releases/main/releases/$DIR_NAME/wippy-darwin-arm64\`" >> $GITHUB_STEP_SUMMARY
+          echo "### 📥 Download from GitHub Release:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🔗 Quick Access Links:" >> $GITHUB_STEP_SUMMARY
-          echo "- [Main Branch (Stable)](https://github.com/wippyai/wippy-releases/tree/main/releases/wippy/main)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Develop Branch (Development)](https://github.com/wippyai/wippy-releases/tree/main/releases/wippy/develop)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Latest Build (Any Branch)](https://github.com/wippyai/wippy-releases/tree/main/releases/wippy/latest)" >> $GITHUB_STEP_SUMMARY
+          echo "### ℹ️ Note:" >> $GITHUB_STEP_SUMMARY
+          echo "All binaries are optimized with UPX compression (~80% size reduction) and available for download from the GitHub release assets." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,16 +14,17 @@ on:
         type: string
 
 jobs:
-  # Quality checks and conditional builds - stable platforms only (Linux + Windows)
+  # Quality checks - only for pull requests
   quality-checks:
     name: Quality Checks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Test only on stable platforms (Linux + Windows) to avoid runner issues
+          # Test only on stable platforms (Linux + Windows) for PRs
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "amd64"
@@ -34,23 +35,75 @@ jobs:
             arch: "amd64"
             run_lint: false
             run_tests: true
-          # ARM64 platforms - build only for releases (no testing to save budget)
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}
+      CGO_ENABLED: 1
+      BINARY_NAME: wippy
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      # Run linter only on Ubuntu AMD64
+      - name: Run linter
+        if: matrix.os == 'ubuntu-latest' && matrix.run_lint == true
+        uses: golangci/golangci-lint-action@v8.0.0
+        env:
+          CGO_ENABLED: 1
+        with:
+          version: v2.2.1
+          only-new-issues: false
+          args: --timeout=10m --build-tags=race ./...
+
+      # Run tests on all platforms
+      - name: Run unit tests (Linux/macOS)
+        if: matrix.os != 'windows-latest' && matrix.run_tests == true
+        env:
+          GORACE: "halt_on_error=1"
+        run: make test
+
+      - name: Run unit tests (Windows)
+        if: matrix.os == 'windows-latest' && matrix.run_tests == true
+        shell: msys2 {0}
+        env:
+          GORACE: "halt_on_error=1"
+        run: make test
+
+  # Release builds - only for tags and workflow_dispatch
+  release-builds:
+    name: Release Builds (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # All platforms for releases
+          - os: "ubuntu-latest"
+            platform: "linux"
+            arch: "amd64"
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "arm64"
-            run_lint: false
-            run_tests: false
-          # macOS platforms - using macOS-13 for better availability
+          - os: "windows-latest"
+            platform: "windows"
+            arch: "amd64"
           - os: "macos-13"
             platform: "darwin"
             arch: "amd64"
-            run_lint: false
-            run_tests: false
           - os: "macos-13"
             platform: "darwin"
             arch: "arm64"
-            run_lint: false
-            run_tests: false
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}
@@ -272,8 +325,8 @@ jobs:
   release:
     name: Create Release in wippy-releases
     runs-on: ubuntu-latest
-    needs: quality-checks
-    if: always() && (needs.quality-checks.result != 'failure') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'release/'))
+    needs: release-builds
+    if: always() && (needs.release-builds.result != 'failure') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'release/'))
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}
@@ -305,6 +358,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts/
+          pattern: wippy-*
 
       - name: Extract and organize binaries
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,7 +60,24 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Clean tag name
+      - name: Clean tag name (Linux/macOS)
+        if: matrix.os != 'windows-latest'
+        run: |
+          # Remove 'v' prefix and 'release/' prefix for filename
+          if [[ "${{ env.TAG_NAME }}" == v* ]]; then
+            CLEAN_TAG="${TAG_NAME#v}"
+          elif [[ "${{ env.TAG_NAME }}" == release/* ]]; then
+            CLEAN_TAG="${TAG_NAME#release/}"
+          else
+            CLEAN_TAG="${{ env.TAG_NAME }}"
+          fi
+          echo "CLEAN_TAG=$CLEAN_TAG" >> $GITHUB_ENV
+          echo "Original tag: ${{ env.TAG_NAME }}"
+          echo "Clean tag: $CLEAN_TAG"
+
+      - name: Clean tag name (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
         run: |
           # Remove 'v' prefix and 'release/' prefix for filename
           if [[ "${{ env.TAG_NAME }}" == v* ]]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -241,12 +241,16 @@ jobs:
       - name: Build Linux AMD64 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
+          # Download PackCLI for this platform only
+          ./scripts/packcli-integration/download-packcli.sh latest linux-amd64
           make build-release-linux-amd64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Build Linux ARM64 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
+          # Download PackCLI for this platform only
+          ./scripts/packcli-integration/download-packcli.sh latest linux-arm64
           make build-release-linux-arm64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-linux-arm64-${{ env.CLEAN_TAG }}.tar.gz"
 
@@ -254,6 +258,8 @@ jobs:
         if: matrix.os == 'windows-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         shell: msys2 {0}
         run: |
+          # Download PackCLI for this platform only
+          ./scripts/packcli-integration/download-packcli.sh latest windows-amd64
           make build-release-windows-amd64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip"
 
@@ -262,6 +268,8 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         run: |
+          # Download PackCLI for this platform only
+          ./scripts/packcli-integration/download-packcli.sh latest darwin-amd64
           make build-release-darwin-amd64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz"
 
@@ -270,6 +278,8 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         run: |
+          # Download PackCLI for this platform only
+          ./scripts/packcli-integration/download-packcli.sh latest darwin-arm64
           make build-release-darwin-arm64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz"
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -326,30 +326,20 @@ jobs:
           echo "📦 Available binaries for release:"
           ls -la ./release-binaries/ || echo "No binaries found"
 
-      - name: Download PackCLI binaries
-        run: |
-          echo "🔧 Downloading latest PackCLI binaries for integration..."
-
-          # Use local PackCLI integration script
-          chmod +x ./scripts/packcli-integration/download-packcli.sh
-
-          # Always download the latest available PackCLI version
-          # This avoids version confusion since Wippy and PackCLI have independent release cycles
-          echo "📦 Downloading latest PackCLI version (independent of Wippy version)..."
-
-          if ./scripts/packcli-integration/download-packcli.sh "latest"; then
-            echo "✅ PackCLI binaries downloaded successfully"
-            # Move PackCLI binaries to release directory
-            mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
-            mv packcli-metadata.json ./release-binaries/ 2>/dev/null || echo "No PackCLI metadata to move"
-            echo "✅ PackCLI binaries included in Wippy release"
-          else
-            echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
-            echo "   This is normal if PackCLI hasn't been built yet"
-          fi
-
-          echo "📦 Final binaries for release:"
-          ls -la ./release-binaries/ || echo "No binaries found"
+            # PackCLI binaries - download latest PackCLI release
+            - name: Download PackCLI binaries
+              run: |
+                echo "🔧 Downloading latest PackCLI binaries for integration..."
+                chmod +x ./scripts/packcli-integration/download-packcli.sh
+                if ./scripts/packcli-integration/download-packcli.sh "latest"; then
+                  echo "✅ PackCLI binaries downloaded successfully"
+                  mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
+                  echo "✅ PackCLI binaries included in Wippy release"
+                else
+                  echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
+                fi
+                echo "📦 Final binaries for release:"
+                ls -la ./release-binaries/ || echo "No binaries found"
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,6 +67,15 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Setup msys (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-upx
+          path-type: inherit
+
       - name: Clean tag name (Linux/macOS)
         if: matrix.os != 'windows-latest'
         run: |
@@ -97,15 +106,6 @@ jobs:
           echo "CLEAN_TAG=$CLEAN_TAG" >> $GITHUB_ENV
           echo "Original tag: ${{ env.TAG_NAME }}"
           echo "Clean tag: $CLEAN_TAG"
-
-      - name: Setup msys (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-upx
-          path-type: inherit
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -380,20 +380,20 @@ jobs:
           echo "📦 Available binaries for release:"
           ls -la ./release-binaries/ || echo "No binaries found"
 
-            # PackCLI binaries - download latest PackCLI release
-            - name: Download PackCLI binaries
-              run: |
-                echo "🔧 Downloading latest PackCLI binaries for integration..."
-                chmod +x ./scripts/packcli-integration/download-packcli.sh
-                if ./scripts/packcli-integration/download-packcli.sh "latest"; then
-                  echo "✅ PackCLI binaries downloaded successfully"
-                  mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
-                  echo "✅ PackCLI binaries included in Wippy release"
-                else
-                  echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
-                fi
-                echo "📦 Final binaries for release:"
-                ls -la ./release-binaries/ || echo "No binaries found"
+      # PackCLI binaries - download latest PackCLI release
+      - name: Download PackCLI binaries
+        run: |
+          echo "🔧 Downloading latest PackCLI binaries for integration..."
+          chmod +x ./scripts/packcli-integration/download-packcli.sh
+          if ./scripts/packcli-integration/download-packcli.sh "latest"; then
+            echo "✅ PackCLI binaries downloaded successfully"
+            mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
+            echo "✅ PackCLI binaries included in Wippy release"
+          else
+            echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
+          fi
+          echo "📦 Final binaries for release:"
+          ls -la ./release-binaries/ || echo "No binaries found"
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -215,7 +215,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross libsqlite3-dev upx-ucl
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
           # Install SQLite3 and UPX via Homebrew
           brew install sqlite3 upx
@@ -268,9 +268,21 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         run: |
+          echo "🍎 Building macOS AMD64..."
+          echo "📁 Current directory: $(pwd)"
+          echo "📁 Directory contents:"
+          ls -la
+
           # Download PackCLI for this platform only
+          echo "📥 Downloading PackCLI for darwin-amd64..."
           ./scripts/packcli-integration/download-packcli.sh latest darwin-amd64
+
+          echo "🔨 Building release archive..."
           make build-release-darwin-amd64 VERSION=${{ env.CLEAN_TAG }}
+
+          echo "📁 Contents after build:"
+          ls -la ./dist/ || echo "No ./dist directory found"
+
           echo "✅ Created wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Build macOS ARM64
@@ -278,12 +290,39 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         run: |
+          echo "🍎 Building macOS ARM64..."
+          echo "📁 Current directory: $(pwd)"
+          echo "📁 Directory contents:"
+          ls -la
+
           # Download PackCLI for this platform only
+          echo "📥 Downloading PackCLI for darwin-arm64..."
           ./scripts/packcli-integration/download-packcli.sh latest darwin-arm64
+
+          echo "🔨 Building release archive..."
           make build-release-darwin-arm64 VERSION=${{ env.CLEAN_TAG }}
+
+          echo "📁 Contents after build:"
+          ls -la ./dist/ || echo "No ./dist directory found"
+
           echo "✅ Created wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Upload build artifacts
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: |
+          echo "🔍 Checking for build artifacts..."
+          if [ -d "./dist" ] && [ "$(ls -A ./dist 2>/dev/null)" ]; then
+            echo "📦 Found artifacts in ./dist:"
+            ls -la ./dist/
+            echo "📤 Uploading artifacts..."
+          else
+            echo "⚠️ No artifacts found in ./dist - skipping upload"
+            echo "📁 Current directory contents:"
+            ls -la
+            exit 0
+          fi
+
+      - name: Upload artifacts to GitHub
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,13 +40,13 @@ jobs:
             arch: "arm64"
             run_lint: false
             run_tests: false
-          # macOS platforms - build only for releases (runners often unavailable)
-          - os: "macos-latest"
+          # macOS platforms - using macOS-13 for better availability
+          - os: "macos-13"
             platform: "darwin"
             arch: "amd64"
             run_lint: false
             run_tests: false
-          - os: "macos-latest"
+          - os: "macos-13"
             platform: "darwin"
             arch: "arm64"
             run_lint: false
@@ -229,7 +229,9 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe | awk '{print $5}')"
 
       - name: Build macOS AMD64
-        if: matrix.os == 'macos-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'macos-13' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        timeout-minutes: 15
+        continue-on-error: true
         run: |
           make build-runner-darwin-amd64
           cd ./dist
@@ -243,7 +245,9 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-darwin-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build macOS ARM64
-        if: matrix.os == 'macos-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: matrix.os == 'macos-13' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        timeout-minutes: 15
+        continue-on-error: true
         run: |
           make build-runner-darwin-arm64
           cd ./dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -445,6 +445,29 @@ jobs:
             ./release-binaries/*
           draft: false
           prerelease: ${{ contains(env.TAG_NAME, 'alpha') || contains(env.TAG_NAME, 'beta') || contains(env.TAG_NAME, 'rc') }}
+          generate_release_notes: false
+
+      - name: Remove Source Code Archives
+        run: |
+          echo "🗑️ Removing automatically generated source code archives..."
+
+          # Get release assets
+          ASSETS=$(curl -s -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/wippyai/wippy-releases/releases/tags/${{ env.TAG_NAME }}" | \
+            jq -r '.assets[] | select(.name | test("Source code")) | .id')
+
+          if [ -n "$ASSETS" ]; then
+            echo "$ASSETS" | while read asset_id; do
+              if [ -n "$asset_id" ]; then
+                echo "🗑️ Deleting asset ID: $asset_id"
+                curl -X DELETE -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+                  "https://api.github.com/repos/wippyai/wippy-releases/releases/assets/$asset_id"
+              fi
+            done
+            echo "✅ Source code archives removed successfully"
+          else
+            echo "ℹ️ No source code archives found to remove"
+          fi
 
       - name: Release Summary
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -309,6 +309,7 @@ jobs:
 
       - name: Upload build artifacts
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        shell: bash
         run: |
           echo "🔍 Checking for build artifacts..."
           if [ -d "./dist" ] && [ "$(ls -A ./dist 2>/dev/null)" ]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -256,6 +256,7 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-darwin-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Upload build artifacts
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: wippy-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.CLEAN_TAG }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -404,7 +404,7 @@ jobs:
           \`\`\`powershell
           # Extract the archive
           Expand-Archive wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip
-          cd wippy-windows-amd64-${{ env.CLEAN_TAG }}
+          # Files are extracted directly to current directory
 
           # Run Wippy
           .\wippy.exe --help
@@ -418,7 +418,7 @@ jobs:
           \`\`\`bash
           # Extract the archive
           tar -xzf wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz
-          cd wippy-linux-amd64-${{ env.CLEAN_TAG }}
+          # Files are extracted directly to current directory
 
           # Make executables and run
           chmod +x wippy packcli
@@ -431,7 +431,7 @@ jobs:
           \`\`\`bash
           # Extract the archive
           tar -xzf wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz  # or wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz for Apple Silicon
-          cd wippy-darwin-amd64-${{ env.CLEAN_TAG }}
+          # Files are extracted directly to current directory
 
           # Make executables and run
           chmod +x wippy packcli

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,26 +23,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Only test on Linux AMD64 for PRs (fastest, cheapest)
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "amd64"
             run_lint: true
+            run_tests: true
+          # Build only on other platforms (no tests to save time)
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "arm64"
             run_lint: false
+            run_tests: false
           - os: "windows-latest"
             platform: "windows"
             arch: "amd64"
             run_lint: false
+            run_tests: false
           - os: "macos-latest"
             platform: "darwin"
             arch: "amd64"
             run_lint: false
+            run_tests: false
           - os: "macos-latest"
             platform: "darwin"
             arch: "arm64"
             run_lint: false
+            run_tests: false
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}
@@ -162,22 +169,22 @@ jobs:
           sqlite3 --version
           upx --version
 
-      - name: Run unit tests
-        if: matrix.os != 'windows-latest'
+      - name: Run unit tests (Linux/macOS)
+        if: matrix.os != 'windows-latest' && matrix.run_tests == true
         env:
           GORACE: "halt_on_error=1"
         run: make test
 
       - name: Run unit tests (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && matrix.run_tests == true
         shell: msys2 {0}
         env:
           GORACE: "halt_on_error=1"
         run: make test
 
-      # Build optimized binaries
+      # Build optimized binaries (only for releases or when needed)
       - name: Build Linux AMD64 (Ubuntu)
-        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64'
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           make build-runner-linux-amd64
           cd ./dist
@@ -191,7 +198,7 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-linux-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build Linux ARM64 (Ubuntu)
-        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64'
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           make build-runner-linux-arm64
           cd ./dist
@@ -205,7 +212,7 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-linux-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build Windows AMD64
-        if: matrix.os == 'windows-latest' && matrix.arch == 'amd64'
+        if: matrix.os == 'windows-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         shell: msys2 {0}
         run: |
           make build-runner-windows-amd64
@@ -220,7 +227,7 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe | awk '{print $5}')"
 
       - name: Build macOS AMD64
-        if: matrix.os == 'macos-latest' && matrix.arch == 'amd64'
+        if: matrix.os == 'macos-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           make build-runner-darwin-amd64
           cd ./dist
@@ -234,7 +241,7 @@ jobs:
           echo "📊 Binary size after compression: $(ls -lh wippy-darwin-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
 
       - name: Build macOS ARM64
-        if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
+        if: matrix.os == 'macos-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           make build-runner-darwin-arm64
           cd ./dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -279,7 +279,7 @@ jobs:
         with:
           name: wippy-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.CLEAN_TAG }}
           path: ./dist/
-          retention-days: 365
+          retention-days: 90
 
   # Release job - creates GitHub release with binaries in wippy-releases repository
   release:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,7 +260,7 @@ jobs:
         with:
           name: wippy-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.CLEAN_TAG }}
           path: ./dist/
-          retention-days: 30
+          retention-days: 365
 
   # Release job - creates GitHub release with binaries in wippy-releases repository
   release:
@@ -320,6 +320,31 @@ jobs:
           echo "📦 Available binaries for release:"
           ls -la ./release-binaries/ || echo "No binaries found"
 
+      - name: Download PackCLI binaries
+        run: |
+          echo "🔧 Downloading latest PackCLI binaries for integration..."
+
+          # Use local PackCLI integration script
+          chmod +x ./scripts/packcli-integration/download-packcli.sh
+
+          # Always download the latest available PackCLI version
+          # This avoids version confusion since Wippy and PackCLI have independent release cycles
+          echo "📦 Downloading latest PackCLI version (independent of Wippy version)..."
+
+          if ./scripts/packcli-integration/download-packcli.sh "latest"; then
+            echo "✅ PackCLI binaries downloaded successfully"
+            # Move PackCLI binaries to release directory
+            mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
+            mv packcli-metadata.json ./release-binaries/ 2>/dev/null || echo "No PackCLI metadata to move"
+            echo "✅ PackCLI binaries included in Wippy release"
+          else
+            echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
+            echo "   This is normal if PackCLI hasn't been built yet"
+          fi
+
+          echo "📦 Final binaries for release:"
+          ls -la ./release-binaries/ || echo "No binaries found"
+
       - name: Generate checksums
         run: |
           cd ./release-binaries
@@ -362,40 +387,82 @@ jobs:
 
           ## Downloads
 
-          ### Windows
+          ### Wippy Runtime
+          #### Windows
           - **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe\` (compressed with UPX)
 
-          ### Linux
+          #### Linux
           - **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
           - **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
 
-          ### macOS
+          #### macOS
           - **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
           - **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
+
+          ### PackCLI (Helper Tool)
+          PackCLI is included as a helper tool for module management and development.
+
+          #### Windows
+          - **Windows AMD64**: \`packcli-windows-amd64.exe\`
+
+          #### Linux
+          - **Linux AMD64**: \`packcli-linux-amd64\`
+          - **Linux ARM64**: \`packcli-linux-arm64\`
+
+          #### macOS
+          - **macOS AMD64**: \`packcli-darwin-amd64\`
+          - **macOS ARM64**: \`packcli-darwin-arm64\`
 
           ### Binary Optimization
           All binaries are optimized for minimal size with UPX compression (~80% size reduction).
 
           ## Installation
 
-          ### Windows
+          ### Wippy Runtime
+          #### Windows
           \`\`\`powershell
           # Download the appropriate binary
           wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe --help
           \`\`\`
 
-          ### Linux
+          #### Linux
           \`\`\`bash
           # Download and make executable
           chmod +x wippy-linux-amd64-${{ env.CLEAN_TAG }}
           ./wippy-linux-amd64-${{ env.CLEAN_TAG }} --help
           \`\`\`
 
-          ### macOS
+          #### macOS
           \`\`\`bash
           # Download and make executable
           chmod +x wippy-darwin-amd64-${{ env.CLEAN_TAG }}  # or wippy-darwin-arm64-${{ env.CLEAN_TAG }} for Apple Silicon
           ./wippy-darwin-amd64-${{ env.CLEAN_TAG }} --help
+          \`\`\`
+
+          ### PackCLI Helper Tool
+          PackCLI is included for module management and development tasks.
+
+          #### Windows
+          \`\`\`powershell
+          # Use PackCLI for module operations
+          packcli-windows-amd64.exe --help
+          packcli-windows-amd64.exe module init my-module
+          \`\`\`
+
+          #### Linux
+          \`\`\`bash
+          # Download and make executable
+          chmod +x packcli-linux-amd64
+          ./packcli-linux-amd64 --help
+          ./packcli-linux-amd64 module init my-module
+          \`\`\`
+
+          #### macOS
+          \`\`\`bash
+          # Download and make executable
+          chmod +x packcli-darwin-amd64  # or packcli-darwin-arm64 for Apple Silicon
+          ./packcli-darwin-amd64 --help
+          ./packcli-darwin-amd64 module init my-module
           \`\`\`
 
           ## Verification
@@ -452,11 +519,20 @@ jobs:
           echo "- [GitHub Release in wippy-releases](https://github.com/wippyai/wippy-releases/releases/tag/${{ env.TAG_NAME }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📥 Download from GitHub Release:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Wippy Runtime:" >> $GITHUB_STEP_SUMMARY
           echo "- **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe\`" >> $GITHUB_STEP_SUMMARY
           echo "- **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### PackCLI Helper Tool:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Linux AMD64**: \`packcli-linux-amd64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Linux ARM64**: \`packcli-linux-arm64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Windows AMD64**: \`packcli-windows-amd64.exe\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS AMD64**: \`packcli-darwin-amd64\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS ARM64**: \`packcli-darwin-arm64\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### ℹ️ Note:" >> $GITHUB_STEP_SUMMARY
           echo "All binaries are optimized with UPX compression (~80% size reduction) and available for download from the GitHub release assets." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,9 +98,6 @@ jobs:
           - os: "windows-latest"
             platform: "windows"
             arch: "amd64"
-          - os: "windows-latest"
-            platform: "windows"
-            arch: "arm64"
           - os: "macos-13"
             platform: "darwin"
             arch: "amd64"
@@ -260,13 +257,6 @@ jobs:
           make build-release-windows-amd64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip"
 
-      - name: Build Windows ARM64
-        if: matrix.os == 'windows-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        shell: msys2 {0}
-        run: |
-          make build-release-windows-arm64 VERSION=${{ env.CLEAN_TAG }}
-          echo "✅ Created wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip"
-
       - name: Build macOS AMD64
         if: matrix.os == 'macos-13' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         timeout-minutes: 15
@@ -399,7 +389,6 @@ jobs:
 
           #### Windows
           - **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip\`
-          - **Windows ARM64**: \`wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip\`
 
           #### Linux
           - **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz\`
@@ -413,11 +402,9 @@ jobs:
 
           ### Windows
           \`\`\`powershell
-          # Extract the archive (choose appropriate version)
-          Expand-Archive wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip  # For AMD64
-          # or
-          Expand-Archive wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip  # For ARM64
-          cd wippy-windows-amd64-${{ env.CLEAN_TAG }}  # or wippy-windows-arm64-${{ env.CLEAN_TAG }}
+          # Extract the archive
+          Expand-Archive wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip
+          cd wippy-windows-amd64-${{ env.CLEAN_TAG }}
 
           # Run Wippy
           .\wippy.exe --help
@@ -505,6 +492,5 @@ jobs:
           echo "- **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Windows ARM64**: \`wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip\`" >> $GITHUB_STEP_SUMMARY
           echo "- **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
           echo "- **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,6 +98,9 @@ jobs:
           - os: "windows-latest"
             platform: "windows"
             arch: "amd64"
+          - os: "windows-latest"
+            platform: "windows"
+            arch: "arm64"
           - os: "macos-13"
             platform: "darwin"
             arch: "amd64"
@@ -257,6 +260,13 @@ jobs:
           make build-release-windows-amd64 VERSION=${{ env.CLEAN_TAG }}
           echo "✅ Created wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip"
 
+      - name: Build Windows ARM64
+        if: matrix.os == 'windows-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        shell: msys2 {0}
+        run: |
+          make build-release-windows-arm64 VERSION=${{ env.CLEAN_TAG }}
+          echo "✅ Created wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip"
+
       - name: Build macOS AMD64
         if: matrix.os == 'macos-13' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         timeout-minutes: 15
@@ -389,6 +399,7 @@ jobs:
 
           #### Windows
           - **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip\`
+          - **Windows ARM64**: \`wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip\`
 
           #### Linux
           - **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz\`
@@ -402,9 +413,11 @@ jobs:
 
           ### Windows
           \`\`\`powershell
-          # Extract the archive
-          Expand-Archive wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip
-          cd wippy-windows-amd64-${{ env.CLEAN_TAG }}
+          # Extract the archive (choose appropriate version)
+          Expand-Archive wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip  # For AMD64
+          # or
+          Expand-Archive wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip  # For ARM64
+          cd wippy-windows-amd64-${{ env.CLEAN_TAG }}  # or wippy-windows-arm64-${{ env.CLEAN_TAG }}
 
           # Run Wippy
           .\wippy.exe --help
@@ -492,5 +505,6 @@ jobs:
           echo "- **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Windows ARM64**: \`wippy-windows-arm64-${{ env.CLEAN_TAG }}.zip\`" >> $GITHUB_STEP_SUMMARY
           echo "- **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
           echo "- **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 jobs:
-  # Quality checks and conditional builds - optimized for budget
+  # Quality checks and conditional builds - optimized for budget (AMD64 testing only)
   quality-checks:
     name: Quality Checks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -23,26 +23,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Only test on Linux AMD64 for PRs (fastest, cheapest)
+          # Test only on AMD64 platforms to save CI budget
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "amd64"
             run_lint: true
             run_tests: true
-          # Build only on other platforms (no tests to save time)
-          - os: "ubuntu-latest"
-            platform: "linux"
-            arch: "arm64"
-            run_lint: false
-            run_tests: false
           - os: "windows-latest"
             platform: "windows"
             arch: "amd64"
             run_lint: false
-            run_tests: false
+            run_tests: true
           - os: "macos-latest"
             platform: "darwin"
             arch: "amd64"
+            run_lint: false
+            run_tests: true
+          # ARM64 platforms - build only for releases (no testing to save budget)
+          - os: "ubuntu-latest"
+            platform: "linux"
+            arch: "arm64"
             run_lint: false
             run_tests: false
           - os: "macos-latest"
@@ -143,7 +143,7 @@ jobs:
         shell: msys2 {0}
         run: go mod download
 
-      # Run linter only on Ubuntu AMD64 to avoid duplication and save budget
+      # Run linter only on Ubuntu AMD64 to avoid duplication (linter is platform-independent)
       - name: Run linter
         if: matrix.os == 'ubuntu-latest' && matrix.run_lint == true
         uses: golangci/golangci-lint-action@v8.0.0
@@ -169,7 +169,7 @@ jobs:
           sqlite3 --version
           upx --version
 
-      # Run tests only on Linux AMD64 for PRs to save budget
+      # Run tests only on AMD64 platforms to save CI budget
       - name: Run unit tests (Linux/macOS)
         if: matrix.os != 'windows-latest' && matrix.run_tests == true
         env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v*"
       - "release/*"
+  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -104,16 +105,16 @@ jobs:
         shell: msys2 {0}
         run: go mod download
 
-      #   # Run linter only on Ubuntu AMD64 to avoid duplication
-      #   - name: Run linter
-      #     if: matrix.os == 'ubuntu-latest' && matrix.run_lint == true
-      #     uses: golangci/golangci-lint-action@v8.0.0
-      #     env:
-      #       CGO_ENABLED: 1
-      #     with:
-      #       version: v2.2.1
-      #       only-new-issues: false
-      #       args: --timeout=10m --build-tags=race ./...
+      # Run linter only on Ubuntu AMD64 to avoid duplication
+      - name: Run linter
+        if: matrix.os == 'ubuntu-latest' && matrix.run_lint == true
+        uses: golangci/golangci-lint-action@v8.0.0
+        env:
+          CGO_ENABLED: 1
+        with:
+          version: v2.2.1
+          only-new-issues: false
+          args: --timeout=10m --build-tags=race ./...
 
       - name: Install cross-compilation tools (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -130,18 +131,18 @@ jobs:
           sqlite3 --version
           upx --version
 
-      #   - name: Run unit tests
-      #     if: matrix.os != 'windows-latest'
-      #     env:
-      #       GORACE: "halt_on_error=1"
-      #     run: make test
+      - name: Run unit tests
+        if: matrix.os != 'windows-latest'
+        env:
+          GORACE: "halt_on_error=1"
+        run: make test
 
-      #   - name: Run unit tests (Windows)
-      #     if: matrix.os == 'windows-latest'
-      #     shell: msys2 {0}
-      #     env:
-      #       GORACE: "halt_on_error=1"
-      #     run: make test
+      - name: Run unit tests (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
+        env:
+          GORACE: "halt_on_error=1"
+        run: make test
 
       # Build optimized binaries
       - name: Build Linux AMD64 (Ubuntu)
@@ -227,7 +228,7 @@ jobs:
     name: Create Release in wippy-releases
     runs-on: ubuntu-latest
     needs: lint-test-build
-    if: always() && (needs.lint-test-build.result != 'failure')
+    if: always() && (needs.lint-test-build.result != 'failure') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'release/'))
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-upx
+          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-upx zip
           path-type: inherit
 
       - name: Clean tag name (Linux/macOS)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,9 +14,9 @@ on:
         type: string
 
 jobs:
-  # Combined lint, test and build job - optimized to avoid duplication
-  lint-test-build:
-    name: Lint, Test & Build (${{ matrix.os }})
+  # Quality checks and conditional builds - optimized for budget
+  quality-checks:
+    name: Quality Checks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -143,7 +143,7 @@ jobs:
         shell: msys2 {0}
         run: go mod download
 
-      # Run linter only on Ubuntu AMD64 to avoid duplication
+      # Run linter only on Ubuntu AMD64 to avoid duplication and save budget
       - name: Run linter
         if: matrix.os == 'ubuntu-latest' && matrix.run_lint == true
         uses: golangci/golangci-lint-action@v8.0.0
@@ -169,6 +169,7 @@ jobs:
           sqlite3 --version
           upx --version
 
+      # Run tests only on Linux AMD64 for PRs to save budget
       - name: Run unit tests (Linux/macOS)
         if: matrix.os != 'windows-latest' && matrix.run_tests == true
         env:
@@ -182,7 +183,7 @@ jobs:
           GORACE: "halt_on_error=1"
         run: make test
 
-      # Build optimized binaries (only for releases or when needed)
+      # Build optimized binaries (only for releases to save budget on PRs)
       - name: Build Linux AMD64 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
@@ -261,12 +262,12 @@ jobs:
           path: ./dist/
           retention-days: 30
 
-  # Release job - creates GitHub release in wippy-releases repository
+  # Release job - creates GitHub release with binaries in wippy-releases repository
   release:
     name: Create Release in wippy-releases
     runs-on: ubuntu-latest
-    needs: lint-test-build
-    if: always() && (needs.lint-test-build.result != 'failure') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'release/'))
+    needs: quality-checks
+    if: always() && (needs.quality-checks.result != 'failure') && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'release/'))
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -320,45 +320,35 @@ jobs:
           path: ./artifacts/
           pattern: wippy-*
 
-      - name: Extract and organize binaries
+      - name: Extract release archives
         run: |
           mkdir -p ./release-binaries
 
           echo "🔍 Available artifacts:"
           ls -la ./artifacts/ || echo "No artifacts found"
 
-          # Extract binaries from all artifacts
+          # Extract only release archives from artifacts (not individual binaries)
           for artifact_dir in ./artifacts/wippy-*; do
             if [ -d "$artifact_dir" ]; then
-              echo "📦 Copying from $artifact_dir"
+              echo "📦 Processing artifact: $artifact_dir"
               echo "📦 Contents of $artifact_dir:"
               ls -la "$artifact_dir" || echo "Empty directory"
-              cp -r "$artifact_dir"/* ./release-binaries/ 2>/dev/null || true
+              
+              # Copy only archive files (*.tar.gz, *.zip)
+              find "$artifact_dir" -name "*.tar.gz" -o -name "*.zip" | while read archive; do
+                echo "📦 Copying archive: $archive"
+                cp "$archive" ./release-binaries/
+              done
             fi
           done
 
-          echo "📦 Available binaries for release:"
-          ls -la ./release-binaries/ || echo "No binaries found"
+          echo "📦 Available release archives:"
+          ls -la ./release-binaries/ || echo "No archives found"
 
-      # PackCLI binaries - download latest PackCLI release
-      - name: Download PackCLI binaries
-        run: |
-          echo "🔧 Downloading latest PackCLI binaries for integration..."
-          chmod +x ./scripts/packcli-integration/download-packcli.sh
-          if ./scripts/packcli-integration/download-packcli.sh "latest"; then
-            echo "✅ PackCLI binaries downloaded successfully"
-            mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
-            echo "✅ PackCLI binaries included in Wippy release"
-          else
-            echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
-          fi
-          echo "📦 Final binaries for release:"
-          ls -la ./release-binaries/ || echo "No binaries found"
-
-      - name: List release binaries
+      - name: List release archives
         run: |
           cd ./release-binaries
-          echo "📦 Available binaries for release:"
+          echo "📦 Available release archives:"
           ls -la
 
       - name: Create Release Notes
@@ -463,7 +453,7 @@ jobs:
           echo "**Tag**: \`${{ env.TAG_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Release Binaries:" >> $GITHUB_STEP_SUMMARY
+          echo "### 📦 Release Archives:" >> $GITHUB_STEP_SUMMARY
           if [ -d "./release-binaries" ]; then
             for file in ./release-binaries/*; do
               if [ -f "$file" ]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,81 +237,41 @@ jobs:
           GORACE: "halt_on_error=1"
         run: make test
 
-      # Build optimized binaries (only for releases to save budget on PRs)
+      # Build binaries (only for releases to save budget on PRs)
       - name: Build Linux AMD64 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
-          make build-runner-linux-amd64
-          cd ./dist
-          mv runner-linux-amd64 wippy-linux-amd64-${{ env.CLEAN_TAG }}
-          echo "✅ Built wippy-linux-amd64-${{ env.CLEAN_TAG }}"
-          echo "📊 Binary size before compression: $(ls -lh wippy-linux-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
-
-          # Compress with UPX
-          upx --best --lzma wippy-linux-amd64-${{ env.CLEAN_TAG }}
-          echo "✅ Compressed wippy-linux-amd64-${{ env.CLEAN_TAG }} with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-linux-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
+          make build-release-linux-amd64 VERSION=${{ env.CLEAN_TAG }}
+          echo "✅ Created wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Build Linux ARM64 (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
-          make build-runner-linux-arm64
-          cd ./dist
-          mv runner-linux-arm64 wippy-linux-arm64-${{ env.CLEAN_TAG }}
-          echo "✅ Built wippy-linux-arm64-${{ env.CLEAN_TAG }}"
-          echo "📊 Binary size before compression: $(ls -lh wippy-linux-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
-
-          # Compress with UPX
-          upx --best --lzma wippy-linux-arm64-${{ env.CLEAN_TAG }}
-          echo "✅ Compressed wippy-linux-arm64-${{ env.CLEAN_TAG }} with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-linux-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
+          make build-release-linux-arm64 VERSION=${{ env.CLEAN_TAG }}
+          echo "✅ Created wippy-linux-arm64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Build Windows AMD64
         if: matrix.os == 'windows-latest' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         shell: msys2 {0}
         run: |
-          make build-runner-windows-amd64
-          cd ./dist
-          mv runner-windows-amd64.exe wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe
-          echo "✅ Built wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe"
-          echo "📊 Binary size before compression: $(ls -lh wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe | awk '{print $5}')"
-
-          # Compress with UPX
-          upx --best --lzma wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe
-          echo "✅ Compressed wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe | awk '{print $5}')"
+          make build-release-windows-amd64 VERSION=${{ env.CLEAN_TAG }}
+          echo "✅ Created wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip"
 
       - name: Build macOS AMD64
         if: matrix.os == 'macos-13' && matrix.arch == 'amd64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         timeout-minutes: 15
         continue-on-error: true
         run: |
-          make build-runner-darwin-amd64
-          cd ./dist
-          mv runner-darwin-amd64 wippy-darwin-amd64-${{ env.CLEAN_TAG }}
-          echo "✅ Built wippy-darwin-amd64-${{ env.CLEAN_TAG }}"
-          echo "📊 Binary size before compression: $(ls -lh wippy-darwin-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
-
-          # Compress with UPX (force macOS support)
-          upx --best --lzma --force-macos wippy-darwin-amd64-${{ env.CLEAN_TAG }}
-          echo "✅ Compressed wippy-darwin-amd64-${{ env.CLEAN_TAG }} with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-darwin-amd64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
+          make build-release-darwin-amd64 VERSION=${{ env.CLEAN_TAG }}
+          echo "✅ Created wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Build macOS ARM64
         if: matrix.os == 'macos-13' && matrix.arch == 'arm64' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         timeout-minutes: 15
         continue-on-error: true
         run: |
-          make build-runner-darwin-arm64
-          cd ./dist
-          mv runner-darwin-arm64 wippy-darwin-arm64-${{ env.CLEAN_TAG }}
-          echo "✅ Built wippy-darwin-arm64-${{ env.CLEAN_TAG }}"
-          echo "📊 Binary size before compression: $(ls -lh wippy-darwin-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
-
-          # Compress with UPX (force macOS support)
-          upx --best --lzma --force-macos wippy-darwin-arm64-${{ env.CLEAN_TAG }}
-          echo "✅ Compressed wippy-darwin-arm64-${{ env.CLEAN_TAG }} with UPX"
-          echo "📊 Binary size after compression: $(ls -lh wippy-darwin-arm64-${{ env.CLEAN_TAG }} | awk '{print $5}')"
+          make build-release-darwin-arm64 VERSION=${{ env.CLEAN_TAG }}
+          echo "✅ Created wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz"
 
       - name: Upload build artifacts
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
@@ -395,23 +355,10 @@ jobs:
           echo "📦 Final binaries for release:"
           ls -la ./release-binaries/ || echo "No binaries found"
 
-      - name: Generate checksums
+      - name: List release binaries
         run: |
           cd ./release-binaries
-          echo "Generating checksums..."
-
-          # Generate SHA256 checksums
-          for file in *; do
-            if [ -f "$file" ]; then
-              sha256sum "$file" > "${file}.sha256"
-              echo "✅ Generated checksum for $file"
-            fi
-          done
-
-          # Create a combined checksums file
-          cat *.sha256 > checksums.txt
-          echo "✅ Created combined checksums.txt"
-
+          echo "📦 Available binaries for release:"
           ls -la
 
       - name: Create Release Notes
@@ -437,89 +384,60 @@ jobs:
 
           ## Downloads
 
-          ### Wippy Runtime
-          #### Windows
-          - **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe\` (compressed with UPX)
-
-          #### Linux
-          - **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
-          - **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
-
-          #### macOS
-          - **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
-          - **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}\` (compressed with UPX)
-
-          ### PackCLI (Helper Tool)
-          PackCLI is included as a helper tool for module management and development.
+          ### Platform-Specific Archives
+          Each archive contains both Wippy runtime and PackCLI helper tool.
 
           #### Windows
-          - **Windows AMD64**: \`packcli-windows-amd64.exe\`
+          - **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip\`
 
           #### Linux
-          - **Linux AMD64**: \`packcli-linux-amd64\`
-          - **Linux ARM64**: \`packcli-linux-arm64\`
+          - **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz\`
+          - **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}.tar.gz\`
 
           #### macOS
-          - **macOS AMD64**: \`packcli-darwin-amd64\`
-          - **macOS ARM64**: \`packcli-darwin-arm64\`
-
-          ### Binary Optimization
-          All binaries are optimized for minimal size with UPX compression (~80% size reduction).
+          - **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz\`
+          - **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz\`
 
           ## Installation
 
-          ### Wippy Runtime
-          #### Windows
+          ### Windows
           \`\`\`powershell
-          # Download the appropriate binary
-          wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe --help
+          # Extract the archive
+          Expand-Archive wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip
+          cd wippy-windows-amd64-${{ env.CLEAN_TAG }}
+
+          # Run Wippy
+          .\wippy.exe --help
+
+          # Run PackCLI
+          .\packcli.exe --help
+          .\packcli.exe module init my-module
           \`\`\`
 
-          #### Linux
+          ### Linux
           \`\`\`bash
-          # Download and make executable
-          chmod +x wippy-linux-amd64-${{ env.CLEAN_TAG }}
-          ./wippy-linux-amd64-${{ env.CLEAN_TAG }} --help
+          # Extract the archive
+          tar -xzf wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz
+          cd wippy-linux-amd64-${{ env.CLEAN_TAG }}
+
+          # Make executables and run
+          chmod +x wippy packcli
+          ./wippy --help
+          ./packcli --help
+          ./packcli module init my-module
           \`\`\`
 
-          #### macOS
+          ### macOS
           \`\`\`bash
-          # Download and make executable
-          chmod +x wippy-darwin-amd64-${{ env.CLEAN_TAG }}  # or wippy-darwin-arm64-${{ env.CLEAN_TAG }} for Apple Silicon
-          ./wippy-darwin-amd64-${{ env.CLEAN_TAG }} --help
-          \`\`\`
+          # Extract the archive
+          tar -xzf wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz  # or wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz for Apple Silicon
+          cd wippy-darwin-amd64-${{ env.CLEAN_TAG }}
 
-          ### PackCLI Helper Tool
-          PackCLI is included for module management and development tasks.
-
-          #### Windows
-          \`\`\`powershell
-          # Use PackCLI for module operations
-          packcli-windows-amd64.exe --help
-          packcli-windows-amd64.exe module init my-module
-          \`\`\`
-
-          #### Linux
-          \`\`\`bash
-          # Download and make executable
-          chmod +x packcli-linux-amd64
-          ./packcli-linux-amd64 --help
-          ./packcli-linux-amd64 module init my-module
-          \`\`\`
-
-          #### macOS
-          \`\`\`bash
-          # Download and make executable
-          chmod +x packcli-darwin-amd64  # or packcli-darwin-arm64 for Apple Silicon
-          ./packcli-darwin-amd64 --help
-          ./packcli-darwin-amd64 module init my-module
-          \`\`\`
-
-          ## Verification
-
-          Verify the integrity of downloaded files using the provided checksums:
-          \`\`\`bash
-          sha256sum -c checksums.txt
+          # Make executables and run
+          chmod +x wippy packcli
+          ./wippy --help
+          ./packcli --help
+          ./packcli module init my-module
           \`\`\`
           EOF
 
@@ -545,10 +463,10 @@ jobs:
           echo "**Tag**: \`${{ env.TAG_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Optimized Binaries (UPX Compressed):" >> $GITHUB_STEP_SUMMARY
+          echo "### 📦 Release Binaries:" >> $GITHUB_STEP_SUMMARY
           if [ -d "./release-binaries" ]; then
             for file in ./release-binaries/*; do
-              if [ -f "$file" ] && [[ "$file" != *.sha256 ]] && [[ "$file" != checksums.txt ]]; then
+              if [ -f "$file" ]; then
                 filename=$(basename "$file")
                 size=$(stat -c%s "$file" 2>/dev/null || echo "Unknown")
                 if [ "$size" != "Unknown" ] && [ "$size" -gt 0 ]; then
@@ -570,19 +488,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📥 Download from GitHub Release:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "#### Wippy Runtime:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.exe\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "#### PackCLI Helper Tool:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Linux AMD64**: \`packcli-linux-amd64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Linux ARM64**: \`packcli-linux-arm64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Windows AMD64**: \`packcli-windows-amd64.exe\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS AMD64**: \`packcli-darwin-amd64\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **macOS ARM64**: \`packcli-darwin-arm64\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### ℹ️ Note:" >> $GITHUB_STEP_SUMMARY
-          echo "All binaries are optimized with UPX compression (~80% size reduction) and available for download from the GitHub release assets." >> $GITHUB_STEP_SUMMARY
+          echo "#### Platform-Specific Archives (contain both Wippy and PackCLI):" >> $GITHUB_STEP_SUMMARY
+          echo "- **Linux AMD64**: \`wippy-linux-amd64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Linux ARM64**: \`wippy-linux-arm64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Windows AMD64**: \`wippy-windows-amd64-${{ env.CLEAN_TAG }}.zip\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS AMD64**: \`wippy-darwin-amd64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **macOS ARM64**: \`wippy-darwin-arm64-${{ env.CLEAN_TAG }}.tar.gz\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,7 +51,7 @@ jobs:
       TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
       # Remove 'v' prefix and 'release/' prefix for filename
       VERSION_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-      CLEAN_TAG: ${{ contains(github.event.inputs.tag || github.ref_name, 'v') && replace(github.event.inputs.tag || github.ref_name, 'v', '') || replace(github.event.inputs.tag || github.ref_name, 'release/', '') }}
+      CLEAN_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
     steps:
       - name: Check out code
@@ -59,6 +59,20 @@ jobs:
         with:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: Clean tag name
+        run: |
+          # Remove 'v' prefix and 'release/' prefix for filename
+          if [[ "${{ env.TAG_NAME }}" == v* ]]; then
+            CLEAN_TAG="${TAG_NAME#v}"
+          elif [[ "${{ env.TAG_NAME }}" == release/* ]]; then
+            CLEAN_TAG="${TAG_NAME#release/}"
+          else
+            CLEAN_TAG="${{ env.TAG_NAME }}"
+          fi
+          echo "CLEAN_TAG=$CLEAN_TAG" >> $GITHUB_ENV
+          echo "Original tag: ${{ env.TAG_NAME }}"
+          echo "Clean tag: $CLEAN_TAG"
 
       - name: Setup msys (Windows)
         if: matrix.os == 'windows-latest'
@@ -233,7 +247,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN_IGOR }}
       TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
-      CLEAN_TAG: ${{ contains(github.event.inputs.tag || github.ref_name, 'v') && replace(github.event.inputs.tag || github.ref_name, 'v', '') || replace(github.event.inputs.tag || github.ref_name, 'release/', '') }}
+      CLEAN_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
     steps:
       - name: Check out code
@@ -241,6 +255,20 @@ jobs:
         with:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: Clean tag name
+        run: |
+          # Remove 'v' prefix and 'release/' prefix for filename
+          if [[ "${{ env.TAG_NAME }}" == v* ]]; then
+            CLEAN_TAG="${TAG_NAME#v}"
+          elif [[ "${{ env.TAG_NAME }}" == release/* ]]; then
+            CLEAN_TAG="${TAG_NAME#release/}"
+          else
+            CLEAN_TAG="${{ env.TAG_NAME }}"
+          fi
+          echo "CLEAN_TAG=$CLEAN_TAG" >> $GITHUB_ENV
+          echo "Original tag: ${{ env.TAG_NAME }}"
+          echo "Clean tag: $CLEAN_TAG"
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 jobs:
-  # Quality checks and conditional builds - optimized for budget (AMD64 testing only)
+  # Quality checks and conditional builds - stable platforms only (Linux + Windows)
   quality-checks:
     name: Quality Checks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Test only on AMD64 platforms to save CI budget
+          # Test only on stable platforms (Linux + Windows) to avoid runner issues
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "amd64"
@@ -34,15 +34,16 @@ jobs:
             arch: "amd64"
             run_lint: false
             run_tests: true
-          - os: "macos-latest"
-            platform: "darwin"
-            arch: "amd64"
-            run_lint: false
-            run_tests: true
           # ARM64 platforms - build only for releases (no testing to save budget)
           - os: "ubuntu-latest"
             platform: "linux"
             arch: "arm64"
+            run_lint: false
+            run_tests: false
+          # macOS platforms - build only for releases (runners often unavailable)
+          - os: "macos-latest"
+            platform: "darwin"
+            arch: "amd64"
             run_lint: false
             run_tests: false
           - os: "macos-latest"
@@ -169,7 +170,7 @@ jobs:
           sqlite3 --version
           upx --version
 
-      # Run tests only on AMD64 platforms to save CI budget
+      # Run tests only on stable platforms (Linux + Windows) to avoid runner issues
       - name: Run unit tests (Linux/macOS)
         if: matrix.os != 'windows-latest' && matrix.run_tests == true
         env:

--- a/Makefile
+++ b/Makefile
@@ -116,13 +116,6 @@ build-runner-windows-amd64:
 		-buildmode=pie \
 		-o "./dist/runner-windows-amd64.exe" "./cmd/runner/"
 
-# Windows ARM64 build - requires special toolchain, not supported on standard Windows runners
-build-runner-windows-arm64:
-	@echo "⚠️  Windows ARM64 build is not supported on standard Windows runners"
-	@echo "This target is kept for local development with proper ARM64 toolchain"
-	mkdir -p ./dist
-	CGO_ENABLED=1 GOOS=windows GOARCH=arm64 go build --tags "fts5 sqlite_vec" -o "./dist/runner-windows-arm64.exe" "./cmd/runner/"
-
 # Standard Darwin builds (works on any macOS)
 build-runner-darwin-amd64:
 	mkdir -p ./dist
@@ -163,7 +156,7 @@ build-runner-darwin-universal--on-M1: build-runner-darwin-arm64--on-M1 build-run
 VERSION ?= $(shell git describe --tags --always --dirty)
 
 # Create release archives for all platforms
-build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-windows-arm64 build-release-darwin-amd64 build-release-darwin-arm64
+build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-darwin-amd64 build-release-darwin-arm64
 
 # Linux AMD64 release archive
 build-release-linux-amd64: build-runner-linux-amd64
@@ -221,25 +214,6 @@ build-release-windows-amd64: build-runner-windows-amd64
 	cd ./dist/release-temp && zip -r ../wippy-windows-amd64-$(VERSION).zip wippy-windows-amd64-$(VERSION)/
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
-
-# Windows ARM64 release archive
-build-release-windows-arm64: build-runner-windows-arm64
-	@echo "Creating Windows ARM64 release archive..."
-	mkdir -p ./dist/release-temp/wippy-windows-arm64-$(VERSION)
-	cp ./dist/runner-windows-arm64.exe ./dist/release-temp/wippy-windows-arm64-$(VERSION)/wippy.exe
-	@if [ -f "./packcli-windows-arm64.exe" ]; then \
-		cp ./packcli-windows-arm64.exe ./dist/release-temp/wippy-windows-arm64-$(VERSION)/packcli.exe; \
-	else \
-		echo "⚠️  PackCLI binary not found for Windows ARM64"; \
-	fi
-	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy-windows-arm64-$(VERSION)/wippy.exe
-	@if [ -f "./dist/release-temp/wippy-windows-arm64-$(VERSION)/packcli.exe" ]; then \
-		upx --best --lzma ./dist/release-temp/wippy-windows-arm64-$(VERSION)/packcli.exe; \
-	fi
-	cd ./dist/release-temp && zip -r ../wippy-windows-arm64-$(VERSION).zip wippy-windows-arm64-$(VERSION)/
-	rm -rf ./dist/release-temp
-	@echo "✅ Created wippy-windows-arm64-$(VERSION).zip"
 
 # macOS AMD64 release archive
 build-release-darwin-amd64: build-runner-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,14 @@ build-runner-windows-amd64:
 # Standard Darwin builds (works on any macOS)
 build-runner-darwin-amd64:
 	mkdir -p ./dist
-	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build --tags "fts5 sqlite_vec" \
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC=clang go build --tags "fts5 sqlite_vec" \
 		-ldflags="-s -w -X main.version=$(shell git describe --tags --always --dirty)" \
 		-trimpath \
 		-o ./dist/runner-darwin-amd64 ./cmd/runner/
 
 build-runner-darwin-arm64:
 	mkdir -p ./dist
-	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build --tags "fts5 sqlite_vec" \
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC=clang go build --tags "fts5 sqlite_vec" \
 		-ldflags="-s -w -X main.version=$(shell git describe --tags --always --dirty)" \
 		-trimpath \
 		-o ./dist/runner-darwin-arm64 ./cmd/runner/

--- a/Makefile
+++ b/Makefile
@@ -156,127 +156,37 @@ build-runner-darwin-universal--on-M1: build-runner-darwin-arm64--on-M1 build-run
 VERSION ?= $(shell git describe --tags --always --dirty)
 
 # Create release archives for all platforms
-build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-darwin-amd64 build-release-darwin-arm64
+build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-windows-arm64 build-release-darwin-amd64 build-release-darwin-arm64
+
+# Universal archive builder function
+# Usage: $(call build-archive,platform,arch,format)
+define build-archive
+	./scripts/build-release-archive.sh $(1) $(2) $(3) $(VERSION)
+endef
 
 # Linux AMD64 release archive
 build-release-linux-amd64: build-runner-linux-amd64
-	@echo "Creating Linux AMD64 release archive..."
-	mkdir -p ./dist/release-temp
-	cp ./dist/runner-linux-amd64 ./dist/release-temp/wippy
-	@if [ -f "./packcli-linux-amd64" ]; then \
-		cp ./packcli-linux-amd64 ./dist/release-temp/packcli; \
-	else \
-		echo "⚠️  PackCLI binary not found for Linux AMD64"; \
-	fi
-	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy
-	@if [ -f "./dist/release-temp/packcli" ]; then \
-		upx --best --lzma ./dist/release-temp/packcli; \
-	fi
-	cd ./dist/release-temp && \
-		if [ -f packcli ]; then \
-			tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy packcli; \
-		else \
-			tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy; \
-		fi
-	rm -rf ./dist/release-temp
-	@echo "✅ Created wippy-linux-amd64-$(VERSION).tar.gz"
+	$(call build-archive,linux,amd64,tar.gz)
 
 # Linux ARM64 release archive
 build-release-linux-arm64: build-runner-linux-arm64
-	@echo "Creating Linux ARM64 release archive..."
-	mkdir -p ./dist/release-temp
-	cp ./dist/runner-linux-arm64 ./dist/release-temp/wippy
-	@if [ -f "./packcli-linux-arm64" ]; then \
-		cp ./packcli-linux-arm64 ./dist/release-temp/packcli; \
-	else \
-		echo "⚠️  PackCLI binary not found for Linux ARM64"; \
-	fi
-	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy
-	@if [ -f "./dist/release-temp/packcli" ]; then \
-		upx --best --lzma ./dist/release-temp/packcli; \
-	fi
-	cd ./dist/release-temp && \
-		if [ -f packcli ]; then \
-			tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy packcli; \
-		else \
-			tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy; \
-		fi
-	rm -rf ./dist/release-temp
-	@echo "✅ Created wippy-linux-arm64-$(VERSION).tar.gz"
+	$(call build-archive,linux,arm64,tar.gz)
 
 # Windows AMD64 release archive
 build-release-windows-amd64: build-runner-windows-amd64
-	@echo "Creating Windows AMD64 release archive..."
-	mkdir -p ./dist/release-temp
-	cp ./dist/runner-windows-amd64.exe ./dist/release-temp/wippy.exe
-	@if [ -f "./packcli-windows-amd64.exe" ]; then \
-		cp ./packcli-windows-amd64.exe ./dist/release-temp/packcli.exe; \
-	else \
-		echo "⚠️  PackCLI binary not found for Windows AMD64"; \
-	fi
-	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy.exe
-	@if [ -f "./dist/release-temp/packcli.exe" ]; then \
-		upx --best --lzma ./dist/release-temp/packcli.exe; \
-	fi
-	cd ./dist/release-temp && \
-		if [ -f packcli.exe ]; then \
-			zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe packcli.exe; \
-		else \
-			zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe; \
-		fi
-	rm -rf ./dist/release-temp
-	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
+	$(call build-archive,windows,amd64,zip)
+
+# Windows ARM64 release archive (optional - may not have runner binary)
+build-release-windows-arm64:
+	$(call build-archive,windows,arm64,zip)
 
 # macOS AMD64 release archive
 build-release-darwin-amd64: build-runner-darwin-amd64
-	@echo "Creating macOS AMD64 release archive..."
-	mkdir -p ./dist/release-temp
-	cp ./dist/runner-darwin-amd64 ./dist/release-temp/wippy
-	@if [ -f "./packcli-darwin-amd64" ]; then \
-		cp ./packcli-darwin-amd64 ./dist/release-temp/packcli; \
-	else \
-		echo "⚠️  PackCLI binary not found for macOS AMD64"; \
-	fi
-	# Compress binaries with UPX (force macOS support)
-	upx --best --lzma --force-macos ./dist/release-temp/wippy
-	@if [ -f "./dist/release-temp/packcli" ]; then \
-		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
-	fi
-	cd ./dist/release-temp && \
-		if [ -f packcli ]; then \
-			tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy packcli; \
-		else \
-			tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy; \
-		fi
-	rm -rf ./dist/release-temp
-	@echo "✅ Created wippy-darwin-amd64-$(VERSION).tar.gz"
+	$(call build-archive,darwin,amd64,tar.gz)
 
 # macOS ARM64 release archive
 build-release-darwin-arm64: build-runner-darwin-arm64
-	@echo "Creating macOS ARM64 release archive..."
-	mkdir -p ./dist/release-temp
-	cp ./dist/runner-darwin-arm64 ./dist/release-temp/wippy
-	@if [ -f "./packcli-darwin-arm64" ]; then \
-		cp ./packcli-darwin-arm64 ./dist/release-temp/packcli; \
-	else \
-		echo "⚠️  PackCLI binary not found for macOS ARM64"; \
-	fi
-	# Compress binaries with UPX (force macOS support)
-	upx --best --lzma --force-macos ./dist/release-temp/wippy
-	@if [ -f "./dist/release-temp/packcli" ]; then \
-		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
-	fi
-	cd ./dist/release-temp && \
-		if [ -f packcli ]; then \
-			tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy packcli; \
-		else \
-			tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy; \
-		fi
-	rm -rf ./dist/release-temp
-	@echo "✅ Created wippy-darwin-arm64-$(VERSION).tar.gz"
+	$(call build-archive,darwin,arm64,tar.gz)
 
 # Build runner with embedded data (example: make build-runner-embed EMBED_DIR=/path/to/your/data)
 build-runner-embed:

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ build-runner-darwin-universal--on-M1: build-runner-darwin-arm64--on-M1 build-run
 VERSION ?= $(shell git describe --tags --always --dirty)
 
 # Create release archives for all platforms
-build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-darwin-amd64 build-release-darwin-arm64
+build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-windows-arm64 build-release-darwin-amd64 build-release-darwin-arm64
 
 # Linux AMD64 release archive
 build-release-linux-amd64: build-runner-linux-amd64
@@ -221,6 +221,25 @@ build-release-windows-amd64: build-runner-windows-amd64
 	cd ./dist/release-temp && zip -r ../wippy-windows-amd64-$(VERSION).zip wippy-windows-amd64-$(VERSION)/
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
+
+# Windows ARM64 release archive
+build-release-windows-arm64: build-runner-windows-arm64
+	@echo "Creating Windows ARM64 release archive..."
+	mkdir -p ./dist/release-temp/wippy-windows-arm64-$(VERSION)
+	cp ./dist/runner-windows-arm64.exe ./dist/release-temp/wippy-windows-arm64-$(VERSION)/wippy.exe
+	@if [ -f "./packcli-windows-arm64.exe" ]; then \
+		cp ./packcli-windows-arm64.exe ./dist/release-temp/wippy-windows-arm64-$(VERSION)/packcli.exe; \
+	else \
+		echo "⚠️  PackCLI binary not found for Windows ARM64"; \
+	fi
+	# Compress binaries with UPX
+	upx --best --lzma ./dist/release-temp/wippy-windows-arm64-$(VERSION)/wippy.exe
+	@if [ -f "./dist/release-temp/wippy-windows-arm64-$(VERSION)/packcli.exe" ]; then \
+		upx --best --lzma ./dist/release-temp/wippy-windows-arm64-$(VERSION)/packcli.exe; \
+	fi
+	cd ./dist/release-temp && zip -r ../wippy-windows-arm64-$(VERSION).zip wippy-windows-arm64-$(VERSION)/
+	rm -rf ./dist/release-temp
+	@echo "✅ Created wippy-windows-arm64-$(VERSION).zip"
 
 # macOS AMD64 release archive
 build-release-darwin-amd64: build-runner-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ build-release-linux-amd64: build-runner-linux-amd64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy packcli
+	cd ./dist/release-temp && tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-linux-amd64-$(VERSION).tar.gz"
 
@@ -192,7 +192,7 @@ build-release-linux-arm64: build-runner-linux-arm64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy packcli
+	cd ./dist/release-temp && tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-linux-arm64-$(VERSION).tar.gz"
 
@@ -211,7 +211,7 @@ build-release-windows-amd64: build-runner-windows-amd64
 	@if [ -f "./dist/release-temp/packcli.exe" ]; then \
 		upx --best --lzma ./dist/release-temp/packcli.exe; \
 	fi
-	cd ./dist/release-temp && zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe packcli.exe
+	cd ./dist/release-temp && zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe $(if [ -f packcli.exe ]; then echo packcli.exe; fi)
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
 
@@ -230,7 +230,7 @@ build-release-darwin-amd64: build-runner-darwin-amd64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy packcli
+	cd ./dist/release-temp && tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-darwin-amd64-$(VERSION).tar.gz"
 
@@ -249,7 +249,7 @@ build-release-darwin-arm64: build-runner-darwin-arm64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy packcli
+	cd ./dist/release-temp && tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-darwin-arm64-$(VERSION).tar.gz"
 

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,12 @@ build-release-linux-amd64: build-runner-linux-amd64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
+	cd ./dist/release-temp && \
+		if [ -f packcli ]; then \
+			tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy packcli; \
+		else \
+			tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy; \
+		fi
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-linux-amd64-$(VERSION).tar.gz"
 
@@ -192,7 +197,12 @@ build-release-linux-arm64: build-runner-linux-arm64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
+	cd ./dist/release-temp && \
+		if [ -f packcli ]; then \
+			tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy packcli; \
+		else \
+			tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy; \
+		fi
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-linux-arm64-$(VERSION).tar.gz"
 
@@ -211,7 +221,12 @@ build-release-windows-amd64: build-runner-windows-amd64
 	@if [ -f "./dist/release-temp/packcli.exe" ]; then \
 		upx --best --lzma ./dist/release-temp/packcli.exe; \
 	fi
-	cd ./dist/release-temp && zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe $(if [ -f packcli.exe ]; then echo packcli.exe; fi)
+	cd ./dist/release-temp && \
+		if [ -f packcli.exe ]; then \
+			zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe packcli.exe; \
+		else \
+			zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe; \
+		fi
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
 
@@ -230,7 +245,12 @@ build-release-darwin-amd64: build-runner-darwin-amd64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
+	cd ./dist/release-temp && \
+		if [ -f packcli ]; then \
+			tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy packcli; \
+		else \
+			tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy; \
+		fi
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-darwin-amd64-$(VERSION).tar.gz"
 
@@ -249,7 +269,12 @@ build-release-darwin-arm64: build-runner-darwin-arm64
 	@if [ -f "./dist/release-temp/packcli" ]; then \
 		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy $(if [ -f packcli ]; then echo packcli; fi)
+	cd ./dist/release-temp && \
+		if [ -f packcli ]; then \
+			tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy packcli; \
+		else \
+			tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy; \
+		fi
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-darwin-arm64-$(VERSION).tar.gz"
 

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,11 @@ build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-rel
 # Universal archive builder function
 # Usage: $(call build-archive,platform,arch,format)
 define build-archive
-	./scripts/build-release-archive.sh $(1) $(2) $(3) $(VERSION)
+	@if [ "$(1)" = "windows" ]; then \
+		bash ./scripts/build-release-archive.sh $(1) $(2) $(3) $(VERSION); \
+	else \
+		./scripts/build-release-archive.sh $(1) $(2) $(3) $(VERSION); \
+	fi
 endef
 
 # Linux AMD64 release archive

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,107 @@ build-runner-darwin-universal--on-M1: build-runner-darwin-arm64--on-M1 build-run
 	mkdir -p ./dist
 	lipo -create -output ./dist/runner-darwin-universal ./dist/runner-darwin-arm64 ./dist/runner-darwin-amd64
 
+# Release packaging targets
+VERSION ?= $(shell git describe --tags --always --dirty)
+
+# Create release archives for all platforms
+build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-release-windows-amd64 build-release-darwin-amd64 build-release-darwin-arm64
+
+# Linux AMD64 release archive
+build-release-linux-amd64: build-runner-linux-amd64
+	@echo "Creating Linux AMD64 release archive..."
+	mkdir -p ./dist/release-temp/wippy-linux-amd64-$(VERSION)
+	cp ./dist/runner-linux-amd64 ./dist/release-temp/wippy-linux-amd64-$(VERSION)/wippy
+	@if [ -f "./packcli-linux-amd64" ]; then \
+		cp ./packcli-linux-amd64 ./dist/release-temp/wippy-linux-amd64-$(VERSION)/packcli; \
+	else \
+		echo "⚠️  PackCLI binary not found for Linux AMD64"; \
+	fi
+	# Compress binaries with UPX
+	upx --best --lzma ./dist/release-temp/wippy-linux-amd64-$(VERSION)/wippy
+	@if [ -f "./dist/release-temp/wippy-linux-amd64-$(VERSION)/packcli" ]; then \
+		upx --best --lzma ./dist/release-temp/wippy-linux-amd64-$(VERSION)/packcli; \
+	fi
+	cd ./dist/release-temp && tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy-linux-amd64-$(VERSION)/
+	rm -rf ./dist/release-temp
+	@echo "✅ Created wippy-linux-amd64-$(VERSION).tar.gz"
+
+# Linux ARM64 release archive
+build-release-linux-arm64: build-runner-linux-arm64
+	@echo "Creating Linux ARM64 release archive..."
+	mkdir -p ./dist/release-temp/wippy-linux-arm64-$(VERSION)
+	cp ./dist/runner-linux-arm64 ./dist/release-temp/wippy-linux-arm64-$(VERSION)/wippy
+	@if [ -f "./packcli-linux-arm64" ]; then \
+		cp ./packcli-linux-arm64 ./dist/release-temp/wippy-linux-arm64-$(VERSION)/packcli; \
+	else \
+		echo "⚠️  PackCLI binary not found for Linux ARM64"; \
+	fi
+	# Compress binaries with UPX
+	upx --best --lzma ./dist/release-temp/wippy-linux-arm64-$(VERSION)/wippy
+	@if [ -f "./dist/release-temp/wippy-linux-arm64-$(VERSION)/packcli" ]; then \
+		upx --best --lzma ./dist/release-temp/wippy-linux-arm64-$(VERSION)/packcli; \
+	fi
+	cd ./dist/release-temp && tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy-linux-arm64-$(VERSION)/
+	rm -rf ./dist/release-temp
+	@echo "✅ Created wippy-linux-arm64-$(VERSION).tar.gz"
+
+# Windows AMD64 release archive
+build-release-windows-amd64: build-runner-windows-amd64
+	@echo "Creating Windows AMD64 release archive..."
+	mkdir -p ./dist/release-temp/wippy-windows-amd64-$(VERSION)
+	cp ./dist/runner-windows-amd64.exe ./dist/release-temp/wippy-windows-amd64-$(VERSION)/wippy.exe
+	@if [ -f "./packcli-windows-amd64.exe" ]; then \
+		cp ./packcli-windows-amd64.exe ./dist/release-temp/wippy-windows-amd64-$(VERSION)/packcli.exe; \
+	else \
+		echo "⚠️  PackCLI binary not found for Windows AMD64"; \
+	fi
+	# Compress binaries with UPX
+	upx --best --lzma ./dist/release-temp/wippy-windows-amd64-$(VERSION)/wippy.exe
+	@if [ -f "./dist/release-temp/wippy-windows-amd64-$(VERSION)/packcli.exe" ]; then \
+		upx --best --lzma ./dist/release-temp/wippy-windows-amd64-$(VERSION)/packcli.exe; \
+	fi
+	cd ./dist/release-temp && zip -r ../wippy-windows-amd64-$(VERSION).zip wippy-windows-amd64-$(VERSION)/
+	rm -rf ./dist/release-temp
+	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
+
+# macOS AMD64 release archive
+build-release-darwin-amd64: build-runner-darwin-amd64
+	@echo "Creating macOS AMD64 release archive..."
+	mkdir -p ./dist/release-temp/wippy-darwin-amd64-$(VERSION)
+	cp ./dist/runner-darwin-amd64 ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/wippy
+	@if [ -f "./packcli-darwin-amd64" ]; then \
+		cp ./packcli-darwin-amd64 ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/packcli; \
+	else \
+		echo "⚠️  PackCLI binary not found for macOS AMD64"; \
+	fi
+	# Compress binaries with UPX (force macOS support)
+	upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/wippy
+	@if [ -f "./dist/release-temp/wippy-darwin-amd64-$(VERSION)/packcli" ]; then \
+		upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/packcli; \
+	fi
+	cd ./dist/release-temp && tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy-darwin-amd64-$(VERSION)/
+	rm -rf ./dist/release-temp
+	@echo "✅ Created wippy-darwin-amd64-$(VERSION).tar.gz"
+
+# macOS ARM64 release archive
+build-release-darwin-arm64: build-runner-darwin-arm64
+	@echo "Creating macOS ARM64 release archive..."
+	mkdir -p ./dist/release-temp/wippy-darwin-arm64-$(VERSION)
+	cp ./dist/runner-darwin-arm64 ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/wippy
+	@if [ -f "./packcli-darwin-arm64" ]; then \
+		cp ./packcli-darwin-arm64 ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/packcli; \
+	else \
+		echo "⚠️  PackCLI binary not found for macOS ARM64"; \
+	fi
+	# Compress binaries with UPX (force macOS support)
+	upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/wippy
+	@if [ -f "./dist/release-temp/wippy-darwin-arm64-$(VERSION)/packcli" ]; then \
+		upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/packcli; \
+	fi
+	cd ./dist/release-temp && tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy-darwin-arm64-$(VERSION)/
+	rm -rf ./dist/release-temp
+	@echo "✅ Created wippy-darwin-arm64-$(VERSION).tar.gz"
+
 # Build runner with embedded data (example: make build-runner-embed EMBED_DIR=/path/to/your/data)
 build-runner-embed:
 	@echo "Building runner with embedded data"

--- a/Makefile
+++ b/Makefile
@@ -63,14 +63,17 @@ build-runner-optimized:
 	@ls -lh ./dist/runner-$(shell go env GOOS)-$(shell go env GOARCH)
 
 # Build with UPX compression (maximum size reduction)
+# Note: UPX compression is disabled on macOS due to crash issues on macOS Ventura 13.0+
+# See: https://github.com/upx/upx/issues/612
 build-runner-compressed: build-runner-optimized
 	@echo "Compressing binary with UPX..."
 	@if [ "$(shell go env GOOS)" = "darwin" ]; then \
-		upx --best --lzma --force-macos ./dist/runner-$(shell go env GOOS)-$(shell go env GOARCH); \
+		echo "⚠️  UPX compression disabled on macOS due to crash issues (see https://github.com/upx/upx/issues/612)"; \
+		echo "Using optimized binary without compression..."; \
 	else \
 		upx --best --lzma ./dist/runner-$(shell go env GOOS)-$(shell go env GOARCH); \
 	fi
-	@echo "Final compressed binary size:"
+	@echo "Final binary size:"
 	@ls -lh ./dist/runner-$(shell go env GOOS)-$(shell go env GOARCH)
 
 # Cross-compilation targets (require appropriate toolchains)
@@ -119,14 +122,14 @@ build-runner-windows-amd64:
 # Standard Darwin builds (works on any macOS)
 build-runner-darwin-amd64:
 	mkdir -p ./dist
-	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC=clang go build --tags "fts5 sqlite_vec" \
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build --tags "fts5 sqlite_vec" \
 		-ldflags="-s -w -X main.version=$(shell git describe --tags --always --dirty)" \
 		-trimpath \
 		-o ./dist/runner-darwin-amd64 ./cmd/runner/
 
 build-runner-darwin-arm64:
 	mkdir -p ./dist
-	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC=clang go build --tags "fts5 sqlite_vec" \
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build --tags "fts5 sqlite_vec" \
 		-ldflags="-s -w -X main.version=$(shell git describe --tags --always --dirty)" \
 		-trimpath \
 		-o ./dist/runner-darwin-arm64 ./cmd/runner/

--- a/Makefile
+++ b/Makefile
@@ -161,95 +161,95 @@ build-release-all: build-release-linux-amd64 build-release-linux-arm64 build-rel
 # Linux AMD64 release archive
 build-release-linux-amd64: build-runner-linux-amd64
 	@echo "Creating Linux AMD64 release archive..."
-	mkdir -p ./dist/release-temp/wippy-linux-amd64-$(VERSION)
-	cp ./dist/runner-linux-amd64 ./dist/release-temp/wippy-linux-amd64-$(VERSION)/wippy
+	mkdir -p ./dist/release-temp
+	cp ./dist/runner-linux-amd64 ./dist/release-temp/wippy
 	@if [ -f "./packcli-linux-amd64" ]; then \
-		cp ./packcli-linux-amd64 ./dist/release-temp/wippy-linux-amd64-$(VERSION)/packcli; \
+		cp ./packcli-linux-amd64 ./dist/release-temp/packcli; \
 	else \
 		echo "⚠️  PackCLI binary not found for Linux AMD64"; \
 	fi
 	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy-linux-amd64-$(VERSION)/wippy
-	@if [ -f "./dist/release-temp/wippy-linux-amd64-$(VERSION)/packcli" ]; then \
-		upx --best --lzma ./dist/release-temp/wippy-linux-amd64-$(VERSION)/packcli; \
+	upx --best --lzma ./dist/release-temp/wippy
+	@if [ -f "./dist/release-temp/packcli" ]; then \
+		upx --best --lzma ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy-linux-amd64-$(VERSION)/
+	cd ./dist/release-temp && tar -czf ../wippy-linux-amd64-$(VERSION).tar.gz wippy packcli
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-linux-amd64-$(VERSION).tar.gz"
 
 # Linux ARM64 release archive
 build-release-linux-arm64: build-runner-linux-arm64
 	@echo "Creating Linux ARM64 release archive..."
-	mkdir -p ./dist/release-temp/wippy-linux-arm64-$(VERSION)
-	cp ./dist/runner-linux-arm64 ./dist/release-temp/wippy-linux-arm64-$(VERSION)/wippy
+	mkdir -p ./dist/release-temp
+	cp ./dist/runner-linux-arm64 ./dist/release-temp/wippy
 	@if [ -f "./packcli-linux-arm64" ]; then \
-		cp ./packcli-linux-arm64 ./dist/release-temp/wippy-linux-arm64-$(VERSION)/packcli; \
+		cp ./packcli-linux-arm64 ./dist/release-temp/packcli; \
 	else \
 		echo "⚠️  PackCLI binary not found for Linux ARM64"; \
 	fi
 	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy-linux-arm64-$(VERSION)/wippy
-	@if [ -f "./dist/release-temp/wippy-linux-arm64-$(VERSION)/packcli" ]; then \
-		upx --best --lzma ./dist/release-temp/wippy-linux-arm64-$(VERSION)/packcli; \
+	upx --best --lzma ./dist/release-temp/wippy
+	@if [ -f "./dist/release-temp/packcli" ]; then \
+		upx --best --lzma ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy-linux-arm64-$(VERSION)/
+	cd ./dist/release-temp && tar -czf ../wippy-linux-arm64-$(VERSION).tar.gz wippy packcli
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-linux-arm64-$(VERSION).tar.gz"
 
 # Windows AMD64 release archive
 build-release-windows-amd64: build-runner-windows-amd64
 	@echo "Creating Windows AMD64 release archive..."
-	mkdir -p ./dist/release-temp/wippy-windows-amd64-$(VERSION)
-	cp ./dist/runner-windows-amd64.exe ./dist/release-temp/wippy-windows-amd64-$(VERSION)/wippy.exe
+	mkdir -p ./dist/release-temp
+	cp ./dist/runner-windows-amd64.exe ./dist/release-temp/wippy.exe
 	@if [ -f "./packcli-windows-amd64.exe" ]; then \
-		cp ./packcli-windows-amd64.exe ./dist/release-temp/wippy-windows-amd64-$(VERSION)/packcli.exe; \
+		cp ./packcli-windows-amd64.exe ./dist/release-temp/packcli.exe; \
 	else \
 		echo "⚠️  PackCLI binary not found for Windows AMD64"; \
 	fi
 	# Compress binaries with UPX
-	upx --best --lzma ./dist/release-temp/wippy-windows-amd64-$(VERSION)/wippy.exe
-	@if [ -f "./dist/release-temp/wippy-windows-amd64-$(VERSION)/packcli.exe" ]; then \
-		upx --best --lzma ./dist/release-temp/wippy-windows-amd64-$(VERSION)/packcli.exe; \
+	upx --best --lzma ./dist/release-temp/wippy.exe
+	@if [ -f "./dist/release-temp/packcli.exe" ]; then \
+		upx --best --lzma ./dist/release-temp/packcli.exe; \
 	fi
-	cd ./dist/release-temp && zip -r ../wippy-windows-amd64-$(VERSION).zip wippy-windows-amd64-$(VERSION)/
+	cd ./dist/release-temp && zip ../wippy-windows-amd64-$(VERSION).zip wippy.exe packcli.exe
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-windows-amd64-$(VERSION).zip"
 
 # macOS AMD64 release archive
 build-release-darwin-amd64: build-runner-darwin-amd64
 	@echo "Creating macOS AMD64 release archive..."
-	mkdir -p ./dist/release-temp/wippy-darwin-amd64-$(VERSION)
-	cp ./dist/runner-darwin-amd64 ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/wippy
+	mkdir -p ./dist/release-temp
+	cp ./dist/runner-darwin-amd64 ./dist/release-temp/wippy
 	@if [ -f "./packcli-darwin-amd64" ]; then \
-		cp ./packcli-darwin-amd64 ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/packcli; \
+		cp ./packcli-darwin-amd64 ./dist/release-temp/packcli; \
 	else \
 		echo "⚠️  PackCLI binary not found for macOS AMD64"; \
 	fi
 	# Compress binaries with UPX (force macOS support)
-	upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/wippy
-	@if [ -f "./dist/release-temp/wippy-darwin-amd64-$(VERSION)/packcli" ]; then \
-		upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-amd64-$(VERSION)/packcli; \
+	upx --best --lzma --force-macos ./dist/release-temp/wippy
+	@if [ -f "./dist/release-temp/packcli" ]; then \
+		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy-darwin-amd64-$(VERSION)/
+	cd ./dist/release-temp && tar -czf ../wippy-darwin-amd64-$(VERSION).tar.gz wippy packcli
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-darwin-amd64-$(VERSION).tar.gz"
 
 # macOS ARM64 release archive
 build-release-darwin-arm64: build-runner-darwin-arm64
 	@echo "Creating macOS ARM64 release archive..."
-	mkdir -p ./dist/release-temp/wippy-darwin-arm64-$(VERSION)
-	cp ./dist/runner-darwin-arm64 ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/wippy
+	mkdir -p ./dist/release-temp
+	cp ./dist/runner-darwin-arm64 ./dist/release-temp/wippy
 	@if [ -f "./packcli-darwin-arm64" ]; then \
-		cp ./packcli-darwin-arm64 ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/packcli; \
+		cp ./packcli-darwin-arm64 ./dist/release-temp/packcli; \
 	else \
 		echo "⚠️  PackCLI binary not found for macOS ARM64"; \
 	fi
 	# Compress binaries with UPX (force macOS support)
-	upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/wippy
-	@if [ -f "./dist/release-temp/wippy-darwin-arm64-$(VERSION)/packcli" ]; then \
-		upx --best --lzma --force-macos ./dist/release-temp/wippy-darwin-arm64-$(VERSION)/packcli; \
+	upx --best --lzma --force-macos ./dist/release-temp/wippy
+	@if [ -f "./dist/release-temp/packcli" ]; then \
+		upx --best --lzma --force-macos ./dist/release-temp/packcli; \
 	fi
-	cd ./dist/release-temp && tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy-darwin-arm64-$(VERSION)/
+	cd ./dist/release-temp && tar -czf ../wippy-darwin-arm64-$(VERSION).tar.gz wippy packcli
 	rm -rf ./dist/release-temp
 	@echo "✅ Created wippy-darwin-arm64-$(VERSION).tar.gz"
 

--- a/scripts/build-release-archive.sh
+++ b/scripts/build-release-archive.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Build release archive script
+# Usage: ./scripts/build-release-archive.sh <platform> <arch> <format> <version>
+# Example: ./scripts/build-release-archive.sh linux amd64 tar.gz 0.0.14-alpha
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+# Check arguments
+if [ $# -ne 4 ]; then
+    print_error "Usage: $0 <platform> <arch> <format> <version>"
+    print_error "Example: $0 linux amd64 tar.gz 0.0.14-alpha"
+    exit 1
+fi
+
+PLATFORM="$1"
+ARCH="$2"
+FORMAT="$3"
+VERSION="$4"
+
+print_info "Building release archive for $PLATFORM-$ARCH ($FORMAT) version $VERSION"
+
+# Create temporary directory
+TEMP_DIR="./dist/release-temp"
+mkdir -p "$TEMP_DIR"
+
+# Determine file extensions based on platform
+if [ "$PLATFORM" = "windows" ]; then
+    RUNNER_EXT=".exe"
+    PACKCLI_EXT=".exe"
+else
+    RUNNER_EXT=""
+    PACKCLI_EXT=""
+fi
+
+# Function to find and copy PackCLI binary
+copy_packcli() {
+    local packcli_pattern="packcli-${PLATFORM}-${ARCH}"
+    local packcli_file=""
+    
+    # Look for PackCLI files with version suffix
+    for file in ./packcli-${PLATFORM}-${ARCH}*; do
+        if [ -f "$file" ]; then
+            packcli_file="$file"
+            break
+        fi
+    done
+    
+    if [ -n "$packcli_file" ]; then
+        cp "$packcli_file" "$TEMP_DIR/packcli$PACKCLI_EXT"
+        print_success "Copied PackCLI: $packcli_file -> packcli$PACKCLI_EXT"
+        return 0
+    else
+        print_warning "PackCLI binary not found for $PLATFORM-$ARCH"
+        return 1
+    fi
+}
+
+# Function to find and copy runner binary
+copy_runner() {
+    local runner_file="./dist/runner-${PLATFORM}-${ARCH}${RUNNER_EXT}"
+    
+    if [ -f "$runner_file" ]; then
+        cp "$runner_file" "$TEMP_DIR/wippy$RUNNER_EXT"
+        print_success "Copied runner: $runner_file -> wippy$RUNNER_EXT"
+        return 0
+    else
+        print_warning "Runner binary not found for $PLATFORM-$ARCH"
+        return 1
+    fi
+}
+
+# Copy binaries
+copy_runner || true  # Don't fail if runner is missing
+copy_packcli || true  # Don't fail if PackCLI is missing
+
+# Check if we have at least one binary
+if [ ! -f "$TEMP_DIR/wippy$RUNNER_EXT" ] && [ ! -f "$TEMP_DIR/packcli$PACKCLI_EXT" ]; then
+    print_error "No binaries found for $PLATFORM-$ARCH"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+# For Windows ARM64, PackCLI-only releases are allowed
+if [ "$PLATFORM" = "windows" ] && [ "$ARCH" = "arm64" ] && [ ! -f "$TEMP_DIR/wippy$RUNNER_EXT" ] && [ -f "$TEMP_DIR/packcli$PACKCLI_EXT" ]; then
+    print_warning "Windows ARM64 PackCLI-only release (no runner binary)"
+fi
+
+# Compress binaries with UPX
+print_info "Compressing binaries with UPX..."
+
+if [ -f "$TEMP_DIR/wippy$RUNNER_EXT" ]; then
+    if [ "$PLATFORM" = "darwin" ]; then
+        upx --best --lzma --force-macos "$TEMP_DIR/wippy$RUNNER_EXT" || print_warning "UPX skipped wippy$RUNNER_EXT (file too small or other reason)"
+    else
+        upx --best --lzma "$TEMP_DIR/wippy$RUNNER_EXT" || print_warning "UPX skipped wippy$RUNNER_EXT (file too small or other reason)"
+    fi
+    print_success "Processed wippy$RUNNER_EXT"
+fi
+
+if [ -f "$TEMP_DIR/packcli$PACKCLI_EXT" ]; then
+    if [ "$PLATFORM" = "darwin" ]; then
+        upx --best --lzma --force-macos "$TEMP_DIR/packcli$PACKCLI_EXT" || print_warning "UPX skipped packcli$PACKCLI_EXT (file too small or other reason)"
+    else
+        upx --best --lzma "$TEMP_DIR/packcli$PACKCLI_EXT" || print_warning "UPX skipped packcli$PACKCLI_EXT (file too small or other reason)"
+    fi
+    print_success "Processed packcli$PACKCLI_EXT"
+fi
+
+# Create archive
+ARCHIVE_NAME="wippy-${PLATFORM}-${ARCH}-${VERSION}.${FORMAT}"
+print_info "Creating archive: $ARCHIVE_NAME"
+
+cd "$TEMP_DIR"
+
+# Build file list for archive
+FILES=""
+if [ -f "wippy$RUNNER_EXT" ]; then
+    FILES="$FILES wippy$RUNNER_EXT"
+fi
+if [ -f "packcli$PACKCLI_EXT" ]; then
+    FILES="$FILES packcli$PACKCLI_EXT"
+fi
+
+# Create archive based on format
+if [ "$FORMAT" = "tar.gz" ]; then
+    tar -czf "../$ARCHIVE_NAME" $FILES
+elif [ "$FORMAT" = "zip" ]; then
+    zip "../$ARCHIVE_NAME" $FILES
+else
+    print_error "Unsupported format: $FORMAT"
+    cd - > /dev/null
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+cd - > /dev/null
+
+# Cleanup
+rm -rf "$TEMP_DIR"
+
+print_success "Created $ARCHIVE_NAME"
+print_info "Archive contents:"
+if [ "$FORMAT" = "tar.gz" ]; then
+    tar -tzf "./dist/$ARCHIVE_NAME"
+elif [ "$FORMAT" = "zip" ]; then
+    unzip -l "./dist/$ARCHIVE_NAME"
+fi
+
+print_success "Release archive build completed successfully!"

--- a/scripts/packcli-integration/README.md
+++ b/scripts/packcli-integration/README.md
@@ -10,21 +10,20 @@ PackCLI is a helper tool that doesn't have its own releases. Instead, it's built
 
 1. **PackCLI Build Process** (in `estimation-engine/packer`):
    - When a tag is created, PackCLI builds binaries for all platforms
-   - Binaries are uploaded to S3 storage (`wippy-releases/packcli/{version}/`)
-   - A "latest" symlink is created pointing to the newest version
+   - Binaries are uploaded to GitHub releases in the `wippyai/runtime` repository
    - Metadata is created with version information
 
 2. **Wippy Release Process** (in this repository):
-   - When Wippy creates a release, it downloads the latest available PackCLI binaries
+   - When Wippy creates a release, it downloads the latest available PackCLI binaries from GitHub releases
    - **No version matching**: Wippy and PackCLI have independent release cycles
    - PackCLI binaries are included as assets in the Wippy release
    - Users get both Wippy runtime and PackCLI helper tool
 
 ## Scripts
 
-### 1. `download-packcli.sh` (Primary - S3)
+### 1. `download-packcli.sh` (Primary - GitHub)
 
-Downloads PackCLI binaries from S3 storage.
+Downloads PackCLI binaries from GitHub releases.
 
 ```bash
 # Download latest version
@@ -39,13 +38,13 @@ Downloads PackCLI binaries from S3 storage.
 
 **Features:**
 - Auto-detects platform (Linux, macOS, Windows)
-- Downloads from S3 bucket `wippy-releases/packcli/`
+- Downloads from GitHub releases in `wippyai/runtime` repository
 - Includes metadata with build information
 - Tests downloaded binary
 
-### 2. `download-packcli-github.sh` (Fallback - GitHub)
+### 2. `download-packcli-github.sh` (Alternative - GitHub)
 
-Downloads PackCLI binaries from GitHub draft releases.
+Downloads PackCLI binaries from GitHub releases in the `wippyai/wippy-releases` repository.
 
 ```bash
 # Download latest version
@@ -60,7 +59,7 @@ Downloads PackCLI binaries from GitHub draft releases.
 
 **Features:**
 - Auto-detects platform (Linux, macOS, Windows)
-- Downloads from GitHub draft releases
+- Downloads from GitHub releases in `wippyai/wippy-releases` repository
 - Includes metadata with build information
 - Tests downloaded binary
 
@@ -93,16 +92,16 @@ The integration is configured in `.github/workflows/ci-cd.yml`:
 
 ## Binary Storage
 
-PackCLI binaries are stored in two locations:
+PackCLI binaries are stored in GitHub releases:
 
-### Primary: S3 Storage
-- **Bucket**: `wippy-releases`
-- **Path**: `packcli/{version}/`
-- **URLs**: `https://wippy-releases.s3.amazonaws.com/packcli/{version}/packcli-{platform}`
+### Primary: GitHub Releases
+- **Repository**: `wippyai/runtime`
+- **Type**: Regular releases
+- **URLs**: `https://github.com/wippyai/runtime/releases/download/{version}/packcli-{platform}`
 
-### Fallback: GitHub Draft Releases
+### Alternative: GitHub Releases (Alternative Repository)
 - **Repository**: `wippyai/wippy-releases`
-- **Type**: Draft releases (not published)
+- **Type**: Regular releases
 - **URLs**: `https://github.com/wippyai/wippy-releases/releases/download/{version}/packcli-{platform}`
 
 ## Platform Support
@@ -126,7 +125,7 @@ PackCLI is automatically included in Wippy release notes:
 ### Common Issues
 
 1. **PackCLI binaries not found**: This is normal for new Wippy versions - PackCLI will be available in future releases
-2. **Download script fails**: Check S3/GitHub access and permissions
+2. **Download script fails**: Check GitHub access and permissions
 3. **Binary not executable**: Ensure proper permissions are set
 
 ### Debug Mode
@@ -159,5 +158,5 @@ To test the integration locally:
 For issues with PackCLI integration:
 - Check the PackCLI repository: `estimation-engine/packer`
 - Review the build logs in GitLab CI/CD
-- Verify S3/GitHub access and permissions
+- Verify GitHub access and permissions
 - Check Wippy release logs in GitHub Actions

--- a/scripts/packcli-integration/README.md
+++ b/scripts/packcli-integration/README.md
@@ -1,0 +1,163 @@
+# PackCLI Integration for Wippy
+
+This directory contains scripts for integrating PackCLI (Packer CLI) with Wippy releases.
+
+## Overview
+
+PackCLI is a helper tool that doesn't have its own releases. Instead, it's built and made available for Wippy to include in its releases. This integration allows Wippy to automatically download and include PackCLI binaries when creating releases.
+
+## How It Works
+
+1. **PackCLI Build Process** (in `estimation-engine/packer`):
+   - When a tag is created, PackCLI builds binaries for all platforms
+   - Binaries are uploaded to S3 storage (`wippy-releases/packcli/{version}/`)
+   - A "latest" symlink is created pointing to the newest version
+   - Metadata is created with version information
+
+2. **Wippy Release Process** (in this repository):
+   - When Wippy creates a release, it downloads the latest available PackCLI binaries
+   - **No version matching**: Wippy and PackCLI have independent release cycles
+   - PackCLI binaries are included as assets in the Wippy release
+   - Users get both Wippy runtime and PackCLI helper tool
+
+## Scripts
+
+### 1. `download-packcli.sh` (Primary - S3)
+
+Downloads PackCLI binaries from S3 storage.
+
+```bash
+# Download latest version
+./download-packcli.sh
+
+# Download specific version
+./download-packcli.sh v1.2.3
+
+# Download for specific platform
+./download-packcli.sh v1.2.3 linux-amd64
+```
+
+**Features:**
+- Auto-detects platform (Linux, macOS, Windows)
+- Downloads from S3 bucket `wippy-releases/packcli/`
+- Includes metadata with build information
+- Tests downloaded binary
+
+### 2. `download-packcli-github.sh` (Fallback - GitHub)
+
+Downloads PackCLI binaries from GitHub draft releases.
+
+```bash
+# Download latest version
+./download-packcli-github.sh
+
+# Download specific version
+./download-packcli-github.sh v1.2.3
+
+# Download for specific platform
+./download-packcli-github.sh v1.2.3 linux-amd64
+```
+
+**Features:**
+- Auto-detects platform (Linux, macOS, Windows)
+- Downloads from GitHub draft releases
+- Includes metadata with build information
+- Tests downloaded binary
+
+## Integration in Wippy CI/CD
+
+The integration is configured in `.github/workflows/ci-cd.yml`:
+
+```yaml
+- name: Download PackCLI binaries
+  run: |
+    echo "🔧 Downloading latest PackCLI binaries for integration..."
+    
+    # Use local PackCLI integration script
+    chmod +x ./scripts/packcli-integration/download-packcli.sh
+    
+    # Always download the latest available PackCLI version
+    echo "📦 Downloading latest PackCLI version (independent of Wippy version)..."
+    
+    if ./scripts/packcli-integration/download-packcli.sh "latest"; then
+      echo "✅ PackCLI binaries downloaded successfully"
+      # Move PackCLI binaries to release directory
+      mv packcli-* ./release-binaries/ 2>/dev/null || echo "No PackCLI binaries to move"
+      mv packcli-metadata.json ./release-binaries/ 2>/dev/null || echo "No PackCLI metadata to move"
+      echo "✅ PackCLI binaries included in Wippy release"
+    else
+      echo "⚠️  PackCLI binaries not available - Wippy release will be created without PackCLI"
+      echo "   This is normal if PackCLI hasn't been built yet"
+    fi
+```
+
+## Binary Storage
+
+PackCLI binaries are stored in two locations:
+
+### Primary: S3 Storage
+- **Bucket**: `wippy-releases`
+- **Path**: `packcli/{version}/`
+- **URLs**: `https://wippy-releases.s3.amazonaws.com/packcli/{version}/packcli-{platform}`
+
+### Fallback: GitHub Draft Releases
+- **Repository**: `wippyai/wippy-releases`
+- **Type**: Draft releases (not published)
+- **URLs**: `https://github.com/wippyai/wippy-releases/releases/download/{version}/packcli-{platform}`
+
+## Platform Support
+
+- **Linux AMD64**: `packcli-linux-amd64`
+- **Linux ARM64**: `packcli-linux-arm64`
+- **macOS AMD64**: `packcli-darwin-amd64`
+- **macOS ARM64**: `packcli-darwin-arm64`
+- **Windows AMD64**: `packcli-windows-amd64.exe`
+
+## Release Notes Integration
+
+PackCLI is automatically included in Wippy release notes:
+
+- **Downloads section**: Lists all PackCLI binaries
+- **Installation section**: Provides usage examples
+- **Release summary**: Shows PackCLI binary information
+
+## Troubleshooting
+
+### Common Issues
+
+1. **PackCLI binaries not found**: This is normal for new Wippy versions - PackCLI will be available in future releases
+2. **Download script fails**: Check S3/GitHub access and permissions
+3. **Binary not executable**: Ensure proper permissions are set
+
+### Debug Mode
+
+Run scripts with debug output:
+
+```bash
+bash -x ./scripts/packcli-integration/download-packcli.sh v1.2.3
+```
+
+## Development
+
+To test the integration locally:
+
+1. **Build PackCLI** in the packer repository:
+   ```bash
+   cd /path/to/estimation-engine/packer
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+2. **Test download** in wippy:
+   ```bash
+   cd /path/to/runtime
+   ./scripts/packcli-integration/download-packcli.sh v1.2.3
+   ```
+
+## Support
+
+For issues with PackCLI integration:
+- Check the PackCLI repository: `estimation-engine/packer`
+- Review the build logs in GitLab CI/CD
+- Verify S3/GitHub access and permissions
+- Check Wippy release logs in GitHub Actions

--- a/scripts/packcli-integration/download-packcli-github.sh
+++ b/scripts/packcli-integration/download-packcli-github.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Alternative script for wippy to download packcli binaries from GitHub
+# This uses GitHub as intermediate storage instead of S3
+# Usage: ./download-packcli-github.sh [version] [platform]
+
+set -e
+
+# Configuration
+GITHUB_REPO="wippyai/wippy-releases"
+PACKCLI_VERSION=${1:-"latest"}
+PLATFORM=${2:-"auto"}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}🔧 PackCLI Downloader for Wippy (GitHub)${NC}"
+echo "============================================="
+
+# Auto-detect platform if not specified
+if [ "$PLATFORM" = "auto" ]; then
+    case "$(uname -s)" in
+        Linux*)     PLATFORM="linux-amd64";;
+        Darwin*)    PLATFORM="darwin-amd64";;
+        CYGWIN*|MINGW*|MSYS*) PLATFORM="windows-amd64";;
+        *)          echo -e "${RED}❌ Unsupported platform: $(uname -s)${NC}"; exit 1;;
+    esac
+fi
+
+echo "📦 Version: $PACKCLI_VERSION"
+echo "🖥️  Platform: $PLATFORM"
+
+# Determine binary name
+if [ "$PLATFORM" = "windows-amd64" ]; then
+    BINARY_NAME="packcli-windows-amd64.exe"
+else
+    BINARY_NAME="packcli-${PLATFORM}"
+fi
+
+# Construct GitHub URLs
+if [ "$PACKCLI_VERSION" = "latest" ]; then
+    # For latest, we need to find the most recent release
+    echo "🔍 Finding latest release..."
+    LATEST_RELEASE=$(curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases/latest")
+    PACKCLI_VERSION=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
+    echo "📋 Latest release: $PACKCLI_VERSION"
+fi
+
+BINARY_URL="https://github.com/${GITHUB_REPO}/releases/download/${PACKCLI_VERSION}/${BINARY_NAME}"
+METADATA_URL="https://github.com/${GITHUB_REPO}/releases/download/${PACKCLI_VERSION}/packcli-metadata.json"
+
+echo "📥 Binary URL: $BINARY_URL"
+echo "📋 Metadata URL: $METADATA_URL"
+
+# Download metadata
+echo "📋 Downloading metadata..."
+if ! curl -s -f "$METADATA_URL" > packcli-metadata.json; then
+    echo -e "${YELLOW}⚠️  Metadata not found, continuing without it...${NC}"
+    METADATA_AVAILABLE=false
+else
+    METADATA_AVAILABLE=true
+    VERSION=$(jq -r '.version' packcli-metadata.json)
+    COMMIT=$(jq -r '.commit' packcli-metadata.json)
+    BUILD_DATE=$(jq -r '.build_date' packcli-metadata.json)
+    
+    echo "✅ Metadata downloaded:"
+    echo "   Version: $VERSION"
+    echo "   Commit: $COMMIT"
+    echo "   Build Date: $BUILD_DATE"
+fi
+
+# Download binary
+echo "📥 Downloading $BINARY_NAME..."
+if ! curl -L -f "$BINARY_URL" -o "$BINARY_NAME"; then
+    echo -e "${RED}❌ Failed to download binary from $BINARY_URL${NC}"
+    echo "   Make sure the release exists and contains the binary for platform $PLATFORM"
+    exit 1
+fi
+
+# Make executable (except for Windows)
+if [ "$PLATFORM" != "windows-amd64" ]; then
+    chmod +x "$BINARY_NAME"
+fi
+
+echo -e "${GREEN}✅ Successfully downloaded PackCLI $PACKCLI_VERSION for $PLATFORM${NC}"
+echo "📁 Binary: $BINARY_NAME"
+
+# Test the binary
+echo "🧪 Testing binary..."
+if [ "$PLATFORM" = "windows-amd64" ]; then
+    ./"$BINARY_NAME" --version
+else
+    ./"$BINARY_NAME" --version
+fi
+
+echo ""
+echo -e "${GREEN}🎉 PackCLI is ready for wippy integration!${NC}"
+echo ""
+echo "Next steps:"
+echo "  1. Include $BINARY_NAME in your wippy release assets"
+echo "  2. Update your wippy documentation with PackCLI usage"
+echo "  3. Clean up: rm $BINARY_NAME packcli-metadata.json"

--- a/scripts/packcli-integration/download-packcli-github.sh
+++ b/scripts/packcli-integration/download-packcli-github.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Alternative script for wippy to download packcli binaries from GitHub
-# This uses GitHub as intermediate storage instead of S3
+# This downloads from the wippyai/wippy-releases repository
 # Usage: ./download-packcli-github.sh [version] [platform]
 
 set -e

--- a/scripts/packcli-integration/download-packcli.sh
+++ b/scripts/packcli-integration/download-packcli.sh
@@ -19,71 +19,80 @@ NC='\033[0m' # No Color
 echo -e "${GREEN}🔧 PackCLI Downloader for Wippy${NC}"
 echo "=================================="
 
-# Auto-detect platform if not specified
-if [ "$PLATFORM" = "auto" ]; then
-    case "$(uname -s)" in
-        Linux*)     PLATFORM="linux-amd64";;
-        Darwin*)    PLATFORM="darwin-amd64";;
-        CYGWIN*|MINGW*|MSYS*) PLATFORM="windows-amd64";;
-        *)          echo -e "${RED}❌ Unsupported platform: $(uname -s)${NC}"; exit 1;;
-    esac
-fi
-
 echo "📦 Version: $PACKCLI_VERSION"
-echo "🖥️  Platform: $PLATFORM"
-
-# Determine binary name
-if [ "$PLATFORM" = "windows-amd64" ]; then
-    BINARY_NAME="packcli-windows-amd64.exe"
-else
-    BINARY_NAME="packcli-${PLATFORM}"
-fi
 
 # Get latest version if needed
 if [ "$PACKCLI_VERSION" = "latest" ]; then
-    echo "🔍 Getting latest version from GitHub API..."
-    LATEST_VERSION=$(curl -s "https://api.github.com/repos/$GITHUB_REPO/releases/latest" | jq -r '.tag_name')
+    echo "🔍 Getting latest PackCLI version from GitHub API..."
+    # Get the most recent PackCLI release by creation date
+    LATEST_VERSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases" | jq -r '.[] | select(.name | test("PackCLI")) | [.created_at, .tag_name] | @tsv' | sort -r | head -1 | cut -f2)
     if [ "$LATEST_VERSION" = "null" ] || [ -z "$LATEST_VERSION" ]; then
-        echo -e "${RED}❌ Failed to get latest version from GitHub${NC}"
+        echo -e "${RED}❌ Failed to get latest PackCLI version from GitHub${NC}"
+        echo "   Available PackCLI releases:"
+        curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases" | jq -r '.[] | select(.name | test("PackCLI")) | .created_at + " - " + .name + " (" + .tag_name + ")"' | head -5
         exit 1
     fi
     PACKCLI_VERSION="$LATEST_VERSION"
-    echo "✅ Latest version: $PACKCLI_VERSION"
+    echo "✅ Latest PackCLI version: $PACKCLI_VERSION"
 fi
 
-# Construct GitHub URLs
-BINARY_URL="https://github.com/$GITHUB_REPO/releases/download/$PACKCLI_VERSION/$BINARY_NAME"
+# We'll download all PackCLI assets from the release
 
-echo "📥 Binary URL: $BINARY_URL"
+# Download all PackCLI assets from the release
+echo "📥 Downloading all PackCLI assets from release $PACKCLI_VERSION..."
 
-# Download binary
-echo "📥 Downloading $BINARY_NAME..."
-if ! curl -L -f "$BINARY_URL" -o "$BINARY_NAME"; then
-    echo -e "${RED}❌ Failed to download binary from $BINARY_URL${NC}"
-    echo "   Make sure the release exists: https://github.com/$GITHUB_REPO/releases/tag/$PACKCLI_VERSION"
+# Get all assets from the release
+ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases/tags/$PACKCLI_VERSION" | jq -r '.assets[] | select(.name | test("packcli")) | [.name, .url] | @tsv')
+
+if [ -z "$ASSETS" ]; then
+    echo -e "${RED}❌ No PackCLI assets found in release $PACKCLI_VERSION${NC}"
     exit 1
 fi
 
-# Make executable (except for Windows)
-if [ "$PLATFORM" != "windows-amd64" ]; then
-    chmod +x "$BINARY_NAME"
+# Download each asset
+echo "$ASSETS" | while IFS=$'\t' read -r asset_name asset_url; do
+    echo "📥 Downloading $asset_name..."
+    if curl -L -f -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" "$asset_url" -o "$asset_name"; then
+        echo "✅ Downloaded $asset_name"
+        # Make executable (except for Windows .exe files)
+        if [[ "$asset_name" != *.exe ]]; then
+            chmod +x "$asset_name"
+        fi
+    else
+        echo -e "${RED}❌ Failed to download $asset_name${NC}"
+    fi
+done
+
+echo -e "${GREEN}✅ Successfully downloaded all PackCLI assets from $PACKCLI_VERSION${NC}"
+echo "📁 Downloaded files:"
+ls -la packcli-* 2>/dev/null || echo "No PackCLI files found"
+
+# Test one of the binaries (prefer linux-amd64 if available)
+TEST_BINARY=""
+if [ -f "packcli-linux-amd64" ]; then
+    TEST_BINARY="packcli-linux-amd64"
+elif [ -f "packcli-darwin-amd64" ]; then
+    TEST_BINARY="packcli-darwin-amd64"
+elif [ -f "packcli-windows-amd64.exe" ]; then
+    TEST_BINARY="packcli-windows-amd64.exe"
+else
+    # Find any packcli binary
+    TEST_BINARY=$(ls packcli-* 2>/dev/null | head -1)
 fi
 
-echo -e "${GREEN}✅ Successfully downloaded PackCLI $PACKCLI_VERSION for $PLATFORM${NC}"
-echo "📁 Binary: $BINARY_NAME"
-
-# Test the binary
-echo "🧪 Testing binary..."
-if [ "$PLATFORM" = "windows-amd64" ]; then
-    ./"$BINARY_NAME" --version
-else
-    ./"$BINARY_NAME" --version
+if [ -n "$TEST_BINARY" ]; then
+    echo "🧪 Testing binary: $TEST_BINARY"
+    if [[ "$TEST_BINARY" == *.exe ]]; then
+        ./"$TEST_BINARY" --version
+    else
+        ./"$TEST_BINARY" --version
+    fi
 fi
 
 echo ""
 echo -e "${GREEN}🎉 PackCLI is ready for wippy integration!${NC}"
 echo ""
 echo "Next steps:"
-echo "  1. Include $BINARY_NAME in your wippy release assets"
+echo "  1. Include all PackCLI binaries in your wippy release assets"
 echo "  2. Update your wippy documentation with PackCLI usage"
-echo "  3. Clean up: rm $BINARY_NAME"
+echo "  3. Clean up: rm packcli-*"

--- a/scripts/packcli-integration/download-packcli.sh
+++ b/scripts/packcli-integration/download-packcli.sh
@@ -99,26 +99,38 @@ echo -e "${GREEN}✅ Successfully downloaded all PackCLI assets from $PACKCLI_VE
 echo "📁 Downloaded files:"
 ls -la packcli-* 2>/dev/null || echo "No PackCLI files found"
 
-# Test one of the binaries (prefer linux-amd64 if available)
+# Test one of the binaries (only if compatible with current architecture)
 TEST_BINARY=""
-if [ -f "packcli-linux-amd64" ]; then
-    TEST_BINARY="packcli-linux-amd64"
-elif [ -f "packcli-darwin-amd64" ]; then
-    TEST_BINARY="packcli-darwin-amd64"
-elif [ -f "packcli-windows-amd64.exe" ]; then
-    TEST_BINARY="packcli-windows-amd64.exe"
-else
-    # Find any packcli binary
-    TEST_BINARY=$(ls packcli-* 2>/dev/null | head -1)
+CURRENT_ARCH=$(uname -m)
+CURRENT_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+echo "🔍 Current system: $CURRENT_OS-$CURRENT_ARCH"
+
+# Map current architecture to expected binary names
+if [ "$CURRENT_OS" = "linux" ]; then
+    if [ "$CURRENT_ARCH" = "x86_64" ] && [ -f "packcli-linux-amd64" ]; then
+        TEST_BINARY="packcli-linux-amd64"
+    elif [ "$CURRENT_ARCH" = "aarch64" ] && [ -f "packcli-linux-arm64" ]; then
+        TEST_BINARY="packcli-linux-arm64"
+    fi
+elif [ "$CURRENT_OS" = "darwin" ]; then
+    if [ "$CURRENT_ARCH" = "x86_64" ] && [ -f "packcli-darwin-amd64" ]; then
+        TEST_BINARY="packcli-darwin-amd64"
+    elif [ "$CURRENT_ARCH" = "arm64" ] && [ -f "packcli-darwin-arm64" ]; then
+        TEST_BINARY="packcli-darwin-arm64"
+    fi
 fi
 
 if [ -n "$TEST_BINARY" ]; then
-    echo "🧪 Testing binary: $TEST_BINARY"
+    echo "🧪 Testing compatible binary: $TEST_BINARY"
     if [[ "$TEST_BINARY" == *.exe ]]; then
         ./"$TEST_BINARY" --version
     else
         ./"$TEST_BINARY" --version
     fi
+else
+    echo "ℹ️ No compatible binary found for testing ($CURRENT_OS-$CURRENT_ARCH)"
+    echo "   This is normal when downloading binaries for different architectures"
 fi
 
 echo ""

--- a/scripts/packcli-integration/download-packcli.sh
+++ b/scripts/packcli-integration/download-packcli.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-GITHUB_REPO="wippyai/wippy-releases"
+GITHUB_REPO="wippyai/runtime"
 PACKCLI_VERSION=${1:-"latest"}
 PLATFORM=${2:-"auto"}
 

--- a/scripts/packcli-integration/download-packcli.sh
+++ b/scripts/packcli-integration/download-packcli.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Script for wippy to download packcli binaries from GitHub
+# Usage: ./download-packcli.sh [version] [platform]
+
+set -e
+
+# Configuration
+GITHUB_REPO="wippyai/wippy-releases"
+PACKCLI_VERSION=${1:-"latest"}
+PLATFORM=${2:-"auto"}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}🔧 PackCLI Downloader for Wippy${NC}"
+echo "=================================="
+
+# Auto-detect platform if not specified
+if [ "$PLATFORM" = "auto" ]; then
+    case "$(uname -s)" in
+        Linux*)     PLATFORM="linux-amd64";;
+        Darwin*)    PLATFORM="darwin-amd64";;
+        CYGWIN*|MINGW*|MSYS*) PLATFORM="windows-amd64";;
+        *)          echo -e "${RED}❌ Unsupported platform: $(uname -s)${NC}"; exit 1;;
+    esac
+fi
+
+echo "📦 Version: $PACKCLI_VERSION"
+echo "🖥️  Platform: $PLATFORM"
+
+# Determine binary name
+if [ "$PLATFORM" = "windows-amd64" ]; then
+    BINARY_NAME="packcli-windows-amd64.exe"
+else
+    BINARY_NAME="packcli-${PLATFORM}"
+fi
+
+# Get latest version if needed
+if [ "$PACKCLI_VERSION" = "latest" ]; then
+    echo "🔍 Getting latest version from GitHub API..."
+    LATEST_VERSION=$(curl -s "https://api.github.com/repos/$GITHUB_REPO/releases/latest" | jq -r '.tag_name')
+    if [ "$LATEST_VERSION" = "null" ] || [ -z "$LATEST_VERSION" ]; then
+        echo -e "${RED}❌ Failed to get latest version from GitHub${NC}"
+        exit 1
+    fi
+    PACKCLI_VERSION="$LATEST_VERSION"
+    echo "✅ Latest version: $PACKCLI_VERSION"
+fi
+
+# Construct GitHub URLs
+BINARY_URL="https://github.com/$GITHUB_REPO/releases/download/$PACKCLI_VERSION/$BINARY_NAME"
+
+echo "📥 Binary URL: $BINARY_URL"
+
+# Download binary
+echo "📥 Downloading $BINARY_NAME..."
+if ! curl -L -f "$BINARY_URL" -o "$BINARY_NAME"; then
+    echo -e "${RED}❌ Failed to download binary from $BINARY_URL${NC}"
+    echo "   Make sure the release exists: https://github.com/$GITHUB_REPO/releases/tag/$PACKCLI_VERSION"
+    exit 1
+fi
+
+# Make executable (except for Windows)
+if [ "$PLATFORM" != "windows-amd64" ]; then
+    chmod +x "$BINARY_NAME"
+fi
+
+echo -e "${GREEN}✅ Successfully downloaded PackCLI $PACKCLI_VERSION for $PLATFORM${NC}"
+echo "📁 Binary: $BINARY_NAME"
+
+# Test the binary
+echo "🧪 Testing binary..."
+if [ "$PLATFORM" = "windows-amd64" ]; then
+    ./"$BINARY_NAME" --version
+else
+    ./"$BINARY_NAME" --version
+fi
+
+echo ""
+echo -e "${GREEN}🎉 PackCLI is ready for wippy integration!${NC}"
+echo ""
+echo "Next steps:"
+echo "  1. Include $BINARY_NAME in your wippy release assets"
+echo "  2. Update your wippy documentation with PackCLI usage"
+echo "  3. Clean up: rm $BINARY_NAME"

--- a/scripts/packcli-integration/download-packcli.sh
+++ b/scripts/packcli-integration/download-packcli.sh
@@ -54,9 +54,23 @@ echo "$ASSETS" | while IFS=$'\t' read -r asset_name asset_url; do
     echo "📥 Downloading $asset_name..."
     if curl -L -f -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" "$asset_url" -o "$asset_name"; then
         echo "✅ Downloaded $asset_name"
+        
+        # Rename file to short format expected by Makefile
+        # Convert packcli-linux-arm64-v0.0.7-alpha7 -> packcli-linux-arm64
+        # Convert packcli-windows-amd64-v0.0.7-alpha7.exe -> packcli-windows-amd64.exe
+        short_name=$(echo "$asset_name" | sed -E 's/-v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*(\.[a-z]+)?$/\2/')
+        # If the regex didn't match, try a simpler approach
+        if [ "$short_name" = "$asset_name" ]; then
+            short_name=$(echo "$asset_name" | sed -E 's/-v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*//')
+        fi
+        if [ "$short_name" != "$asset_name" ]; then
+            mv "$asset_name" "$short_name"
+            echo "📝 Renamed $asset_name -> $short_name"
+        fi
+        
         # Make executable (except for Windows .exe files)
-        if [[ "$asset_name" != *.exe ]]; then
-            chmod +x "$asset_name"
+        if [[ "$short_name" != *.exe ]]; then
+            chmod +x "$short_name"
         fi
     else
         echo -e "${RED}❌ Failed to download $asset_name${NC}"

--- a/scripts/packcli-integration/download-packcli.sh
+++ b/scripts/packcli-integration/download-packcli.sh
@@ -2,13 +2,17 @@
 
 # Script for wippy to download packcli binaries from GitHub
 # Usage: ./download-packcli.sh [version] [platform]
+# Examples:
+#   ./download-packcli.sh latest                    # Download all PackCLI binaries
+#   ./download-packcli.sh latest linux-amd64       # Download only linux-amd64 PackCLI
+#   ./download-packcli.sh v0.0.7-alpha7 windows-amd64  # Download specific version for specific platform
 
 set -e
 
 # Configuration
 GITHUB_REPO="wippyai/runtime"
 PACKCLI_VERSION=${1:-"latest"}
-PLATFORM=${2:-"auto"}
+PLATFORM_FILTER=${2:-""}
 
 # Colors for output
 RED='\033[0;31m'
@@ -38,14 +42,28 @@ fi
 
 # We'll download all PackCLI assets from the release
 
-# Download all PackCLI assets from the release
-echo "📥 Downloading all PackCLI assets from release $PACKCLI_VERSION..."
+# Download PackCLI assets from the release
+if [ -n "$PLATFORM_FILTER" ]; then
+    echo "📥 Downloading PackCLI $PLATFORM_FILTER from release $PACKCLI_VERSION..."
+else
+    echo "📥 Downloading all PackCLI assets from release $PACKCLI_VERSION..."
+fi
 
-# Get all assets from the release
-ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases/tags/$PACKCLI_VERSION" | jq -r '.assets[] | select(.name | test("packcli")) | [.name, .url] | @tsv')
+# Get assets from the release with optional platform filter
+if [ -n "$PLATFORM_FILTER" ]; then
+    ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases/tags/$PACKCLI_VERSION" | jq -r ".assets[] | select(.name | test(\"packcli.*$PLATFORM_FILTER\")) | [.name, .url] | @tsv")
+else
+    ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases/tags/$PACKCLI_VERSION" | jq -r '.assets[] | select(.name | test("packcli")) | [.name, .url] | @tsv')
+fi
 
 if [ -z "$ASSETS" ]; then
-    echo -e "${RED}❌ No PackCLI assets found in release $PACKCLI_VERSION${NC}"
+    if [ -n "$PLATFORM_FILTER" ]; then
+        echo -e "${RED}❌ No PackCLI assets found for platform $PLATFORM_FILTER in release $PACKCLI_VERSION${NC}"
+    else
+        echo -e "${RED}❌ No PackCLI assets found in release $PACKCLI_VERSION${NC}"
+    fi
+    echo "   Available PackCLI releases:"
+    curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_REPO/releases" | jq -r '.[] | select(.name | test("PackCLI")) | .created_at + " - " + .name + " (" + .tag_name + ")"' | head -5
     exit 1
 fi
 


### PR DESCRIPTION
- Change triggers to only run on release tags (v*, release/*)
- Update binary names to include version tag (e.g., wippy-darwin-amd64-1.2.3-alpha)
- Replace wippy-releases commits with GitHub releases
- Remove PR workflow and simplify release process
- Publish binaries as assets in wippy-releases repository