### PR TITLE
Add linux-arm64 build target and bump go-lua to v1.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build-wippy-local:
 		./cmd/wippy/
 
 .PHONY: build-wippy-all
-build-wippy-all: build-wippy-linux-amd64 build-wippy-darwin-amd64 build-wippy-darwin-arm64 build-wippy-windows-amd64
+build-wippy-all: build-wippy-linux-amd64 build-wippy-linux-arm64 build-wippy-darwin-amd64 build-wippy-darwin-arm64 build-wippy-windows-amd64
 
 .PHONY: build-wippy-linux-amd64
 build-wippy-linux-amd64:
@@ -85,6 +85,16 @@ build-wippy-linux-amd64:
 		-ldflags="$(WIPPY_LDFLAGS)" \
 		-trimpath \
 		-o ./dist/wippy-linux-amd64 \
+		./cmd/wippy/
+
+.PHONY: build-wippy-linux-arm64
+build-wippy-linux-arm64:
+	mkdir -p ./dist
+	CGO_LDFLAGS="" CGO_CFLAGS="" CC=aarch64-linux-gnu-gcc \
+	CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build --tags "fts5 sqlite_vec" \
+		-ldflags="$(WIPPY_LDFLAGS)" \
+		-trimpath \
+		-o ./dist/wippy-linux-arm64 \
 		./cmd/wippy/
 
 .PHONY: build-wippy-darwin-amd64

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/tree-sitter/tree-sitter-php v0.24.2
 	github.com/tree-sitter/tree-sitter-python v0.25.0
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
-	github.com/wippyai/go-lua v1.5.5
+	github.com/wippyai/go-lua v1.5.6
 	github.com/wippyai/module-registry-proto-go v0.0.1
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,8 @@ github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xf
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/wippyai/go-lua v1.5.5 h1:qfeoArGJZc291XNBmwynY0sZR/3DNAwBEMW0gabRvXA=
 github.com/wippyai/go-lua v1.5.5/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
+github.com/wippyai/go-lua v1.5.6 h1:IYJWVdFqHYeMt1fTcsqptB4INum4gcZlGCwDrFMEo74=
+github.com/wippyai/go-lua v1.5.6/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/module-registry-proto-go v0.0.1 h1:EYnW8MTrI/gs7TJ0ilTVgJal3e0NWmXQigeamrXu0mk=
 github.com/wippyai/module-registry-proto-go v0.0.1/go.mod h1:p4ihYQKRQuqRVLxaH1YL0IEnkz4zKdyfVADOwvA5Tno=
 github.com/wippyai/tree-sitter-markdown v0.0.3 h1:u6e53+hzPSS848Xhm+I48SwtvWQHrC21wDrogdwCwuc=


### PR DESCRIPTION
This pull request improves the build process for the `wippy` project by adding support for building Linux ARM64 binaries and updating a dependency version. The most important changes are:

Build process enhancements:
* Added a new `build-wippy-linux-arm64` target to the `Makefile` to enable building the `wippy` binary for the Linux ARM64 architecture, and updated the `build-wippy-all` target to include this new build. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L79-R79) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R90-R99)

Dependency updates:
* Upgraded the `github.com/wippyai/go-lua` dependency from version `v1.5.5` to `v1.5.6` in `go.mod`.