### PR TITLE
- removes uneccessary cache and fixes race over ids

### DIFF
--- a/cmd/runner/app/app.go
+++ b/cmd/runner/app/app.go
@@ -547,7 +547,7 @@ func (a *App) loadApplicationState(ctx context.Context, appFS iofs.FS) (regapi.C
 
 	cleanup, err := initOpenTelemetry(
 		context.Background(),
-		os.Getenv("OTEL_ENDPOINT"),
+		os.Getenv("OTEL_ENDPOINT"), // todo: cleanup to env layer
 		os.Getenv("OTEL_SERVICE_NAME"),
 		os.Getenv("OTEL_SERVICE_VERSION"),
 		a.logger,

--- a/cmd/runner/app/services.go
+++ b/cmd/runner/app/services.go
@@ -366,7 +366,7 @@ func withLuaRuntime(a *App) []eventbus.EventHandler {
 				ostime.NewOSTimeModule(),
 				channel.NewChannelModule(),
 				timemod.NewTimeModule(),
-				logger.NewLoggerModule(a.logger.Named("app")),
+				logger.NewLoggerModule(a.logger),
 				base64.NewBase64Module(),
 				jsonmod.NewJSONModule(),
 				fsmod.NewFSModule(),

--- a/runtime/lua/code/memory_graph.go
+++ b/runtime/lua/code/memory_graph.go
@@ -79,7 +79,6 @@ type MemoryGraph struct {
 	nodes map[registry.ID]*Node
 
 	// Performance caches
-	stringCache           map[registry.ID]string  // Cache for ID.String() results
 	dependencyLevelsCache [][]*Node               // Cache for DependencyLevels result
 	dependentsCache       map[registry.ID][]*Node // Cache for GetAllDependents results
 	cacheValid            bool                    // Whether caches are valid
@@ -90,7 +89,6 @@ func NewMemoryGraph() *MemoryGraph {
 	return &MemoryGraph{
 		graph:           graph.New[registry.ID, Edge](),
 		nodes:           make(map[registry.ID]*Node),
-		stringCache:     make(map[registry.ID]string),
 		dependentsCache: make(map[registry.ID][]*Node),
 		cacheValid:      true,
 	}
@@ -103,16 +101,6 @@ func (m *MemoryGraph) invalidateCache() {
 	for k := range m.dependentsCache {
 		delete(m.dependentsCache, k)
 	}
-}
-
-// getIDString returns a cached string representation of the ID
-func (m *MemoryGraph) getIDString(id registry.ID) string {
-	if str, exists := m.stringCache[id]; exists {
-		return str
-	}
-	str := id.String()
-	m.stringCache[id] = str
-	return str
 }
 
 // hasCycle performs DFS-based cycle detection without cloning the graph
@@ -189,7 +177,6 @@ func (m *MemoryGraph) RemoveNode(id registry.ID) error {
 	}
 
 	delete(m.nodes, id)
-	delete(m.stringCache, id)
 	m.invalidateCache()
 	return nil
 }
@@ -365,9 +352,8 @@ func (m *MemoryGraph) DependencyLevels() ([][]*Node, error) {
 			}
 		}
 
-		// Sort using cached strings to avoid fmt.Sprintf in hot path
 		sort.Slice(level, func(i, j int) bool {
-			return m.getIDString(level[i].ID) < m.getIDString(level[j].ID)
+			return level[i].ID.String() < level[j].ID.String()
 		})
 
 		levels = append(levels, level)

--- a/service/template/manager.go
+++ b/service/template/manager.go
@@ -124,16 +124,12 @@ func (m *Manager) handleTemplateAdd(_ context.Context, entry registry.Entry) err
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Decode configuration
-	cfg := new(template.Config)
-	if err := m.dtt.Unmarshal(entry.Data, cfg); err != nil {
+	cfg, err := decodeEntity[template.Config](entry, m.dtt)
+	if err != nil {
 		return fmt.Errorf("failed to unmarshal template config: %w", err)
 	}
-
-	// Initialize defaults and validate
-	cfg.InitDefaults()
-	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid template config: %w", err)
+	if entry.Meta != nil {
+		cfg.Meta = entry.Meta
 	}
 
 	// Set namespace if not specified
@@ -188,10 +184,13 @@ func (m *Manager) handleTemplateUpdate(_ context.Context, entry registry.Entry) 
 		return fmt.Errorf("%w: %s", ErrTemplateNotFound, entry.ID)
 	}
 
-	// Decode configuration
-	cfg := new(template.Config)
-	if err := m.dtt.Unmarshal(entry.Data, cfg); err != nil {
+	cfg, err := decodeEntity[template.Config](entry, m.dtt)
+	if err != nil {
 		return fmt.Errorf("failed to unmarshal template config: %w", err)
+	}
+
+	if entry.Meta != nil {
+		cfg.Meta = entry.Meta
 	}
 
 	// Initialize defaults and validate
@@ -355,9 +354,8 @@ func (m *Manager) handleSetAdd(ctx context.Context, entry registry.Entry) error 
 		return fmt.Errorf("template set %s already exists", entry.ID)
 	}
 
-	// Decode configuration
-	cfg := new(template.SetConfig)
-	if err := m.dtt.Unmarshal(entry.Data, cfg); err != nil {
+	cfg, err := decodeEntity[template.SetConfig](entry, m.dtt)
+	if err != nil {
 		return fmt.Errorf("failed to unmarshal set config: %w", err)
 	}
 
@@ -407,8 +405,8 @@ func (m *Manager) handleSetUpdate(ctx context.Context, entry registry.Entry) err
 	}
 
 	// Decode configuration
-	cfg := new(template.SetConfig)
-	if err := m.dtt.Unmarshal(entry.Data, cfg); err != nil {
+	cfg, err := decodeEntity[template.SetConfig](entry, m.dtt)
+	if err != nil {
 		return fmt.Errorf("failed to unmarshal set config: %w", err)
 	}
 
@@ -533,4 +531,34 @@ func (m *Manager) Acquire(
 
 	// Create a resource for the template
 	return set.Acquire(ctx, registry.ID{Name: entry.Name}, mode)
+}
+
+//
+// Helper functions
+//
+
+// decodeEntity is a helper to decode registry entries into specific configs
+func decodeEntity[T any](entry registry.Entry, transcoder payload.Transcoder) (*T, error) {
+	if entry.Data == nil {
+		return nil, fmt.Errorf("configuration data is required")
+	}
+
+	cfg := new(T)
+	if err := transcoder.Unmarshal(entry.Data, cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// Validate if the config implements Validate()
+	if df, ok := interface{}(cfg).(interface{ InitDefaults() }); ok {
+		df.InitDefaults()
+	}
+
+	// Validate if the config implements Validate()
+	if validator, ok := interface{}(cfg).(interface{ Validate() error }); ok {
+		if err := validator.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+	}
+
+	return cfg, nil
 }

--- a/system/eventbus/bus.go
+++ b/system/eventbus/bus.go
@@ -306,10 +306,10 @@ func (b *Bus) processActions() bool {
 				// Check contexts and deliver
 				select {
 				case <-a.sendEvent.ctx.Done():
-					// Event context cancelled
+					// Event context canceled
 					goto cleanup
 				case <-s.ctx.Done():
-					// Subscriber context cancelled, mark for cleanup
+					// Subscriber context canceled, mark for cleanup
 					expiredSubs = append(expiredSubs, id)
 					continue
 				case s.eventCh <- a.sendEvent.event:

--- a/system/eventbus/bus.go
+++ b/system/eventbus/bus.go
@@ -1,6 +1,7 @@
 package eventbus
 
 import (
+	"container/list"
 	"context"
 	"errors"
 	"fmt"
@@ -14,17 +15,27 @@ import (
 type actionType int
 
 const (
-	subscribe actionType = iota
-	unsubscribe
-	send
-	stop
+	actionSubscribe actionType = iota
+	actionUnsubscribe
+	actionSend
+	actionStop
 )
 
 type action struct {
 	actionType  actionType
-	subscribe   sub
-	unsubscribe unsub
-	event       sendEvent
+	subscribe   *subscribeRequest
+	unsubscribe *unsubscribeRequest
+	sendEvent   *sendEvent
+}
+
+type subscribeRequest struct {
+	sub    sub
+	doneCh chan error
+}
+
+type unsubscribeRequest struct {
+	subID  event.SubscriberID
+	doneCh chan struct{}
 }
 
 type sendEvent struct {
@@ -34,15 +45,10 @@ type sendEvent struct {
 
 type sub struct {
 	subID   event.SubscriberID
+	ctx     context.Context
 	system  *wildcard.Wildcard
 	kind    *wildcard.Wildcard
 	eventCh chan<- event.Event
-	doneCh  chan bool
-}
-
-type unsub struct {
-	subID  event.SubscriberID
-	doneCh chan bool
 }
 
 // Bus is an event bus that handles pub/sub message distribution with support for
@@ -50,29 +56,32 @@ type unsub struct {
 // for subscribing, unsubscribing, and sending events.
 type Bus struct {
 	subscribers       map[event.SubscriberID]sub
-	actions           chan action
-	wg                sync.WaitGroup
 	subscriberCounter uint64
-	closed            chan any
+
+	// Single queue for all operations - unbounded linked list
+	actionQueue *list.List
+	actionMu    sync.Mutex
+	actionReady chan struct{} // Signal that actions are available
+
+	wg     sync.WaitGroup
+	closed atomic.Bool
 }
 
-// NewBus creates a new event bus instance with the provided logger.
-// It initializes internal channels and starts the event handling goroutine.
+// NewBus creates a new event bus instance.
 func NewBus() *Bus {
 	b := &Bus{
 		subscribers: make(map[event.SubscriberID]sub),
-		actions:     make(chan action, 100), // Buffered channel for all actions
-		closed:      make(chan any),
+		actionQueue: list.New(),
+		actionReady: make(chan struct{}, 1), // Buffered so signal never blocks
 	}
 
 	b.wg.Add(1)
-	go b.handleActions()
+	go b.dispatcher()
 
 	return b
 }
 
 // Subscribe creates a new subscription for events from the specified system.
-// It returns a unique subscriber Alias that can be used to unsubscribe later.
 func (b *Bus) Subscribe(
 	ctx context.Context,
 	system event.System,
@@ -82,7 +91,6 @@ func (b *Bus) Subscribe(
 }
 
 // SubscribeP creates a new subscription for events matching both system and kind filters.
-// It supports wildcard patterns in both system and kind parameters.
 func (b *Bus) SubscribeP(
 	ctx context.Context,
 	system event.System,
@@ -96,6 +104,7 @@ func (b *Bus) SubscribeP(
 	if ch == nil {
 		return "", errors.New("nil channel provided")
 	}
+
 	subID := b.generateSubscriberID()
 	var w *wildcard.Wildcard
 	if kind != "" {
@@ -109,132 +118,249 @@ func (b *Bus) SubscribeP(
 
 	sub := sub{
 		subID:   subID,
+		ctx:     ctx,
 		system:  sw,
 		kind:    w,
 		eventCh: ch,
-		doneCh:  make(chan bool),
 	}
 
-	select {
-	case b.actions <- action{actionType: subscribe, subscribe: sub}:
-	case <-b.closed:
-		return "", errors.New("bus is closed")
-	case <-ctx.Done():
-		return "", ctx.Err()
+	req := &subscribeRequest{
+		sub:    sub,
+		doneCh: make(chan error, 1),
 	}
 
+	// Enqueue subscribe request
+	if err := b.enqueueAction(action{
+		actionType: actionSubscribe,
+		subscribe:  req,
+	}); err != nil {
+		return "", err
+	}
+
+	// Wait for response
 	select {
+	case err := <-req.doneCh:
+		return subID, err
 	case <-ctx.Done():
 		return "", ctx.Err()
-	case <-b.closed:
-		return "", errors.New("bus is closed")
-	case <-sub.doneCh:
-		return subID, nil
 	}
 }
 
-// Unsubscribe removes the subscription identified by the given subscriber Alias.
-// It closes the associated event channel.
+// Unsubscribe removes the subscription identified by the given subscriber ID.
 func (b *Bus) Unsubscribe(ctx context.Context, subID event.SubscriberID) {
 	if ctx.Err() != nil {
 		return
 	}
 
-	unsub := unsub{
+	req := &unsubscribeRequest{
 		subID:  subID,
-		doneCh: make(chan bool),
+		doneCh: make(chan struct{}, 1),
 	}
 
-	select {
-	case b.actions <- action{actionType: unsubscribe, unsubscribe: unsub}:
-	case <-b.closed:
-	case <-ctx.Done():
-	}
+	// Enqueue unsubscribe request (ignore error, already closed)
+	_ = b.enqueueAction(action{
+		actionType:  actionUnsubscribe,
+		unsubscribe: req,
+	})
 
+	// Wait for response
 	select {
+	case <-req.doneCh:
 	case <-ctx.Done():
-	case <-b.closed:
-	case <-unsub.doneCh:
 	}
 }
 
-// Send publishes an event to all matching subscribers based on their system and kind filters.
-// The event delivery is skipped if the context is canceled.
+// Send publishes an event to all matching subscribers.
+// This is guaranteed to never block and never lose messages.
 func (b *Bus) Send(ctx context.Context, e event.Event) {
-	select {
-	case b.actions <- action{actionType: send, event: sendEvent{event: e, ctx: ctx}}:
-	case <-b.closed:
-	case <-ctx.Done():
+	if ctx.Err() != nil {
+		return
 	}
+
+	// Enqueue send event (ignore error if closed)
+	_ = b.enqueueAction(action{
+		actionType: actionSend,
+		sendEvent: &sendEvent{
+			event: e,
+			ctx:   ctx,
+		},
+	})
 }
 
-// todo: add send and block for critical events
-
-// Stop gracefully shuts down the event bus by closing all subscriber channels
-// and stopping the event handling goroutine.
+// Stop gracefully shuts down the event bus.
 func (b *Bus) Stop() {
+	// Atomically set closed and enqueue stop action
+	b.actionMu.Lock()
+	if b.closed.Swap(true) {
+		b.actionMu.Unlock()
+		return // Already closed
+	}
+	b.actionQueue.PushBack(action{
+		actionType: actionStop,
+	})
+	b.actionMu.Unlock()
+
+	// Signal dispatcher
 	select {
-	case b.actions <- action{actionType: stop}:
-	case <-b.closed:
+	case b.actionReady <- struct{}{}:
+	default:
 	}
 
 	b.wg.Wait()
 }
 
-func (b *Bus) handleActions() {
+// enqueueAction adds an action to the queue and signals the dispatcher
+// Returns error if bus is closed
+func (b *Bus) enqueueAction(a action) error {
+	// Atomically check closed and enqueue to prevent TOCTOU race
+	b.actionMu.Lock()
+	defer b.actionMu.Unlock()
+
+	if b.closed.Load() {
+		// Respond to control operations immediately
+		switch a.actionType {
+		case actionSubscribe:
+			a.subscribe.doneCh <- errors.New("bus is closed")
+		case actionUnsubscribe:
+			a.unsubscribe.doneCh <- struct{}{}
+		case actionSend:
+			// Silently drop send operations when closed
+		case actionStop:
+			// Should not happen, but handle gracefully
+		}
+		return errors.New("bus is closed")
+	}
+
+	b.actionQueue.PushBack(a)
+
+	// Signal dispatcher (non-blocking due to buffered channel)
+	// Release lock before signaling to avoid holding lock during channel operation
+	b.actionMu.Unlock()
+	select {
+	case b.actionReady <- struct{}{}:
+	default:
+		// Signal already pending, dispatcher will process all queued actions
+	}
+	b.actionMu.Lock() // Re-acquire for defer unlock
+
+	return nil
+}
+
+// dispatcher is the main event loop that processes all operations
+func (b *Bus) dispatcher() {
 	defer b.wg.Done()
 
-	for a := range b.actions {
-		select {
-		case <-b.closed:
-			return
-		default:
-		}
+	for {
+		// Wait for actions
+		<-b.actionReady
 
-		switch a.actionType {
-		case subscribe:
-			b.subscribers[a.subscribe.subID] = a.subscribe
-			a.subscribe.doneCh <- true
-		case unsubscribe:
-			b.handleUnsubscribe(a.unsubscribe.subID)
-			a.unsubscribe.doneCh <- true
-		case send:
-			if a.event.ctx.Err() != nil {
-				continue
-			}
-
-			for _, s := range b.subscribers {
-				if s.system != nil && !s.system.Match(a.event.event.System) {
-					continue
-				}
-
-				if s.kind != nil && !s.kind.Match(a.event.event.Kind) {
-					continue
-				}
-
-				select {
-				case <-a.event.ctx.Done():
-					continue
-				case <-b.closed:
-					continue
-				case s.eventCh <- a.event.event:
-					continue
-				}
-			}
-
-		case stop:
-			// todo: possibly have more strategies
-			for id := range b.subscribers {
-				b.handleUnsubscribe(id)
-			}
-			close(b.closed)
-			return
+		// Process all pending actions
+		if !b.processActions() {
+			return // Stop requested
 		}
 	}
 }
 
-func (b *Bus) handleUnsubscribe(subID event.SubscriberID) {
-	delete(b.subscribers, subID)
+// processActions drains the action queue and processes all actions
+// Returns false if stop was requested
+func (b *Bus) processActions() bool {
+	// Swap out the queue atomically
+	b.actionMu.Lock()
+	if b.actionQueue.Len() == 0 {
+		b.actionMu.Unlock()
+		return true
+	}
+	actions := b.actionQueue
+	b.actionQueue = list.New()
+	b.actionMu.Unlock()
+
+	// Process all actions
+	for e := actions.Front(); e != nil; e = e.Next() {
+		a := e.Value.(action)
+
+		switch a.actionType {
+		case actionSubscribe:
+			b.subscribers[a.subscribe.sub.subID] = a.subscribe.sub
+			a.subscribe.doneCh <- nil
+
+		case actionUnsubscribe:
+			delete(b.subscribers, a.unsubscribe.subID)
+			a.unsubscribe.doneCh <- struct{}{}
+
+		case actionSend:
+			if a.sendEvent.ctx.Err() != nil {
+				continue
+			}
+
+			var expiredSubs []event.SubscriberID
+
+			for id, s := range b.subscribers {
+				// Check filters
+				if s.system != nil && !s.system.Match(a.sendEvent.event.System) {
+					continue
+				}
+				if s.kind != nil && !s.kind.Match(a.sendEvent.event.Kind) {
+					continue
+				}
+
+				// Check contexts and deliver
+				select {
+				case <-a.sendEvent.ctx.Done():
+					// Event context cancelled
+					goto cleanup
+				case <-s.ctx.Done():
+					// Subscriber context cancelled, mark for cleanup
+					expiredSubs = append(expiredSubs, id)
+					continue
+				case s.eventCh <- a.sendEvent.event:
+					// Delivered successfully
+				}
+			}
+
+		cleanup:
+			// Clean up expired subscribers
+			for _, id := range expiredSubs {
+				delete(b.subscribers, id)
+			}
+
+		case actionStop:
+			// Clean up all subscribers
+			b.subscribers = make(map[event.SubscriberID]sub)
+
+			// Drain remaining actions and reject any control requests
+			b.drainQueue()
+
+			return false // Signal to exit dispatcher
+		}
+	}
+
+	return true
+}
+
+// drainQueue processes remaining actions after stop, rejecting control operations
+func (b *Bus) drainQueue() {
+	b.actionMu.Lock()
+	remaining := b.actionQueue
+	b.actionQueue = list.New()
+	b.actionMu.Unlock()
+
+	// Process remaining actions
+	for e := remaining.Front(); e != nil; e = e.Next() {
+		a := e.Value.(action)
+
+		switch a.actionType {
+		case actionSubscribe:
+			// Reject with error
+			a.subscribe.doneCh <- errors.New("bus is closed")
+		case actionUnsubscribe:
+			// Acknowledge unsubscribe (no-op since we're stopping)
+			a.unsubscribe.doneCh <- struct{}{}
+		case actionSend:
+			// Drop send events during shutdown
+		case actionStop:
+			// Ignore additional stop actions
+		}
+	}
 }
 
 func (b *Bus) generateSubscriberID() event.SubscriberID {

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	api "github.com/ponyruntime/pony/api/logs"
 
@@ -168,16 +169,20 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 		logFields = append(logFields, field)
 	}
 
-	go c.bus.Send(context.Background(), event.Event{
-		System: api.System,
-		Kind:   api.Entry,
-		Path:   ent.LoggerName,
-		Data: struct {
-			Entry  LogEntry   `json:"entry"`
-			Fields []LogField `json:"fields"`
-		}{
-			Entry:  logEntry,
-			Fields: logFields,
-		},
-	})
+	// we only run this code in debug mode, so a second timeout is fine
+	go func() {
+		ctx, _ := context.WithTimeout(context.Background(), time.Second)
+		c.bus.Send(ctx, event.Event{
+			System: api.System,
+			Kind:   api.Entry,
+			Path:   ent.LoggerName,
+			Data: struct {
+				Entry  LogEntry   `json:"entry"`
+				Fields []LogField `json:"fields"`
+			}{
+				Entry:  logEntry,
+				Fields: logFields,
+			},
+		})
+	}()
 }

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -132,6 +132,46 @@ func fieldTypeToString(ft zapcore.FieldType) string {
 		return "int8"
 	case zapcore.Uint8Type:
 		return "uint8"
+	case zapcore.UnknownType:
+		return "unknown"
+	case zapcore.ArrayMarshalerType:
+		return "unknown"
+	case zapcore.ObjectMarshalerType:
+		return "unknown"
+	case zapcore.BinaryType:
+		return "unknown"
+	case zapcore.BoolType:
+		return "unknown"
+	case zapcore.ByteStringType:
+		return "unknown"
+	case zapcore.Complex128Type:
+		return "unknown"
+	case zapcore.Complex64Type:
+		return "unknown"
+	case zapcore.DurationType:
+		return "unknown"
+	case zapcore.Float64Type:
+		return "unknown"
+	case zapcore.Float32Type:
+		return "unknown"
+	case zapcore.TimeType:
+		return "unknown"
+	case zapcore.TimeFullType:
+		return "unknown"
+	case zapcore.UintptrType:
+		return "unknown"
+	case zapcore.ReflectType:
+		return "unknown"
+	case zapcore.NamespaceType:
+		return "unknown"
+	case zapcore.StringerType:
+		return "unknown"
+	case zapcore.ErrorType:
+		return "unknown"
+	case zapcore.SkipType:
+		return "unknown"
+	case zapcore.InlineMarshalerType:
+		return "unknown"
 	default:
 		return "unknown"
 	}
@@ -160,7 +200,47 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 		case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
 			field.Int = f.Integer
 		case zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type:
-			field.Int = int64(f.Integer)
+			field.Int = f.Integer
+		case zapcore.UnknownType:
+			field.String = f.String
+		case zapcore.ArrayMarshalerType:
+			field.String = f.String
+		case zapcore.ObjectMarshalerType:
+			field.String = f.String
+		case zapcore.BinaryType:
+			field.String = f.String
+		case zapcore.BoolType:
+			field.String = f.String
+		case zapcore.ByteStringType:
+			field.String = f.String
+		case zapcore.Complex128Type:
+			field.String = f.String
+		case zapcore.Complex64Type:
+			field.String = f.String
+		case zapcore.DurationType:
+			field.String = f.String
+		case zapcore.Float64Type:
+			field.String = f.String
+		case zapcore.Float32Type:
+			field.String = f.String
+		case zapcore.TimeType:
+			field.String = f.String
+		case zapcore.TimeFullType:
+			field.String = f.String
+		case zapcore.UintptrType:
+			field.String = f.String
+		case zapcore.ReflectType:
+			field.String = f.String
+		case zapcore.NamespaceType:
+			field.String = f.String
+		case zapcore.StringerType:
+			field.String = f.String
+		case zapcore.ErrorType:
+			field.String = f.String
+		case zapcore.SkipType:
+			field.String = f.String
+		case zapcore.InlineMarshalerType:
+			field.String = f.String
 		default:
 			field.String = f.String
 		}

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -3,7 +3,6 @@ package logs
 import (
 	"context"
 	"sync/atomic"
-	"time"
 
 	api "github.com/ponyruntime/pony/api/logs"
 
@@ -169,10 +168,7 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 		logFields = append(logFields, field)
 	}
 
-	// we only run this code in debug mode, so a second timeout is fine
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
-
-	c.bus.Send(ctx, event.Event{
+	go c.bus.Send(context.Background(), event.Event{
 		System: api.System,
 		Kind:   api.Entry,
 		Path:   ent.LoggerName,

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -3,7 +3,6 @@ package logs
 import (
 	"context"
 	"sync/atomic"
-	"time"
 
 	api "github.com/ponyruntime/pony/api/logs"
 
@@ -170,19 +169,16 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 	}
 
 	// we only run this code in debug mode, so a second timeout is fine
-	go func() {
-		ctx, _ := context.WithTimeout(context.Background(), time.Second)
-		c.bus.Send(ctx, event.Event{
-			System: api.System,
-			Kind:   api.Entry,
-			Path:   ent.LoggerName,
-			Data: struct {
-				Entry  LogEntry   `json:"entry"`
-				Fields []LogField `json:"fields"`
-			}{
-				Entry:  logEntry,
-				Fields: logFields,
-			},
-		})
-	}()
+	c.bus.Send(context.Background(), event.Event{
+		System: api.System,
+		Kind:   api.Entry,
+		Path:   ent.LoggerName,
+		Data: struct {
+			Entry  LogEntry   `json:"entry"`
+			Fields []LogField `json:"fields"`
+		}{
+			Entry:  logEntry,
+			Fields: logFields,
+		},
+	})
 }

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -14,7 +14,7 @@ import (
 type Core struct {
 	downstream zapcore.Core
 	bus        event.Bus
-	config     *atomic.Value // holds api.Config
+	config     *atomic.Value
 }
 
 func NewCore(downstream zapcore.Core, bus event.Bus) api.Core {
@@ -113,6 +113,31 @@ type LogField struct {
 	Int    int64  `json:"int"`
 }
 
+func fieldTypeToString(ft zapcore.FieldType) string {
+	switch ft {
+	case zapcore.StringType:
+		return "string"
+	case zapcore.Int64Type:
+		return "int64"
+	case zapcore.Int32Type:
+		return "int32"
+	case zapcore.Uint64Type:
+		return "uint64"
+	case zapcore.Uint32Type:
+		return "uint32"
+	case zapcore.Int16Type:
+		return "int16"
+	case zapcore.Uint16Type:
+		return "uint16"
+	case zapcore.Int8Type:
+		return "int8"
+	case zapcore.Uint8Type:
+		return "uint8"
+	default:
+		return "unknown"
+	}
+}
+
 func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 	logEntry := LogEntry{
 		Level:      int(ent.Level),
@@ -127,7 +152,7 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 	for _, f := range fields {
 		field := LogField{
 			Key:  f.Key,
-			Type: string(f.Type),
+			Type: fieldTypeToString(f.Type),
 		}
 
 		switch f.Type {
@@ -144,10 +169,8 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 		logFields = append(logFields, field)
 	}
 
-	// This code runs in debug mode only, avoid blocking at cancelling self-listening services
-	// todo: revisit later, see keeper.logger
+	// we only run this code in debug mode, so a second timeout is fine
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)
-	// cancel ignored
 
 	c.bus.Send(ctx, event.Event{
 		System: api.System,

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -146,8 +146,8 @@ func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
 
 	// This code runs in debug mode only, avoid blocking at cancelling self-listening services
 	// todo: revisit later, see keeper.logger
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	// cancel ignored
 
 	c.bus.Send(ctx, event.Event{
 		System: api.System,

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	api "github.com/ponyruntime/pony/api/logs"
 
@@ -42,12 +43,10 @@ func (c *Core) GetConfig() api.Config {
 func (c *Core) Enabled(level zapcore.Level) bool {
 	cfg := c.config.Load().(api.Config)
 
-	// Enable if event streaming is on (accepts all levels)
 	if cfg.StreamToEvents {
 		return true
 	}
 
-	// Enable if downstream is on AND level meets minimum threshold
 	if cfg.PropagateDownstream && level >= cfg.MinLevel {
 		return true
 	}
@@ -75,14 +74,12 @@ func (c *Core) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.Check
 func (c *Core) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	cfg := c.config.Load().(api.Config)
 
-	// Send to downstream only if enabled AND level meets threshold
 	if cfg.PropagateDownstream && ent.Level >= cfg.MinLevel {
 		if err := c.downstream.Write(ent, fields); err != nil {
 			return err
 		}
 	}
 
-	// Always stream to events if enabled (no level filtering)
 	if cfg.StreamToEvents {
 		c.publishLogEvent(ent, fields)
 	}
@@ -100,17 +97,68 @@ func (c *Core) Sync() error {
 	return nil
 }
 
+type LogEntry struct {
+	Level      int    `json:"level"`
+	Time       int64  `json:"time"`
+	LoggerName string `json:"logger_name"`
+	Message    string `json:"message"`
+	Caller     string `json:"caller"`
+	Stack      string `json:"stack"`
+}
+
+type LogField struct {
+	Key    string `json:"key"`
+	Type   string `json:"type"`
+	String string `json:"string"`
+	Int    int64  `json:"int"`
+}
+
 func (c *Core) publishLogEvent(ent zapcore.Entry, fields []zapcore.Field) {
-	c.bus.Send(context.Background(), event.Event{
+	logEntry := LogEntry{
+		Level:      int(ent.Level),
+		Time:       ent.Time.UnixNano(),
+		LoggerName: ent.LoggerName,
+		Message:    ent.Message,
+		Caller:     ent.Caller.String(),
+		Stack:      ent.Stack,
+	}
+
+	logFields := make([]LogField, 0, len(fields))
+	for _, f := range fields {
+		field := LogField{
+			Key:  f.Key,
+			Type: string(f.Type),
+		}
+
+		switch f.Type {
+		case zapcore.StringType:
+			field.String = f.String
+		case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
+			field.Int = f.Integer
+		case zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type:
+			field.Int = int64(f.Integer)
+		default:
+			field.String = f.String
+		}
+
+		logFields = append(logFields, field)
+	}
+
+	// This code runs in debug mode only, avoid blocking at cancelling self-listening services
+	// todo: revisit later, see keeper.logger
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	c.bus.Send(ctx, event.Event{
 		System: api.System,
 		Kind:   api.Entry,
 		Path:   ent.LoggerName,
 		Data: struct {
-			Entry  zapcore.Entry   `json:"entry"`
-			Fields []zapcore.Field `json:"fields"`
+			Entry  LogEntry   `json:"entry"`
+			Fields []LogField `json:"fields"`
 		}{
-			Entry:  ent,
-			Fields: fields,
+			Entry:  logEntry,
+			Fields: logFields,
 		},
 	})
 }

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -31,15 +31,13 @@ func NewRegistry(
 	log *zap.Logger,
 ) *Reg {
 	reg := &Reg{
-		history: history,
-		runner:  runner,
-		builder: builder,
-		state:   registry.State{},
-		log:     log,
+		history:        history,
+		runner:         runner,
+		builder:        builder,
+		state:          registry.State{},
+		log:            log,
+		currentVersion: version.FromParent(nil, 0), // initial version
 	}
-
-	// Default boot version
-	reg.versionNum.Store(1)
 
 	return reg
 }

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -30,13 +30,18 @@ func NewRegistry(
 	builder registry.StateBuilder,
 	log *zap.Logger,
 ) *Reg {
-	return &Reg{
+	reg := &Reg{
 		history: history,
 		runner:  runner,
 		builder: builder,
 		state:   registry.State{},
 		log:     log,
 	}
+
+	// Default boot version
+	reg.versionNum.Store(1)
+
+	return reg
 }
 
 // --- EntryReader Interface Implementation ---


### PR DESCRIPTION
This pull request simplifies the caching logic in the `MemoryGraph` implementation by removing the custom cache for string representations of node IDs. The code now directly uses the `String()` method of `registry.ID` where needed, reducing memory usage and code complexity.

**Performance cache simplification:**

* Removed the `stringCache` field from the `MemoryGraph` struct, eliminating the cache for `ID.String()` results.
* Updated the `NewMemoryGraph` constructor to no longer initialize the `stringCache` map.
* Deleted the `getIDString` method, which previously handled cached string representations of node IDs.
* Removed the line that deleted entries from `stringCache` in the `RemoveNode` method.

**Dependency sorting update:**

* Changed the sorting logic in `DependencyLevels` to use `ID.String()` directly instead of the cached string, simplifying the code path.