### PR TITLE
fix(wippy): EE2-1956 avoid loading modules folder (as part of project files) when it’s located inside the project directory

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,27 @@
+# Go Testing Rules
+
+## ✅ DO:
+- Use `testify`: `require.NoError(t, err)` and `assert.Equal(t, want, got)`
+- Always add `t.Parallel()` to tests and subtests - runs faster and catches race conditions (only if no shared state/side effects)
+- Use table-driven tests with descriptive names
+- Group tests with `t.Run("group name", func(t *testing.T) {...})`
+- Test edge cases: nil, empty, zero, boundary values
+- Extract repeated values to constants at top of test
+- Name tests: `TestType_Method_Scenario` format
+- Use `assert.ErrorAssertionFunc` in table-driven tests: add field `assertErr assert.ErrorAssertionFunc` and pass `assert.Error` or `assert.NoError` directly (see https://pkg.go.dev/github.com/stretchr/testify/assert#example-ErrorAssertionFunc)
+- Use `any` instead of `interface{}` (Go 1.18+)
+
+## ❌ DON'T:
+- Don't use `if (err != nil) != tt.wantErr` - use `assert.ErrorAssertionFunc` field with `assert.Error` or `assert.NoError`
+- Don't use plain `if got != want` - use `assert.Equal`
+- Don't use `t.Fatalf` for non-critical checks - use `assert`
+- Don't use `t.Parallel()` if tests have shared state, side effects (DB, files), or resource conflicts (ports)
+- Don't use `t.Logf` for test progress - test names should be self-explanatory
+- Don't write comments explaining expected behavior - test name should be clear
+- Don't repeat test data - use constants or table-driven tests
+- Don't write code that takes 15 seconds to understand - keep it simple
+
+## Before Commit:
+```bash
+make lint  # Must be 0 issues
+```

--- a/.cursorrules
+++ b/.cursorrules
@@ -21,6 +21,43 @@
 - Don't repeat test data - use constants or table-driven tests
 - Don't write code that takes 15 seconds to understand - keep it simple
 
+## Cross-Platform Development
+
+### Platform Support
+- Tests run on: **Linux**, **macOS**, and **Windows**
+- Wippy builds for multiple platforms:
+  - Windows: x86
+  - Linux: amd64, arm
+  - macOS: arm, amd64
+- Write code that works correctly on all supported platforms
+
+### File System Considerations
+- **NEVER** hardcode path separators (`/` or `\`)
+- Use `filepath.Join()` and `filepath.Clean()` for path construction
+- Use `os.PathSeparator` when you need the separator character
+- Use `filepath.IsAbs()` to check absolute paths (works cross-platform)
+- Use `filepath.Rel()` and `filepath.Abs()` for path operations
+- Prefer `os.UserHomeDir()`, `os.UserConfigDir()`, `os.TempDir()` over hardcoded paths
+- Be careful with `~` expansion - it's shell-specific, not OS-specific
+- Test path handling on all three platforms when possible
+
+### Platform-Specific Code
+- Use `runtime.GOOS` for platform detection when necessary:
+  ```go
+  if runtime.GOOS == "windows" {
+      // Windows-specific code
+  }
+  ```
+- Prefer cross-platform solutions over platform-specific workarounds
+- Document any platform-specific behavior clearly
+
+### Common Pitfalls
+- ❌ `"/path/to/file"` - hardcoded Unix path
+- ❌ `"C:\\path\\to\\file"` - hardcoded Windows path
+- ❌ `strings.Split(path, "/")` - assumes Unix separator
+- ✅ `filepath.Join("path", "to", "file")` - cross-platform
+- ✅ `filepath.Split(path)` - cross-platform path splitting
+
 ## Before Commit:
 ```bash
 make lint  # Must be 0 issues

--- a/cmd/runner/app/app.go
+++ b/cmd/runner/app/app.go
@@ -89,6 +89,90 @@ type appConfig struct {
 	clusterAdvertise  string
 
 	runtimeConfig *runtimeconfig.Config
+
+	// Directories to exclude from source scanning
+	excludeDirs []string
+}
+
+// filteredFS wraps an fs.FS and filters out multiple directories.
+// It pre-cleans all exclude paths for efficient comparison.
+type filteredFS struct {
+	fs                 iofs.FS
+	excludeDirs        []string
+	cleanedExcludeDirs []string // Pre-cleaned paths for performance
+}
+
+// Open implements fs.FS
+func (f *filteredFS) Open(name string) (iofs.File, error) {
+	if f.shouldExclude(name) {
+		return nil, iofs.ErrNotExist
+	}
+	return f.fs.Open(name)
+}
+
+// ReadDir implements fs.ReadDirFS
+func (f *filteredFS) ReadDir(name string) ([]iofs.DirEntry, error) {
+	if f.shouldExclude(name) {
+		return nil, iofs.ErrNotExist
+	}
+
+	entries, err := iofs.ReadDir(f.fs, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out the excluded directories from the results
+	filtered := make([]iofs.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		entryPath := filepath.Join(name, entry.Name())
+		if !f.shouldExclude(entryPath) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	return filtered, nil
+}
+
+// newFilteredFS creates a new filteredFS with pre-cleaned exclude paths for performance.
+func newFilteredFS(fs iofs.FS, excludeDirs []string) *filteredFS {
+	cleanedDirs := make([]string, 0, len(excludeDirs))
+	for _, dir := range excludeDirs {
+		if dir != "" {
+			cleanedDirs = append(cleanedDirs, filepath.Clean(dir))
+		}
+	}
+	return &filteredFS{
+		fs:                 fs,
+		excludeDirs:        excludeDirs,
+		cleanedExcludeDirs: cleanedDirs,
+	}
+}
+
+// shouldExclude checks if a path should be excluded.
+// It uses pre-cleaned paths for efficient O(n) comparison where n is the number of exclude directories.
+func (f *filteredFS) shouldExclude(name string) bool {
+	if len(f.cleanedExcludeDirs) == 0 {
+		return false
+	}
+
+	// Clean the path once for comparison
+	cleanName := filepath.Clean(name)
+
+	// Check against each pre-cleaned excluded directory
+	for _, cleanExclude := range f.cleanedExcludeDirs {
+		// Check if the path is exactly the exclude directory
+		if cleanName == cleanExclude {
+			return true
+		}
+
+		// Check if the path is inside the exclude directory
+		rel, err := filepath.Rel(cleanExclude, cleanName)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			return true
+		}
+	}
+
+	return false
 }
 
 type Option func(*appConfig)
@@ -133,6 +217,12 @@ func WithProfiling(enabled bool) Option {
 func WithRuntimeConfig(cfg *runtimeconfig.Config) Option {
 	return func(c *appConfig) {
 		c.runtimeConfig = cfg
+	}
+}
+
+func WithExcludeDirs(excludeDirs []string) Option {
+	return func(c *appConfig) {
+		c.excludeDirs = excludeDirs
 	}
 }
 
@@ -522,6 +612,11 @@ func (a *App) Start() error {
 			return fmt.Errorf("open folder %s: %w", a.config.folderPath, err)
 		}
 		fSys = osRoot.FS()
+	}
+
+	// Apply filtering if we have directories to exclude
+	if len(a.config.excludeDirs) > 0 {
+		fSys = newFilteredFS(fSys, a.config.excludeDirs)
 	}
 
 	bootCtx, cancel := context.WithTimeout(appCtx, 300*time.Second)

--- a/cmd/runner/app/deps.go
+++ b/cmd/runner/app/deps.go
@@ -88,6 +88,9 @@ func (dm *DependencyManager) UpdateDependencies(ctx context.Context) error {
 
 	// Prepare list of directories to exclude from source scanning
 	excludeDirs = dm.prepareExcludeDirs(srcDir, modulesDir, existingLock, existingLockPath)
+	if len(excludeDirs) > 0 {
+		dm.logger.Debug("Excluding directories from source scanning", zap.Strings("directories", excludeDirs))
+	}
 
 	entries, err := dm.loadRegistryEntries(ctx, srcDir, excludeDirs)
 	if err != nil {
@@ -203,78 +206,29 @@ func (dm *DependencyManager) loadRegistryEntries(ctx context.Context, srcDir str
 	return entries, nil
 }
 
-// prepareExcludeDirs prepares a list of directories to exclude from source scanning.
-//
-// It calculates relative paths (relative to srcDir) for:
-//   - modules directory (if inside source directory)
-//   - replacement directories from lock file (if inside source directory)
-//
-// Parameters:
-//   - srcDir: source directory path (relative to dm.folderPath)
-//   - modulesDir: modules directory path (relative to dm.folderPath)
-//   - lockFile: parsed lock file (may be nil)
-//   - lockPath: path to the lock file
-//
-// Returns a list of relative paths (relative to srcDir) to exclude.
-// Paths outside the source directory or paths that fail validation are
-// silently skipped with debug logging.
-//
-// Example:
-//
-//	srcDir = "."
-//	modulesDir = ".wippy"
-//	→ returns [".wippy"]
 func (dm *DependencyManager) prepareExcludeDirs(srcDir, modulesDir string, lockFile *deps.LockFile, lockPath string) []string {
-	// Validate inputs
 	if srcDir == "" {
-		dm.logger.Warn("prepareExcludeDirs called with empty srcDir, using '.' as default")
 		srcDir = "."
 	}
 
+	absSrcPath := filepath.Join(dm.folderPath, srcDir)
 	var excludeDirs []string
 
-	// Exclude modules directory if it's inside source directory
+	// Add modules directory
 	if modulesDir != "" {
 		absModulesPath := filepath.Join(dm.folderPath, modulesDir)
-		absSrcPath := filepath.Join(dm.folderPath, srcDir)
-
-		relModulesPath, err := filepath.Rel(absSrcPath, absModulesPath)
-		if err != nil {
-			dm.logger.Debug("Failed to calculate relative path for modules directory",
-				zap.String("src_dir", srcDir),
-				zap.String("modules_dir", modulesDir),
-				zap.Error(err))
-		} else if !strings.HasPrefix(relModulesPath, "..") {
-			excludeDirs = append(excludeDirs, relModulesPath)
-			dm.logger.Debug("Filtering out modules directory from source scanning",
-				zap.String("src_dir", srcDir),
-				zap.String("modules_dir", modulesDir),
-				zap.String("relative_path", relModulesPath))
+		if relPath, err := filepath.Rel(absSrcPath, absModulesPath); err == nil && !strings.HasPrefix(relPath, "..") {
+			excludeDirs = append(excludeDirs, relPath)
 		}
 	}
 
-	// Exclude replacement directories if they are inside source directory
+	// Add replacements directories
 	if lockFile != nil && len(lockFile.Replacements) > 0 {
 		lockFileDir := filepath.Dir(lockPath)
-		absSrcPath := filepath.Join(dm.folderPath, srcDir)
-
 		for _, replacement := range lockFile.Replacements {
-			absReplacementPath := filepath.Join(lockFileDir, replacement.To)
-			relReplacementPath, err := filepath.Rel(absSrcPath, absReplacementPath)
-			if err != nil {
-				dm.logger.Debug("Failed to calculate relative path for replacement",
-					zap.String("module", replacement.From),
-					zap.String("replacement_path", replacement.To),
-					zap.Error(err))
-				continue
-			}
-
-			if !strings.HasPrefix(relReplacementPath, "..") {
-				excludeDirs = append(excludeDirs, relReplacementPath)
-				dm.logger.Debug("Filtering out replacement directory from source scanning",
-					zap.String("module", replacement.From),
-					zap.String("replacement_path", replacement.To),
-					zap.String("relative_path", relReplacementPath))
+			absPath := filepath.Join(lockFileDir, replacement.To)
+			if relPath, err := filepath.Rel(absSrcPath, absPath); err == nil && !strings.HasPrefix(relPath, "..") {
+				excludeDirs = append(excludeDirs, relPath)
 			}
 		}
 	}

--- a/cmd/runner/app/deps.go
+++ b/cmd/runner/app/deps.go
@@ -72,15 +72,24 @@ func (dm *DependencyManager) InstallDependenciesFromLockFile(ctx context.Context
 
 // UpdateDependencies updates dependencies and regenerates lock file
 func (dm *DependencyManager) UpdateDependencies(ctx context.Context) error {
-	var srcDir string
+	var srcDir, modulesDir string
+	var excludeDirs []string
+
 	existingLockPath := filepath.Join(dm.folderPath, dm.lockFile)
-	if existingLock, err := deps.LoadLockFile(existingLockPath); err == nil {
+	var existingLock *deps.LockFile
+	if lock, err := deps.LoadLockFile(existingLockPath); err == nil {
+		existingLock = lock
 		srcDir = existingLock.Directories.Src
+		modulesDir = existingLock.Directories.Modules
 	} else {
 		srcDir = "."
+		modulesDir = deps.WippyFolder
 	}
 
-	entries, err := dm.loadRegistryEntries(ctx, srcDir)
+	// Prepare list of directories to exclude from source scanning
+	excludeDirs = dm.prepareExcludeDirs(srcDir, modulesDir, existingLock, existingLockPath)
+
+	entries, err := dm.loadRegistryEntries(ctx, srcDir, excludeDirs)
 	if err != nil {
 		return fmt.Errorf("load registry entries: %w", err)
 	}
@@ -116,13 +125,6 @@ func (dm *DependencyManager) UpdateDependencies(ctx context.Context) error {
 	loadResult, err := registryLoader.Load(ctx)
 	if err != nil {
 		return fmt.Errorf("load dependencies: %w", err)
-	}
-
-	var modulesDir string
-	if existingLock, err := deps.LoadLockFile(existingLockPath); err == nil {
-		modulesDir = existingLock.Directories.Modules
-	} else {
-		modulesDir = ".wippy"
 	}
 
 	lockFile := deps.ConvertToLockFile(loadResult, modulesDir, srcDir)
@@ -175,7 +177,7 @@ func (dm *DependencyManager) CleanUnusedPackages(lockFile *deps.LockFile) error 
 	return nil
 }
 
-func (dm *DependencyManager) loadRegistryEntries(ctx context.Context, srcDir string) ([]regapi.Entry, error) {
+func (dm *DependencyManager) loadRegistryEntries(ctx context.Context, srcDir string, excludeDirs []string) ([]regapi.Entry, error) {
 	dtt := transcoder.GlobalTranscoder()
 	json.Register(dtt)
 	yaml.Register(dtt)
@@ -186,7 +188,12 @@ func (dm *DependencyManager) loadRegistryEntries(ctx context.Context, srcDir str
 	))
 
 	srcPath := filepath.Join(dm.folderPath, srcDir)
-	fsys := os.DirFS(srcPath)
+	var fsys = os.DirFS(srcPath)
+
+	// Apply filtering if we have directories to exclude
+	if len(excludeDirs) > 0 {
+		fsys = newFilteredFS(fsys, excludeDirs)
+	}
 
 	entries, err := folderLoader.LoadFS(ctx, fsys)
 	if err != nil {
@@ -194,6 +201,85 @@ func (dm *DependencyManager) loadRegistryEntries(ctx context.Context, srcDir str
 	}
 
 	return entries, nil
+}
+
+// prepareExcludeDirs prepares a list of directories to exclude from source scanning.
+//
+// It calculates relative paths (relative to srcDir) for:
+//   - modules directory (if inside source directory)
+//   - replacement directories from lock file (if inside source directory)
+//
+// Parameters:
+//   - srcDir: source directory path (relative to dm.folderPath)
+//   - modulesDir: modules directory path (relative to dm.folderPath)
+//   - lockFile: parsed lock file (may be nil)
+//   - lockPath: path to the lock file
+//
+// Returns a list of relative paths (relative to srcDir) to exclude.
+// Paths outside the source directory or paths that fail validation are
+// silently skipped with debug logging.
+//
+// Example:
+//
+//	srcDir = "."
+//	modulesDir = ".wippy"
+//	→ returns [".wippy"]
+func (dm *DependencyManager) prepareExcludeDirs(srcDir, modulesDir string, lockFile *deps.LockFile, lockPath string) []string {
+	// Validate inputs
+	if srcDir == "" {
+		dm.logger.Warn("prepareExcludeDirs called with empty srcDir, using '.' as default")
+		srcDir = "."
+	}
+
+	var excludeDirs []string
+
+	// Exclude modules directory if it's inside source directory
+	if modulesDir != "" {
+		absModulesPath := filepath.Join(dm.folderPath, modulesDir)
+		absSrcPath := filepath.Join(dm.folderPath, srcDir)
+
+		relModulesPath, err := filepath.Rel(absSrcPath, absModulesPath)
+		if err != nil {
+			dm.logger.Debug("Failed to calculate relative path for modules directory",
+				zap.String("src_dir", srcDir),
+				zap.String("modules_dir", modulesDir),
+				zap.Error(err))
+		} else if !strings.HasPrefix(relModulesPath, "..") {
+			excludeDirs = append(excludeDirs, relModulesPath)
+			dm.logger.Debug("Filtering out modules directory from source scanning",
+				zap.String("src_dir", srcDir),
+				zap.String("modules_dir", modulesDir),
+				zap.String("relative_path", relModulesPath))
+		}
+	}
+
+	// Exclude replacement directories if they are inside source directory
+	if lockFile != nil && len(lockFile.Replacements) > 0 {
+		lockFileDir := filepath.Dir(lockPath)
+		absSrcPath := filepath.Join(dm.folderPath, srcDir)
+
+		for _, replacement := range lockFile.Replacements {
+			absReplacementPath := filepath.Join(lockFileDir, replacement.To)
+			relReplacementPath, err := filepath.Rel(absSrcPath, absReplacementPath)
+			if err != nil {
+				dm.logger.Debug("Failed to calculate relative path for replacement",
+					zap.String("module", replacement.From),
+					zap.String("replacement_path", replacement.To),
+					zap.Error(err))
+				continue
+			}
+
+			if !strings.HasPrefix(relReplacementPath, "..") {
+				excludeDirs = append(excludeDirs, relReplacementPath)
+				dm.logger.Debug("Filtering out replacement directory from source scanning",
+					zap.String("module", replacement.From),
+					zap.String("replacement_path", replacement.To),
+					zap.String("relative_path", relReplacementPath))
+			}
+		}
+	}
+
+	return excludeDirs
 }
 
 // createModuleLoaderManagerWithTempDirAndReplacements creates a module loader manager

--- a/cmd/runner/app/deps_test.go
+++ b/cmd/runner/app/deps_test.go
@@ -109,7 +109,6 @@ func TestDependencyManager_prepareExcludeDirs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/runner/app/deps_test.go
+++ b/cmd/runner/app/deps_test.go
@@ -5,10 +5,15 @@ import (
 	"testing"
 
 	"github.com/ponyruntime/pony/deps"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 
+const lockFileName = "wippy.lock"
+
 func TestDependencyManager_prepareExcludeDirs(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 
 	tests := []struct {
@@ -104,43 +109,40 @@ func TestDependencyManager_prepareExcludeDirs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dm := &DependencyManager{
 				folderPath: tt.folderPath,
-				lockFile:   "wippy.lock",
+				lockFile:   lockFileName,
 				logger:     logger,
 			}
 
 			got := dm.prepareExcludeDirs(tt.srcDir, tt.modulesDir, tt.lockFile, tt.lockPath)
 
-			if len(got) != len(tt.want) {
-				t.Errorf("prepareExcludeDirs() got %d items, want %d items\ngot: %v\nwant: %v",
-					len(got), len(tt.want), got, tt.want)
-				return
-			}
-
-			// Convert to map for easier comparison
 			gotMap := make(map[string]bool)
 			for _, item := range got {
 				gotMap[filepath.Clean(item)] = true
 			}
 
-			for _, wantItem := range tt.want {
-				cleanWant := filepath.Clean(wantItem)
-				if !gotMap[cleanWant] {
-					t.Errorf("prepareExcludeDirs() missing expected item: %s\ngot: %v\nwant: %v",
-						wantItem, got, tt.want)
-				}
+			wantMap := make(map[string]bool)
+			for _, item := range tt.want {
+				wantMap[filepath.Clean(item)] = true
 			}
+
+			assert.Equal(t, wantMap, gotMap)
 		})
 	}
 }
 
 func TestDependencyManager_prepareExcludeDirs_WithTrailingSlashes(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 	dm := &DependencyManager{
 		folderPath: "/app/",
-		lockFile:   "wippy.lock",
+		lockFile:   lockFileName,
 		logger:     logger,
 	}
 
@@ -152,17 +154,16 @@ func TestDependencyManager_prepareExcludeDirs_WithTrailingSlashes(t *testing.T) 
 
 	got := dm.prepareExcludeDirs(".", ".wippy/", lockFile, "/app/wippy.lock")
 
-	// Should still work correctly with trailing slashes
-	if len(got) != 2 {
-		t.Errorf("prepareExcludeDirs() with trailing slashes got %d items, want 2", len(got))
-	}
+	assert.Equal(t, 2, len(got))
 }
 
 func TestDependencyManager_prepareExcludeDirs_EmptyReplacements(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 	dm := &DependencyManager{
 		folderPath: "/app",
-		lockFile:   "wippy.lock",
+		lockFile:   lockFileName,
 		logger:     logger,
 	}
 
@@ -172,16 +173,16 @@ func TestDependencyManager_prepareExcludeDirs_EmptyReplacements(t *testing.T) {
 
 	got := dm.prepareExcludeDirs(".", ".wippy", lockFile, "/app/wippy.lock")
 
-	if len(got) != 1 {
-		t.Errorf("prepareExcludeDirs() with empty replacements got %d items, want 1", len(got))
-	}
+	assert.Equal(t, 1, len(got))
 }
 
 func TestDependencyManager_prepareExcludeDirs_AbsoluteReplacementPaths(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 	dm := &DependencyManager{
 		folderPath: "/app",
-		lockFile:   "wippy.lock",
+		lockFile:   lockFileName,
 		logger:     logger,
 	}
 
@@ -194,9 +195,6 @@ func TestDependencyManager_prepareExcludeDirs_AbsoluteReplacementPaths(t *testin
 
 	got := dm.prepareExcludeDirs(".", ".wippy", lockFile, "/app/wippy.lock")
 
-	// Paths that resolve outside the srcDir should not be included
-	// We expect only .wippy to be included
-	// Note: absolute paths and paths starting with .. should be excluded
 	foundOutsidePath := false
 	for _, dir := range got {
 		if dir == "absolute" || dir == "outside" || filepath.IsAbs(dir) {
@@ -204,12 +202,6 @@ func TestDependencyManager_prepareExcludeDirs_AbsoluteReplacementPaths(t *testin
 		}
 	}
 
-	if foundOutsidePath {
-		t.Errorf("prepareExcludeDirs() included paths outside srcDir: %v", got)
-	}
-
-	// At minimum, we should have .wippy
-	if len(got) < 1 {
-		t.Errorf("prepareExcludeDirs() got %d items, want at least 1 (.wippy)", len(got))
-	}
+	assert.False(t, foundOutsidePath, "prepareExcludeDirs() included paths outside srcDir: %v", got)
+	assert.GreaterOrEqual(t, len(got), 1, "prepareExcludeDirs() should have at least 1 item (.wippy)")
 }

--- a/cmd/runner/app/deps_test.go
+++ b/cmd/runner/app/deps_test.go
@@ -1,0 +1,215 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ponyruntime/pony/deps"
+	"go.uber.org/zap"
+)
+
+func TestDependencyManager_prepareExcludeDirs(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name       string
+		folderPath string
+		srcDir     string
+		modulesDir string
+		lockPath   string
+		lockFile   *deps.LockFile
+		want       []string
+	}{
+		{
+			name:       "no exclusions",
+			folderPath: "/app",
+			srcDir:     ".",
+			modulesDir: "",
+			lockPath:   "/app/wippy.lock",
+			lockFile:   nil,
+			want:       []string{},
+		},
+		{
+			name:       "exclude modules directory inside src",
+			folderPath: "/app",
+			srcDir:     ".",
+			modulesDir: ".wippy",
+			lockPath:   "/app/wippy.lock",
+			lockFile:   nil,
+			want:       []string{".wippy"},
+		},
+		{
+			name:       "modules outside src directory",
+			folderPath: "/app",
+			srcDir:     "src",
+			modulesDir: ".wippy",
+			lockPath:   "/app/wippy.lock",
+			lockFile:   nil,
+			want:       []string{},
+		},
+		{
+			name:       "exclude replacements inside src",
+			folderPath: "/app",
+			srcDir:     ".",
+			modulesDir: ".wippy",
+			lockPath:   "/app/wippy.lock",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./local/module1"},
+					{From: "test/module2", To: "./local/module2"},
+				},
+			},
+			want: []string{".wippy", "local/module1", "local/module2"},
+		},
+		{
+			name:       "replacements outside src directory",
+			folderPath: "/app",
+			srcDir:     "src",
+			modulesDir: "src/.wippy",
+			lockPath:   "/app/wippy.lock",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./local/module1"},
+				},
+			},
+			want: []string{".wippy"},
+		},
+		{
+			name:       "complex nested structure",
+			folderPath: "/home/user/project",
+			srcDir:     "app/src",
+			modulesDir: "app/src/.wippy",
+			lockPath:   "/home/user/project/app/wippy.lock",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./src/local/module1"},
+					{From: "test/module2", To: "./replacements/module2"},
+				},
+			},
+			want: []string{".wippy", "local/module1"},
+		},
+		{
+			name:       "src dir with dot",
+			folderPath: "/app",
+			srcDir:     ".",
+			modulesDir: ".wippy",
+			lockPath:   "/app/wippy.lock",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module", To: "./replacements/test"},
+				},
+			},
+			want: []string{".wippy", "replacements/test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dm := &DependencyManager{
+				folderPath: tt.folderPath,
+				lockFile:   "wippy.lock",
+				logger:     logger,
+			}
+
+			got := dm.prepareExcludeDirs(tt.srcDir, tt.modulesDir, tt.lockFile, tt.lockPath)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("prepareExcludeDirs() got %d items, want %d items\ngot: %v\nwant: %v",
+					len(got), len(tt.want), got, tt.want)
+				return
+			}
+
+			// Convert to map for easier comparison
+			gotMap := make(map[string]bool)
+			for _, item := range got {
+				gotMap[filepath.Clean(item)] = true
+			}
+
+			for _, wantItem := range tt.want {
+				cleanWant := filepath.Clean(wantItem)
+				if !gotMap[cleanWant] {
+					t.Errorf("prepareExcludeDirs() missing expected item: %s\ngot: %v\nwant: %v",
+						wantItem, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDependencyManager_prepareExcludeDirs_WithTrailingSlashes(t *testing.T) {
+	logger := zap.NewNop()
+	dm := &DependencyManager{
+		folderPath: "/app/",
+		lockFile:   "wippy.lock",
+		logger:     logger,
+	}
+
+	lockFile := &deps.LockFile{
+		Replacements: []deps.Replacement{
+			{From: "test/module", To: "./replacements/test/"},
+		},
+	}
+
+	got := dm.prepareExcludeDirs(".", ".wippy/", lockFile, "/app/wippy.lock")
+
+	// Should still work correctly with trailing slashes
+	if len(got) != 2 {
+		t.Errorf("prepareExcludeDirs() with trailing slashes got %d items, want 2", len(got))
+	}
+}
+
+func TestDependencyManager_prepareExcludeDirs_EmptyReplacements(t *testing.T) {
+	logger := zap.NewNop()
+	dm := &DependencyManager{
+		folderPath: "/app",
+		lockFile:   "wippy.lock",
+		logger:     logger,
+	}
+
+	lockFile := &deps.LockFile{
+		Replacements: []deps.Replacement{},
+	}
+
+	got := dm.prepareExcludeDirs(".", ".wippy", lockFile, "/app/wippy.lock")
+
+	if len(got) != 1 {
+		t.Errorf("prepareExcludeDirs() with empty replacements got %d items, want 1", len(got))
+	}
+}
+
+func TestDependencyManager_prepareExcludeDirs_AbsoluteReplacementPaths(t *testing.T) {
+	logger := zap.NewNop()
+	dm := &DependencyManager{
+		folderPath: "/app",
+		lockFile:   "wippy.lock",
+		logger:     logger,
+	}
+
+	lockFile := &deps.LockFile{
+		Replacements: []deps.Replacement{
+			{From: "test/module1", To: "/absolute/path/module"},
+			{From: "test/module2", To: "../outside/module"},
+		},
+	}
+
+	got := dm.prepareExcludeDirs(".", ".wippy", lockFile, "/app/wippy.lock")
+
+	// Paths that resolve outside the srcDir should not be included
+	// We expect only .wippy to be included
+	// Note: absolute paths and paths starting with .. should be excluded
+	foundOutsidePath := false
+	for _, dir := range got {
+		if dir == "absolute" || dir == "outside" || filepath.IsAbs(dir) {
+			foundOutsidePath = true
+		}
+	}
+
+	if foundOutsidePath {
+		t.Errorf("prepareExcludeDirs() included paths outside srcDir: %v", got)
+	}
+
+	// At minimum, we should have .wippy
+	if len(got) < 1 {
+		t.Errorf("prepareExcludeDirs() got %d items, want at least 1 (.wippy)", len(got))
+	}
+}

--- a/cmd/runner/app/filtered_fs_test.go
+++ b/cmd/runner/app/filtered_fs_test.go
@@ -76,7 +76,6 @@ func TestFilteredFS_Open(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -138,7 +137,6 @@ func TestFilteredFS_ReadDir(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -229,7 +227,6 @@ func TestFilteredFS_shouldExclude(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/runner/app/filtered_fs_test.go
+++ b/cmd/runner/app/filtered_fs_test.go
@@ -1,16 +1,24 @@
 package app
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDirPerm  = 0755
+	testFilePerm = 0600
 )
 
 func TestFilteredFS_Open(t *testing.T) {
-	// Create a test filesystem
+	t.Parallel()
+
 	fsys := fstest.MapFS{
 		"file.txt":              &fstest.MapFile{Data: []byte("content")},
 		"excluded/file.txt":     &fstest.MapFile{Data: []byte("excluded")},
@@ -23,71 +31,64 @@ func TestFilteredFS_Open(t *testing.T) {
 		name        string
 		excludeDirs []string
 		openPath    string
-		wantErr     bool
+		assertErr   assert.ErrorAssertionFunc
 		errType     error
 	}{
 		{
 			name:        "open normal file",
 			excludeDirs: []string{"excluded"},
 			openPath:    "file.txt",
-			wantErr:     false,
+			assertErr:   assert.NoError,
 		},
 		{
 			name:        "open excluded file",
 			excludeDirs: []string{"excluded"},
 			openPath:    "excluded/file.txt",
-			wantErr:     true,
+			assertErr:   assert.Error,
 			errType:     fs.ErrNotExist,
 		},
 		{
 			name:        "open excluded subdirectory",
 			excludeDirs: []string{"excluded"},
 			openPath:    "excluded/sub/file.txt",
-			wantErr:     true,
+			assertErr:   assert.Error,
 			errType:     fs.ErrNotExist,
 		},
 		{
 			name:        "open with multiple exclusions",
 			excludeDirs: []string{"excluded", "normal"},
 			openPath:    "normal/file.txt",
-			wantErr:     true,
+			assertErr:   assert.Error,
 			errType:     fs.ErrNotExist,
 		},
 		{
 			name:        "open non-excluded with multiple exclusions",
 			excludeDirs: []string{"excluded", "normal"},
 			openPath:    "another.txt",
-			wantErr:     false,
+			assertErr:   assert.NoError,
 		},
 		{
 			name:        "no exclusions",
 			excludeDirs: []string{},
 			openPath:    "excluded/file.txt",
-			wantErr:     false,
+			assertErr:   assert.NoError,
 		},
 	}
 
 	for _, tt := range tests {
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filtered := newFilteredFS(fsys, tt.excludeDirs)
 
 			file, err := filtered.Open(tt.openPath)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Open() expected error, got nil")
-					return
-				}
-				if tt.errType != nil && !errors.Is(err, tt.errType) {
-					t.Errorf("Open() error = %v, want %v", err, tt.errType)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Open() unexpected error: %v", err)
-					return
-				}
-				if file == nil {
-					t.Errorf("Open() returned nil file")
-				}
+			tt.assertErr(t, err)
+			if tt.errType != nil && err != nil {
+				assert.ErrorIs(t, err, tt.errType)
+			}
+			if err == nil {
+				require.NotNil(t, file)
 				file.Close()
 			}
 		})
@@ -95,7 +96,8 @@ func TestFilteredFS_Open(t *testing.T) {
 }
 
 func TestFilteredFS_ReadDir(t *testing.T) {
-	// Create a test filesystem
+	t.Parallel()
+
 	fsys := fstest.MapFS{
 		"file1.txt":          &fstest.MapFile{Data: []byte("file1")},
 		"file2.txt":          &fstest.MapFile{Data: []byte("file2")},
@@ -136,38 +138,34 @@ func TestFilteredFS_ReadDir(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			filtered := newFilteredFS(fsys, tt.excludeDirs)
 
 			entries, err := filtered.ReadDir(tt.readPath)
-			if err != nil {
-				t.Errorf("ReadDir() unexpected error: %v", err)
-				return
-			}
+			require.NoError(t, err)
 
 			entryNames := make(map[string]bool)
 			for _, entry := range entries {
 				entryNames[entry.Name()] = true
 			}
 
-			// Check that wanted entries are present
 			for _, want := range tt.wantContains {
-				if !entryNames[want] {
-					t.Errorf("ReadDir() missing expected entry: %s, got entries: %v", want, entryNames)
-				}
+				assert.True(t, entryNames[want], "ReadDir() missing expected entry: %s", want)
 			}
 
-			// Check that excluded entries are not present
 			for _, exclude := range tt.wantExcludes {
-				if entryNames[exclude] {
-					t.Errorf("ReadDir() contains excluded entry: %s", exclude)
-				}
+				assert.False(t, entryNames[exclude], "ReadDir() contains excluded entry: %s", exclude)
 			}
 		})
 	}
 }
 
 func TestFilteredFS_shouldExclude(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		excludeDirs []string
@@ -231,23 +229,21 @@ func TestFilteredFS_shouldExclude(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			f := newFilteredFS(nil, tt.excludeDirs)
 
 			got := f.shouldExclude(tt.path)
-			if got != tt.want {
-				t.Errorf("shouldExclude() = %v, want %v for path %s with excludeDirs %v",
-					got, tt.want, tt.path, tt.excludeDirs)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
 func TestFilteredFS_Integration(t *testing.T) {
-	// Create a temporary directory structure for integration testing
 	tmpDir := t.TempDir()
 
-	// Create test structure
 	dirs := []string{
 		".wippy/vendor",
 		"replacements/module1",
@@ -266,22 +262,15 @@ func TestFilteredFS_Integration(t *testing.T) {
 	}
 
 	for _, dir := range dirs {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, dir), testDirPerm))
 	}
 
 	for file, content := range files {
 		fullPath := filepath.Join(tmpDir, file)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(fullPath, []byte(content), 0600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), testDirPerm))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), testFilePerm))
 	}
 
-	// Create filtered FS
 	osFS := os.DirFS(tmpDir)
 	filtered := newFilteredFS(osFS, []string{
 		".wippy",
@@ -289,43 +278,25 @@ func TestFilteredFS_Integration(t *testing.T) {
 		"replacements/module2",
 	})
 
-	// Test ReadDir at root
 	entries, err := filtered.ReadDir(".")
-	if err != nil {
-		t.Fatalf("ReadDir failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Check that excluded directories are not present
 	for _, entry := range entries {
-		if entry.Name() == ".wippy" {
-			t.Errorf("ReadDir returned excluded directory: .wippy")
-		}
+		assert.NotEqual(t, ".wippy", entry.Name(), "ReadDir returned excluded directory: .wippy")
 		if entry.Name() == "replacements" {
-			// Replacements dir itself should be visible, but its subdirs should be filtered
 			subEntries, err := filtered.ReadDir("replacements")
-			if err != nil {
-				t.Fatalf("ReadDir(replacements) failed: %v", err)
-			}
+			require.NoError(t, err)
 			for _, sub := range subEntries {
-				if sub.Name() == "module1" || sub.Name() == "module2" {
-					t.Errorf("ReadDir returned excluded subdirectory: replacements/%s", sub.Name())
-				}
+				assert.NotContains(t, []string{"module1", "module2"}, sub.Name(), "ReadDir returned excluded subdirectory: replacements/%s", sub.Name())
 			}
 		}
 	}
 
-	// Try to open excluded file
 	_, err = filtered.Open(".wippy/vendor/test/module.lua")
-	if err == nil {
-		t.Error("Open() should fail for excluded file")
-	}
+	assert.Error(t, err, "Open() should fail for excluded file")
 
-	// Try to open normal file
 	file, err := filtered.Open("app.yaml")
-	if err != nil {
-		t.Errorf("Open() failed for normal file: %v", err)
-	}
-	if file != nil {
-		file.Close()
-	}
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	file.Close()
 }

--- a/cmd/runner/app/filtered_fs_test.go
+++ b/cmd/runner/app/filtered_fs_test.go
@@ -1,0 +1,331 @@
+package app
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+func TestFilteredFS_Open(t *testing.T) {
+	// Create a test filesystem
+	fsys := fstest.MapFS{
+		"file.txt":              &fstest.MapFile{Data: []byte("content")},
+		"excluded/file.txt":     &fstest.MapFile{Data: []byte("excluded")},
+		"excluded/sub/file.txt": &fstest.MapFile{Data: []byte("excluded sub")},
+		"normal/file.txt":       &fstest.MapFile{Data: []byte("normal")},
+		"another.txt":           &fstest.MapFile{Data: []byte("another")},
+	}
+
+	tests := []struct {
+		name        string
+		excludeDirs []string
+		openPath    string
+		wantErr     bool
+		errType     error
+	}{
+		{
+			name:        "open normal file",
+			excludeDirs: []string{"excluded"},
+			openPath:    "file.txt",
+			wantErr:     false,
+		},
+		{
+			name:        "open excluded file",
+			excludeDirs: []string{"excluded"},
+			openPath:    "excluded/file.txt",
+			wantErr:     true,
+			errType:     fs.ErrNotExist,
+		},
+		{
+			name:        "open excluded subdirectory",
+			excludeDirs: []string{"excluded"},
+			openPath:    "excluded/sub/file.txt",
+			wantErr:     true,
+			errType:     fs.ErrNotExist,
+		},
+		{
+			name:        "open with multiple exclusions",
+			excludeDirs: []string{"excluded", "normal"},
+			openPath:    "normal/file.txt",
+			wantErr:     true,
+			errType:     fs.ErrNotExist,
+		},
+		{
+			name:        "open non-excluded with multiple exclusions",
+			excludeDirs: []string{"excluded", "normal"},
+			openPath:    "another.txt",
+			wantErr:     false,
+		},
+		{
+			name:        "no exclusions",
+			excludeDirs: []string{},
+			openPath:    "excluded/file.txt",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := newFilteredFS(fsys, tt.excludeDirs)
+
+			file, err := filtered.Open(tt.openPath)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Open() expected error, got nil")
+					return
+				}
+				if tt.errType != nil && !errors.Is(err, tt.errType) {
+					t.Errorf("Open() error = %v, want %v", err, tt.errType)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Open() unexpected error: %v", err)
+					return
+				}
+				if file == nil {
+					t.Errorf("Open() returned nil file")
+				}
+				file.Close()
+			}
+		})
+	}
+}
+
+func TestFilteredFS_ReadDir(t *testing.T) {
+	// Create a test filesystem
+	fsys := fstest.MapFS{
+		"file1.txt":          &fstest.MapFile{Data: []byte("file1")},
+		"file2.txt":          &fstest.MapFile{Data: []byte("file2")},
+		"excluded/file.txt":  &fstest.MapFile{Data: []byte("excluded")},
+		"normal/file.txt":    &fstest.MapFile{Data: []byte("normal")},
+		"another/file.txt":   &fstest.MapFile{Data: []byte("another")},
+		"excluded2/file.txt": &fstest.MapFile{Data: []byte("excluded2")},
+	}
+
+	tests := []struct {
+		name         string
+		excludeDirs  []string
+		readPath     string
+		wantContains []string
+		wantExcludes []string
+	}{
+		{
+			name:         "read root with single exclusion",
+			excludeDirs:  []string{"excluded"},
+			readPath:     ".",
+			wantContains: []string{"file1.txt", "file2.txt", "normal", "another"},
+			wantExcludes: []string{"excluded"},
+		},
+		{
+			name:         "read root with multiple exclusions",
+			excludeDirs:  []string{"excluded", "excluded2"},
+			readPath:     ".",
+			wantContains: []string{"file1.txt", "file2.txt", "normal", "another"},
+			wantExcludes: []string{"excluded", "excluded2"},
+		},
+		{
+			name:         "read root with no exclusions",
+			excludeDirs:  []string{},
+			readPath:     ".",
+			wantContains: []string{"file1.txt", "file2.txt", "excluded", "normal", "another", "excluded2"},
+			wantExcludes: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := newFilteredFS(fsys, tt.excludeDirs)
+
+			entries, err := filtered.ReadDir(tt.readPath)
+			if err != nil {
+				t.Errorf("ReadDir() unexpected error: %v", err)
+				return
+			}
+
+			entryNames := make(map[string]bool)
+			for _, entry := range entries {
+				entryNames[entry.Name()] = true
+			}
+
+			// Check that wanted entries are present
+			for _, want := range tt.wantContains {
+				if !entryNames[want] {
+					t.Errorf("ReadDir() missing expected entry: %s, got entries: %v", want, entryNames)
+				}
+			}
+
+			// Check that excluded entries are not present
+			for _, exclude := range tt.wantExcludes {
+				if entryNames[exclude] {
+					t.Errorf("ReadDir() contains excluded entry: %s", exclude)
+				}
+			}
+		})
+	}
+}
+
+func TestFilteredFS_shouldExclude(t *testing.T) {
+	tests := []struct {
+		name        string
+		excludeDirs []string
+		path        string
+		want        bool
+	}{
+		{
+			name:        "exclude exact match",
+			excludeDirs: []string{"excluded"},
+			path:        "excluded",
+			want:        true,
+		},
+		{
+			name:        "exclude subdirectory",
+			excludeDirs: []string{"excluded"},
+			path:        "excluded/sub/file.txt",
+			want:        true,
+		},
+		{
+			name:        "don't exclude different directory",
+			excludeDirs: []string{"excluded"},
+			path:        "normal/file.txt",
+			want:        false,
+		},
+		{
+			name:        "multiple exclusions - first matches",
+			excludeDirs: []string{"dir1", "dir2", "dir3"},
+			path:        "dir1/file.txt",
+			want:        true,
+		},
+		{
+			name:        "multiple exclusions - last matches",
+			excludeDirs: []string{"dir1", "dir2", "dir3"},
+			path:        "dir3/file.txt",
+			want:        true,
+		},
+		{
+			name:        "multiple exclusions - none match",
+			excludeDirs: []string{"dir1", "dir2", "dir3"},
+			path:        "other/file.txt",
+			want:        false,
+		},
+		{
+			name:        "empty exclusions",
+			excludeDirs: []string{},
+			path:        "any/path",
+			want:        false,
+		},
+		{
+			name:        "path with dots",
+			excludeDirs: []string{".wippy"},
+			path:        ".wippy/vendor/module",
+			want:        true,
+		},
+		{
+			name:        "clean paths comparison",
+			excludeDirs: []string{"excluded"},
+			path:        "./excluded/file.txt",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFilteredFS(nil, tt.excludeDirs)
+
+			got := f.shouldExclude(tt.path)
+			if got != tt.want {
+				t.Errorf("shouldExclude() = %v, want %v for path %s with excludeDirs %v",
+					got, tt.want, tt.path, tt.excludeDirs)
+			}
+		})
+	}
+}
+
+func TestFilteredFS_Integration(t *testing.T) {
+	// Create a temporary directory structure for integration testing
+	tmpDir := t.TempDir()
+
+	// Create test structure
+	dirs := []string{
+		".wippy/vendor",
+		"replacements/module1",
+		"replacements/module2",
+		"src",
+		"public",
+	}
+
+	files := map[string]string{
+		"app.yaml":                      "content",
+		"src/main.lua":                  "content",
+		"public/index.html":             "content",
+		".wippy/vendor/test/module.lua": "should be excluded",
+		"replacements/module1/code.lua": "should be excluded",
+		"replacements/module2/code.lua": "should be excluded",
+	}
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for file, content := range files {
+		fullPath := filepath.Join(tmpDir, file)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create filtered FS
+	osFS := os.DirFS(tmpDir)
+	filtered := newFilteredFS(osFS, []string{
+		".wippy",
+		"replacements/module1",
+		"replacements/module2",
+	})
+
+	// Test ReadDir at root
+	entries, err := filtered.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+
+	// Check that excluded directories are not present
+	for _, entry := range entries {
+		if entry.Name() == ".wippy" {
+			t.Errorf("ReadDir returned excluded directory: .wippy")
+		}
+		if entry.Name() == "replacements" {
+			// Replacements dir itself should be visible, but its subdirs should be filtered
+			subEntries, err := filtered.ReadDir("replacements")
+			if err != nil {
+				t.Fatalf("ReadDir(replacements) failed: %v", err)
+			}
+			for _, sub := range subEntries {
+				if sub.Name() == "module1" || sub.Name() == "module2" {
+					t.Errorf("ReadDir returned excluded subdirectory: replacements/%s", sub.Name())
+				}
+			}
+		}
+	}
+
+	// Try to open excluded file
+	_, err = filtered.Open(".wippy/vendor/test/module.lua")
+	if err == nil {
+		t.Error("Open() should fail for excluded file")
+	}
+
+	// Try to open normal file
+	file, err := filtered.Open("app.yaml")
+	if err != nil {
+		t.Errorf("Open() failed for normal file: %v", err)
+	}
+	if file != nil {
+		file.Close()
+	}
+}

--- a/cmd/runner/cmd/init.go
+++ b/cmd/runner/cmd/init.go
@@ -12,7 +12,7 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new lock file",
-	Long:  "Initialize a new lock file with the specified directory structure.",
+	Long:  fmt.Sprintf("Initialize a new lock file with default directory structure (src: '%s', modules: '%s').", deps.DefaultSrcDir, deps.DefaultModulesDir),
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger, err := createLogger()
 		if err != nil {
@@ -20,19 +20,17 @@ var initCmd = &cobra.Command{
 		}
 
 		lockFile, _ := cmd.Flags().GetString("lock-file")
-		srcDir, _ := cmd.Flags().GetString("src-dir")
-		modulesDir, _ := cmd.Flags().GetString("modules-dir")
 
 		// Check if lock file already exists
 		if _, err := os.Stat(lockFile); err == nil {
 			return fmt.Errorf("lock file already exists: %s", lockFile)
 		}
 
-		// Create empty lock file with directories
+		// Create empty lock file with default directories
 		lockFileObj := &deps.LockFile{
 			Directories: deps.Directories{
-				Modules: modulesDir,
-				Src:     srcDir,
+				Modules: deps.DefaultModulesDir,
+				Src:     deps.DefaultSrcDir,
 			},
 			Modules: []deps.LockedModule{},
 		}
@@ -44,8 +42,8 @@ var initCmd = &cobra.Command{
 
 		logger.Info("Lock file initialized successfully",
 			zap.String("path", lockFile),
-			zap.String("src_dir", srcDir),
-			zap.String("modules_dir", modulesDir))
+			zap.String("src_dir", deps.DefaultSrcDir),
+			zap.String("modules_dir", deps.DefaultModulesDir))
 
 		return nil
 	},
@@ -55,6 +53,4 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 
 	initCmd.Flags().StringP("lock-file", "l", "wippy.lock", "path to lock file")
-	initCmd.Flags().StringP("src-dir", "d", ".", "source directory path")
-	initCmd.Flags().StringP("modules-dir", "m", ".wippy", "modules directory path")
 }

--- a/cmd/runner/cmd/run.go
+++ b/cmd/runner/cmd/run.go
@@ -152,6 +152,9 @@ var runCmd = &cobra.Command{
 		consoleLogging, eventStreaming := GetLoggingConfig()
 		minLevel := GetVerboseLevel()
 
+		// Prepare list of directories to exclude from source scanning
+		excludeDirs := prepareExcludeDirs(appDir, absModulesDir, absLockDir, lockFileObj, logger)
+
 		app, err := appbuild.NewApp(
 			logger,
 			appbuild.WithPaths(appDir, absLockPath, absModulesDir, absLockDir, useEmbed),
@@ -159,6 +162,7 @@ var runCmd = &cobra.Command{
 			appbuild.WithProfiling(enableProfiling),
 			appbuild.WithCluster(clusterEnabled, clusterName, clusterBind, clusterPort, clusterJoin, clusterSecret, clusterSecretFile, clusterAdvertise),
 			appbuild.WithRuntimeConfig(runtimeCfg),
+			appbuild.WithExcludeDirs(excludeDirs),
 		)
 		if err != nil {
 			logger.Error("failed to create application", zap.Error(err))
@@ -221,4 +225,87 @@ func init() {
 	runCmd.Flags().String("cluster-secret", "", "cluster secret key (base64 encoded string)")
 	runCmd.Flags().String("cluster-secret-file", "", "path to file containing cluster secret key")
 	runCmd.Flags().String("cluster-advertise", "", "cluster advertise IP address")
+}
+
+// prepareExcludeDirs prepares a list of directories to exclude from source scanning.
+//
+// It calculates relative paths for:
+//   - modules directory (if inside source directory)
+//   - replacement directories from lock file (if inside source directory)
+//
+// Parameters:
+//   - folderPath: absolute path to the source/application directory
+//   - modulesDirPath: absolute path to the modules directory
+//   - lockFileDir: directory containing the lock file
+//   - lockFile: parsed lock file (may be nil)
+//   - logger: logger instance for debug output
+//
+// Returns a list of relative paths to exclude. Paths outside the source directory
+// or paths that fail validation are silently skipped with debug logging.
+//
+// Example:
+//
+//	folderPath = "/app"
+//	modulesDirPath = "/app/.wippy/vendor"
+//	→ returns [".wippy/vendor"]
+func prepareExcludeDirs(folderPath, modulesDirPath, lockFileDir string, lockFile *deps.LockFile, logger *zap.Logger) []string {
+	// Validate inputs
+	if folderPath == "" {
+		if logger != nil {
+			logger.Warn("prepareExcludeDirs called with empty folderPath")
+		}
+		return []string{}
+	}
+
+	var excludeDirs []string
+
+	// Exclude modules directory if it's inside source directory
+	if modulesDirPath != "" {
+		relModulesPath, err := filepath.Rel(folderPath, modulesDirPath)
+		if err != nil {
+			if logger != nil {
+				logger.Debug("Failed to calculate relative path for modules directory",
+					zap.String("folder_path", folderPath),
+					zap.String("modules_dir_path", modulesDirPath),
+					zap.Error(err))
+			}
+		} else if !strings.HasPrefix(relModulesPath, "..") {
+			excludeDirs = append(excludeDirs, relModulesPath)
+			if logger != nil {
+				logger.Debug("Filtering out modules directory from source scanning",
+					zap.String("folder_path", folderPath),
+					zap.String("modules_dir_path", modulesDirPath),
+					zap.String("relative_path", relModulesPath))
+			}
+		}
+	}
+
+	// Exclude replacement directories if they are inside source directory
+	if lockFile != nil && len(lockFile.Replacements) > 0 {
+		for _, replacement := range lockFile.Replacements {
+			absReplacementPath := filepath.Join(lockFileDir, replacement.To)
+			relReplacementPath, err := filepath.Rel(folderPath, absReplacementPath)
+			if err != nil {
+				if logger != nil {
+					logger.Debug("Failed to calculate relative path for replacement",
+						zap.String("module", replacement.From),
+						zap.String("replacement_path", replacement.To),
+						zap.Error(err))
+				}
+				continue
+			}
+
+			if !strings.HasPrefix(relReplacementPath, "..") {
+				excludeDirs = append(excludeDirs, relReplacementPath)
+				if logger != nil {
+					logger.Debug("Filtering out replacement directory from source scanning",
+						zap.String("module", replacement.From),
+						zap.String("replacement_path", replacement.To),
+						zap.String("relative_path", relReplacementPath))
+				}
+			}
+		}
+	}
+
+	return excludeDirs
 }

--- a/cmd/runner/cmd/run.go
+++ b/cmd/runner/cmd/run.go
@@ -154,6 +154,9 @@ var runCmd = &cobra.Command{
 
 		// Prepare list of directories to exclude from source scanning
 		excludeDirs := prepareExcludeDirs(appDir, absModulesDir, absLockDir, lockFileObj, logger)
+		if len(excludeDirs) > 0 {
+			logger.Debug("Excluding directories from source scanning", zap.Strings("directories", excludeDirs))
+		}
 
 		app, err := appbuild.NewApp(
 			logger,
@@ -214,9 +217,7 @@ func init() {
 	runCmd.Flags().StringP("lock-file", "l", "wippy.lock", "path to lock file")
 	runCmd.Flags().BoolP("profiling", "p", false, "enable performance profiling")
 	runCmd.Flags().Bool("use-embed", false, "use embedded files")
-
 	runCmd.Flags().StringSliceP("runtime-config", "r", []string{}, "runtime configuration in format namespace:entry:field=value (can be specified multiple times). Entry and field can contain dots.")
-
 	runCmd.Flags().BoolP("cluster", "C", false, "enable cluster membership")
 	runCmd.Flags().StringP("cluster-name", "n", "", "cluster node name (defaults to hostname)")
 	runCmd.Flags().String("cluster-bind", "0.0.0.0", "cluster bind address")
@@ -248,61 +249,26 @@ func init() {
 //	folderPath = "/app"
 //	modulesDirPath = "/app/.wippy/vendor"
 //	→ returns [".wippy/vendor"]
-func prepareExcludeDirs(folderPath, modulesDirPath, lockFileDir string, lockFile *deps.LockFile, logger *zap.Logger) []string {
-	// Validate inputs
+func prepareExcludeDirs(folderPath, modulesDirPath, lockFileDir string, lockFile *deps.LockFile, _ *zap.Logger) []string {
 	if folderPath == "" {
-		if logger != nil {
-			logger.Warn("prepareExcludeDirs called with empty folderPath")
-		}
 		return []string{}
 	}
 
 	var excludeDirs []string
 
-	// Exclude modules directory if it's inside source directory
+	// Add modules directory
 	if modulesDirPath != "" {
-		relModulesPath, err := filepath.Rel(folderPath, modulesDirPath)
-		if err != nil {
-			if logger != nil {
-				logger.Debug("Failed to calculate relative path for modules directory",
-					zap.String("folder_path", folderPath),
-					zap.String("modules_dir_path", modulesDirPath),
-					zap.Error(err))
-			}
-		} else if !strings.HasPrefix(relModulesPath, "..") {
-			excludeDirs = append(excludeDirs, relModulesPath)
-			if logger != nil {
-				logger.Debug("Filtering out modules directory from source scanning",
-					zap.String("folder_path", folderPath),
-					zap.String("modules_dir_path", modulesDirPath),
-					zap.String("relative_path", relModulesPath))
-			}
+		if relPath, err := filepath.Rel(folderPath, modulesDirPath); err == nil && !strings.HasPrefix(relPath, "..") {
+			excludeDirs = append(excludeDirs, relPath)
 		}
 	}
 
-	// Exclude replacement directories if they are inside source directory
+	// Add replacements directories
 	if lockFile != nil && len(lockFile.Replacements) > 0 {
 		for _, replacement := range lockFile.Replacements {
-			absReplacementPath := filepath.Join(lockFileDir, replacement.To)
-			relReplacementPath, err := filepath.Rel(folderPath, absReplacementPath)
-			if err != nil {
-				if logger != nil {
-					logger.Debug("Failed to calculate relative path for replacement",
-						zap.String("module", replacement.From),
-						zap.String("replacement_path", replacement.To),
-						zap.Error(err))
-				}
-				continue
-			}
-
-			if !strings.HasPrefix(relReplacementPath, "..") {
-				excludeDirs = append(excludeDirs, relReplacementPath)
-				if logger != nil {
-					logger.Debug("Filtering out replacement directory from source scanning",
-						zap.String("module", replacement.From),
-						zap.String("replacement_path", replacement.To),
-						zap.String("relative_path", relReplacementPath))
-				}
+			absPath := filepath.Join(lockFileDir, replacement.To)
+			if relPath, err := filepath.Rel(folderPath, absPath); err == nil && !strings.HasPrefix(relPath, "..") {
+				excludeDirs = append(excludeDirs, relPath)
 			}
 		}
 	}

--- a/cmd/runner/cmd/run_test.go
+++ b/cmd/runner/cmd/run_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ponyruntime/pony/deps"
+	"go.uber.org/zap"
+)
+
+func TestPrepareExcludeDirs(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name           string
+		folderPath     string
+		modulesDirPath string
+		lockFileDir    string
+		lockFile       *deps.LockFile
+		want           []string
+	}{
+		{
+			name:           "no exclusions",
+			folderPath:     "/app",
+			modulesDirPath: "",
+			lockFileDir:    "/app",
+			lockFile:       nil,
+			want:           []string{},
+		},
+		{
+			name:           "exclude modules directory inside source",
+			folderPath:     "/app",
+			modulesDirPath: "/app/.wippy/vendor",
+			lockFileDir:    "/app",
+			lockFile:       nil,
+			want:           []string{".wippy/vendor"},
+		},
+		{
+			name:           "exclude modules directory outside source",
+			folderPath:     "/app/src",
+			modulesDirPath: "/app/.wippy/vendor",
+			lockFileDir:    "/app",
+			lockFile:       nil,
+			want:           []string{},
+		},
+		{
+			name:           "exclude replacements inside source",
+			folderPath:     "/app",
+			modulesDirPath: "/app/.wippy/vendor",
+			lockFileDir:    "/app",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./replacements/module1"},
+					{From: "test/module2", To: "./replacements/module2"},
+				},
+			},
+			want: []string{".wippy/vendor", "replacements/module1", "replacements/module2"},
+		},
+		{
+			name:           "exclude replacements outside source",
+			folderPath:     "/app/src",
+			modulesDirPath: "/app/.wippy/vendor",
+			lockFileDir:    "/app",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./replacements/module1"},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name:           "mixed: some inside, some outside",
+			folderPath:     "/app",
+			modulesDirPath: "/app/.wippy/vendor",
+			lockFileDir:    "/app",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./local/module1"},
+					{From: "test/module2", To: "../external/module2"},
+				},
+			},
+			want: []string{".wippy/vendor", "local/module1"},
+		},
+		{
+			name:           "absolute paths",
+			folderPath:     "/home/user/app",
+			modulesDirPath: "/home/user/app/.wippy/vendor",
+			lockFileDir:    "/home/user/app",
+			lockFile: &deps.LockFile{
+				Replacements: []deps.Replacement{
+					{From: "test/module1", To: "./replacements/module1"},
+				},
+			},
+			want: []string{".wippy/vendor", "replacements/module1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prepareExcludeDirs(tt.folderPath, tt.modulesDirPath, tt.lockFileDir, tt.lockFile, logger)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("prepareExcludeDirs() got %d items, want %d items\ngot: %v\nwant: %v", len(got), len(tt.want), got, tt.want)
+				return
+			}
+
+			// Convert to map for easier comparison
+			gotMap := make(map[string]bool)
+			for _, item := range got {
+				// Normalize paths for comparison
+				gotMap[filepath.Clean(item)] = true
+			}
+
+			for _, wantItem := range tt.want {
+				cleanWant := filepath.Clean(wantItem)
+				if !gotMap[cleanWant] {
+					t.Errorf("prepareExcludeDirs() missing expected item: %s\ngot: %v", wantItem, got)
+				}
+			}
+		})
+	}
+}
+
+func TestPrepareExcludeDirs_EmptyLockFile(t *testing.T) {
+	logger := zap.NewNop()
+
+	lockFile := &deps.LockFile{
+		Replacements: []deps.Replacement{},
+	}
+
+	got := prepareExcludeDirs("/app", "/app/.wippy/vendor", "/app", lockFile, logger)
+
+	if len(got) != 1 {
+		t.Errorf("prepareExcludeDirs() with empty replacements got %d items, want 1", len(got))
+	}
+}
+
+func TestPrepareExcludeDirs_NilLogger(t *testing.T) {
+	// Should not panic with nil logger (though we pass zap.NewNop() in real code)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("prepareExcludeDirs() panicked: %v", r)
+		}
+	}()
+
+	_ = prepareExcludeDirs("/app", "/app/.wippy/vendor", "/app", nil, zap.NewNop())
+}

--- a/cmd/runner/cmd/run_test.go
+++ b/cmd/runner/cmd/run_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/ponyruntime/pony/deps"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 
 func TestPrepareExcludeDirs(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 
 	tests := []struct {
@@ -96,32 +99,30 @@ func TestPrepareExcludeDirs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := prepareExcludeDirs(tt.folderPath, tt.modulesDirPath, tt.lockFileDir, tt.lockFile, logger)
 
-			if len(got) != len(tt.want) {
-				t.Errorf("prepareExcludeDirs() got %d items, want %d items\ngot: %v\nwant: %v", len(got), len(tt.want), got, tt.want)
-				return
-			}
-
-			// Convert to map for easier comparison
 			gotMap := make(map[string]bool)
 			for _, item := range got {
-				// Normalize paths for comparison
 				gotMap[filepath.Clean(item)] = true
 			}
 
-			for _, wantItem := range tt.want {
-				cleanWant := filepath.Clean(wantItem)
-				if !gotMap[cleanWant] {
-					t.Errorf("prepareExcludeDirs() missing expected item: %s\ngot: %v", wantItem, got)
-				}
+			wantMap := make(map[string]bool)
+			for _, item := range tt.want {
+				wantMap[filepath.Clean(item)] = true
 			}
+
+			assert.Equal(t, wantMap, gotMap)
 		})
 	}
 }
 
 func TestPrepareExcludeDirs_EmptyLockFile(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 
 	lockFile := &deps.LockFile{
@@ -130,13 +131,12 @@ func TestPrepareExcludeDirs_EmptyLockFile(t *testing.T) {
 
 	got := prepareExcludeDirs("/app", "/app/.wippy/vendor", "/app", lockFile, logger)
 
-	if len(got) != 1 {
-		t.Errorf("prepareExcludeDirs() with empty replacements got %d items, want 1", len(got))
-	}
+	assert.Equal(t, 1, len(got))
 }
 
 func TestPrepareExcludeDirs_NilLogger(t *testing.T) {
-	// Should not panic with nil logger (though we pass zap.NewNop() in real code)
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("prepareExcludeDirs() panicked: %v", r)

--- a/cmd/runner/cmd/run_test.go
+++ b/cmd/runner/cmd/run_test.go
@@ -99,7 +99,6 @@ func TestPrepareExcludeDirs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/runner/cmd/update.go
+++ b/cmd/runner/cmd/update.go
@@ -12,7 +12,7 @@ import (
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update dependencies and regenerate lock file",
-	Long:  "If the lock file is missing, runs init. Resolves dependencies and calculates a diff. Writes a new lock file and runs install afterwards.",
+	Long:  "If the lock file is missing, runs init. Resolves dependencies and calculates a diff. Writes a new lock file and runs install afterwards (unless --lock flag is used).",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger, err := createLogger()
 		if err != nil {
@@ -25,9 +25,14 @@ var updateCmd = &cobra.Command{
 
 func runUpdate(cmd *cobra.Command, _ []string, logger *zap.Logger) error {
 	lockFile, _ := cmd.Flags().GetString("lock-file")
+	lockOnly, _ := cmd.Flags().GetBool("lock")
 	folderPath := "."
 
-	logger.Info("Updating dependencies")
+	if lockOnly {
+		logger.Info("Updating dependencies (lock file only, skipping installation)")
+	} else {
+		logger.Info("Updating dependencies")
+	}
 
 	// Check if lock file exists and load old lock file BEFORE update to compare later
 	lockPath, err := deps.FindLockFile(folderPath, lockFile)
@@ -35,22 +40,11 @@ func runUpdate(cmd *cobra.Command, _ []string, logger *zap.Logger) error {
 	if err != nil {
 		logger.Info("Lock file not found, running init")
 
-		// Create default init parameters
-		srcDir, _ := cmd.Flags().GetString("src-dir")
-		modulesDir, _ := cmd.Flags().GetString("modules-dir")
-
-		if srcDir == "" {
-			srcDir = "."
-		}
-		if modulesDir == "" {
-			modulesDir = ".wippy"
-		}
-
-		// Create empty lock file with directories
+		// Create empty lock file with default directories
 		lockFileObj := &deps.LockFile{
 			Directories: deps.Directories{
-				Modules: modulesDir,
-				Src:     srcDir,
+				Modules: deps.DefaultModulesDir,
+				Src:     deps.DefaultSrcDir,
 			},
 			Modules: []deps.LockedModule{},
 		}
@@ -63,8 +57,8 @@ func runUpdate(cmd *cobra.Command, _ []string, logger *zap.Logger) error {
 
 		logger.Info("Lock file initialized",
 			zap.String("path", lockFile),
-			zap.String("src_dir", srcDir),
-			zap.String("modules_dir", modulesDir))
+			zap.String("src_dir", deps.DefaultSrcDir),
+			zap.String("modules_dir", deps.DefaultModulesDir))
 		// oldLock remains nil for new lock file
 	} else {
 		logger.Debug("Found existing lock file", zap.String("path", lockPath))
@@ -123,6 +117,26 @@ func runUpdate(cmd *cobra.Command, _ []string, logger *zap.Logger) error {
 		}
 	}
 
+	// Install dependencies unless --lock flag is set
+	if !lockOnly {
+		logger.Info("Installing dependencies from updated lock file")
+
+		// Validate replacements before installation
+		if err := newLock.ValidateReplacements(lockFile); err != nil {
+			logger.Error("invalid replacement paths", zap.Error(err))
+			return fmt.Errorf("invalid replacement paths: %w", err)
+		}
+
+		if err := depsManager.InstallDependenciesFromLockFile(cmd.Context(), newLock, lockFile); err != nil {
+			logger.Error("failed to install dependencies", zap.Error(err))
+			return fmt.Errorf("failed to install dependencies: %w", err)
+		}
+
+		logger.Info("Dependencies installed successfully")
+	} else {
+		logger.Info("Skipping installation (--lock flag is set)")
+	}
+
 	logger.Info("Update completed successfully")
 	return nil
 }
@@ -131,6 +145,5 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 
 	updateCmd.Flags().StringP("lock-file", "l", "wippy.lock", "path to lock file")
-	updateCmd.Flags().StringP("src-dir", "d", ".", "source directory path")
-	updateCmd.Flags().StringP("modules-dir", "m", ".wippy", "modules directory path")
+	updateCmd.Flags().Bool("lock", false, "only update lock file without installing dependencies")
 }

--- a/deps/constants.go
+++ b/deps/constants.go
@@ -17,6 +17,8 @@ const (
 	// Default directories
 	DefaultModulesDir = ".wippy"
 	DefaultSrcDir     = "."
+	WippyFolder       = ".wippy"
+	VendorFolder      = ".wippy/vendor"
 	TempUpdateDir     = ".wippy-update.tmp"
 	TempVendorFolder  = ".wippy-update.tmp/vendor"
 

--- a/deps/manager.go
+++ b/deps/manager.go
@@ -18,9 +18,6 @@ import (
 	modulev1 "github.com/wippyai/module-registry-proto-go/registry/module/v1"
 )
 
-// VendorFolder is a name of vendor folder.
-const VendorFolder = ".wippy/vendor"
-
 // ManifestLoader provides the way to load manifest information into the manager.
 type ManifestLoader interface {
 	LoadManifest(ctx context.Context) (*Manifest, error)

--- a/runtime/lua/modules/sql/db_test.go
+++ b/runtime/lua/modules/sql/db_test.go
@@ -1,9 +1,11 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
+	"github.com/ponyruntime/pony/api/resource"
 	sqlapi "github.com/ponyruntime/pony/api/service/sql"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -126,7 +128,20 @@ func TestDBExecute(t *testing.T) {
 
 	vm, uw, runner, ctx := setupLuaWithDB(t, mockRes)
 	defer vm.Close()
-	defer func() { _ = uw.Close() }()
+
+	// Preserve resources from context before closing UOW
+	// runner.Execute creates its own UOW, so we need to close the initial one
+	// but preserve resources in a new context
+	mockRegistry := resource.GetResources(ctx)
+	require.NotNil(t, mockRegistry, "Resource registry should be in context")
+
+	// Close the initial UOW before Execute - runner.Execute creates its own UOW
+	// This prevents deadlock as coroutines would use the wrong UOW
+	err = uw.Close()
+	require.NoError(t, err)
+
+	// Create a new context with resources but without UOW
+	execCtx := resource.WithResources(context.Background(), mockRegistry)
 
 	err = vm.Import(`
 		function test_db_execute()
@@ -142,7 +157,7 @@ func TestDBExecute(t *testing.T) {
 	`, "test", "test_db_execute")
 	require.NoError(t, err)
 
-	result, err := runner.Execute(ctx, "test_db_execute")
+	result, err := runner.Execute(execCtx, "test_db_execute")
 	require.NoError(t, err)
 	assert.Equal(t, lua.LString("new"), result)
 }

--- a/service/exec/native/native_test.go
+++ b/service/exec/native/native_test.go
@@ -453,8 +453,8 @@ func TestExecutor_Stderr(t *testing.T) {
 		// On Windows, we need to use CMD to redirect to stderr
 		command = "cmd /c echo error message 1>&2"
 	} else {
-		// On Unix systems - use a more reliable approach
-		command = "bash -c 'echo error message >&2'"
+		// On Unix systems - use sh instead of bash for better compatibility
+		command = "sh -c 'echo error message >&2'"
 	}
 
 	// Create the process
@@ -462,16 +462,15 @@ func TestExecutor_Stderr(t *testing.T) {
 	process, err := nativeExecutor.NewProcess(command, exec.ProcessOptions{})
 	assert.NoError(t, err)
 
-	err = process.Start()
-	assert.NoError(t, err)
-
-	// Start reading immediately in a goroutine
+	// Start reading BEFORE starting the process to avoid race conditions
 	sb := new(strings.Builder)
 	readDone := make(chan struct{})
 	processDone := make(chan struct{})
+	readStarted := make(chan struct{})
 
 	go func() {
 		defer close(readDone)
+		close(readStarted)
 		timeout := time.After(3 * time.Second)
 
 		for {
@@ -495,6 +494,13 @@ func TestExecutor_Stderr(t *testing.T) {
 			}
 		}
 	}()
+
+	// Wait for reading goroutine to start
+	<-readStarted
+
+	// Now start the process
+	err = process.Start()
+	assert.NoError(t, err)
 
 	// Wait for the process to complete in a separate goroutine
 	go func() {

--- a/service/memstore/memstore_test.go
+++ b/service/memstore/memstore_test.go
@@ -431,10 +431,11 @@ func TestMemoryStore_CleanupBehavior(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set multiple entries with different TTLs
+	// Use longer TTLs to account for CI/CD timing variations
 	keys := []registry.ID{
 		registry.ParseID("test:expire-50ms"),
 		registry.ParseID("test:expire-100ms"),
-		registry.ParseID("test:expire-150ms"),
+		registry.ParseID("test:expire-200ms"),
 		registry.ParseID("test:no-expire"),
 	}
 
@@ -444,7 +445,7 @@ func TestMemoryStore_CleanupBehavior(t *testing.T) {
 	err = ms.Set(ctx, createTestEntryWithTTL("test:expire-100ms", "100ms", 100*time.Millisecond))
 	require.NoError(t, err)
 
-	err = ms.Set(ctx, createTestEntryWithTTL("test:expire-150ms", "150ms", 150*time.Millisecond))
+	err = ms.Set(ctx, createTestEntryWithTTL("test:expire-200ms", "200ms", 200*time.Millisecond))
 	require.NoError(t, err)
 
 	err = ms.Set(ctx, createTestEntry("test:no-expire", "forever"))
@@ -457,10 +458,11 @@ func TestMemoryStore_CleanupBehavior(t *testing.T) {
 		assert.True(t, exists, "Key %s should exist initially", key)
 	}
 
-	// Wait for the first cleanup cycle
-	time.Sleep(75 * time.Millisecond)
+	// Wait for the first cleanup cycle (longer than 50ms TTL + cleanup interval)
+	// Use 80ms to check before 100ms key expires, but after 50ms key should be gone
+	time.Sleep(80 * time.Millisecond)
 
-	// After 75ms: 50ms key should be gone, others should remain
+	// After 80ms: 50ms key should be gone, others should remain
 	exists, err := ms.Has(ctx, keys[0]) // 50ms key
 	require.NoError(t, err)
 	assert.False(t, exists, "50ms key should be expired")
@@ -472,9 +474,9 @@ func TestMemoryStore_CleanupBehavior(t *testing.T) {
 	}
 
 	// Wait for the second cleanup cycle
-	time.Sleep(50 * time.Millisecond) // Now at ~125ms total
+	time.Sleep(50 * time.Millisecond) // Now at ~130ms total
 
-	// After 125ms: 50ms and 100ms keys should be gone, others should remain
+	// After 130ms: 50ms and 100ms keys should be gone, others should remain
 	for i := 0; i < 2; i++ {
 		exists, err = ms.Has(ctx, keys[i])
 		require.NoError(t, err)
@@ -488,9 +490,9 @@ func TestMemoryStore_CleanupBehavior(t *testing.T) {
 	}
 
 	// Wait for the third cleanup cycle
-	time.Sleep(50 * time.Millisecond) // Now at ~175ms total
+	time.Sleep(100 * time.Millisecond) // Now at ~230ms total
 
-	// After 175ms: All except the non-expiring key should be gone
+	// After 230ms: All except the non-expiring key should be gone
 	for i := 0; i < 3; i++ {
 		exists, err = ms.Has(ctx, keys[i])
 		require.NoError(t, err)

--- a/tests/minimal_app/README.md
+++ b/tests/minimal_app/README.md
@@ -1,0 +1,79 @@
+# Minimal Test App
+
+Minimal test structure to verify `.wippy` and `replacements` directory exclusion functionality.
+
+## Size
+- **minimal_app**: ~60KB
+- **app** (full version): ~2.4MB
+- **Savings**: ~40x smaller
+
+## Structure
+
+```
+minimal_app/
+├── wippy.lock              # Lock file with 0 dependencies + 1 replacement
+├── system.yaml             # Minimal system configuration
+├── src/                    # Source code
+│   ├── _index.yaml
+│   └── test_handler.lua
+├── replacements/           # Local module (should be excluded)
+│   └── test_module/
+│       ├── _index.yaml     # Should NOT be loaded
+│       └── should_not_load.lua
+├── data/
+│   └── test.db
+└── public/
+    └── index.html
+```
+
+## Quick Test
+
+```bash
+cd tests/minimal_app
+./test.sh
+```
+
+## Manual Tests
+
+### 1. Test `update`:
+```bash
+../../dist/runner-linux-amd64 update -l wippy.lock -v
+```
+
+**Expected result:**
+- ✅ Filters `.wippy`
+- ✅ Filters `replacements/test_module`
+- ✅ Loads `app:test_handler`
+- ❌ Does NOT load `test.should.not.load:test_entry`
+
+### 2. Test `run`:
+```bash
+timeout 2 ../../dist/runner-linux-amd64 run -l wippy.lock -v
+```
+
+**Expected result:**
+- ✅ Filtering works
+- ✅ Application starts
+- ❌ `should.not.load` does not appear in logs
+
+### 3. Verify exclusion:
+```bash
+grep -i "should.not.load" <(../../dist/runner-linux-amd64 run -l wippy.lock 2>&1) \
+  || echo "✅ replacements directory correctly excluded"
+```
+
+## What is tested
+
+1. **`.wippy/` exclusion** during src scanning
+2. **`replacements/` exclusion** from lock file
+3. **Loading files from `src/`** works correctly
+4. **Minimal configuration** is sufficient for operation
+
+## Usage
+
+This structure is ideal for:
+- ✅ Unit tests
+- ✅ CI/CD pipeline
+- ✅ Quick functionality verification
+- ✅ Minimal debugging environment
+

--- a/tests/minimal_app/integration_test.go
+++ b/tests/minimal_app/integration_test.go
@@ -5,6 +5,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDirName    = "minimal_app"
+	testScriptName = "test.sh"
+	makeTarget     = "build-runner-local"
 )
 
 func TestMinimalAppIntegration(t *testing.T) {
@@ -12,34 +20,21 @@ func TestMinimalAppIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	// Find project root
 	projectRoot, err := findProjectRoot()
-	if err != nil {
-		t.Fatalf("Failed to find project root: %v", err)
-	}
+	require.NoError(t, err, "Failed to find project root")
 
-	// Build runner binary first
-	t.Log("Building runner binary...")
-	buildCmd := exec.Command("make", "build-runner-local")
+	buildCmd := exec.Command("make", makeTarget)
 	buildCmd.Dir = projectRoot
-	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("Failed to build runner: %v\nOutput: %s", err, output)
-	}
+	output, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "Failed to build runner: %s", string(output))
 
-	// Run test.sh script
-	t.Log("Running integration test script...")
-	testDir := filepath.Join(projectRoot, "tests", "minimal_app")
-	testScript := filepath.Join(testDir, "test.sh")
+	testDir := filepath.Join(projectRoot, "tests", testDirName)
+	testScript := filepath.Join(testDir, testScriptName)
 
 	cmd := exec.Command("/bin/bash", testScript)
 	cmd.Dir = testDir
-	output, err := cmd.CombinedOutput()
-
-	t.Logf("Test script output:\n%s", output)
-
-	if err != nil {
-		t.Fatalf("Integration test failed: %v", err)
-	}
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, "Integration test failed: %s", string(output))
 }
 
 func findProjectRoot() (string, error) {

--- a/tests/minimal_app/integration_test.go
+++ b/tests/minimal_app/integration_test.go
@@ -1,0 +1,66 @@
+package minimal_app_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMinimalAppIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Find project root
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		t.Fatalf("Failed to find project root: %v", err)
+	}
+
+	// Build runner binary first
+	t.Log("Building runner binary...")
+	buildCmd := exec.Command("make", "build-runner-local")
+	buildCmd.Dir = projectRoot
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to build runner: %v\nOutput: %s", err, output)
+	}
+
+	// Run test.sh script
+	t.Log("Running integration test script...")
+	testDir := filepath.Join(projectRoot, "tests", "minimal_app")
+	testScript := filepath.Join(testDir, "test.sh")
+
+	cmd := exec.Command("/bin/bash", testScript)
+	cmd.Dir = testDir
+	output, err := cmd.CombinedOutput()
+
+	t.Logf("Test script output:\n%s", output)
+
+	if err != nil {
+		t.Fatalf("Integration test failed: %v", err)
+	}
+}
+
+func findProjectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// Walk up until we find go.mod or Makefile
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		if _, err := os.Stat(filepath.Join(dir, "Makefile")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}

--- a/tests/minimal_app/public/index.html
+++ b/tests/minimal_app/public/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<head><title>Minimal Test</title></head>
+<body><h1>Test App</h1></body>
+</html>
+

--- a/tests/minimal_app/replacements/test_module/_index.yaml
+++ b/tests/minimal_app/replacements/test_module/_index.yaml
@@ -1,0 +1,9 @@
+version: "1.0"
+namespace: test.should.not.load
+
+entries:
+  - name: test_entry
+    kind: function
+    meta:
+      comment: Entry that should be excluded during scanning
+

--- a/tests/minimal_app/replacements/test_module/should_not_load.lua
+++ b/tests/minimal_app/replacements/test_module/should_not_load.lua
@@ -1,0 +1,4 @@
+return {
+    should_not_load = true
+}
+

--- a/tests/minimal_app/src/_index.yaml
+++ b/tests/minimal_app/src/_index.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+namespace: app
+
+entries:
+  - name: test_handler
+    kind: function
+    meta:
+      comment: Test handler from main src
+      depends_on:
+        - ns:system
+

--- a/tests/minimal_app/src/test_handler.lua
+++ b/tests/minimal_app/src/test_handler.lua
@@ -1,0 +1,7 @@
+return function(ctx)
+    return {
+        status = 200,
+        body = "OK from main src"
+    }
+end
+

--- a/tests/minimal_app/system.yaml
+++ b/tests/minimal_app/system.yaml
@@ -1,0 +1,30 @@
+version: "1.0"
+namespace: system
+
+entries:
+  - name: db
+    kind: database.sqlite
+    meta:
+      comment: Test SQLite database
+    file: "./data/test.db"
+    
+  - name: gateway
+    kind: http.server
+    meta:
+      comment: Test HTTP server
+    bind: "127.0.0.1"
+    port: 8086
+    public: "./public"
+    
+  - name: api
+    kind: http.router
+    meta:
+      comment: Test API router
+    path: "/api"
+    server: system:gateway
+    
+  - name: processes
+    kind: process.host
+    meta:
+      comment: Test process host
+

--- a/tests/minimal_app/test.sh
+++ b/tests/minimal_app/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+RUNNER="../../dist/runner-linux-amd64"
+
+echo "=== Testing minimal_app ==="
+echo ""
+
+echo "1. Testing 'update' command..."
+UPDATE_OUTPUT=$($RUNNER update -l wippy.lock -vv 2>&1)
+
+echo "$UPDATE_OUTPUT" | grep -q "Excluding directories from source scanning" && echo "   ✅ Exclusion logging works" || (echo "   ❌ No exclusion logging" && exit 1)
+echo "$UPDATE_OUTPUT" | grep -q '".wippy"' && echo "   ✅ Excludes .wippy" || (echo "   ❌ .wippy not excluded" && exit 1)
+echo "$UPDATE_OUTPUT" | grep -q '"replacements/test_module"' && echo "   ✅ Excludes replacements/test_module" || (echo "   ❌ replacements not excluded" && exit 1)
+echo "$UPDATE_OUTPUT" | grep -q "Update completed successfully" && echo "   ✅ Update completed" || (echo "   ❌ Update failed" && exit 1)
+echo ""
+
+echo "2. Testing 'run' command..."
+RUN_OUTPUT=$(timeout 2 $RUNNER run -l wippy.lock -vv 2>&1 || true)
+
+echo "$RUN_OUTPUT" | grep -q "Excluding directories from source scanning" && echo "   ✅ Exclusion logging works" || (echo "   ❌ No exclusion logging" && exit 1)
+echo "$RUN_OUTPUT" | grep -q '".wippy/vendor"' && echo "   ✅ Excludes .wippy/vendor" || (echo "   ❌ .wippy/vendor not excluded" && exit 1)
+echo "$RUN_OUTPUT" | grep -q '"replacements/test_module"' && echo "   ✅ Excludes replacements/test_module" || (echo "   ❌ replacements not excluded" && exit 1)
+echo ""
+
+echo "3. Verifying exclusion..."
+if echo "$RUN_OUTPUT" | grep -qi "should.not.load"; then
+    echo "   ❌ Failed: replacements were NOT excluded"
+    exit 1
+else
+    echo "   ✅ Replacements correctly excluded"
+fi
+echo ""
+
+echo "=== All tests passed! ==="
+

--- a/tests/minimal_app/wippy.lock
+++ b/tests/minimal_app/wippy.lock
@@ -1,0 +1,7 @@
+directories:
+  modules: .wippy
+  src: .
+modules: []
+replacements:
+- from: test/local
+  to: ./replacements/test_module


### PR DESCRIPTION
## Ignore `.wippy` and `replacements` during scanning

### Changes

- Added filtering for `.wippy` and `replacements` directories during source scanning
- Added `--lock` flag to `update` command (updates lock file without installing)
- Removed `-m, --modules-dir` and `-d, --src-dir` flags (now use `.wippy` and `.` by default)
- Optimized `filteredFS` with pre-cleaned paths for better performance

### Breaking Changes

⚠️ Removed CLI flags: `-m, --modules-dir`, `-d, --src-dir`