### PR TITLE
fix: Windows compatibility for term.ReadPassword

### DIFF
--- a/cmd/wippy/cmd/auth.go
+++ b/cmd/wippy/cmd/auth.go
@@ -253,7 +253,7 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 func readTokenInteractive(registry string) (string, error) {
 	fmt.Printf("Enter API token for %s: ", registry)
 
-	tokenBytes, err := term.ReadPassword(syscall.Stdin)
+	tokenBytes, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		reader := bufio.NewReader(os.Stdin)
 		token, err := reader.ReadString('\n')


### PR DESCRIPTION
Cast syscall.Stdin to int for cross-platform compatibility. On Windows, syscall.Stdin is syscall.Handle (uintptr), but term.ReadPassword expects int. The cast is a no-op on Linux/Mac where syscall.Stdin is already int.