### PR TITLE
fix(wippy): EE2-1954 fix permission condition to use exact match

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,28 @@
+# Go Testing Rules
+
+## ✅ DO:
+- Use `testify`: `require.NoError(t, err)` and `assert.Equal(t, want, got)`
+- Always add `t.Parallel()` to tests and subtests
+- Use table-driven tests with descriptive names
+- Group tests with `t.Run("group name", func(t *testing.T) {...})`
+- Test edge cases: nil, empty, zero, boundary values
+- Extract repeated values to constants at top of test
+- Name tests: `TestType_Method_Scenario` format
+- Use `assert.Error(t, err)` or `assert.NoError(t, err)` for error checks
+
+## ❌ DON'T:
+- Don't use `if (err != nil) != tt.wantErr` - use `assert.Error` or `assert.NoError`
+- Don't add `wantErr` field if it's always the same value - just check explicitly
+- Don't use plain `if got != want` - use `assert.Equal`
+- Don't use `t.Fatalf` for non-critical checks - use `assert`
+- Don't skip `t.Parallel()` - tests must run in parallel
+- Don't use `t.Logf` for test progress - test names should be self-explanatory
+- Don't write comments explaining expected behavior - test name should be clear
+- Don't repeat test data - use constants or table-driven tests
+- Don't write code that takes 15 seconds to understand - keep it simple
+
+## Before Commit:
+```bash
+make lint  # Must be 0 issues
+```
+

--- a/.cursorrules
+++ b/.cursorrules
@@ -8,12 +8,11 @@
 - Test edge cases: nil, empty, zero, boundary values
 - Extract repeated values to constants at top of test
 - Name tests: `TestType_Method_Scenario` format
-- Use `assert.Error(t, err)` or `assert.NoError(t, err)` for error checks
+- Use `assert.ErrorAssertionFunc` in table-driven tests: add field `assertErr assert.ErrorAssertionFunc` and pass `assert.Error` or `assert.NoError` directly (see https://pkg.go.dev/github.com/stretchr/testify/assert#example-ErrorAssertionFunc)
 - Use `any` instead of `interface{}` (Go 1.18+)
 
 ## ❌ DON'T:
-- Don't use `if (err != nil) != tt.wantErr` - use `assert.Error` or `assert.NoError`
-- Don't add `wantErr` field if it's always the same value - just check explicitly
+- Don't use `if (err != nil) != tt.wantErr` - use `assert.ErrorAssertionFunc` field with `assert.Error` or `assert.NoError`
 - Don't use plain `if got != want` - use `assert.Equal`
 - Don't use `t.Fatalf` for non-critical checks - use `assert`
 - Don't use `t.Parallel()` if tests have shared state, side effects (DB, files), or resource conflicts (ports)

--- a/.cursorrules
+++ b/.cursorrules
@@ -2,20 +2,21 @@
 
 ## ✅ DO:
 - Use `testify`: `require.NoError(t, err)` and `assert.Equal(t, want, got)`
-- Always add `t.Parallel()` to tests and subtests
+- Always add `t.Parallel()` to tests and subtests - runs faster and catches race conditions (only if no shared state/side effects)
 - Use table-driven tests with descriptive names
 - Group tests with `t.Run("group name", func(t *testing.T) {...})`
 - Test edge cases: nil, empty, zero, boundary values
 - Extract repeated values to constants at top of test
 - Name tests: `TestType_Method_Scenario` format
 - Use `assert.Error(t, err)` or `assert.NoError(t, err)` for error checks
+- Use `any` instead of `interface{}` (Go 1.18+)
 
 ## ❌ DON'T:
 - Don't use `if (err != nil) != tt.wantErr` - use `assert.Error` or `assert.NoError`
 - Don't add `wantErr` field if it's always the same value - just check explicitly
 - Don't use plain `if got != want` - use `assert.Equal`
 - Don't use `t.Fatalf` for non-critical checks - use `assert`
-- Don't skip `t.Parallel()` - tests must run in parallel
+- Don't use `t.Parallel()` if tests have shared state, side effects (DB, files), or resource conflicts (ports)
 - Don't use `t.Logf` for test progress - test names should be self-explanatory
 - Don't write comments explaining expected behavior - test name should be clear
 - Don't repeat test data - use constants or table-driven tests

--- a/service/policy/condition_evaluator.go
+++ b/service/policy/condition_evaluator.go
@@ -387,7 +387,6 @@ func toString(value any) (string, bool) {
 	case bool:
 		return strconv.FormatBool(v), true
 	case []any, []string, []int:
-		// Don't convert slices to strings to avoid substring matching on array string representation
 		return "", false
 	}
 

--- a/service/policy/condition_evaluator.go
+++ b/service/policy/condition_evaluator.go
@@ -386,6 +386,8 @@ func toString(value any) (string, bool) {
 		return strconv.FormatFloat(v, 'f', -1, 64), true
 	case bool:
 		return strconv.FormatBool(v), true
+	case []any, []string, []int:
+		return "", false
 	}
 
 	return fmt.Sprintf("%v", value), true

--- a/service/policy/condition_evaluator_test.go
+++ b/service/policy/condition_evaluator_test.go
@@ -1162,6 +1162,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 			value     any
 			actorMeta registry.Metadata
 			want      bool
+			assertErr assert.ErrorAssertionFunc
 		}{
 			{
 				name:      "exact match found in array",
@@ -1169,6 +1170,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "distributor-admin",
 				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "exact match not found - substring in array element not matched",
@@ -1176,6 +1178,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "match found in multi-element array",
@@ -1183,6 +1186,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "super-admin",
 				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin", "viewer"}},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "no match in single-element array",
@@ -1190,6 +1194,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"roles": []string{"viewer"}},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "empty array returns false",
@@ -1197,6 +1202,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"roles": []string{}},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 		}
 
@@ -1213,7 +1219,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-				require.NoError(t, err, "unexpected error during evaluation")
+				tt.assertErr(t, err)
 				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
 			})
 		}
@@ -1228,6 +1234,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 			value     any
 			actorMeta registry.Metadata
 			want      bool
+			assertErr assert.ErrorAssertionFunc
 		}{
 			{
 				name:      "exact match not in array returns true",
@@ -1235,6 +1242,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "exact match found in array returns false",
@@ -1242,6 +1250,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "distributor-admin",
 				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "value not in single-element array returns true",
@@ -1249,6 +1258,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"roles": []string{"viewer"}},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "empty array returns true - value not contained",
@@ -1256,6 +1266,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"roles": []string{}},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 		}
 
@@ -1272,7 +1283,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-				require.NoError(t, err, "unexpected error during evaluation")
+				tt.assertErr(t, err)
 				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
 			})
 		}
@@ -1287,6 +1298,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 			value     any
 			actorMeta registry.Metadata
 			want      bool
+			assertErr assert.ErrorAssertionFunc
 		}{
 			{
 				name:      "substring match found",
@@ -1294,6 +1306,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": "distributor-admin"},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "exact match found",
@@ -1301,6 +1314,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": "admin"},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "substring not found",
@@ -1308,6 +1322,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": "viewer"},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "empty string field returns false",
@@ -1315,6 +1330,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": ""},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 		}
 
@@ -1331,7 +1347,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-				require.NoError(t, err, "unexpected error during evaluation")
+				tt.assertErr(t, err)
 				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
 			})
 		}
@@ -1346,6 +1362,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 			value     any
 			actorMeta registry.Metadata
 			want      bool
+			assertErr assert.ErrorAssertionFunc
 		}{
 			{
 				name:      "substring found returns false",
@@ -1353,6 +1370,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": "distributor-admin"},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "substring not found returns true",
@@ -1360,6 +1378,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": "viewer"},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "empty string returns true - value not contained",
@@ -1367,6 +1386,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     "admin",
 				actorMeta: registry.Metadata{"role": ""},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 		}
 
@@ -1383,7 +1403,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-				require.NoError(t, err, "unexpected error during evaluation")
+				tt.assertErr(t, err)
 				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
 			})
 		}
@@ -1398,6 +1418,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 			value     any
 			actorMeta registry.Metadata
 			want      bool
+			assertErr assert.ErrorAssertionFunc
 		}{
 			{
 				name:      "single value not in list",
@@ -1405,6 +1426,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     []string{"admin", "distributor-admin", "super-admin"},
 				actorMeta: registry.Metadata{"role": "viewer"},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "single value found in list",
@@ -1412,6 +1434,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     []string{"admin", "distributor-admin", "super-admin"},
 				actorMeta: registry.Metadata{"role": "distributor-admin"},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "empty string not in list",
@@ -1419,6 +1442,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     []string{"admin", "viewer"},
 				actorMeta: registry.Metadata{"role": ""},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 		}
 
@@ -1435,7 +1459,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-				require.NoError(t, err, "unexpected error during evaluation")
+				tt.assertErr(t, err)
 				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
 			})
 		}
@@ -1450,6 +1474,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 			value     any
 			actorMeta registry.Metadata
 			want      bool
+			assertErr assert.ErrorAssertionFunc
 		}{
 			{
 				name:      "single value found in list",
@@ -1457,6 +1482,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     []string{"admin", "distributor-admin", "super-admin"},
 				actorMeta: registry.Metadata{"role": "distributor-admin"},
 				want:      true,
+				assertErr: assert.NoError,
 			},
 			{
 				name:      "single value not in list",
@@ -1464,6 +1490,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 				value:     []string{"admin", "distributor-admin", "super-admin"},
 				actorMeta: registry.Metadata{"role": "viewer"},
 				want:      false,
+				assertErr: assert.NoError,
 			},
 		}
 
@@ -1480,7 +1507,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-				require.NoError(t, err, "unexpected error during evaluation")
+				tt.assertErr(t, err)
 				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
 			})
 		}
@@ -1506,7 +1533,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 
 			got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
 
-			require.NoError(t, err, "unexpected error during evaluation")
+			assert.NoError(t, err, "unexpected error during evaluation")
 			// Returns true because the array []string{"distributor-admin"} is not equal
 			// to any of the strings in the nin list. This demonstrates that nin is not
 			// appropriate for checking array element membership.

--- a/service/policy/condition_evaluator_test.go
+++ b/service/policy/condition_evaluator_test.go
@@ -1298,8 +1298,6 @@ func TestRoleMatchingBehavior(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("EvaluateCondition() got = %v, want %v\nComment: %s", got, tt.want, tt.comment)
-			} else {
-				t.Logf("✓ %s", tt.comment)
 			}
 		})
 	}

--- a/service/policy/condition_evaluator_test.go
+++ b/service/policy/condition_evaluator_test.go
@@ -1159,7 +1159,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 		tests := []struct {
 			name      string
 			field     string
-			value     interface{}
+			value     any
 			actorMeta registry.Metadata
 			want      bool
 		}{
@@ -1225,7 +1225,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 		tests := []struct {
 			name      string
 			field     string
-			value     interface{}
+			value     any
 			actorMeta registry.Metadata
 			want      bool
 		}{
@@ -1284,7 +1284,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 		tests := []struct {
 			name      string
 			field     string
-			value     interface{}
+			value     any
 			actorMeta registry.Metadata
 			want      bool
 		}{
@@ -1343,7 +1343,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 		tests := []struct {
 			name      string
 			field     string
-			value     interface{}
+			value     any
 			actorMeta registry.Metadata
 			want      bool
 		}{
@@ -1395,7 +1395,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 		tests := []struct {
 			name      string
 			field     string
-			value     interface{}
+			value     any
 			actorMeta registry.Metadata
 			want      bool
 		}{
@@ -1447,7 +1447,7 @@ func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
 		tests := []struct {
 			name      string
 			field     string
-			value     interface{}
+			value     any
 			actorMeta registry.Metadata
 			want      bool
 		}{

--- a/service/policy/condition_evaluator_test.go
+++ b/service/policy/condition_evaluator_test.go
@@ -3,6 +3,9 @@ package policy
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ponyruntime/pony/api/registry"
 	"github.com/ponyruntime/pony/api/security"
 	"github.com/ponyruntime/pony/api/service/policy"
@@ -1135,172 +1138,381 @@ func TestTypeConversions(t *testing.T) {
 	})
 }
 
-func TestRoleMatchingBehavior(t *testing.T) {
+// TestConditionEvaluator_OperatorBehaviorOnRoles tests the semantic differences between
+// contains/ncontains operators (which work on arrays and strings differently) and
+// in/nin operators (which perform membership checks on the field value itself).
+func TestConditionEvaluator_OperatorBehaviorOnRoles(t *testing.T) {
+	t.Parallel()
+
 	evaluator, err := NewConditionEvaluator([]policy.Condition{})
-	if err != nil {
-		t.Fatalf("Failed to create evaluator: %v", err)
-	}
+	require.NoError(t, err, "failed to initialize condition evaluator")
 
-	tests := []struct {
-		name      string
-		condition policy.Condition
-		actor     security.Actor
-		action    string
-		resource  string
-		meta      registry.Metadata
-		want      bool
-		wantErr   bool
-		comment   string
-	}{
-		{
-			name: "ncontains with role array - exact match only (user case FIXED)",
-			condition: policy.Condition{
-				Field:    "actor.meta.roles",
-				Operator: "ncontains",
-				Value:    "admin",
-			},
-			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     true, // FIXED: returns TRUE because exact 'admin' is NOT in array
-			wantErr:  false,
-			comment:  "FIXED: ncontains returns TRUE because exact 'admin' string is NOT in array (only 'distributor-admin', 'super-admin')",
-		},
-		{
-			name: "ncontains with role array - exact match exists",
-			condition: policy.Condition{
-				Field:    "actor.meta.roles",
-				Operator: "ncontains",
-				Value:    "distributor-admin",
-			},
-			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     false,
-			wantErr:  false,
-			comment:  "ncontains returns FALSE because exact 'distributor-admin' IS in array",
-		},
-		{
-			name: "contains with role array - exact match only (FIXED)",
-			condition: policy.Condition{
-				Field:    "actor.meta.roles",
-				Operator: "contains",
-				Value:    "admin",
-			},
-			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     false, // FIXED: returns FALSE because exact 'admin' is NOT in array
-			wantErr:  false,
-			comment:  "FIXED: contains returns FALSE because exact 'admin' string is NOT in array (substring doesn't match)",
-		},
-		{
-			name: "contains with role array - exact match exists",
-			condition: policy.Condition{
-				Field:    "actor.meta.roles",
-				Operator: "contains",
-				Value:    "distributor-admin",
-			},
-			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     true,
-			wantErr:  false,
-			comment:  "contains returns TRUE because exact 'distributor-admin' IS in array",
-		},
-		{
-			name: "nin operator - WRONG USAGE: comparing array to list",
-			condition: policy.Condition{
-				Field:    "actor.meta.roles",
-				Operator: "nin",
-				Value:    []string{"admin", "distributor-admin", "super-admin"},
-			},
-			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin"}}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     true, // Returns TRUE because array ["distributor-admin"] != string "distributor-admin"
-			wantErr:  false,
-			comment:  "nin compares WHOLE ARRAY as value - array [\"distributor-admin\"] is NOT equal to any string in list, so returns TRUE (not correct usage)",
-		},
-		{
-			name: "nin operator - CORRECT USAGE: single role value not in admin list",
-			condition: policy.Condition{
-				Field:    "actor.meta.role", // Single value, not array!
-				Operator: "nin",
-				Value:    []string{"admin", "distributor-admin", "super-admin"},
-			},
-			actor:    newMockActor("user123", registry.Metadata{"role": "user"}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     true,
-			wantErr:  false,
-			comment:  "CORRECT: nin returns TRUE because 'user' (single value) is NOT in admin roles list",
-		},
-		{
-			name: "nin operator - CORRECT USAGE: single role value IS in admin list",
-			condition: policy.Condition{
-				Field:    "actor.meta.role", // Single value, not array!
-				Operator: "nin",
-				Value:    []string{"admin", "distributor-admin", "super-admin"},
-			},
-			actor:    newMockActor("user123", registry.Metadata{"role": "distributor-admin"}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     false,
-			wantErr:  false,
-			comment:  "CORRECT: nin returns FALSE because 'distributor-admin' (single value) IS in admin roles list",
-		},
-		{
-			name: "contains vs ncontains on string field - substring behavior",
-			condition: policy.Condition{
-				Field:    "actor.meta.role",
-				Operator: "contains",
-				Value:    "admin",
-			},
-			actor:    newMockActor("user123", registry.Metadata{"role": "distributor-admin"}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     true,
-			wantErr:  false,
-			comment:  "contains on STRING performs substring match - 'admin' is IN 'distributor-admin'",
-		},
-		{
-			name: "ncontains on string field - substring behavior",
-			condition: policy.Condition{
-				Field:    "actor.meta.role",
-				Operator: "ncontains",
-				Value:    "admin",
-			},
-			actor:    newMockActor("user123", registry.Metadata{"role": "distributor-admin"}),
-			action:   "read",
-			resource: "document",
-			meta:     nil,
-			want:     false,
-			wantErr:  false,
-			comment:  "ncontains on STRING performs substring check - 'admin' IS in 'distributor-admin', so returns FALSE",
-		},
-	}
+	const (
+		testAction   = "read"
+		testResource = "document"
+		testActorID  = "user123"
+	)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := evaluator.EvaluateCondition(tt.condition, tt.actor, tt.action, tt.resource, tt.meta)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("EvaluateCondition() error = %v, wantErr %v", err, tt.wantErr)
-				return
+	t.Run("contains operator on array fields", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			field     string
+			value     interface{}
+			actorMeta registry.Metadata
+			want      bool
+		}{
+			{
+				name:      "exact match found in array",
+				field:     "actor.meta.roles",
+				value:     "distributor-admin",
+				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
+				want:      true,
+			},
+			{
+				name:      "exact match not found - substring in array element not matched",
+				field:     "actor.meta.roles",
+				value:     "admin",
+				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
+				want:      false,
+			},
+			{
+				name:      "match found in multi-element array",
+				field:     "actor.meta.roles",
+				value:     "super-admin",
+				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin", "viewer"}},
+				want:      true,
+			},
+			{
+				name:      "no match in single-element array",
+				field:     "actor.meta.roles",
+				value:     "admin",
+				actorMeta: registry.Metadata{"roles": []string{"viewer"}},
+				want:      false,
+			},
+			{
+				name:      "empty array returns false",
+				field:     "actor.meta.roles",
+				value:     "admin",
+				actorMeta: registry.Metadata{"roles": []string{}},
+				want:      false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				condition := policy.Condition{
+					Field:    tt.field,
+					Operator: "contains",
+					Value:    tt.value,
+				}
+				actor := newMockActor(testActorID, tt.actorMeta)
+
+				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+				require.NoError(t, err, "unexpected error during evaluation")
+				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
+			})
+		}
+	})
+
+	t.Run("ncontains operator on array fields", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			field     string
+			value     interface{}
+			actorMeta registry.Metadata
+			want      bool
+		}{
+			{
+				name:      "exact match not in array returns true",
+				field:     "actor.meta.roles",
+				value:     "admin",
+				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
+				want:      true,
+			},
+			{
+				name:      "exact match found in array returns false",
+				field:     "actor.meta.roles",
+				value:     "distributor-admin",
+				actorMeta: registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}},
+				want:      false,
+			},
+			{
+				name:      "value not in single-element array returns true",
+				field:     "actor.meta.roles",
+				value:     "admin",
+				actorMeta: registry.Metadata{"roles": []string{"viewer"}},
+				want:      true,
+			},
+			{
+				name:      "empty array returns true - value not contained",
+				field:     "actor.meta.roles",
+				value:     "admin",
+				actorMeta: registry.Metadata{"roles": []string{}},
+				want:      true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				condition := policy.Condition{
+					Field:    tt.field,
+					Operator: "ncontains",
+					Value:    tt.value,
+				}
+				actor := newMockActor(testActorID, tt.actorMeta)
+
+				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+				require.NoError(t, err, "unexpected error during evaluation")
+				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
+			})
+		}
+	})
+
+	t.Run("contains operator on string fields", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			field     string
+			value     interface{}
+			actorMeta registry.Metadata
+			want      bool
+		}{
+			{
+				name:      "substring match found",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": "distributor-admin"},
+				want:      true,
+			},
+			{
+				name:      "exact match found",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": "admin"},
+				want:      true,
+			},
+			{
+				name:      "substring not found",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": "viewer"},
+				want:      false,
+			},
+			{
+				name:      "empty string field returns false",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": ""},
+				want:      false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				condition := policy.Condition{
+					Field:    tt.field,
+					Operator: "contains",
+					Value:    tt.value,
+				}
+				actor := newMockActor(testActorID, tt.actorMeta)
+
+				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+				require.NoError(t, err, "unexpected error during evaluation")
+				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
+			})
+		}
+	})
+
+	t.Run("ncontains operator on string fields", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			field     string
+			value     interface{}
+			actorMeta registry.Metadata
+			want      bool
+		}{
+			{
+				name:      "substring found returns false",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": "distributor-admin"},
+				want:      false,
+			},
+			{
+				name:      "substring not found returns true",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": "viewer"},
+				want:      true,
+			},
+			{
+				name:      "empty string returns true - value not contained",
+				field:     "actor.meta.role",
+				value:     "admin",
+				actorMeta: registry.Metadata{"role": ""},
+				want:      true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				condition := policy.Condition{
+					Field:    tt.field,
+					Operator: "ncontains",
+					Value:    tt.value,
+				}
+				actor := newMockActor(testActorID, tt.actorMeta)
+
+				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+				require.NoError(t, err, "unexpected error during evaluation")
+				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
+			})
+		}
+	})
+
+	t.Run("nin operator with scalar field values", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			field     string
+			value     interface{}
+			actorMeta registry.Metadata
+			want      bool
+		}{
+			{
+				name:      "single value not in list",
+				field:     "actor.meta.role",
+				value:     []string{"admin", "distributor-admin", "super-admin"},
+				actorMeta: registry.Metadata{"role": "viewer"},
+				want:      true,
+			},
+			{
+				name:      "single value found in list",
+				field:     "actor.meta.role",
+				value:     []string{"admin", "distributor-admin", "super-admin"},
+				actorMeta: registry.Metadata{"role": "distributor-admin"},
+				want:      false,
+			},
+			{
+				name:      "empty string not in list",
+				field:     "actor.meta.role",
+				value:     []string{"admin", "viewer"},
+				actorMeta: registry.Metadata{"role": ""},
+				want:      true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				condition := policy.Condition{
+					Field:    tt.field,
+					Operator: "nin",
+					Value:    tt.value,
+				}
+				actor := newMockActor(testActorID, tt.actorMeta)
+
+				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+				require.NoError(t, err, "unexpected error during evaluation")
+				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
+			})
+		}
+	})
+
+	t.Run("in operator with scalar field values", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			field     string
+			value     interface{}
+			actorMeta registry.Metadata
+			want      bool
+		}{
+			{
+				name:      "single value found in list",
+				field:     "actor.meta.role",
+				value:     []string{"admin", "distributor-admin", "super-admin"},
+				actorMeta: registry.Metadata{"role": "distributor-admin"},
+				want:      true,
+			},
+			{
+				name:      "single value not in list",
+				field:     "actor.meta.role",
+				value:     []string{"admin", "distributor-admin", "super-admin"},
+				actorMeta: registry.Metadata{"role": "viewer"},
+				want:      false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				condition := policy.Condition{
+					Field:    tt.field,
+					Operator: "in",
+					Value:    tt.value,
+				}
+				actor := newMockActor(testActorID, tt.actorMeta)
+
+				got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+				require.NoError(t, err, "unexpected error during evaluation")
+				assert.Equal(t, tt.want, got, "condition evaluation result mismatch")
+			})
+		}
+	})
+
+	t.Run("operator behavior with array field values", func(t *testing.T) {
+		t.Parallel()
+
+		// Note: nin/in operators compare the entire array value against list elements.
+		// This is typically not the desired behavior for role checking.
+		// Use contains/ncontains for element-wise array matching instead.
+		t.Run("nin with array field compares whole array", func(t *testing.T) {
+			t.Parallel()
+
+			condition := policy.Condition{
+				Field:    "actor.meta.roles",
+				Operator: "nin",
+				Value:    []string{"admin", "distributor-admin", "super-admin"},
 			}
-			if got != tt.want {
-				t.Errorf("EvaluateCondition() got = %v, want %v\nComment: %s", got, tt.want, tt.comment)
-			}
+			actor := newMockActor(testActorID, registry.Metadata{
+				"roles": []string{"distributor-admin"},
+			})
+
+			got, err := evaluator.EvaluateCondition(condition, actor, testAction, testResource, nil)
+
+			require.NoError(t, err, "unexpected error during evaluation")
+			// Returns true because the array []string{"distributor-admin"} is not equal
+			// to any of the strings in the nin list. This demonstrates that nin is not
+			// appropriate for checking array element membership.
+			assert.True(t, got, "nin should compare entire array value, not elements")
 		})
-	}
+	})
 }
 
 func TestComplexNestedConditions(t *testing.T) {

--- a/service/policy/condition_evaluator_test.go
+++ b/service/policy/condition_evaluator_test.go
@@ -1135,6 +1135,176 @@ func TestTypeConversions(t *testing.T) {
 	})
 }
 
+func TestRoleMatchingBehavior(t *testing.T) {
+	evaluator, err := NewConditionEvaluator([]policy.Condition{})
+	if err != nil {
+		t.Fatalf("Failed to create evaluator: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		condition policy.Condition
+		actor     security.Actor
+		action    string
+		resource  string
+		meta      registry.Metadata
+		want      bool
+		wantErr   bool
+		comment   string
+	}{
+		{
+			name: "ncontains with role array - exact match only (user case FIXED)",
+			condition: policy.Condition{
+				Field:    "actor.meta.roles",
+				Operator: "ncontains",
+				Value:    "admin",
+			},
+			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     true, // FIXED: returns TRUE because exact 'admin' is NOT in array
+			wantErr:  false,
+			comment:  "FIXED: ncontains returns TRUE because exact 'admin' string is NOT in array (only 'distributor-admin', 'super-admin')",
+		},
+		{
+			name: "ncontains with role array - exact match exists",
+			condition: policy.Condition{
+				Field:    "actor.meta.roles",
+				Operator: "ncontains",
+				Value:    "distributor-admin",
+			},
+			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     false,
+			wantErr:  false,
+			comment:  "ncontains returns FALSE because exact 'distributor-admin' IS in array",
+		},
+		{
+			name: "contains with role array - exact match only (FIXED)",
+			condition: policy.Condition{
+				Field:    "actor.meta.roles",
+				Operator: "contains",
+				Value:    "admin",
+			},
+			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     false, // FIXED: returns FALSE because exact 'admin' is NOT in array
+			wantErr:  false,
+			comment:  "FIXED: contains returns FALSE because exact 'admin' string is NOT in array (substring doesn't match)",
+		},
+		{
+			name: "contains with role array - exact match exists",
+			condition: policy.Condition{
+				Field:    "actor.meta.roles",
+				Operator: "contains",
+				Value:    "distributor-admin",
+			},
+			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin", "super-admin"}}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     true,
+			wantErr:  false,
+			comment:  "contains returns TRUE because exact 'distributor-admin' IS in array",
+		},
+		{
+			name: "nin operator - WRONG USAGE: comparing array to list",
+			condition: policy.Condition{
+				Field:    "actor.meta.roles",
+				Operator: "nin",
+				Value:    []string{"admin", "distributor-admin", "super-admin"},
+			},
+			actor:    newMockActor("user123", registry.Metadata{"roles": []string{"distributor-admin"}}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     true, // Returns TRUE because array ["distributor-admin"] != string "distributor-admin"
+			wantErr:  false,
+			comment:  "nin compares WHOLE ARRAY as value - array [\"distributor-admin\"] is NOT equal to any string in list, so returns TRUE (not correct usage)",
+		},
+		{
+			name: "nin operator - CORRECT USAGE: single role value not in admin list",
+			condition: policy.Condition{
+				Field:    "actor.meta.role", // Single value, not array!
+				Operator: "nin",
+				Value:    []string{"admin", "distributor-admin", "super-admin"},
+			},
+			actor:    newMockActor("user123", registry.Metadata{"role": "user"}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     true,
+			wantErr:  false,
+			comment:  "CORRECT: nin returns TRUE because 'user' (single value) is NOT in admin roles list",
+		},
+		{
+			name: "nin operator - CORRECT USAGE: single role value IS in admin list",
+			condition: policy.Condition{
+				Field:    "actor.meta.role", // Single value, not array!
+				Operator: "nin",
+				Value:    []string{"admin", "distributor-admin", "super-admin"},
+			},
+			actor:    newMockActor("user123", registry.Metadata{"role": "distributor-admin"}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     false,
+			wantErr:  false,
+			comment:  "CORRECT: nin returns FALSE because 'distributor-admin' (single value) IS in admin roles list",
+		},
+		{
+			name: "contains vs ncontains on string field - substring behavior",
+			condition: policy.Condition{
+				Field:    "actor.meta.role",
+				Operator: "contains",
+				Value:    "admin",
+			},
+			actor:    newMockActor("user123", registry.Metadata{"role": "distributor-admin"}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     true,
+			wantErr:  false,
+			comment:  "contains on STRING performs substring match - 'admin' is IN 'distributor-admin'",
+		},
+		{
+			name: "ncontains on string field - substring behavior",
+			condition: policy.Condition{
+				Field:    "actor.meta.role",
+				Operator: "ncontains",
+				Value:    "admin",
+			},
+			actor:    newMockActor("user123", registry.Metadata{"role": "distributor-admin"}),
+			action:   "read",
+			resource: "document",
+			meta:     nil,
+			want:     false,
+			wantErr:  false,
+			comment:  "ncontains on STRING performs substring check - 'admin' IS in 'distributor-admin', so returns FALSE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := evaluator.EvaluateCondition(tt.condition, tt.actor, tt.action, tt.resource, tt.meta)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EvaluateCondition() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("EvaluateCondition() got = %v, want %v\nComment: %s", got, tt.want, tt.comment)
+			} else {
+				t.Logf("✓ %s", tt.comment)
+			}
+		})
+	}
+}
+
 func TestComplexNestedConditions(t *testing.T) {
 	conditions := []policy.Condition{
 		{


### PR DESCRIPTION
Fix Permission Condition Evaluation for Role Arrays (EE2-1954)

Fixed bug in policy condition evaluator where contains/ncontains operators incorrectly performed substring matching on role arrays instead of exact element matching. Now actor.meta.roles ncontains "admin" correctly returns TRUE when roles are ["distributor-admin", "super-admin"].
Changes: Modified toString() to prevent array-to-string conversion + added comprehensive test suite