### PR TITLE
Make terminal host stop idempotent

### DIFF
--- a/service/terminal/host.go
+++ b/service/terminal/host.go
@@ -35,6 +35,7 @@ type Host struct {
 	id        registry.ID
 	running   atomic.Bool
 	shutdown  atomic.Bool
+	stopCalls atomic.Uint64
 }
 
 // NewHost creates a new terminal host with actor scheduler.
@@ -172,15 +173,21 @@ func (h *Host) Start(ctx context.Context) (<-chan any, error) {
 
 // Stop implements supervisor.Service.
 func (h *Host) Stop(ctx context.Context) error {
-	if !h.running.Load() {
+	stopAttempt := h.stopCalls.Add(1)
+	if !h.running.Swap(false) {
+		h.log.Warn("terminal host stop requested while already stopped",
+			zap.String("id", h.id.String()),
+			zap.Uint64("attempt", stopAttempt),
+			zap.Bool("shutdown", h.shutdown.Load()))
 		return nil
 	}
 
 	h.shutdown.Store(true)
-	h.log.Info("terminal host stopping", zap.String("id", h.id.String()))
+	h.log.Info("terminal host stopping",
+		zap.String("id", h.id.String()),
+		zap.Uint64("attempt", stopAttempt))
 
 	h.scheduler.Stop(ctx)
-	h.running.Store(false)
 	close(h.statusCh)
 
 	if h.raw != nil {

--- a/service/terminal/host_test.go
+++ b/service/terminal/host_test.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -117,6 +118,67 @@ func TestHost_StopNotRunning(t *testing.T) {
 
 	err := h.Stop(context.Background())
 	require.NoError(t, err)
+}
+
+func TestHost_StopTwice_NoPanic(t *testing.T) {
+	id := registry.ID{NS: "test", Name: "host1"}
+	cfg := &terminalapi.HostConfig{}
+	factory := &mockFactory{}
+	logCtrl := logs.NewConfigurator(nil, zap.NewNop())
+	log := zap.NewNop()
+
+	scheduler := actor.NewScheduler(&mockCommandRegistry{},
+		actor.WithWorkers(1),
+	)
+
+	h := NewHost(id, cfg, scheduler, factory, logCtrl, log)
+
+	_, err := h.Start(context.Background())
+	require.NoError(t, err)
+
+	err = h.Stop(context.Background())
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		err = h.Stop(context.Background())
+	})
+	require.NoError(t, err)
+}
+
+func TestHost_StopConcurrent_NoPanic(t *testing.T) {
+	id := registry.ID{NS: "test", Name: "host1"}
+	cfg := &terminalapi.HostConfig{}
+	factory := &mockFactory{}
+	logCtrl := logs.NewConfigurator(nil, zap.NewNop())
+	log := zap.NewNop()
+
+	scheduler := actor.NewScheduler(&mockCommandRegistry{},
+		actor.WithWorkers(1),
+	)
+
+	h := NewHost(id, cfg, scheduler, factory, logCtrl, log)
+
+	_, err := h.Start(context.Background())
+	require.NoError(t, err)
+
+	const stopCalls = 8
+	errCh := make(chan error, stopCalls)
+	var wg sync.WaitGroup
+	wg.Add(stopCalls)
+
+	for i := 0; i < stopCalls; i++ {
+		go func() {
+			defer wg.Done()
+			errCh <- h.Stop(context.Background())
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for stopErr := range errCh {
+		require.NoError(t, stopErr)
+	}
 }
 
 func TestHost_Run_NotRunning(t *testing.T) {


### PR DESCRIPTION
This pull request improves the robustness of the `Host` service's stop logic by making the stop operation idempotent and safe for concurrent calls. It also adds comprehensive tests to ensure that multiple or concurrent stop requests do not cause panics or errors.

Key changes include:

### Host stop logic improvements

* Added a `stopCalls` atomic counter to the `Host` struct to track the number of stop attempts. (`service/terminal/host.go`)
* Modified the `Stop` method to use atomic operations, ensuring that stopping a host is safe to call multiple times and from multiple goroutines. The method now logs repeated stop attempts and prevents redundant operations. (`service/terminal/host.go`)

### Testing for stop behavior

* Added `TestHost_StopTwice_NoPanic` to verify that calling `Stop` twice does not panic or return an error. (`service/terminal/host_test.go`)
* Added `TestHost_StopConcurrent_NoPanic` to verify that multiple concurrent calls to `Stop` are handled safely without panics or errors. (`service/terminal/host_test.go`)
* Imported the `sync` package to support concurrent test execution. (`service/terminal/host_test.go`)