### PR TITLE
feat: mTLS and custom CA support for HTTP client

### DIFF
--- a/api/service/http/command.go
+++ b/api/service/http/command.go
@@ -19,6 +19,15 @@ const (
 	RequestBatch dispatcher.CommandID = 61 // Execute multiple HTTP requests concurrently
 )
 
+// TLSConfig holds per-request TLS settings for mTLS and custom CA support.
+type TLSConfig struct {
+	ServerName         string
+	CertPEM            []byte
+	KeyPEM             []byte
+	CAPEM              []byte
+	InsecureSkipVerify bool
+}
+
 // RequestCmd represents an HTTP request to be executed.
 // All fields are serializable for WASM/cross-boundary execution.
 type RequestCmd struct {
@@ -26,11 +35,12 @@ type RequestCmd struct {
 	Query           map[string]string
 	Cookies         map[string]string
 	Form            map[string]string
-	BasicAuthUser   string
-	URL             string
+	TLS             *TLSConfig
 	Method          string
+	URL             string
 	BasicAuthPass   string
 	UnixSocket      string
+	BasicAuthUser   string
 	Body            []byte
 	Files           []FileUpload
 	Timeout         time.Duration
@@ -73,6 +83,7 @@ func (c *RequestCmd) Release() {
 	c.Files = nil
 	c.BasicAuthUser = ""
 	c.BasicAuthPass = ""
+	c.TLS = nil
 	c.Stream = false
 	c.MaxResponseBody = 0
 	requestCmdPool.Put(c)

--- a/runtime/lua/modules/httpclient/module.go
+++ b/runtime/lua/modules/httpclient/module.go
@@ -139,6 +139,14 @@ func makeMethod(method string) lua.LGoFunc {
 			}
 		}
 
+		if opts.tls != nil && opts.tls.InsecureSkipVerify {
+			if !security.IsAllowed(ctx, "http_client.insecure_tls", urlStr, nil) {
+				l.Push(lua.LNil)
+				l.Push(lua.NewLuaError(l, "not allowed: insecure TLS for "+urlStr).WithKind(lua.PermissionDenied).WithRetryable(false))
+				return 2
+			}
+		}
+
 		if !security.IsAllowed(ctx, "http_client.request", urlStr, nil) {
 			l.Push(lua.LNil)
 			l.Push(lua.NewLuaError(l, "not allowed: "+urlStr).WithKind(lua.PermissionDenied).WithRetryable(false))
@@ -190,6 +198,14 @@ func request(l *lua.LState) int {
 		}
 	}
 
+	if opts.tls != nil && opts.tls.InsecureSkipVerify {
+		if !security.IsAllowed(ctx, "http_client.insecure_tls", urlStr, nil) {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "not allowed: insecure TLS for "+urlStr).WithKind(lua.PermissionDenied).WithRetryable(false))
+			return 2
+		}
+	}
+
 	if !security.IsAllowed(ctx, "http_client.request", urlStr, nil) {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, "not allowed: "+urlStr).WithKind(lua.PermissionDenied).WithRetryable(false))
@@ -229,6 +245,7 @@ func populateYield(yield *RequestYield, method, url string, opts *requestOptions
 	yield.BasicAuthPass = opts.basicAuthPass
 	yield.Stream = opts.stream
 	yield.MaxResponseBody = opts.maxResponseBody
+	yield.TLS = opts.tls
 
 	// Convert files
 	if len(opts.files) > 0 {
@@ -264,10 +281,11 @@ func populateYield(yield *RequestYield, method, url string, opts *requestOptions
 }
 
 type requestOptions struct {
-	headers         map[string]string
+	tls             *httpapi.TLSConfig
 	query           map[string]string
 	cookies         map[string]string
 	form            map[string]string
+	headers         map[string]string
 	unixSocket      string
 	basicAuthUser   string
 	basicAuthPass   string
@@ -403,6 +421,11 @@ func parseOptions(l *lua.LState, idx int) *requestOptions {
 		opts.maxResponseBody = int64(lua.LVAsNumber(maxBody))
 	}
 
+	// TLS configuration
+	if tlsVal := tbl.RawGetString("tls"); tlsVal.Type() == lua.LTTable {
+		opts.tls = parseTLSConfig(tlsVal.(*lua.LTable))
+	}
+
 	return opts
 }
 
@@ -495,6 +518,13 @@ func requestBatch(l *lua.LState) int {
 					return
 				}
 			}
+			if opts.tls != nil && opts.tls.InsecureSkipVerify {
+				if !security.IsAllowed(ctx, "http_client.insecure_tls", urlStr, nil) {
+					parseErr = "not allowed: insecure TLS for " + urlStr
+					parseErrKind = lua.PermissionDenied
+					return
+				}
+			}
 			// Streaming not supported in batch
 			if opts.stream {
 				parseErr = "streaming not supported in batch requests"
@@ -522,6 +552,7 @@ func requestBatch(l *lua.LState) int {
 		req.BasicAuthUser = opts.basicAuthUser
 		req.BasicAuthPass = opts.basicAuthPass
 		req.MaxResponseBody = opts.maxResponseBody
+		req.TLS = opts.tls
 
 		if len(opts.files) > 0 {
 			req.Files = make([]httpapi.FileUpload, len(opts.files))
@@ -546,6 +577,39 @@ func requestBatch(l *lua.LState) int {
 
 	l.Push(yield)
 	return -1
+}
+
+// parseTLSConfig extracts TLS configuration from a Lua table.
+// Returns nil if the table contains no recognized TLS fields.
+func parseTLSConfig(tbl *lua.LTable) *httpapi.TLSConfig {
+	cfg := &httpapi.TLSConfig{}
+	hasFields := false
+
+	if cert := tbl.RawGetString("cert"); cert.Type() == lua.LTString {
+		cfg.CertPEM = []byte(cert.String())
+		hasFields = true
+	}
+	if key := tbl.RawGetString("key"); key.Type() == lua.LTString {
+		cfg.KeyPEM = []byte(key.String())
+		hasFields = true
+	}
+	if ca := tbl.RawGetString("ca"); ca.Type() == lua.LTString {
+		cfg.CAPEM = []byte(ca.String())
+		hasFields = true
+	}
+	if serverName := tbl.RawGetString("server_name"); serverName.Type() == lua.LTString {
+		cfg.ServerName = serverName.String()
+		hasFields = true
+	}
+	if insecure := tbl.RawGetString("insecure_skip_verify"); insecure.Type() == lua.LTBool {
+		cfg.InsecureSkipVerify = bool(insecure.(lua.LBool))
+		hasFields = true
+	}
+
+	if !hasFields {
+		return nil
+	}
+	return cfg
 }
 
 // parseOptionsFromTable extracts request options from a Lua table.
@@ -648,6 +712,10 @@ func parseOptionsFromTable(tbl *lua.LTable) *requestOptions {
 
 	if maxBody := tbl.RawGetString("max_response_body"); maxBody.Type() == lua.LTNumber || maxBody.Type() == lua.LTInteger {
 		opts.maxResponseBody = int64(lua.LVAsNumber(maxBody))
+	}
+
+	if tlsVal := tbl.RawGetString("tls"); tlsVal.Type() == lua.LTTable {
+		opts.tls = parseTLSConfig(tlsVal.(*lua.LTable))
 	}
 
 	return opts

--- a/runtime/lua/modules/httpclient/module_test.go
+++ b/runtime/lua/modules/httpclient/module_test.go
@@ -1,13 +1,74 @@
 package httpclient
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
 	"time"
 
 	lua "github.com/wippyai/go-lua"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/security"
+	httpapi "github.com/wippyai/runtime/api/service/http"
 )
+
+func generateTestCerts(t *testing.T) (caCertPEM, clientCertPEM, clientKeyPEM []byte) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate client key: %v", err)
+	}
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create client cert: %v", err)
+	}
+	clientCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("marshal client key: %v", err)
+	}
+	clientKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER})
+
+	return caCertPEM, clientCertPEM, clientKeyPEM
+}
 
 // bind loads the module into the given state for testing.
 func bind(l *lua.LState) {
@@ -544,6 +605,227 @@ func TestParseDurationOptions(t *testing.T) {
 			t.Errorf("expected 60s, got %v", parsed.timeout)
 		}
 	})
+}
+
+func TestParseTLSOptions(t *testing.T) {
+	t.Run("full TLS config", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		tlsTbl := l.CreateTable(0, 5)
+		tlsTbl.RawSetString("cert", lua.LString("-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----"))
+		tlsTbl.RawSetString("key", lua.LString("-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----"))
+		tlsTbl.RawSetString("ca", lua.LString("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"))
+		tlsTbl.RawSetString("server_name", lua.LString("kubernetes"))
+		tlsTbl.RawSetString("insecure_skip_verify", lua.LFalse)
+
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("tls", tlsTbl)
+		l.Push(opts)
+
+		parsed := parseOptions(l, 1)
+		if parsed.tls == nil {
+			t.Fatal("expected TLS config")
+		}
+		if string(parsed.tls.CertPEM) != "-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----" {
+			t.Errorf("cert mismatch: %s", parsed.tls.CertPEM)
+		}
+		if string(parsed.tls.KeyPEM) != "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----" {
+			t.Errorf("key mismatch: %s", parsed.tls.KeyPEM)
+		}
+		if string(parsed.tls.CAPEM) != "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----" {
+			t.Errorf("ca mismatch: %s", parsed.tls.CAPEM)
+		}
+		if parsed.tls.ServerName != "kubernetes" {
+			t.Errorf("server_name mismatch: %s", parsed.tls.ServerName)
+		}
+		if parsed.tls.InsecureSkipVerify {
+			t.Error("insecure_skip_verify should be false")
+		}
+	})
+
+	t.Run("insecure_skip_verify true", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		tlsTbl := l.CreateTable(0, 1)
+		tlsTbl.RawSetString("insecure_skip_verify", lua.LTrue)
+
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("tls", tlsTbl)
+		l.Push(opts)
+
+		parsed := parseOptions(l, 1)
+		if parsed.tls == nil {
+			t.Fatal("expected TLS config")
+		}
+		if !parsed.tls.InsecureSkipVerify {
+			t.Error("insecure_skip_verify should be true")
+		}
+	})
+
+	t.Run("no TLS config", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("body", lua.LString("test"))
+		l.Push(opts)
+
+		parsed := parseOptions(l, 1)
+		if parsed.tls != nil {
+			t.Error("expected nil TLS config")
+		}
+	})
+
+	t.Run("empty TLS table", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		tlsTbl := l.CreateTable(0, 0)
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("tls", tlsTbl)
+		l.Push(opts)
+
+		parsed := parseOptions(l, 1)
+		if parsed.tls != nil {
+			t.Error("empty tls table should produce nil config")
+		}
+	})
+}
+
+func TestParseTLSOptionsPartial(t *testing.T) {
+	t.Run("only CA", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		tlsTbl := l.CreateTable(0, 1)
+		tlsTbl.RawSetString("ca", lua.LString("ca-pem-data"))
+
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("tls", tlsTbl)
+		l.Push(opts)
+
+		parsed := parseOptions(l, 1)
+		if parsed.tls == nil {
+			t.Fatal("expected TLS config")
+		}
+		if string(parsed.tls.CAPEM) != "ca-pem-data" {
+			t.Errorf("ca mismatch: %s", parsed.tls.CAPEM)
+		}
+		if len(parsed.tls.CertPEM) > 0 {
+			t.Error("cert should be empty")
+		}
+		if len(parsed.tls.KeyPEM) > 0 {
+			t.Error("key should be empty")
+		}
+	})
+
+	t.Run("only insecure_skip_verify", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		tlsTbl := l.CreateTable(0, 1)
+		tlsTbl.RawSetString("insecure_skip_verify", lua.LTrue)
+
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("tls", tlsTbl)
+		l.Push(opts)
+
+		parsed := parseOptions(l, 1)
+		if parsed.tls == nil {
+			t.Fatal("expected TLS config")
+		}
+		if !parsed.tls.InsecureSkipVerify {
+			t.Error("insecure_skip_verify should be true")
+		}
+		if len(parsed.tls.CertPEM) > 0 || len(parsed.tls.KeyPEM) > 0 || len(parsed.tls.CAPEM) > 0 {
+			t.Error("PEM fields should be empty")
+		}
+	})
+
+	t.Run("parseOptionsFromTable with TLS", func(t *testing.T) {
+		l := lua.NewState()
+		defer l.Close()
+
+		tlsTbl := l.CreateTable(0, 2)
+		tlsTbl.RawSetString("cert", lua.LString("cert-data"))
+		tlsTbl.RawSetString("key", lua.LString("key-data"))
+
+		opts := l.CreateTable(0, 1)
+		opts.RawSetString("tls", tlsTbl)
+
+		parsed := parseOptionsFromTable(opts)
+		if parsed.tls == nil {
+			t.Fatal("expected TLS config")
+		}
+		if string(parsed.tls.CertPEM) != "cert-data" {
+			t.Errorf("cert mismatch: %s", parsed.tls.CertPEM)
+		}
+		if string(parsed.tls.KeyPEM) != "key-data" {
+			t.Errorf("key mismatch: %s", parsed.tls.KeyPEM)
+		}
+	})
+}
+
+func TestParseTLSOptionsEmptyStringsIgnored(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	tlsTbl := l.CreateTable(0, 2)
+	tlsTbl.RawSetString("cert", lua.LString(""))
+	tlsTbl.RawSetString("key", lua.LString(""))
+
+	opts := l.CreateTable(0, 1)
+	opts.RawSetString("tls", tlsTbl)
+	l.Push(opts)
+
+	parsed := parseOptions(l, 1)
+	if parsed.tls == nil {
+		t.Fatal("expected TLS config")
+	}
+	if len(parsed.tls.CertPEM) != 0 {
+		t.Error("empty string cert should produce empty bytes")
+	}
+}
+
+func TestPopulateYieldTLS(t *testing.T) {
+	_, clientCert, clientKey := generateTestCerts(t)
+
+	yield := AcquireRequestYield()
+	defer ReleaseRequestYield(yield)
+
+	opts := &requestOptions{
+		tls: &httpapi.TLSConfig{
+			CertPEM:    clientCert,
+			KeyPEM:     clientKey,
+			ServerName: "test.local",
+		},
+	}
+
+	populateYield(yield, "GET", "https://test.local", opts)
+
+	if yield.TLS == nil {
+		t.Fatal("TLS should be set on yield")
+	}
+	if string(yield.TLS.CertPEM) != string(clientCert) {
+		t.Error("cert mismatch on yield")
+	}
+	if yield.TLS.ServerName != "test.local" {
+		t.Errorf("server_name mismatch: %s", yield.TLS.ServerName)
+	}
+}
+
+func TestPopulateYieldNoTLS(t *testing.T) {
+	yield := AcquireRequestYield()
+	defer ReleaseRequestYield(yield)
+
+	opts := &requestOptions{}
+	populateYield(yield, "GET", "https://example.com", opts)
+
+	if yield.TLS != nil {
+		t.Error("TLS should be nil when not configured")
+	}
 }
 
 func TestParseOptionsFromTableDuration(t *testing.T) {

--- a/runtime/lua/modules/httpclient/types.go
+++ b/runtime/lua/modules/httpclient/types.go
@@ -22,6 +22,15 @@ var responseType = typ.NewRecord().
 	OptField("stream", streamReaderType).
 	Build()
 
+// TLSOptions type for per-request TLS configuration
+var tlsOptionsType = typ.NewRecord().
+	OptField("cert", typ.String).
+	OptField("key", typ.String).
+	OptField("ca", typ.String).
+	OptField("server_name", typ.String).
+	OptField("insecure_skip_verify", typ.Boolean).
+	Build()
+
 // RequestOptions type for request configuration
 var requestOptionsType = typ.NewRecord().
 	OptField("headers", typ.NewMap(typ.String, typ.String)).
@@ -35,6 +44,7 @@ var requestOptionsType = typ.NewRecord().
 	OptField("auth", typ.Any).
 	OptField("stream", typ.Boolean).
 	OptField("max_response_body", typ.Number).
+	OptField("tls", tlsOptionsType).
 	Build()
 
 // ModuleTypes returns the type manifest for the http_client module.
@@ -44,6 +54,7 @@ func ModuleTypes() *io.Manifest {
 	// Register exported types
 	m.DefineType("Response", responseType)
 	m.DefineType("RequestOptions", requestOptionsType)
+	m.DefineType("TLSOptions", tlsOptionsType)
 	m.DefineType("StreamReader", streamReaderType)
 
 	// Function type for HTTP methods (get, post, put, etc.)

--- a/service/http/client/client_pool.go
+++ b/service/http/client/client_pool.go
@@ -2,21 +2,30 @@ package client
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
 	"net"
 	gohttp "net/http"
 	"sync"
 	"time"
+
+	httpapi "github.com/wippyai/runtime/api/service/http"
 )
 
 // clientKey identifies a unique client configuration.
 type clientKey struct {
-	unixSocket string
-	timeout    time.Duration
+	unixSocket     string
+	tlsFingerprint string
+	timeout        time.Duration
 }
 
 // clientOnce ensures single initialization of a client.
 type clientOnce struct {
 	client *gohttp.Client
+	err    error
 	once   sync.Once
 }
 
@@ -107,6 +116,117 @@ func (p *Pool) GetClient(timeout time.Duration, unixSocket string) *gohttp.Clien
 	return co.client
 }
 
+// GetClientWithTLS returns a pooled client configured with custom TLS settings.
+// Clients with the same TLS fingerprint, timeout, and socket are reused.
+// Fingerprint is checked first; PEM parsing only happens on cache miss.
+func (p *Pool) GetClientWithTLS(timeout time.Duration, unixSocket string, cfg *httpapi.TLSConfig) (*gohttp.Client, error) {
+	if cfg == nil {
+		return p.GetClient(timeout, unixSocket), nil
+	}
+
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	fp := tlsFingerprint(cfg)
+	key := clientKey{timeout: timeout, unixSocket: unixSocket, tlsFingerprint: fp}
+
+	// Fast path: entry exists (once.Do handles init race)
+	if v, ok := p.clients.Load(key); ok {
+		co := v.(*clientOnce)
+		co.once.Do(func() {
+			tlsCfg, err := buildTLSConfig(cfg)
+			if err != nil {
+				co.err = err
+				return
+			}
+			co.client = createClientFromTLS(timeout, unixSocket, tlsCfg)
+		})
+		if co.err != nil {
+			return nil, co.err
+		}
+		return co.client, nil
+	}
+
+	// Slow path: validate PEM upfront, then cache
+	tlsCfg, err := buildTLSConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	co := &clientOnce{}
+	actual, loaded := p.clients.LoadOrStore(key, co)
+	if loaded {
+		co = actual.(*clientOnce)
+	}
+
+	co.once.Do(func() {
+		co.client = createClientFromTLS(timeout, unixSocket, tlsCfg)
+	})
+
+	return co.client, nil
+}
+
+// buildTLSConfig constructs a *tls.Config from the per-request TLS configuration.
+func buildTLSConfig(cfg *httpapi.TLSConfig) (*tls.Config, error) {
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	hasCert := len(cfg.CertPEM) > 0
+	hasKey := len(cfg.KeyPEM) > 0
+	if hasCert != hasKey {
+		return nil, fmt.Errorf("both cert and key must be provided together")
+	}
+	if hasCert {
+		cert, err := tls.X509KeyPair(cfg.CertPEM, cfg.KeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("parse client certificate: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if len(cfg.CAPEM) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(cfg.CAPEM) {
+			return nil, fmt.Errorf("parse CA certificate: no valid certificates found")
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	if cfg.ServerName != "" {
+		tlsCfg.ServerName = cfg.ServerName
+	}
+
+	tlsCfg.InsecureSkipVerify = cfg.InsecureSkipVerify
+
+	return tlsCfg, nil
+}
+
+// tlsFingerprint produces a hex-encoded SHA256 hash of the TLS config material,
+// used as a cache key for pooled clients.
+func tlsFingerprint(cfg *httpapi.TLSConfig) string {
+	h := sha256.New()
+	h.Write(cfg.CertPEM)
+	h.Write([]byte{0})
+	h.Write(cfg.KeyPEM)
+	h.Write([]byte{0})
+	h.Write(cfg.CAPEM)
+	h.Write([]byte{0})
+	h.Write([]byte(cfg.ServerName))
+	if cfg.InsecureSkipVerify {
+		h.Write([]byte{1})
+	} else {
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// createClientFromTLS builds an HTTP client with a pre-parsed *tls.Config.
+func createClientFromTLS(timeout time.Duration, unixSocket string, tlsCfg *tls.Config) *gohttp.Client {
+	return createClient(timeout, unixSocket, defaultMaxIdleConns, defaultMaxIdlePerHost, defaultIdleConnTimeout, tlsCfg)
+}
+
 // Size returns the number of pooled clients (for monitoring/testing).
 func (p *Pool) Size() int {
 	count := 0
@@ -117,9 +237,9 @@ func (p *Pool) Size() int {
 	return count
 }
 
-// createClient builds an HTTP client.
+// createClient builds an HTTP client with optional TLS configuration.
 // SSRF protection happens at runtime level via security policies.
-func createClient(timeout time.Duration, unixSocket string, maxIdleConns, maxIdlePerHost int, idleConnTimeout time.Duration) *gohttp.Client {
+func createClient(timeout time.Duration, unixSocket string, maxIdleConns, maxIdlePerHost int, idleConnTimeout time.Duration, tlsCfg ...*tls.Config) *gohttp.Client {
 	dialer := &net.Dialer{
 		Timeout:   defaultDialTimeout,
 		KeepAlive: defaultKeepAlive,
@@ -133,6 +253,10 @@ func createClient(timeout time.Duration, unixSocket string, maxIdleConns, maxIdl
 		ExpectContinueTimeout: defaultExpectContinue,
 		ForceAttemptHTTP2:     true,
 		DialContext:           dialer.DialContext,
+	}
+
+	if len(tlsCfg) > 0 && tlsCfg[0] != nil {
+		transport.TLSClientConfig = tlsCfg[0]
 	}
 
 	if unixSocket != "" {

--- a/service/http/client/handler.go
+++ b/service/http/client/handler.go
@@ -194,7 +194,17 @@ func executeRequest(ctx context.Context, pool *Pool, req *httpapi.RequestCmd, al
 		httpReq.SetBasicAuth(req.BasicAuthUser, req.BasicAuthPass)
 	}
 
-	client := pool.GetClient(req.Timeout, req.UnixSocket)
+	var client *gohttp.Client
+	if req.TLS != nil {
+		var tlsErr error
+		client, tlsErr = pool.GetClientWithTLS(req.Timeout, req.UnixSocket, req.TLS)
+		if tlsErr != nil {
+			return httpapi.Response{Error: tlsErr.Error()}
+		}
+	} else {
+		client = pool.GetClient(req.Timeout, req.UnixSocket)
+	}
+
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		// Per Go docs, resp may be non-nil even on error and body needs closing

--- a/service/http/client/handler_test.go
+++ b/service/http/client/handler_test.go
@@ -2,7 +2,15 @@ package client
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
+	"math/big"
 	gohttp "net/http"
 	"net/http/httptest"
 	"strings"
@@ -748,6 +756,739 @@ func TestDispatcher_RequestFileUploadMissingFieldName(t *testing.T) {
 			t.Errorf("unexpected error: %s", resp.Error)
 		}
 	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// generateTestCerts creates a self-signed CA and a client certificate signed by that CA.
+func generateTestCerts(t *testing.T) (caCertPEM, clientCertPEM, clientKeyPEM []byte) {
+	t.Helper()
+
+	// Generate CA key and cert
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	// Generate client key and cert signed by CA
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate client key: %v", err)
+	}
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create client cert: %v", err)
+	}
+
+	clientCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("marshal client key: %v", err)
+	}
+	clientKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER})
+
+	return caCertPEM, clientCertPEM, clientKeyPEM
+}
+
+// newMTLSServer creates an httptest server that requires client certificates signed by the given CA.
+func newMTLSServer(t *testing.T, caCertPEM []byte, handler gohttp.Handler) *httptest.Server {
+	t.Helper()
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCertPEM) {
+		t.Fatal("failed to add CA cert to pool")
+	}
+
+	ts := httptest.NewUnstartedServer(handler)
+	ts.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  caPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	ts.StartTLS()
+	return ts
+}
+
+func TestClientPoolTLSFingerprint(t *testing.T) {
+	cfg1 := &httpapi.TLSConfig{CertPEM: []byte("cert1"), KeyPEM: []byte("key1")}
+	cfg2 := &httpapi.TLSConfig{CertPEM: []byte("cert1"), KeyPEM: []byte("key1")}
+	cfg3 := &httpapi.TLSConfig{CertPEM: []byte("cert2"), KeyPEM: []byte("key2")}
+
+	fp1 := tlsFingerprint(cfg1)
+	fp2 := tlsFingerprint(cfg2)
+	fp3 := tlsFingerprint(cfg3)
+
+	if fp1 != fp2 {
+		t.Error("identical configs produce different fingerprints")
+	}
+	if fp1 == fp3 {
+		t.Error("different configs produce same fingerprint")
+	}
+	if len(fp1) != 64 {
+		t.Errorf("expected 64-char hex fingerprint, got %d", len(fp1))
+	}
+}
+
+func TestClientPoolTLSFingerprintIncludesAllFields(t *testing.T) {
+	base := &httpapi.TLSConfig{
+		CertPEM:    []byte("cert"),
+		KeyPEM:     []byte("key"),
+		CAPEM:      []byte("ca"),
+		ServerName: "example.com",
+	}
+	withInsecure := &httpapi.TLSConfig{
+		CertPEM:            []byte("cert"),
+		KeyPEM:             []byte("key"),
+		CAPEM:              []byte("ca"),
+		ServerName:         "example.com",
+		InsecureSkipVerify: true,
+	}
+	withDifferentSNI := &httpapi.TLSConfig{
+		CertPEM:    []byte("cert"),
+		KeyPEM:     []byte("key"),
+		CAPEM:      []byte("ca"),
+		ServerName: "other.com",
+	}
+
+	fpBase := tlsFingerprint(base)
+	fpInsecure := tlsFingerprint(withInsecure)
+	fpSNI := tlsFingerprint(withDifferentSNI)
+
+	if fpBase == fpInsecure {
+		t.Error("insecure_skip_verify should change fingerprint")
+	}
+	if fpBase == fpSNI {
+		t.Error("different server_name should change fingerprint")
+	}
+}
+
+func TestClientPoolTLSClientReuse(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+	pool := NewClientPool()
+
+	cfg := &httpapi.TLSConfig{CertPEM: clientCert, KeyPEM: clientKey, CAPEM: caCert}
+	c1, err := pool.GetClientWithTLS(0, "", cfg)
+	if err != nil {
+		t.Fatalf("GetClientWithTLS: %v", err)
+	}
+
+	c2, err := pool.GetClientWithTLS(0, "", cfg)
+	if err != nil {
+		t.Fatalf("GetClientWithTLS: %v", err)
+	}
+
+	if c1 != c2 {
+		t.Error("same TLS config should reuse pooled client")
+	}
+}
+
+func TestClientPoolTLSDifferentConfigs(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+	_, clientCert2, clientKey2 := generateTestCerts(t)
+	pool := NewClientPool()
+
+	cfg1 := &httpapi.TLSConfig{CertPEM: clientCert, KeyPEM: clientKey, CAPEM: caCert}
+	cfg2 := &httpapi.TLSConfig{CertPEM: clientCert2, KeyPEM: clientKey2, CAPEM: caCert}
+
+	c1, err := pool.GetClientWithTLS(0, "", cfg1)
+	if err != nil {
+		t.Fatalf("GetClientWithTLS: %v", err)
+	}
+
+	c2, err := pool.GetClientWithTLS(0, "", cfg2)
+	if err != nil {
+		t.Fatalf("GetClientWithTLS: %v", err)
+	}
+
+	if c1 == c2 {
+		t.Error("different TLS configs should create separate clients")
+	}
+}
+
+func TestClientPoolTLSInvalidCert(t *testing.T) {
+	pool := NewClientPool()
+
+	cfg := &httpapi.TLSConfig{CertPEM: []byte("bad"), KeyPEM: []byte("bad")}
+	_, err := pool.GetClientWithTLS(0, "", cfg)
+	if err == nil {
+		t.Error("expected error for invalid cert/key pair")
+	}
+}
+
+func TestClientPoolTLSNilConfig(t *testing.T) {
+	pool := NewClientPool()
+	c1, err := pool.GetClientWithTLS(0, "", nil)
+	if err != nil {
+		t.Fatalf("GetClientWithTLS(nil): %v", err)
+	}
+	c2 := pool.GetClient(0, "")
+	if c1 != c2 {
+		t.Error("nil TLS config should return default client")
+	}
+}
+
+func TestBuildTLSConfigClientCert(t *testing.T) {
+	_, clientCert, clientKey := generateTestCerts(t)
+	cfg, err := buildTLSConfig(&httpapi.TLSConfig{CertPEM: clientCert, KeyPEM: clientKey})
+	if err != nil {
+		t.Fatalf("buildTLSConfig: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("expected 1 certificate, got %d", len(cfg.Certificates))
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Error("expected MinVersion TLS 1.2")
+	}
+}
+
+func TestBuildTLSConfigCA(t *testing.T) {
+	caCert, _, _ := generateTestCerts(t)
+	cfg, err := buildTLSConfig(&httpapi.TLSConfig{CAPEM: caCert})
+	if err != nil {
+		t.Fatalf("buildTLSConfig: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Error("expected RootCAs to be set")
+	}
+}
+
+func TestBuildTLSConfigInvalidCA(t *testing.T) {
+	_, err := buildTLSConfig(&httpapi.TLSConfig{CAPEM: []byte("not a cert")})
+	if err == nil {
+		t.Error("expected error for invalid CA PEM")
+	}
+}
+
+func TestBuildTLSConfigServerName(t *testing.T) {
+	cfg, err := buildTLSConfig(&httpapi.TLSConfig{ServerName: "example.com"})
+	if err != nil {
+		t.Fatalf("buildTLSConfig: %v", err)
+	}
+	if cfg.ServerName != "example.com" {
+		t.Errorf("expected ServerName 'example.com', got %q", cfg.ServerName)
+	}
+}
+
+func TestBuildTLSConfigCertWithoutKey(t *testing.T) {
+	_, err := buildTLSConfig(&httpapi.TLSConfig{CertPEM: []byte("cert-data")})
+	if err == nil {
+		t.Error("expected error for cert without key")
+	}
+	if !strings.Contains(err.Error(), "both cert and key must be provided") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildTLSConfigKeyWithoutCert(t *testing.T) {
+	_, err := buildTLSConfig(&httpapi.TLSConfig{KeyPEM: []byte("key-data")})
+	if err == nil {
+		t.Error("expected error for key without cert")
+	}
+	if !strings.Contains(err.Error(), "both cert and key must be provided") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildTLSConfigInsecure(t *testing.T) {
+	cfg, err := buildTLSConfig(&httpapi.TLSConfig{InsecureSkipVerify: true})
+	if err != nil {
+		t.Fatalf("buildTLSConfig: %v", err)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify true")
+	}
+}
+
+func TestDispatcher_RequestMTLS(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+
+	ts := newMTLSServer(t, caCert, gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			w.WriteHeader(gohttp.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte("mtls-ok"))
+	}))
+	defer ts.Close()
+
+	// Server uses self-signed cert, client needs server's CA too
+	serverCACert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ts.TLS.Certificates[0].Certificate[0],
+	})
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+		TLS: &httpapi.TLSConfig{
+			CertPEM: clientCert,
+			KeyPEM:  clientKey,
+			CAPEM:   serverCACert,
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error != "" {
+			t.Fatalf("response error: %s", resp.Error)
+		}
+		if resp.StatusCode != 200 {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+		if string(resp.Body) != "mtls-ok" {
+			t.Errorf("expected 'mtls-ok', got %q", resp.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestTLSCustomCA(t *testing.T) {
+	// Use a regular TLS server (no client cert required)
+	ts := httptest.NewTLSServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		_, _ = w.Write([]byte("tls-ok"))
+	}))
+	defer ts.Close()
+
+	serverCACert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ts.TLS.Certificates[0].Certificate[0],
+	})
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+		TLS: &httpapi.TLSConfig{
+			CAPEM: serverCACert,
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error != "" {
+			t.Fatalf("response error: %s", resp.Error)
+		}
+		if resp.StatusCode != 200 {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+		if string(resp.Body) != "tls-ok" {
+			t.Errorf("expected 'tls-ok', got %q", resp.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestTLSInvalidCert(t *testing.T) {
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    "https://example.com",
+		TLS: &httpapi.TLSConfig{
+			CertPEM: []byte("bad-cert"),
+			KeyPEM:  []byte("bad-key"),
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error == "" {
+			t.Error("expected error for invalid cert")
+		}
+		if !strings.Contains(resp.Error, "parse client certificate") {
+			t.Errorf("expected cert parse error, got: %s", resp.Error)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestBatchMTLS(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+
+	ts := newMTLSServer(t, caCert, gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		_, _ = w.Write([]byte(r.URL.Path))
+	}))
+	defer ts.Close()
+
+	serverCACert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ts.TLS.Certificates[0].Certificate[0],
+	})
+
+	tlsCfg := &httpapi.TLSConfig{
+		CertPEM: clientCert,
+		KeyPEM:  clientKey,
+		CAPEM:   serverCACert,
+	}
+
+	d := NewDispatcher()
+	done := make(chan httpapi.BatchResponse, 1)
+
+	err := d.handleRequestBatch(context.Background(), &httpapi.RequestBatchCmd{
+		Requests: []*httpapi.RequestCmd{
+			{Method: "GET", URL: ts.URL + "/a", TLS: tlsCfg},
+			{Method: "GET", URL: ts.URL + "/b", TLS: tlsCfg},
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.BatchResponse)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequestBatch: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if len(resp.Responses) != 2 {
+			t.Fatalf("expected 2 responses, got %d", len(resp.Responses))
+		}
+		for i, r := range resp.Responses {
+			if r.Error != "" {
+				t.Errorf("response %d error: %s", i, r.Error)
+			}
+			if r.StatusCode != 200 {
+				t.Errorf("response %d status: %d", i, r.StatusCode)
+			}
+		}
+		if string(resp.Responses[0].Body) != "/a" {
+			t.Errorf("expected '/a', got %q", resp.Responses[0].Body)
+		}
+		if string(resp.Responses[1].Body) != "/b" {
+			t.Errorf("expected '/b', got %q", resp.Responses[1].Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestTLSInsecureSkipVerify(t *testing.T) {
+	ts := httptest.NewTLSServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		_, _ = w.Write([]byte("insecure-ok"))
+	}))
+	defer ts.Close()
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+		TLS: &httpapi.TLSConfig{
+			InsecureSkipVerify: true,
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error != "" {
+			t.Fatalf("response error: %s", resp.Error)
+		}
+		if resp.StatusCode != 200 {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+		if string(resp.Body) != "insecure-ok" {
+			t.Errorf("expected 'insecure-ok', got %q", resp.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestClientPoolTLSConcurrentAccess(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+	pool := NewClientPool()
+	cfg := &httpapi.TLSConfig{CertPEM: clientCert, KeyPEM: clientKey, CAPEM: caCert}
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	clients := make([]*gohttp.Client, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			c, err := pool.GetClientWithTLS(0, "", cfg)
+			if err != nil {
+				t.Errorf("goroutine %d: %v", idx, err)
+				return
+			}
+			clients[idx] = c
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 1; i < goroutines; i++ {
+		if clients[i] != clients[0] {
+			t.Errorf("goroutine %d got different client", i)
+		}
+	}
+}
+
+func TestClientPoolTLSDoesNotAffectNonTLS(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+	pool := NewClientPool()
+
+	defaultClient := pool.GetClient(0, "")
+	cfg := &httpapi.TLSConfig{CertPEM: clientCert, KeyPEM: clientKey, CAPEM: caCert}
+	tlsClient, err := pool.GetClientWithTLS(0, "", cfg)
+	if err != nil {
+		t.Fatalf("GetClientWithTLS: %v", err)
+	}
+	defaultAfter := pool.GetClient(0, "")
+
+	if defaultClient != defaultAfter {
+		t.Error("TLS client creation changed the default client")
+	}
+	if defaultClient == tlsClient {
+		t.Error("TLS client should differ from default client")
+	}
+}
+
+func TestDispatcher_RequestTLSCertWithoutKey(t *testing.T) {
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    "https://example.com",
+		TLS: &httpapi.TLSConfig{
+			CertPEM: []byte("-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----"),
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error == "" {
+			t.Error("expected error for cert without key")
+		}
+		if !strings.Contains(resp.Error, "both cert and key must be provided") {
+			t.Errorf("unexpected error: %s", resp.Error)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestMTLSWrongClientCert(t *testing.T) {
+	caCert, _, _ := generateTestCerts(t)
+	_, wrongCert, wrongKey := generateTestCerts(t)
+
+	ts := newMTLSServer(t, caCert, gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		_, _ = w.Write([]byte("should not reach"))
+	}))
+	defer ts.Close()
+
+	serverCACert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ts.TLS.Certificates[0].Certificate[0],
+	})
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+		TLS: &httpapi.TLSConfig{
+			CertPEM: wrongCert,
+			KeyPEM:  wrongKey,
+			CAPEM:   serverCACert,
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error == "" {
+			t.Error("expected TLS handshake error for wrong client cert")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestTLSWithoutCA(t *testing.T) {
+	ts := httptest.NewTLSServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		_, _ = w.Write([]byte("should not reach"))
+	}))
+	defer ts.Close()
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+		TLS: &httpapi.TLSConfig{
+			ServerName: "127.0.0.1",
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error == "" {
+			t.Error("expected cert verification error without CA")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestTLSServerName(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCerts(t)
+
+	ts := newMTLSServer(t, caCert, gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		_, _ = w.Write([]byte("sni-ok"))
+	}))
+	defer ts.Close()
+
+	serverCACert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ts.TLS.Certificates[0].Certificate[0],
+	})
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+		TLS: &httpapi.TLSConfig{
+			CertPEM:            clientCert,
+			KeyPEM:             clientKey,
+			CAPEM:              serverCACert,
+			InsecureSkipVerify: true,
+			ServerName:         "custom-sni",
+		},
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error != "" {
+			t.Fatalf("response error: %s", resp.Error)
+		}
+		if string(resp.Body) != "sni-ok" {
+			t.Errorf("expected 'sni-ok', got %q", resp.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_RequestNoTLSUnchanged(t *testing.T) {
+	ts := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		_, _ = w.Write([]byte("plain-ok"))
+	}))
+	defer ts.Close()
+
+	d := NewDispatcher()
+	done := make(chan httpapi.Response, 1)
+
+	err := d.handleRequest(context.Background(), &httpapi.RequestCmd{
+		Method: "GET",
+		URL:    ts.URL,
+	}, 0, &testReceiver{fn: func(data any) {
+		done <- data.(httpapi.Response)
+	}})
+
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	select {
+	case resp := <-done:
+		if resp.Error != "" {
+			t.Fatalf("response error: %s", resp.Error)
+		}
+		if string(resp.Body) != "plain-ok" {
+			t.Errorf("expected 'plain-ok', got %q", resp.Body)
+		}
+	case <-time.After(5 * time.Second):
 		t.Fatal("timeout")
 	}
 }


### PR DESCRIPTION
Per-request TLS configuration via tls option table in Lua: cert/key PEM for client certificates, ca PEM for custom CAs, server_name for SNI override, insecure_skip_verify with security policy gate.

TLS-aware client pooling uses SHA256 fingerprint of config material as cache key. PEM parsing deferred to cache miss. Cert-without-key (or vice versa) returns validation error. Empty tls table treated as no TLS config.