### PR TITLE
Feature/qos 1

### DIFF
--- a/api/service/terminal/context.go
+++ b/api/service/terminal/context.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	contextapi "github.com/wippyai/runtime/api/context"
+	ttyapi "github.com/wippyai/runtime/api/tty"
 )
 
 var terminalKey = &contextapi.Key{Name: "terminal"}
@@ -18,6 +19,7 @@ func Key() *contextapi.Key {
 // PipeContext holds the standard input/output/error streams for terminal operations.
 type PipeContext struct {
 	Raw    RawController
+	Input  ttyapi.InputController
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer

--- a/api/tty/command.go
+++ b/api/tty/command.go
@@ -4,16 +4,25 @@ package tty
 import "github.com/wippyai/runtime/api/dispatcher"
 
 func init() {
-	dispatcher.MustRegisterCommands("tty", Read, ReadLine, RawEnable, RawDisable)
+	dispatcher.MustRegisterCommands("tty",
+		Read, ReadLine, RawEnable, RawDisable,
+		StartInput, StopInput, ScreenSize,
+		EnableMouse, DisableMouse,
+	)
 }
 
 // Command IDs for terminal I/O.
 // Range 70-79 is reserved for terminal operations.
 const (
-	Read       dispatcher.CommandID = 70 // Read bytes from stdin
-	ReadLine   dispatcher.CommandID = 71 // Read a line from stdin
-	RawEnable  dispatcher.CommandID = 72 // Enable raw terminal mode
-	RawDisable dispatcher.CommandID = 73 // Disable raw terminal mode
+	Read         dispatcher.CommandID = 70 // Read bytes from stdin
+	ReadLine     dispatcher.CommandID = 71 // Read a line from stdin
+	RawEnable    dispatcher.CommandID = 72 // Enable raw terminal mode
+	RawDisable   dispatcher.CommandID = 73 // Disable raw terminal mode
+	StartInput   dispatcher.CommandID = 74 // Start terminal input reader
+	StopInput    dispatcher.CommandID = 75 // Stop terminal input reader
+	ScreenSize   dispatcher.CommandID = 76 // Query terminal screen size
+	EnableMouse  dispatcher.CommandID = 77 // Enable mouse event tracking
+	DisableMouse dispatcher.CommandID = 78 // Disable mouse event tracking
 )
 
 // DefaultReadSize is used when read size is not provided or <= 0.
@@ -51,4 +60,44 @@ type RawDisableCmd struct{}
 // CmdID implements dispatcher.Command.
 func (c RawDisableCmd) CmdID() dispatcher.CommandID {
 	return RawDisable
+}
+
+// StartInputCmd starts the terminal input reader.
+type StartInputCmd struct{}
+
+// CmdID implements dispatcher.Command.
+func (c StartInputCmd) CmdID() dispatcher.CommandID {
+	return StartInput
+}
+
+// StopInputCmd stops the terminal input reader.
+type StopInputCmd struct{}
+
+// CmdID implements dispatcher.Command.
+func (c StopInputCmd) CmdID() dispatcher.CommandID {
+	return StopInput
+}
+
+// ScreenSizeCmd queries the terminal screen size.
+type ScreenSizeCmd struct{}
+
+// CmdID implements dispatcher.Command.
+func (c ScreenSizeCmd) CmdID() dispatcher.CommandID {
+	return ScreenSize
+}
+
+// EnableMouseCmd enables mouse event tracking.
+type EnableMouseCmd struct{}
+
+// CmdID implements dispatcher.Command.
+func (c EnableMouseCmd) CmdID() dispatcher.CommandID {
+	return EnableMouse
+}
+
+// DisableMouseCmd disables mouse event tracking.
+type DisableMouseCmd struct{}
+
+// CmdID implements dispatcher.Command.
+func (c DisableMouseCmd) CmdID() dispatcher.CommandID {
+	return DisableMouse
 }

--- a/api/tty/input.go
+++ b/api/tty/input.go
@@ -1,0 +1,10 @@
+package tty
+
+// InputController manages terminal input event reading.
+type InputController interface {
+	Start() error
+	Stop() error
+	ScreenSize() (cols int, rows int, err error)
+	EnableMouse()
+	DisableMouse()
+}

--- a/boot/components/runtime/lua/all.go
+++ b/boot/components/runtime/lua/all.go
@@ -39,6 +39,7 @@ func All() []boot.Component {
 		Text(),
 		Time(),
 		TreeSitter(),
+		TTY(),
 		UUID(),
 		WebSocket(),
 		Workflow(),

--- a/boot/components/runtime/lua/constants.go
+++ b/boot/components/runtime/lua/constants.go
@@ -35,8 +35,9 @@ const (
 	TimeName         = "lua.time"
 	TreeSitterName   = "lua.treesitter"
 	QueueName        = "lua.queue"
+	TTYName = "lua.tty"
 	// UUIDName is a component name (UpstreamName reserved for future use)
-	UUIDName      = "lua.uuid"
+	UUIDName = "lua.uuid"
 	WorkflowName  = "lua.workflow"
 	WebSocketName = "lua.websocket"
 	YAMLName      = "lua.yaml"

--- a/boot/components/runtime/lua/tty.go
+++ b/boot/components/runtime/lua/tty.go
@@ -1,0 +1,27 @@
+package lua
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/runtime/lua/modules/tty"
+)
+
+func TTY() boot.Component {
+	return boot.New(boot.P{
+		Name:      TTYName,
+		DependsOn: []boot.Name{EngineName},
+		Load: func(ctx context.Context) (context.Context, error) {
+			cm := GetCodeManager(ctx)
+			if cm == nil {
+				return ctx, nil
+			}
+
+			if err := AddModules(ctx, cm, tty.Module); err != nil {
+				return ctx, err
+			}
+
+			return ctx, nil
+		},
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,9 @@ require (
 	github.com/charmbracelet/bubbles v0.21.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.5
+	github.com/charmbracelet/x/input v0.3.7
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/coder/websocket v1.8.14
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/expr-lang/expr v1.17.7
@@ -100,9 +103,8 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.5 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
+	github.com/charmbracelet/x/windows v0.2.1 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,12 @@ github.com/charmbracelet/x/ansi v0.11.5 h1:NBWeBpj/lJPE3Q5l+Lusa4+mH6v7487OP8K0r
 github.com/charmbracelet/x/ansi v0.11.5/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
+github.com/charmbracelet/x/input v0.3.7 h1:UzVbkt1vgM9dBQ+K+uRolBlN6IF2oLchmPKKo/aucXo=
+github.com/charmbracelet/x/input v0.3.7/go.mod h1:ZSS9Cia6Cycf2T6ToKIOxeTBTDwl25AGwArJuGaOBH8=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
+github.com/charmbracelet/x/windows v0.2.1 h1:3x7vnbpQrjpuq/4L+I4gNsG5htYoCiA5oe9hLjAij5I=
+github.com/charmbracelet/x/windows v0.2.1/go.mod h1:ptZp16h40gDYqs5TSawSVW+yiLB13j4kSMA0lSCHL0M=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=
@@ -417,8 +421,6 @@ github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaO
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/wippyai/go-lua v1.5.8 h1:qEkaWlYl6OMd0WmtsgKBBWm/DWkPnAwEM2KFQFKdtRU=
-github.com/wippyai/go-lua v1.5.8/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/go-lua v1.5.9 h1:Kelm+NTo1UOMo0vJBRbHe/tGCsML68BB5rR+7WMPn3E=
 github.com/wippyai/go-lua v1.5.9/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/module-registry-proto-go v0.0.1 h1:EYnW8MTrI/gs7TJ0ilTVgJal3e0NWmXQigeamrXu0mk=

--- a/runtime/lua/modules/system/module.go
+++ b/runtime/lua/modules/system/module.go
@@ -76,9 +76,10 @@ func createRuntimeTable() *lua.LTable {
 }
 
 func createProcessTable() *lua.LTable {
-	t := lua.CreateTable(0, 2)
+	t := lua.CreateTable(0, 3)
 	t.RawSetString("pid", lua.LGoFunc(pid))
 	t.RawSetString("hostname", lua.LGoFunc(hostname))
+	t.RawSetString("cwd", lua.LGoFunc(cwd))
 	t.Immutable = true
 	return t
 }
@@ -325,6 +326,25 @@ func pid(l *lua.LState) int {
 	}
 
 	l.Push(lua.LNumber(os.Getpid()))
+	l.Push(lua.LNil)
+	return 2
+}
+
+func cwd(l *lua.LState) int {
+	if !security.IsAllowed(l.Context(), "system.read", "cwd", nil) {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "permission denied: system.read on cwd").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "get working directory").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	l.Push(lua.LString(dir))
 	l.Push(lua.LNil)
 	return 2
 }

--- a/runtime/lua/modules/system/module_test.go
+++ b/runtime/lua/modules/system/module_test.go
@@ -266,6 +266,25 @@ func TestProcessFunctions(t *testing.T) {
 			t.Errorf("hostname test failed: %v", err)
 		}
 	})
+
+	t.Run("cwd", func(t *testing.T) {
+		expectedCwd, _ := os.Getwd()
+		err := l.DoString(`
+			local dir, err = system.process.cwd()
+			assert(err == nil, "expected nil error")
+			assert(type(dir) == "string", "expected string")
+			assert(#dir > 0, "cwd should not be empty")
+			return dir
+		`)
+		if err != nil {
+			t.Errorf("cwd test failed: %v", err)
+		}
+
+		gotCwd := l.Get(-1).String()
+		if gotCwd != expectedCwd {
+			t.Errorf("expected cwd %q, got %q", expectedCwd, gotCwd)
+		}
+	})
 }
 
 func TestSupervisorFunctions(t *testing.T) {

--- a/runtime/lua/modules/system/types.go
+++ b/runtime/lua/modules/system/types.go
@@ -58,6 +58,7 @@ var runtimeType = typ.NewInterface("system.runtime", []typ.Method{
 var processSubType = typ.NewInterface("system.process", []typ.Method{
 	{Name: "pid", Type: typ.Func().Returns(typ.Number, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "hostname", Type: typ.Func().Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "cwd", Type: typ.Func().Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 })
 
 // supervisor submodule type

--- a/runtime/lua/modules/tty/handler.go
+++ b/runtime/lua/modules/tty/handler.go
@@ -1,0 +1,57 @@
+package tty
+
+import (
+	"context"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/service/terminal"
+)
+
+// eventHandler converts TTYEvent Go structs to Lua tables for channel delivery.
+func eventHandler(_ context.Context, l *lua.LState, _ pid.PID, _ string, payloads []payload.Payload) lua.LValue {
+	if len(payloads) == 0 {
+		return lua.LNil
+	}
+
+	p := payloads[0]
+	ev, ok := p.Data().(*terminal.TTYEvent)
+	if !ok {
+		return lua.LNil
+	}
+
+	tbl := l.CreateTable(0, 12)
+	tbl.RawSetString("type", lua.LString(ev.Type))
+
+	switch ev.Type {
+	case "key":
+		tbl.RawSetString("key", lua.LString(ev.Key))
+		tbl.RawSetString("key_type", lua.LString(ev.KeyType))
+		tbl.RawSetString("action", lua.LString(ev.Action))
+		tbl.RawSetString("alt", lua.LBool(ev.Alt))
+		tbl.RawSetString("ctrl", lua.LBool(ev.Ctrl))
+		tbl.RawSetString("shift", lua.LBool(ev.Shift))
+
+	case "mouse":
+		tbl.RawSetString("action", lua.LString(ev.Action))
+		tbl.RawSetString("button", lua.LString(ev.Button))
+		tbl.RawSetString("x", lua.LNumber(ev.X))
+		tbl.RawSetString("y", lua.LNumber(ev.Y))
+		tbl.RawSetString("alt", lua.LBool(ev.Alt))
+		tbl.RawSetString("ctrl", lua.LBool(ev.Ctrl))
+		tbl.RawSetString("shift", lua.LBool(ev.Shift))
+
+	case "resize", "start":
+		tbl.RawSetString("width", lua.LNumber(ev.Width))
+		tbl.RawSetString("height", lua.LNumber(ev.Height))
+
+	case "focus":
+		tbl.RawSetString("focused", lua.LBool(ev.Focused))
+
+	case "paste":
+		tbl.RawSetString("text", lua.LString(ev.Paste))
+	}
+
+	return tbl
+}

--- a/runtime/lua/modules/tty/key_binding.go
+++ b/runtime/lua/modules/tty/key_binding.go
@@ -1,0 +1,179 @@
+package tty
+
+import (
+	"strings"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+const keyBindingTypeName = "tty.KeyBinding"
+
+func init() {
+	value.RegisterTypeMethods(nil, keyBindingTypeName,
+		map[string]lua.LGoFunc{"__tostring": keyBindingToString},
+		map[string]lua.LGoFunc{
+			"matches":     keyBindingMatches,
+			"set_enabled": keyBindingSetEnabled,
+			"is_enabled":  keyBindingIsEnabled,
+			"help":        keyBindingHelp,
+		})
+}
+
+type keyBinding struct {
+	keys     []string
+	helpKey  string
+	helpDesc string
+	enabled  bool
+}
+
+func checkKeyBinding(l *lua.LState) *keyBinding {
+	ud := l.CheckUserData(1)
+	if kb, ok := ud.Value.(*keyBinding); ok {
+		return kb
+	}
+	l.ArgError(1, "tty.KeyBinding expected")
+	return nil
+}
+
+// ttyBind creates a key binding from a table:
+// tty.bind({keys = {"q", "ctrl+c"}, help = {key = "q", desc = "quit"}})
+func ttyBind(l *lua.LState) int {
+	tbl := l.CheckTable(1)
+
+	kb := &keyBinding{enabled: true}
+
+	// Read keys
+	keysVal := tbl.RawGetString("keys")
+	if keysTbl, ok := keysVal.(*lua.LTable); ok {
+		keysTbl.ForEach(func(_, v lua.LValue) {
+			if s, ok := v.(lua.LString); ok {
+				kb.keys = append(kb.keys, string(s))
+			}
+		})
+	}
+
+	// Read help
+	helpVal := tbl.RawGetString("help")
+	if helpTbl, ok := helpVal.(*lua.LTable); ok {
+		if v := helpTbl.RawGetString("key"); v != lua.LNil {
+			kb.helpKey = v.String()
+		}
+		if v := helpTbl.RawGetString("desc"); v != lua.LNil {
+			kb.helpDesc = v.String()
+		}
+	}
+
+	value.PushTypedUserData(l, kb, keyBindingTypeName)
+	return 1
+}
+
+func keyBindingToString(l *lua.LState) int {
+	kb := checkKeyBinding(l)
+	if kb == nil {
+		return 0
+	}
+	l.Push(lua.LString("tty.KeyBinding{" + strings.Join(kb.keys, ", ") + "}"))
+	return 1
+}
+
+// keyBindingMatches checks if an event table matches this binding.
+// event must have: type="key", key or key_type fields, and modifier fields.
+func keyBindingMatches(l *lua.LState) int {
+	kb := checkKeyBinding(l)
+	if kb == nil {
+		return 0
+	}
+
+	if !kb.enabled {
+		l.Push(lua.LFalse)
+		return 1
+	}
+
+	eventTbl := l.CheckTable(2)
+
+	// Only match key events
+	evType := eventTbl.RawGetString("type")
+	if evType.String() != "key" {
+		l.Push(lua.LFalse)
+		return 1
+	}
+
+	evKey := eventTbl.RawGetString("key").String()
+	evKeyType := eventTbl.RawGetString("key_type").String()
+	evCtrl := lua.LVAsBool(eventTbl.RawGetString("ctrl"))
+	evAlt := lua.LVAsBool(eventTbl.RawGetString("alt"))
+	evShift := lua.LVAsBool(eventTbl.RawGetString("shift"))
+
+	// Build the keystroke string from the event
+	keystroke := buildKeystroke(evKey, evKeyType, evCtrl, evAlt, evShift)
+
+	for _, bindKey := range kb.keys {
+		if bindKey == keystroke {
+			l.Push(lua.LTrue)
+			return 1
+		}
+		// Also match against plain key name for simple bindings
+		if bindKey == evKey || bindKey == evKeyType {
+			l.Push(lua.LTrue)
+			return 1
+		}
+	}
+
+	l.Push(lua.LFalse)
+	return 1
+}
+
+func keyBindingSetEnabled(l *lua.LState) int {
+	kb := checkKeyBinding(l)
+	if kb == nil {
+		return 0
+	}
+	kb.enabled = l.CheckBool(2)
+	l.Push(l.Get(1))
+	return 1
+}
+
+func keyBindingIsEnabled(l *lua.LState) int {
+	kb := checkKeyBinding(l)
+	if kb == nil {
+		return 0
+	}
+	l.Push(lua.LBool(kb.enabled))
+	return 1
+}
+
+func keyBindingHelp(l *lua.LState) int {
+	kb := checkKeyBinding(l)
+	if kb == nil {
+		return 0
+	}
+	tbl := l.CreateTable(0, 2)
+	tbl.RawSetString("key", lua.LString(kb.helpKey))
+	tbl.RawSetString("desc", lua.LString(kb.helpDesc))
+	l.Push(tbl)
+	return 1
+}
+
+// buildKeystroke constructs a keystroke string like "ctrl+c" from event fields.
+func buildKeystroke(key, keyType string, ctrl, alt, shift bool) string {
+	var sb strings.Builder
+	if ctrl {
+		sb.WriteString("ctrl+")
+	}
+	if alt {
+		sb.WriteString("alt+")
+	}
+	if shift {
+		sb.WriteString("shift+")
+	}
+
+	// Use key_type for special keys, key for printable chars
+	if keyType != "runes" && keyType != "" && keyType != "unknown" {
+		sb.WriteString(keyType)
+	} else {
+		sb.WriteString(key)
+	}
+
+	return sb.String()
+}

--- a/runtime/lua/modules/tty/module.go
+++ b/runtime/lua/modules/tty/module.go
@@ -1,0 +1,224 @@
+// Package tty provides terminal input events, styles, and rendering for Lua scripts.
+package tty
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/runtime"
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/api/service/terminal"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	svcterm "github.com/wippyai/runtime/service/terminal"
+)
+
+// Module is the tty module definition.
+var Module = &luaapi.ModuleDef{
+	Name:        "tty",
+	Description: "Terminal input events, styles, and rendering",
+	Class:       []string{luaapi.ClassIO, luaapi.ClassNondeterministic},
+	Build:       buildModule,
+	Types:       ModuleTypes,
+}
+
+func buildModule() (*lua.LTable, []luaapi.YieldType) {
+	// Force TrueColor so lipgloss renders properly in terminal processes
+	lipgloss.SetColorProfile(termenv.TrueColor)
+
+	mod := lua.CreateTable(0, 12)
+
+	// Input event functions
+	mod.RawSetString("start", lua.LGoFunc(ttyStart))
+	mod.RawSetString("stop", lua.LGoFunc(ttyStop))
+	mod.RawSetString("screen_size", lua.LGoFunc(ttyScreenSize))
+	mod.RawSetString("events", lua.LGoFunc(ttyEvents))
+	mod.RawSetString("mouse", lua.LGoFunc(ttyMouse))
+
+	// Style
+	mod.RawSetString("style", lua.LGoFunc(ttyStyleNew))
+
+	// Border constants
+	borders := lua.CreateTable(0, 5)
+	borders.RawSetString("NORMAL", lua.LString("normal"))
+	borders.RawSetString("ROUNDED", lua.LString("rounded"))
+	borders.RawSetString("THICK", lua.LString("thick"))
+	borders.RawSetString("DOUBLE", lua.LString("double"))
+	borders.RawSetString("HIDDEN", lua.LString("hidden"))
+	borders.Immutable = true
+	mod.RawSetString("borders", borders)
+
+	// Alignment constants
+	align := lua.CreateTable(0, 3)
+	align.RawSetString("LEFT", lua.LNumber(0))
+	align.RawSetString("CENTER", lua.LNumber(0.5))
+	align.RawSetString("RIGHT", lua.LNumber(1))
+	align.Immutable = true
+	mod.RawSetString("align", align)
+
+	// Text utilities
+	text := lua.CreateTable(0, 11)
+	text.RawSetString("width", lua.LGoFunc(textWidth))
+	text.RawSetString("height", lua.LGoFunc(textHeight))
+	text.RawSetString("size", lua.LGoFunc(textSize))
+	text.RawSetString("join_horizontal", lua.LGoFunc(textJoinHorizontal))
+	text.RawSetString("join_vertical", lua.LGoFunc(textJoinVertical))
+	text.RawSetString("max_width", lua.LGoFunc(textMaxWidth))
+	text.RawSetString("max_height", lua.LGoFunc(textMaxHeight))
+	text.RawSetString("place", lua.LGoFunc(textPlace))
+	text.RawSetString("place_horizontal", lua.LGoFunc(textPlaceHorizontal))
+	text.RawSetString("place_vertical", lua.LGoFunc(textPlaceVertical))
+
+	pos := lua.CreateTable(0, 5)
+	pos.RawSetString("TOP", lua.LNumber(0))
+	pos.RawSetString("LEFT", lua.LNumber(0))
+	pos.RawSetString("CENTER", lua.LNumber(0.5))
+	pos.RawSetString("BOTTOM", lua.LNumber(1))
+	pos.RawSetString("RIGHT", lua.LNumber(1))
+	pos.Immutable = true
+	text.RawSetString("position", pos)
+	text.Immutable = true
+	mod.RawSetString("text", text)
+
+	// Key binding
+	mod.RawSetString("bind", lua.LGoFunc(ttyBind))
+
+	mod.Immutable = true
+
+	yields := make([]luaapi.YieldType, len(yieldTypes))
+	for i, yt := range yieldTypes {
+		yields[i] = luaapi.YieldType{Sample: yt.Sample, CmdID: yt.CmdID}
+	}
+
+	return mod, yields
+}
+
+// ttyStart starts the terminal input reader (yielding).
+func ttyStart(l *lua.LState) int {
+	tc := terminal.GetTerminalContext(l.Context())
+	if tc == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no terminal context").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	if tc.Input == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "input controller unavailable").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	yield := AcquireStartInputYield()
+	l.Push(yield)
+	return -1
+}
+
+// ttyStop stops the terminal input reader (yielding).
+func ttyStop(l *lua.LState) int {
+	tc := terminal.GetTerminalContext(l.Context())
+	if tc == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no terminal context").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	if tc.Input == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "input controller unavailable").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	yield := AcquireStopInputYield()
+	l.Push(yield)
+	return -1
+}
+
+// ttyScreenSize queries the terminal screen size (yielding).
+func ttyScreenSize(l *lua.LState) int {
+	tc := terminal.GetTerminalContext(l.Context())
+	if tc == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no terminal context").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 3
+	}
+	if tc.Input == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "input controller unavailable").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 3
+	}
+
+	yield := AcquireScreenSizeYield()
+	l.Push(yield)
+	return -1
+}
+
+// ttyMouse enables or disables mouse event tracking (yielding).
+func ttyMouse(l *lua.LState) int {
+	tc := terminal.GetTerminalContext(l.Context())
+	if tc == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no terminal context").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	if tc.Input == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "input controller unavailable").
+			WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	enable := l.CheckBool(1)
+	if enable {
+		yield := AcquireEnableMouseYield()
+		l.Push(yield)
+	} else {
+		yield := AcquireDisableMouseYield()
+		l.Push(yield)
+	}
+	return -1
+}
+
+// ttyEvents subscribes to the @tty/events topic and returns a channel.
+func ttyEvents(l *lua.LState) int {
+	ctx := l.Context()
+	if ctx == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no context").
+			WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	_, ok := runtime.GetFramePID(ctx)
+	if !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no process PID").
+			WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	proc := engine.GetProcess(l)
+	if proc == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no process context").
+			WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	ch := engine.NewChannel(64)
+
+	if err := proc.SubscribeExisting(svcterm.TopicTTYEvents, ch); err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "subscribe tty events"))
+		return 2
+	}
+
+	proc.SetTopicHandler(svcterm.TopicTTYEvents, eventHandler)
+	engine.PushChannel(l, ch)
+	return 1
+}

--- a/runtime/lua/modules/tty/module_test.go
+++ b/runtime/lua/modules/tty/module_test.go
@@ -1,0 +1,1496 @@
+package tty
+
+import (
+	"errors"
+	"testing"
+
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/service/terminal"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	svcterm "github.com/wippyai/runtime/service/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bindTTY(l *lua.LState) {
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+}
+
+func TestModuleInfo(t *testing.T) {
+	info := Module.Info()
+	assert.Equal(t, "tty", info.Name)
+	assert.NotEmpty(t, info.Description)
+}
+
+func TestModuleBuild(t *testing.T) {
+	tbl, yields := Module.Build()
+	require.NotNil(t, tbl)
+	assert.Equal(t, 5, len(yields))
+}
+
+func TestYieldTypes(t *testing.T) {
+	_, yields := Module.Build()
+
+	expectedCmds := map[int]bool{
+		int(ttyapi.StartInput):   false,
+		int(ttyapi.StopInput):    false,
+		int(ttyapi.ScreenSize):   false,
+		int(ttyapi.EnableMouse):  false,
+		int(ttyapi.DisableMouse): false,
+	}
+
+	for _, y := range yields {
+		cmdID := int(y.CmdID)
+		if _, ok := expectedCmds[cmdID]; ok {
+			expectedCmds[cmdID] = true
+		}
+	}
+
+	for cmdID, found := range expectedCmds {
+		if !found {
+			t.Errorf("missing yield type for command ID %d", cmdID)
+		}
+	}
+}
+
+func TestModuleFunctions(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	mod := l.GetGlobal("tty")
+	require.Equal(t, lua.LTTable, mod.Type())
+
+	modTbl := mod.(*lua.LTable)
+	funcs := []string{"start", "stop", "screen_size", "events", "style", "bind"}
+	for _, name := range funcs {
+		assert.Equal(t, lua.LTFunction, modTbl.RawGetString(name).Type(), "missing function: %s", name)
+	}
+}
+
+func TestModuleConstants(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	mod := l.GetGlobal("tty").(*lua.LTable)
+
+	// Borders
+	borders := mod.RawGetString("borders")
+	require.Equal(t, lua.LTTable, borders.Type())
+	borderTbl := borders.(*lua.LTable)
+	assert.Equal(t, "normal", borderTbl.RawGetString("NORMAL").String())
+	assert.Equal(t, "rounded", borderTbl.RawGetString("ROUNDED").String())
+	assert.Equal(t, "thick", borderTbl.RawGetString("THICK").String())
+	assert.Equal(t, "double", borderTbl.RawGetString("DOUBLE").String())
+
+	// Align
+	align := mod.RawGetString("align")
+	require.Equal(t, lua.LTTable, align.Type())
+	alignTbl := align.(*lua.LTable)
+	assert.Equal(t, lua.LNumber(0), alignTbl.RawGetString("LEFT"))
+	assert.Equal(t, lua.LNumber(0.5), alignTbl.RawGetString("CENTER"))
+	assert.Equal(t, lua.LNumber(1), alignTbl.RawGetString("RIGHT"))
+
+	// Text utilities and position
+	text := mod.RawGetString("text")
+	require.Equal(t, lua.LTTable, text.Type())
+	textTbl := text.(*lua.LTable)
+	assert.Equal(t, lua.LTFunction, textTbl.RawGetString("width").Type())
+	assert.Equal(t, lua.LTFunction, textTbl.RawGetString("join_horizontal").Type())
+
+	pos := textTbl.RawGetString("position")
+	require.Equal(t, lua.LTTable, pos.Type())
+}
+
+// Stub InputController for testing
+type stubInputController struct {
+	startErr  error
+	stopErr   error
+	sizeCols  int
+	sizeRows  int
+	sizeErr   error
+	startCalls int
+	stopCalls  int
+}
+
+func (s *stubInputController) Start() error {
+	s.startCalls++
+	return s.startErr
+}
+
+func (s *stubInputController) Stop() error {
+	s.stopCalls++
+	return s.stopErr
+}
+
+func (s *stubInputController) ScreenSize() (int, int, error) {
+	return s.sizeCols, s.sizeRows, s.sizeErr
+}
+
+func (s *stubInputController) EnableMouse()  {}
+func (s *stubInputController) DisableMouse() {}
+
+func TestTTYStart_NoContext(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	ret := ttyStart(l)
+	assert.Equal(t, 2, ret)
+	assert.Equal(t, lua.LNil, l.Get(1))
+}
+
+func TestTTYStart_NoInputController(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	_ = terminal.WithTerminalContext(ctx, tc)
+	l.SetContext(ctx)
+
+	ret := ttyStart(l)
+	assert.Equal(t, 2, ret)
+	assert.Equal(t, lua.LNil, l.Get(1))
+}
+
+func TestTTYStart_WithInputController(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	tc.Input = &stubInputController{}
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	_ = terminal.WithTerminalContext(ctx, tc)
+	l.SetContext(ctx)
+
+	ret := ttyStart(l)
+	assert.Equal(t, -1, ret)
+	_, ok := l.Get(1).(*StartInputYield)
+	assert.True(t, ok)
+}
+
+func TestTTYStop_WithInputController(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	tc.Input = &stubInputController{}
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	_ = terminal.WithTerminalContext(ctx, tc)
+	l.SetContext(ctx)
+
+	ret := ttyStop(l)
+	assert.Equal(t, -1, ret)
+	_, ok := l.Get(1).(*StopInputYield)
+	assert.True(t, ok)
+}
+
+func TestTTYScreenSize_WithInputController(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	tc.Input = &stubInputController{}
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	_ = terminal.WithTerminalContext(ctx, tc)
+	l.SetContext(ctx)
+
+	ret := ttyScreenSize(l)
+	assert.Equal(t, -1, ret)
+	_, ok := l.Get(1).(*ScreenSizeYield)
+	assert.True(t, ok)
+}
+
+func TestStartInputYield(t *testing.T) {
+	y := AcquireStartInputYield()
+	assert.Equal(t, ttyapi.StartInput, y.CmdID())
+	assert.Equal(t, ttyapi.StartInput, y.ToCommand().CmdID())
+	assert.Contains(t, y.String(), "start_input")
+	assert.Equal(t, lua.LTUserData, y.Type())
+	ReleaseStartInputYield(y)
+}
+
+func TestStopInputYield(t *testing.T) {
+	y := AcquireStopInputYield()
+	assert.Equal(t, ttyapi.StopInput, y.CmdID())
+	assert.Equal(t, ttyapi.StopInput, y.ToCommand().CmdID())
+	ReleaseStopInputYield(y)
+}
+
+func TestScreenSizeYield(t *testing.T) {
+	y := AcquireScreenSizeYield()
+	assert.Equal(t, ttyapi.ScreenSize, y.CmdID())
+	assert.Equal(t, ttyapi.ScreenSize, y.ToCommand().CmdID())
+	ReleaseScreenSizeYield(y)
+}
+
+func TestStartInputYield_HandleResult_Success(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireStartInputYield()
+	values := y.HandleResult(l, true, nil)
+	assert.Equal(t, lua.LTrue, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+	ReleaseStartInputYield(y)
+}
+
+func TestStartInputYield_HandleResult_Error(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireStartInputYield()
+	values := y.HandleResult(l, nil, errors.New("failed"))
+	assert.Equal(t, lua.LNil, values[0])
+	assert.NotEqual(t, lua.LNil, values[1])
+	ReleaseStartInputYield(y)
+}
+
+func TestScreenSizeYield_HandleResult_Success(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireScreenSizeYield()
+	values := y.HandleResult(l, []int{80, 24}, nil)
+	assert.Equal(t, lua.LNumber(80), values[0])
+	assert.Equal(t, lua.LNumber(24), values[1])
+	assert.Equal(t, lua.LNil, values[2])
+	ReleaseScreenSizeYield(y)
+}
+
+func TestScreenSizeYield_HandleResult_Error(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireScreenSizeYield()
+	values := y.HandleResult(l, nil, errors.New("no terminal"))
+	assert.Equal(t, lua.LNil, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+	assert.NotEqual(t, lua.LNil, values[2])
+	ReleaseScreenSizeYield(y)
+}
+
+func TestEventHandler_KeyEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{
+		Type:    "key",
+		Key:     "a",
+		KeyType: "runes",
+		Ctrl:    true,
+	}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	require.NotNil(t, result)
+
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "key", tbl.RawGetString("type").String())
+	assert.Equal(t, "a", tbl.RawGetString("key").String())
+	assert.Equal(t, "runes", tbl.RawGetString("key_type").String())
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("ctrl"))
+	assert.Equal(t, lua.LFalse, tbl.RawGetString("alt"))
+}
+
+func TestEventHandler_MouseEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{
+		Type:   "mouse",
+		Action: "press",
+		Button: "left",
+		X:      10,
+		Y:      20,
+	}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "mouse", tbl.RawGetString("type").String())
+	assert.Equal(t, "press", tbl.RawGetString("action").String())
+	assert.Equal(t, "left", tbl.RawGetString("button").String())
+	assert.Equal(t, lua.LNumber(10), tbl.RawGetString("x"))
+	assert.Equal(t, lua.LNumber(20), tbl.RawGetString("y"))
+}
+
+func TestEventHandler_ResizeEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{
+		Type:   "resize",
+		Width:  120,
+		Height: 40,
+	}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "resize", tbl.RawGetString("type").String())
+	assert.Equal(t, lua.LNumber(120), tbl.RawGetString("width"))
+	assert.Equal(t, lua.LNumber(40), tbl.RawGetString("height"))
+}
+
+func TestEventHandler_FocusEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{Type: "focus", Focused: true}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "focus", tbl.RawGetString("type").String())
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("focused"))
+}
+
+func TestEventHandler_PasteEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{Type: "paste", Paste: "hello world"}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "paste", tbl.RawGetString("type").String())
+	assert.Equal(t, "hello world", tbl.RawGetString("text").String())
+}
+
+func TestEventHandler_EmptyPayloads(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	result := eventHandler(nil, l, pid.PID{}, "", nil)
+	assert.Equal(t, lua.LNil, result)
+}
+
+func TestEventHandler_WrongPayloadType(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	payloads := []payload.Payload{payload.New("not a TTYEvent")}
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	assert.Equal(t, lua.LNil, result)
+}
+
+func TestStyle_Create(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local s = tty.style()
+		if s == nil then error("style should not be nil") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Render(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local s = tty.style()
+		local result = s:render("hello")
+		if result == nil or result == "" then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Chainable(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local s = tty.style()
+			:bold()
+			:italic()
+			:underline()
+			:foreground("#FF0000")
+			:background("#000000")
+			:padding(1, 2)
+			:margin(1)
+			:width(40)
+			:height(5)
+			:max_width(80)
+			:max_height(10)
+			:align(tty.align.CENTER)
+		local result = s:render("test")
+		if result == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Border(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local s = tty.style()
+			:border("rounded")
+			:border_foreground("#888888")
+		local result = s:render("boxed")
+		if result == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Copy(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local s1 = tty.style():width(10)
+		local s2 = s1:copy():width(20)
+		local r1 = s1:render("a")
+		local r2 = s2:render("a")
+		if r1 == r2 then error("copy should create independent style") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_ValueSemantics(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+
+		-- Chainable methods return new styles without mutating the original
+		local base = tty.style():foreground("#FF0000")
+		local derived = base:width(20)
+		local r1 = base:render("test")
+		local r2 = derived:render("test")
+		if r1 == r2 then error("method should return new style, not mutate original") end
+
+		-- Shared style reused with different parameters produces independent results
+		local shared = tty.style():foreground("#FF0000")
+		local a = shared:width(10):render("x")
+		local b = shared:width(20):render("x")
+		if a == b then error("reuse with different width should produce different results") end
+
+		-- Original shared style remains unaffected after derived usage
+		local before = shared:render("y")
+		local _ = shared:bold():italic():width(50):render("z")
+		local after = shared:render("y")
+		if before ~= after then error("original style was mutated by chained calls") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_Width(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local w = tty.text.width("hello")
+		if w ~= 5 then error("expected width 5, got " .. w) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_Height(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local h = tty.text.height("line1\nline2\nline3")
+		if h ~= 3 then error("expected height 3, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_Size(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local w, h = tty.text.size("hello\nworld!")
+		if w ~= 6 then error("expected width 6, got " .. w) end
+		if h ~= 2 then error("expected height 2, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_JoinHorizontal(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.join_horizontal(tty.text.position.CENTER, "left", "right")
+		if result == nil or result == "" then error("join should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_JoinVertical(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.join_vertical(tty.text.position.LEFT, "top", "bottom")
+		if result == nil or result == "" then error("join should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_MaxWidth(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local max = tty.text.max_width({"short", "much longer string"})
+		if max ~= 18 then error("expected max width 18, got " .. max) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_MaxHeight(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local max = tty.text.max_height({"one", "one\ntwo\nthree"})
+		if max ~= 3 then error("expected max height 3, got " .. max) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_Create(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local kb = tty.bind({keys = {"q", "ctrl+c"}, help = {key = "q", desc = "quit"}})
+		if kb == nil then error("keybinding should not be nil") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_Matches(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local kb = tty.bind({keys = {"q", "ctrl+c"}, help = {key = "q", desc = "quit"}})
+
+		-- Match by key
+		local event = {type = "key", key = "q", key_type = "runes", ctrl = false, alt = false, shift = false}
+		if not kb:matches(event) then error("should match 'q'") end
+
+		-- Match by keystroke
+		local ctrl_c = {type = "key", key = "c", key_type = "runes", ctrl = true, alt = false, shift = false}
+		if not kb:matches(ctrl_c) then error("should match 'ctrl+c'") end
+
+		-- No match
+		local other = {type = "key", key = "x", key_type = "runes", ctrl = false, alt = false, shift = false}
+		if kb:matches(other) then error("should not match 'x'") end
+
+		-- Not a key event
+		local mouse = {type = "mouse", action = "press"}
+		if kb:matches(mouse) then error("should not match mouse events") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_EnableDisable(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local kb = tty.bind({keys = {"q"}, help = {key = "q", desc = "quit"}})
+
+		if not kb:is_enabled() then error("should be enabled by default") end
+
+		kb:set_enabled(false)
+		if kb:is_enabled() then error("should be disabled") end
+
+		local event = {type = "key", key = "q", key_type = "runes", ctrl = false, alt = false, shift = false}
+		if kb:matches(event) then error("disabled binding should not match") end
+
+		kb:set_enabled(true)
+		if not kb:matches(event) then error("re-enabled binding should match") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_Help(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local kb = tty.bind({keys = {"q"}, help = {key = "q", desc = "quit"}})
+		local h = kb:help()
+		if h.key ~= "q" then error("expected help key 'q'") end
+		if h.desc ~= "quit" then error("expected help desc 'quit'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_SpecialKeyMatches(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local kb = tty.bind({keys = {"esc", "enter"}, help = {key = "esc", desc = "cancel"}})
+
+		local esc = {type = "key", key = "esc", key_type = "esc", ctrl = false, alt = false, shift = false}
+		if not kb:matches(esc) then error("should match 'esc'") end
+
+		local enter = {type = "key", key = "enter", key_type = "enter", ctrl = false, alt = false, shift = false}
+		if not kb:matches(enter) then error("should match 'enter'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestModuleTypes(t *testing.T) {
+	m := ModuleTypes()
+	require.NotNil(t, m)
+	assert.NotNil(t, m.Export)
+}
+
+// --- Yield HandleResult edge cases ---
+
+func TestStopInputYield_HandleResult_Success(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireStopInputYield()
+	values := y.HandleResult(l, true, nil)
+	assert.Equal(t, lua.LTrue, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+	ReleaseStopInputYield(y)
+}
+
+func TestStopInputYield_HandleResult_Error(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireStopInputYield()
+	values := y.HandleResult(l, nil, errors.New("stop failed"))
+	assert.Equal(t, lua.LNil, values[0])
+	assert.NotEqual(t, lua.LNil, values[1])
+	ReleaseStopInputYield(y)
+}
+
+func TestStopInputYield_StringAndType(t *testing.T) {
+	y := AcquireStopInputYield()
+	defer ReleaseStopInputYield(y)
+
+	assert.Contains(t, y.String(), "stop_input")
+	assert.Equal(t, lua.LTUserData, y.Type())
+}
+
+func TestScreenSizeYield_StringAndType(t *testing.T) {
+	y := AcquireScreenSizeYield()
+	defer ReleaseScreenSizeYield(y)
+
+	assert.Contains(t, y.String(), "screen_size")
+	assert.Equal(t, lua.LTUserData, y.Type())
+}
+
+func TestScreenSizeYield_HandleResult_InvalidLength(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireScreenSizeYield()
+	values := y.HandleResult(l, []int{80}, nil)
+	assert.Equal(t, lua.LNil, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+	assert.NotEqual(t, lua.LNil, values[2])
+	ReleaseScreenSizeYield(y)
+}
+
+func TestScreenSizeYield_HandleResult_WrongType(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireScreenSizeYield()
+	values := y.HandleResult(l, "not a slice", nil)
+	assert.Equal(t, lua.LNil, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+	assert.NotEqual(t, lua.LNil, values[2])
+	ReleaseScreenSizeYield(y)
+}
+
+func TestHandleBoolResult_NilData(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	values := handleBoolResult(l, nil, nil, "test")
+	assert.Equal(t, lua.LTrue, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+}
+
+func TestHandleBoolResult_FalseValue(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	values := handleBoolResult(l, false, nil, "test")
+	assert.Equal(t, lua.LFalse, values[0])
+	assert.Equal(t, lua.LNil, values[1])
+}
+
+func TestHandleBoolResult_InvalidType(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	values := handleBoolResult(l, "not a bool", nil, "test")
+	assert.Equal(t, lua.LNil, values[0])
+	assert.NotEqual(t, lua.LNil, values[1])
+}
+
+// --- ttyStop / ttyScreenSize no-context paths ---
+
+func TestTTYStop_NoContext(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	ret := ttyStop(l)
+	assert.Equal(t, 2, ret)
+	assert.Equal(t, lua.LNil, l.Get(1))
+}
+
+func TestTTYStop_NoInputController(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	_ = terminal.WithTerminalContext(ctx, tc)
+	l.SetContext(ctx)
+
+	ret := ttyStop(l)
+	assert.Equal(t, 2, ret)
+	assert.Equal(t, lua.LNil, l.Get(1))
+}
+
+func TestTTYScreenSize_NoContext(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	ret := ttyScreenSize(l)
+	assert.Equal(t, 3, ret)
+	assert.Equal(t, lua.LNil, l.Get(1))
+	assert.Equal(t, lua.LNil, l.Get(2))
+}
+
+func TestTTYScreenSize_NoInputController(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	l.SetTop(0)
+
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	_ = terminal.WithTerminalContext(ctx, tc)
+	l.SetContext(ctx)
+
+	ret := ttyScreenSize(l)
+	assert.Equal(t, 3, ret)
+	assert.Equal(t, lua.LNil, l.Get(1))
+	assert.Equal(t, lua.LNil, l.Get(2))
+}
+
+// --- Event handler edge cases ---
+
+func TestEventHandler_StartEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{Type: "start", Width: 80, Height: 24}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "start", tbl.RawGetString("type").String())
+	assert.Equal(t, lua.LNumber(80), tbl.RawGetString("width"))
+	assert.Equal(t, lua.LNumber(24), tbl.RawGetString("height"))
+}
+
+func TestEventHandler_FocusBlurEvent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	blur := &svcterm.TTYEvent{Type: "focus", Focused: false}
+	payloads := []payload.Payload{payload.New(blur)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, lua.LFalse, tbl.RawGetString("focused"))
+}
+
+func TestEventHandler_MouseWithModifiers(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{
+		Type:   "mouse",
+		Action: "motion",
+		Button: "middle",
+		X:      5,
+		Y:      10,
+		Alt:    true,
+		Ctrl:   false,
+		Shift:  true,
+	}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, "motion", tbl.RawGetString("action").String())
+	assert.Equal(t, "middle", tbl.RawGetString("button").String())
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("alt"))
+	assert.Equal(t, lua.LFalse, tbl.RawGetString("ctrl"))
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("shift"))
+}
+
+func TestEventHandler_KeyWithAllModifiers(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ev := &svcterm.TTYEvent{
+		Type:    "key",
+		Key:     "a",
+		KeyType: "runes",
+		Alt:     true,
+		Ctrl:    true,
+		Shift:   true,
+	}
+	payloads := []payload.Payload{payload.New(ev)}
+
+	result := eventHandler(nil, l, pid.PID{}, "", payloads)
+	tbl, ok := result.(*lua.LTable)
+	require.True(t, ok)
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("alt"))
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("ctrl"))
+	assert.Equal(t, lua.LTrue, tbl.RawGetString("shift"))
+}
+
+// --- buildKeystroke tests ---
+
+func TestBuildKeystroke(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		keyType  string
+		ctrl     bool
+		alt      bool
+		shift    bool
+		expected string
+	}{
+		{"simple char", "a", "runes", false, false, false, "a"},
+		{"ctrl+c", "c", "runes", true, false, false, "ctrl+c"},
+		{"alt+x", "x", "runes", false, true, false, "alt+x"},
+		{"shift+a", "A", "runes", false, false, true, "shift+A"},
+		{"ctrl+alt+del", "delete", "delete", true, true, false, "ctrl+alt+delete"},
+		{"special key enter", "enter", "enter", false, false, false, "enter"},
+		{"special key esc", "esc", "esc", false, false, false, "esc"},
+		{"ctrl+shift+f1", "f1", "f1", true, false, true, "ctrl+shift+f1"},
+		{"empty key", "", "", false, false, false, ""},
+		{"unknown keytype", "?", "unknown", false, false, false, "?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildKeystroke(tt.key, tt.keyType, tt.ctrl, tt.alt, tt.shift)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- Style methods ---
+
+func TestStyle_Strikethrough(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():strikethrough()
+		if s == nil then error("strikethrough should return style") end
+		local r = s:render("test")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Faint(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():faint()
+		if s == nil then error("faint should return style") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Blink(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():blink()
+		if s == nil then error("blink should return style") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Reverse(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():reverse()
+		if s == nil then error("reverse should return style") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Inline(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():inline()
+		local r = s:render("inline text")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_AlignVertical(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():height(5):align_vertical(tty.align.CENTER)
+		local r = s:render("centered")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_BorderBackground(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style()
+			:border("rounded")
+			:border_background("#000000")
+		local r = s:render("test")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_Margin(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():margin(1, 2, 3, 4)
+		local r = s:render("text")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_RenderMultipleArgs(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style()
+		local r = s:render("hello", " ", "world")
+		if r == nil or r == "" then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_DisableBoolParam(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():bold(true):bold(false)
+		if s == nil then error("should return style") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_AllBorderTypes(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local borders = {"normal", "rounded", "thick", "double", "hidden"}
+		for _, b in ipairs(borders) do
+			local s = tty.style():border(b)
+			local r = s:render("x")
+			if r == nil then error("render failed for border: " .. b) end
+		end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_BorderWithSides(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():border("rounded", true, false, true, false)
+		local r = s:render("partial border")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_MaxWidthMaxHeight(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():max_width(10):max_height(3)
+		local r = s:render("this is a longer string that should be capped")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_ToString(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style()
+		local str = tostring(s)
+		if str ~= "tty.Style{}" then error("expected 'tty.Style{}', got " .. str) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_DefaultBorder(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style():border("unknown_type")
+		local r = s:render("fallback")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestStyle_MultipleColorArgs(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local s = tty.style()
+			:border("rounded")
+			:border_foreground("#FF0000", "#00FF00", "#0000FF", "#FFFFFF")
+			:border_background("#000000", "#111111", "#222222", "#333333")
+		local r = s:render("multi-color border")
+		if r == nil then error("render should produce output") end
+	`)
+	assert.NoError(t, err)
+}
+
+// --- Text edge cases ---
+
+func TestText_WidthEmpty(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local w = tty.text.width("")
+		if w ~= 0 then error("expected width 0, got " .. w) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_HeightSingleLine(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local h = tty.text.height("single")
+		if h ~= 1 then error("expected height 1, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_SizeEmpty(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local w, h = tty.text.size("")
+		if w ~= 0 then error("expected width 0, got " .. w) end
+		if h ~= 1 then error("expected height 1, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_MaxWidthEmpty(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local max = tty.text.max_width({})
+		if max ~= 0 then error("expected 0, got " .. max) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_MaxHeightEmpty(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local max = tty.text.max_height({})
+		if max ~= 0 then error("expected 0, got " .. max) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_JoinHorizontalContent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local result = tty.text.join_horizontal(tty.text.position.TOP, "AB", "CD")
+		if result ~= "ABCD" then error("expected 'ABCD', got '" .. result .. "'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_JoinVerticalContent(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local result = tty.text.join_vertical(tty.text.position.LEFT, "top", "bottom")
+		local h = tty.text.height(result)
+		if h ~= 2 then error("expected height 2, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+// --- KeyBinding edge cases ---
+
+func TestKeyBinding_MatchesAltKey(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"alt+x"}, help = {key = "alt+x", desc = "special"}})
+		local event = {type = "key", key = "x", key_type = "runes", ctrl = false, alt = true, shift = false}
+		if not kb:matches(event) then error("should match 'alt+x'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_MatchesShiftKey(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"shift+tab"}, help = {key = "shift+tab", desc = "prev"}})
+		local event = {type = "key", key = "tab", key_type = "tab", ctrl = false, alt = false, shift = true}
+		if not kb:matches(event) then error("should match 'shift+tab'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_MatchesCtrlAltCombo(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"ctrl+alt+delete"}, help = {key = "ctrl+alt+del", desc = "reset"}})
+		local event = {type = "key", key = "delete", key_type = "delete", ctrl = true, alt = true, shift = false}
+		if not kb:matches(event) then error("should match 'ctrl+alt+delete'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_NoMatchWrongModifier(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"ctrl+c"}, help = {key = "ctrl+c", desc = "quit"}})
+		-- Plain 'c' without ctrl should not match "ctrl+c" binding via keystroke
+		local event = {type = "key", key = "c", key_type = "runes", ctrl = false, alt = false, shift = false}
+		if kb:matches(event) then error("should not match plain 'c' for ctrl+c binding") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_ToString(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"q", "ctrl+c"}, help = {key = "q", desc = "quit"}})
+		local str = tostring(kb)
+		if str ~= "tty.KeyBinding{q, ctrl+c}" then error("expected 'tty.KeyBinding{q, ctrl+c}', got '" .. str .. "'") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_EmptyKeys(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {}, help = {key = "", desc = ""}})
+		local event = {type = "key", key = "q", key_type = "runes", ctrl = false, alt = false, shift = false}
+		if kb:matches(event) then error("empty binding should not match anything") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_SetEnabledChainable(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"q"}, help = {key = "q", desc = "quit"}})
+		local returned = kb:set_enabled(false)
+		if returned ~= kb then error("set_enabled should return self") end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestKeyBinding_NoHelpTable(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local kb = tty.bind({keys = {"q"}})
+		local h = kb:help()
+		if h.key ~= "" then error("expected empty help key") end
+		if h.desc ~= "" then error("expected empty help desc") end
+	`)
+	assert.NoError(t, err)
+}
+
+// --- Constants completeness ---
+
+func TestModuleConstants_Hidden(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	mod := l.GetGlobal("tty").(*lua.LTable)
+	borderTbl := mod.RawGetString("borders").(*lua.LTable)
+	assert.Equal(t, "hidden", borderTbl.RawGetString("HIDDEN").String())
+}
+
+func TestModuleConstants_TextPosition(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	mod := l.GetGlobal("tty").(*lua.LTable)
+	textTbl := mod.RawGetString("text").(*lua.LTable)
+	posTbl := textTbl.RawGetString("position").(*lua.LTable)
+
+	assert.Equal(t, lua.LNumber(0), posTbl.RawGetString("TOP"))
+	assert.Equal(t, lua.LNumber(0), posTbl.RawGetString("LEFT"))
+	assert.Equal(t, lua.LNumber(0.5), posTbl.RawGetString("CENTER"))
+	assert.Equal(t, lua.LNumber(1), posTbl.RawGetString("BOTTOM"))
+	assert.Equal(t, lua.LNumber(1), posTbl.RawGetString("RIGHT"))
+}
+
+func TestModuleConstants_TextFunctions(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	mod := l.GetGlobal("tty").(*lua.LTable)
+	textTbl := mod.RawGetString("text").(*lua.LTable)
+
+	funcs := []string{
+		"width", "height", "size",
+		"join_horizontal", "join_vertical",
+		"max_width", "max_height",
+		"place", "place_horizontal", "place_vertical",
+	}
+	for _, name := range funcs {
+		assert.Equal(t, lua.LTFunction, textTbl.RawGetString(name).Type(), "missing text function: %s", name)
+	}
+}
+
+func TestText_Place(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.place(20, 5, tty.text.position.CENTER, tty.text.position.CENTER, "hi")
+		if result == nil or result == "" then error("place should produce output") end
+		local w = tty.text.width(result)
+		if w ~= 20 then error("expected width 20, got " .. w) end
+		local h = tty.text.height(result)
+		if h ~= 5 then error("expected height 5, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_PlaceHorizontal(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.place_horizontal(30, tty.text.position.CENTER, "centered")
+		if result == nil or result == "" then error("place_horizontal should produce output") end
+		local w = tty.text.width(result)
+		if w ~= 30 then error("expected width 30, got " .. w) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_PlaceVertical(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.place_vertical(5, tty.text.position.CENTER, "mid")
+		if result == nil or result == "" then error("place_vertical should produce output") end
+		local h = tty.text.height(result)
+		if h ~= 5 then error("expected height 5, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_PlaceTopLeft(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.place(10, 3, tty.text.position.LEFT, tty.text.position.TOP, "AB")
+		local h = tty.text.height(result)
+		if h ~= 3 then error("expected height 3, got " .. h) end
+	`)
+	assert.NoError(t, err)
+}
+
+func TestText_PlaceBottomRight(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+
+	err := l.DoString(`
+		local tty = tty
+		local result = tty.text.place(10, 3, tty.text.position.RIGHT, tty.text.position.BOTTOM, "XY")
+		local w = tty.text.width(result)
+		if w ~= 10 then error("expected width 10, got " .. w) end
+	`)
+	assert.NoError(t, err)
+}

--- a/runtime/lua/modules/tty/style.go
+++ b/runtime/lua/modules/tty/style.go
@@ -1,0 +1,305 @@
+package tty
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+const styleTypeName = "tty.Style"
+
+func init() {
+	value.RegisterTypeMethods(nil, styleTypeName,
+		map[string]lua.LGoFunc{"__tostring": styleToString},
+		map[string]lua.LGoFunc{
+			"render":           styleRender,
+			"foreground":       styleForeground,
+			"background":       styleBackground,
+			"bold":             styleBold,
+			"italic":           styleItalic,
+			"underline":        styleUnderline,
+			"strikethrough":    styleStrikethrough,
+			"faint":            styleFaint,
+			"blink":            styleBlink,
+			"reverse":          styleReverse,
+			"padding":          stylePadding,
+			"margin":           styleMargin,
+			"border":           styleBorder,
+			"border_foreground": styleBorderForeground,
+			"border_background": styleBorderBackground,
+			"width":            styleWidth,
+			"height":           styleHeight,
+			"max_width":        styleMaxWidth,
+			"max_height":       styleMaxHeight,
+			"align":            styleAlign,
+			"align_vertical":   styleAlignVertical,
+			"inline":           styleInline,
+			"copy":             styleCopy,
+		})
+}
+
+type styleWrapper struct {
+	style lipgloss.Style
+}
+
+func checkStyle(l *lua.LState) *styleWrapper {
+	ud := l.CheckUserData(1)
+	if s, ok := ud.Value.(*styleWrapper); ok {
+		return s
+	}
+	l.ArgError(1, "tty.Style expected")
+	return nil
+}
+
+func pushStyle(l *lua.LState, s *styleWrapper) *lua.LUserData {
+	return value.PushTypedUserData(l, s, styleTypeName)
+}
+
+func ttyStyleNew(l *lua.LState) int {
+	s := &styleWrapper{style: lipgloss.NewStyle()}
+	pushStyle(l, s)
+	return 1
+}
+
+func styleToString(l *lua.LState) int {
+	l.Push(lua.LString("tty.Style{}"))
+	return 1
+}
+
+func styleRender(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	n := l.GetTop()
+	strs := make([]string, 0, n-1)
+	for i := 2; i <= n; i++ {
+		strs = append(strs, l.ToString(i))
+	}
+	result := s.style.Render(strs...)
+	l.Push(lua.LString(result))
+	return 1
+}
+
+func pushDerived(l *lua.LState, s lipgloss.Style) int {
+	pushStyle(l, &styleWrapper{style: s})
+	return 1
+}
+
+func styleForeground(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Foreground(lipgloss.Color(l.CheckString(2))))
+}
+
+func styleBackground(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Background(lipgloss.Color(l.CheckString(2))))
+}
+
+func styleBold(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Bold(l.OptBool(2, true)))
+}
+
+func styleItalic(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Italic(l.OptBool(2, true)))
+}
+
+func styleUnderline(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Underline(l.OptBool(2, true)))
+}
+
+func styleStrikethrough(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Strikethrough(l.OptBool(2, true)))
+}
+
+func styleFaint(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Faint(l.OptBool(2, true)))
+}
+
+func styleBlink(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Blink(l.OptBool(2, true)))
+}
+
+func styleReverse(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Reverse(l.OptBool(2, true)))
+}
+
+func stylePadding(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Padding(readSpacingArgs(l, 2)...))
+}
+
+func styleMargin(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Margin(readSpacingArgs(l, 2)...))
+}
+
+func styleBorder(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	border := resolveBorder(l.CheckString(2))
+	sides := make([]bool, 0, 4)
+	for i := 3; i <= l.GetTop(); i++ {
+		sides = append(sides, l.ToBool(i))
+	}
+	return pushDerived(l, s.style.Border(border, sides...))
+}
+
+func styleBorderForeground(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.BorderForeground(readColorArgs(l, 2)...))
+}
+
+func styleBorderBackground(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.BorderBackground(readColorArgs(l, 2)...))
+}
+
+func styleWidth(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Width(l.CheckInt(2)))
+}
+
+func styleHeight(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Height(l.CheckInt(2)))
+}
+
+func styleMaxWidth(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.MaxWidth(l.CheckInt(2)))
+}
+
+func styleMaxHeight(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.MaxHeight(l.CheckInt(2)))
+}
+
+func styleAlign(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Align(lipgloss.Position(l.CheckNumber(2))))
+}
+
+func styleAlignVertical(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.AlignVertical(lipgloss.Position(l.CheckNumber(2))))
+}
+
+func styleInline(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	return pushDerived(l, s.style.Inline(l.OptBool(2, true)))
+}
+
+func styleCopy(l *lua.LState) int {
+	s := checkStyle(l)
+	if s == nil {
+		return 0
+	}
+	cp := &styleWrapper{style: s.style.Copy()}
+	pushStyle(l, cp)
+	return 1
+}
+
+func resolveBorder(name string) lipgloss.Border {
+	switch name {
+	case "normal":
+		return lipgloss.NormalBorder()
+	case "rounded":
+		return lipgloss.RoundedBorder()
+	case "thick":
+		return lipgloss.ThickBorder()
+	case "double":
+		return lipgloss.DoubleBorder()
+	case "hidden":
+		return lipgloss.HiddenBorder()
+	default:
+		return lipgloss.NormalBorder()
+	}
+}
+
+func readSpacingArgs(l *lua.LState, startIdx int) []int {
+	n := l.GetTop()
+	values := make([]int, 0, n-startIdx+1)
+	for i := startIdx; i <= n; i++ {
+		values = append(values, l.CheckInt(i))
+	}
+	return values
+}
+
+func readColorArgs(l *lua.LState, startIdx int) []lipgloss.TerminalColor {
+	n := l.GetTop()
+	colors := make([]lipgloss.TerminalColor, 0, n-startIdx+1)
+	for i := startIdx; i <= n; i++ {
+		colors = append(colors, lipgloss.Color(l.CheckString(i)))
+	}
+	return colors
+}

--- a/runtime/lua/modules/tty/text.go
+++ b/runtime/lua/modules/tty/text.go
@@ -1,0 +1,123 @@
+package tty
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	lua "github.com/wippyai/go-lua"
+)
+
+// textWidth returns the printable width of a string (ANSI-aware).
+func textWidth(l *lua.LState) int {
+	s := l.CheckString(1)
+	l.Push(lua.LNumber(lipgloss.Width(s)))
+	return 1
+}
+
+// textHeight returns the number of lines in a string.
+func textHeight(l *lua.LState) int {
+	s := l.CheckString(1)
+	l.Push(lua.LNumber(lipgloss.Height(s)))
+	return 1
+}
+
+// textSize returns width and height of a string.
+func textSize(l *lua.LState) int {
+	s := l.CheckString(1)
+	w, h := lipgloss.Size(s)
+	l.Push(lua.LNumber(w))
+	l.Push(lua.LNumber(h))
+	return 2
+}
+
+// textJoinHorizontal joins strings horizontally at a given vertical position.
+func textJoinHorizontal(l *lua.LState) int {
+	pos := lipgloss.Position(l.CheckNumber(1))
+	strs := collectStrings(l, 2)
+	result := lipgloss.JoinHorizontal(pos, strs...)
+	l.Push(lua.LString(result))
+	return 1
+}
+
+// textJoinVertical joins strings vertically at a given horizontal position.
+func textJoinVertical(l *lua.LState) int {
+	pos := lipgloss.Position(l.CheckNumber(1))
+	strs := collectStrings(l, 2)
+	result := lipgloss.JoinVertical(pos, strs...)
+	l.Push(lua.LString(result))
+	return 1
+}
+
+// textMaxWidth returns the maximum printable width across a table of strings.
+func textMaxWidth(l *lua.LState) int {
+	tbl := l.CheckTable(1)
+	max := 0
+	tbl.ForEach(func(_, v lua.LValue) {
+		if s, ok := v.(lua.LString); ok {
+			w := lipgloss.Width(string(s))
+			if w > max {
+				max = w
+			}
+		}
+	})
+	l.Push(lua.LNumber(max))
+	return 1
+}
+
+// textMaxHeight returns the maximum height across a table of strings.
+func textMaxHeight(l *lua.LState) int {
+	tbl := l.CheckTable(1)
+	max := 0
+	tbl.ForEach(func(_, v lua.LValue) {
+		if s, ok := v.(lua.LString); ok {
+			h := lipgloss.Height(string(s))
+			if h > max {
+				max = h
+			}
+		}
+	})
+	l.Push(lua.LNumber(max))
+	return 1
+}
+
+// textPlace places a string within a box of given dimensions.
+// place(width, height, hPos, vPos, str)
+func textPlace(l *lua.LState) int {
+	width := l.CheckInt(1)
+	height := l.CheckInt(2)
+	hPos := lipgloss.Position(l.CheckNumber(3))
+	vPos := lipgloss.Position(l.CheckNumber(4))
+	str := l.CheckString(5)
+	result := lipgloss.Place(width, height, hPos, vPos, str)
+	l.Push(lua.LString(result))
+	return 1
+}
+
+// textPlaceHorizontal centers a string horizontally within a given width.
+// place_horizontal(width, pos, str)
+func textPlaceHorizontal(l *lua.LState) int {
+	width := l.CheckInt(1)
+	pos := lipgloss.Position(l.CheckNumber(2))
+	str := l.CheckString(3)
+	result := lipgloss.PlaceHorizontal(width, pos, str)
+	l.Push(lua.LString(result))
+	return 1
+}
+
+// textPlaceVertical centers a string vertically within a given height.
+// place_vertical(height, pos, str)
+func textPlaceVertical(l *lua.LState) int {
+	height := l.CheckInt(1)
+	pos := lipgloss.Position(l.CheckNumber(2))
+	str := l.CheckString(3)
+	result := lipgloss.PlaceVertical(height, pos, str)
+	l.Push(lua.LString(result))
+	return 1
+}
+
+func collectStrings(l *lua.LState, startIdx int) []string {
+	n := l.GetTop()
+	strs := make([]string, 0, n-startIdx+1)
+	for i := startIdx; i <= n; i++ {
+		strs = append(strs, l.ToString(i))
+	}
+	return strs
+}

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -1,0 +1,198 @@
+package tty
+
+import (
+	typio "github.com/wippyai/go-lua/types/io"
+	"github.com/wippyai/go-lua/types/typ"
+)
+
+// Style interface returned by tty.style()
+var styleType = typ.NewInterface("tty.Style", []typ.Method{
+	{Name: "render", Type: typ.Func().Param("self", typ.Self).Variadic(typ.String).Returns(typ.String).Build()},
+	{Name: "foreground", Type: typ.Func().Param("self", typ.Self).Param("color", typ.String).Returns(typ.Self).Build()},
+	{Name: "background", Type: typ.Func().Param("self", typ.Self).Param("color", typ.String).Returns(typ.Self).Build()},
+	{Name: "bold", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "italic", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "underline", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "strikethrough", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "faint", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "blink", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "reverse", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "padding", Type: typ.Func().Param("self", typ.Self).Variadic(typ.Number).Returns(typ.Self).Build()},
+	{Name: "margin", Type: typ.Func().Param("self", typ.Self).Variadic(typ.Number).Returns(typ.Self).Build()},
+	{Name: "border", Type: typ.Func().Param("self", typ.Self).Param("name", typ.String).Variadic(typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "border_foreground", Type: typ.Func().Param("self", typ.Self).Variadic(typ.String).Returns(typ.Self).Build()},
+	{Name: "border_background", Type: typ.Func().Param("self", typ.Self).Variadic(typ.String).Returns(typ.Self).Build()},
+	{Name: "width", Type: typ.Func().Param("self", typ.Self).Param("n", typ.Number).Returns(typ.Self).Build()},
+	{Name: "height", Type: typ.Func().Param("self", typ.Self).Param("n", typ.Number).Returns(typ.Self).Build()},
+	{Name: "max_width", Type: typ.Func().Param("self", typ.Self).Param("n", typ.Number).Returns(typ.Self).Build()},
+	{Name: "max_height", Type: typ.Func().Param("self", typ.Self).Param("n", typ.Number).Returns(typ.Self).Build()},
+	{Name: "align", Type: typ.Func().Param("self", typ.Self).Param("pos", typ.Number).Returns(typ.Self).Build()},
+	{Name: "align_vertical", Type: typ.Func().Param("self", typ.Self).Param("pos", typ.Number).Returns(typ.Self).Build()},
+	{Name: "inline", Type: typ.Func().Param("self", typ.Self).OptParam("enable", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "copy", Type: typ.Func().Param("self", typ.Self).Returns(typ.Self).Build()},
+})
+
+// KeyBinding interface returned by tty.bind()
+var keyBindingType = typ.NewInterface("tty.KeyBinding", []typ.Method{
+	{Name: "matches", Type: typ.Func().Param("self", typ.Self).Param("event", typ.Any).Returns(typ.Boolean).Build()},
+	{Name: "set_enabled", Type: typ.Func().Param("self", typ.Self).Param("enabled", typ.Boolean).Returns(typ.Self).Build()},
+	{Name: "is_enabled", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
+	{Name: "help", Type: typ.Func().Param("self", typ.Self).Returns(bindingHelpType).Build()},
+})
+
+var bindingHelpType = typ.NewRecord().
+	ReadonlyField("key", typ.String).
+	ReadonlyField("desc", typ.String).
+	Build()
+
+var bindingConfigType = typ.NewRecord().
+	Field("keys", typ.NewArray(typ.String)).
+	OptField("help", typ.NewRecord().
+		OptField("key", typ.String).
+		OptField("desc", typ.String).
+		Build()).
+	Build()
+
+// Event types as discriminated union on "type" field
+var keyEventType = typ.NewRecord().
+	ReadonlyField("type", typ.LiteralString("key")).
+	ReadonlyField("key", typ.String).
+	ReadonlyField("key_type", typ.String).
+	ReadonlyField("action", typ.NewUnion(typ.LiteralString("press"), typ.LiteralString("release"))).
+	ReadonlyField("alt", typ.Boolean).
+	ReadonlyField("ctrl", typ.Boolean).
+	ReadonlyField("shift", typ.Boolean).
+	Build()
+
+var mouseEventType = typ.NewRecord().
+	ReadonlyField("type", typ.LiteralString("mouse")).
+	ReadonlyField("action", typ.NewUnion(
+		typ.LiteralString("press"),
+		typ.LiteralString("release"),
+		typ.LiteralString("motion"),
+		typ.LiteralString("wheel"),
+	)).
+	ReadonlyField("button", typ.String).
+	ReadonlyField("x", typ.Number).
+	ReadonlyField("y", typ.Number).
+	ReadonlyField("alt", typ.Boolean).
+	ReadonlyField("ctrl", typ.Boolean).
+	ReadonlyField("shift", typ.Boolean).
+	Build()
+
+var resizeEventType = typ.NewRecord().
+	ReadonlyField("type", typ.LiteralString("resize")).
+	ReadonlyField("width", typ.Number).
+	ReadonlyField("height", typ.Number).
+	Build()
+
+var startEventType = typ.NewRecord().
+	ReadonlyField("type", typ.LiteralString("start")).
+	ReadonlyField("width", typ.Number).
+	ReadonlyField("height", typ.Number).
+	Build()
+
+var focusEventType = typ.NewRecord().
+	ReadonlyField("type", typ.LiteralString("focus")).
+	ReadonlyField("focused", typ.Boolean).
+	Build()
+
+var pasteEventType = typ.NewRecord().
+	ReadonlyField("type", typ.LiteralString("paste")).
+	ReadonlyField("text", typ.String).
+	Build()
+
+var ttyEventType = typ.NewUnion(
+	keyEventType,
+	mouseEventType,
+	resizeEventType,
+	startEventType,
+	focusEventType,
+	pasteEventType,
+)
+
+// Channel type for tty.events()
+var eventChannelType = typ.NewInterface("tty.EventChannel", []typ.Method{
+	{Name: "receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(ttyEventType)).Build()},
+})
+
+// Border constants
+var bordersConstType = typ.NewRecord().
+	ReadonlyField("NORMAL", typ.String).
+	ReadonlyField("ROUNDED", typ.String).
+	ReadonlyField("THICK", typ.String).
+	ReadonlyField("DOUBLE", typ.String).
+	ReadonlyField("HIDDEN", typ.String).
+	Build()
+
+// Alignment constants
+var alignConstType = typ.NewRecord().
+	ReadonlyField("LEFT", typ.Number).
+	ReadonlyField("CENTER", typ.Number).
+	ReadonlyField("RIGHT", typ.Number).
+	Build()
+
+// Position constants
+var positionConstType = typ.NewRecord().
+	ReadonlyField("TOP", typ.Number).
+	ReadonlyField("LEFT", typ.Number).
+	ReadonlyField("CENTER", typ.Number).
+	ReadonlyField("BOTTOM", typ.Number).
+	ReadonlyField("RIGHT", typ.Number).
+	Build()
+
+// Text sub-module
+var textModType typ.Type
+
+func init() {
+	textModType = typ.NewRecord().
+		ReadonlyField("width", typ.Func().Param("s", typ.String).Returns(typ.Number).Build()).
+		ReadonlyField("height", typ.Func().Param("s", typ.String).Returns(typ.Number).Build()).
+		ReadonlyField("size", typ.Func().Param("s", typ.String).Returns(typ.Number, typ.Number).Build()).
+		ReadonlyField("join_horizontal", typ.Func().Param("pos", typ.Number).Variadic(typ.String).Returns(typ.String).Build()).
+		ReadonlyField("join_vertical", typ.Func().Param("pos", typ.Number).Variadic(typ.String).Returns(typ.String).Build()).
+		ReadonlyField("max_width", typ.Func().Param("items", typ.NewArray(typ.String)).Returns(typ.Number).Build()).
+		ReadonlyField("max_height", typ.Func().Param("items", typ.NewArray(typ.String)).Returns(typ.Number).Build()).
+		ReadonlyField("place", typ.Func().Param("width", typ.Number).Param("height", typ.Number).Param("hPos", typ.Number).Param("vPos", typ.Number).Param("str", typ.String).Returns(typ.String).Build()).
+		ReadonlyField("place_horizontal", typ.Func().Param("width", typ.Number).Param("pos", typ.Number).Param("str", typ.String).Returns(typ.String).Build()).
+		ReadonlyField("place_vertical", typ.Func().Param("height", typ.Number).Param("pos", typ.Number).Param("str", typ.String).Returns(typ.String).Build()).
+		ReadonlyField("position", positionConstType).
+		Build()
+}
+
+// ModuleTypes returns the type manifest for the tty module.
+func ModuleTypes() *typio.Manifest {
+	m := typio.NewManifest("tty")
+
+	m.DefineType("Style", styleType)
+	m.DefineType("KeyBinding", keyBindingType)
+	m.DefineType("BindingHelp", bindingHelpType)
+	m.DefineType("BindingConfig", bindingConfigType)
+	m.DefineType("KeyEvent", keyEventType)
+	m.DefineType("MouseEvent", mouseEventType)
+	m.DefineType("ResizeEvent", resizeEventType)
+	m.DefineType("StartEvent", startEventType)
+	m.DefineType("FocusEvent", focusEventType)
+	m.DefineType("PasteEvent", pasteEventType)
+	m.DefineType("TTYEvent", ttyEventType)
+	m.DefineType("EventChannel", eventChannelType)
+
+	moduleMethodsType := typ.NewInterface("tty", []typ.Method{
+		{Name: "start", Type: typ.Func().Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "stop", Type: typ.Func().Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "screen_size", Type: typ.Func().Returns(typ.Number, typ.Number, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "events", Type: typ.Func().Returns(eventChannelType, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "mouse", Type: typ.Func().Param("enable", typ.Boolean).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "style", Type: typ.Func().Returns(styleType).Build()},
+		{Name: "bind", Type: typ.Func().Param("config", bindingConfigType).Returns(keyBindingType).Build()},
+	})
+
+	moduleFieldsType := typ.NewRecord().
+		ReadonlyField("borders", bordersConstType).
+		ReadonlyField("align", alignConstType).
+		ReadonlyField("text", textModType).
+		Build()
+
+	m.SetExport(typ.NewIntersection(moduleMethodsType, moduleFieldsType))
+	return m
+}

--- a/runtime/lua/modules/tty/yields.go
+++ b/runtime/lua/modules/tty/yields.go
@@ -1,0 +1,168 @@
+package tty
+
+import (
+	"sync"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/dispatcher"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+var yieldTypes = []luaYieldType{
+	{Sample: &StartInputYield{}, CmdID: ttyapi.StartInput},
+	{Sample: &StopInputYield{}, CmdID: ttyapi.StopInput},
+	{Sample: &ScreenSizeYield{}, CmdID: ttyapi.ScreenSize},
+	{Sample: &EnableMouseYield{}, CmdID: ttyapi.EnableMouse},
+	{Sample: &DisableMouseYield{}, CmdID: ttyapi.DisableMouse},
+}
+
+type luaYieldType = struct {
+	Sample any
+	CmdID  dispatcher.CommandID
+}
+
+// StartInputYield yields a start-input request.
+type StartInputYield struct{}
+
+var startInputYieldPool = sync.Pool{New: func() any { return &StartInputYield{} }}
+
+func AcquireStartInputYield() *StartInputYield {
+	return startInputYieldPool.Get().(*StartInputYield)
+}
+
+func ReleaseStartInputYield(y *StartInputYield) {
+	startInputYieldPool.Put(y)
+}
+
+func (y *StartInputYield) String() string                { return "<tty_start_input_yield>" }
+func (y *StartInputYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *StartInputYield) CmdID() dispatcher.CommandID   { return ttyapi.StartInput }
+func (y *StartInputYield) ToCommand() dispatcher.Command { return ttyapi.StartInputCmd{} }
+func (y *StartInputYield) Release()                      { ReleaseStartInputYield(y) }
+
+func (y *StartInputYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	return handleBoolResult(l, data, err, "start input")
+}
+
+// StopInputYield yields a stop-input request.
+type StopInputYield struct{}
+
+var stopInputYieldPool = sync.Pool{New: func() any { return &StopInputYield{} }}
+
+func AcquireStopInputYield() *StopInputYield {
+	return stopInputYieldPool.Get().(*StopInputYield)
+}
+
+func ReleaseStopInputYield(y *StopInputYield) {
+	stopInputYieldPool.Put(y)
+}
+
+func (y *StopInputYield) String() string                { return "<tty_stop_input_yield>" }
+func (y *StopInputYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *StopInputYield) CmdID() dispatcher.CommandID   { return ttyapi.StopInput }
+func (y *StopInputYield) ToCommand() dispatcher.Command { return ttyapi.StopInputCmd{} }
+func (y *StopInputYield) Release()                      { ReleaseStopInputYield(y) }
+
+func (y *StopInputYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	return handleBoolResult(l, data, err, "stop input")
+}
+
+// ScreenSizeYield yields a screen-size query.
+type ScreenSizeYield struct{}
+
+var screenSizeYieldPool = sync.Pool{New: func() any { return &ScreenSizeYield{} }}
+
+func AcquireScreenSizeYield() *ScreenSizeYield {
+	return screenSizeYieldPool.Get().(*ScreenSizeYield)
+}
+
+func ReleaseScreenSizeYield(y *ScreenSizeYield) {
+	screenSizeYieldPool.Put(y)
+}
+
+func (y *ScreenSizeYield) String() string                { return "<tty_screen_size_yield>" }
+func (y *ScreenSizeYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *ScreenSizeYield) CmdID() dispatcher.CommandID   { return ttyapi.ScreenSize }
+func (y *ScreenSizeYield) ToCommand() dispatcher.Command { return ttyapi.ScreenSizeCmd{} }
+func (y *ScreenSizeYield) Release()                      { ReleaseScreenSizeYield(y) }
+
+func (y *ScreenSizeYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, lua.LNil, lua.WrapErrorWithLua(l, err, "screen size")}
+	}
+	switch v := data.(type) {
+	case []int:
+		if len(v) == 2 {
+			return []lua.LValue{lua.LNumber(v[0]), lua.LNumber(v[1]), lua.LNil}
+		}
+		return []lua.LValue{lua.LNil, lua.LNil, lua.NewLuaError(l, "invalid screen size response").
+			WithKind(lua.Internal).WithRetryable(false)}
+	default:
+		return []lua.LValue{lua.LNil, lua.LNil, lua.NewLuaError(l, "invalid response type").
+			WithKind(lua.Internal).WithRetryable(false)}
+	}
+}
+
+// EnableMouseYield yields an enable-mouse request.
+type EnableMouseYield struct{}
+
+var enableMouseYieldPool = sync.Pool{New: func() any { return &EnableMouseYield{} }}
+
+func AcquireEnableMouseYield() *EnableMouseYield {
+	return enableMouseYieldPool.Get().(*EnableMouseYield)
+}
+
+func ReleaseEnableMouseYield(y *EnableMouseYield) {
+	enableMouseYieldPool.Put(y)
+}
+
+func (y *EnableMouseYield) String() string                { return "<tty_enable_mouse_yield>" }
+func (y *EnableMouseYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *EnableMouseYield) CmdID() dispatcher.CommandID   { return ttyapi.EnableMouse }
+func (y *EnableMouseYield) ToCommand() dispatcher.Command { return ttyapi.EnableMouseCmd{} }
+func (y *EnableMouseYield) Release()                      { ReleaseEnableMouseYield(y) }
+
+func (y *EnableMouseYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	return handleBoolResult(l, data, err, "enable mouse")
+}
+
+// DisableMouseYield yields a disable-mouse request.
+type DisableMouseYield struct{}
+
+var disableMouseYieldPool = sync.Pool{New: func() any { return &DisableMouseYield{} }}
+
+func AcquireDisableMouseYield() *DisableMouseYield {
+	return disableMouseYieldPool.Get().(*DisableMouseYield)
+}
+
+func ReleaseDisableMouseYield(y *DisableMouseYield) {
+	disableMouseYieldPool.Put(y)
+}
+
+func (y *DisableMouseYield) String() string                { return "<tty_disable_mouse_yield>" }
+func (y *DisableMouseYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *DisableMouseYield) CmdID() dispatcher.CommandID   { return ttyapi.DisableMouse }
+func (y *DisableMouseYield) ToCommand() dispatcher.Command { return ttyapi.DisableMouseCmd{} }
+func (y *DisableMouseYield) Release()                      { ReleaseDisableMouseYield(y) }
+
+func (y *DisableMouseYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	return handleBoolResult(l, data, err, "disable mouse")
+}
+
+func handleBoolResult(l *lua.LState, data any, err error, op string) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, op)}
+	}
+	switch v := data.(type) {
+	case bool:
+		if v {
+			return []lua.LValue{lua.LTrue, lua.LNil}
+		}
+		return []lua.LValue{lua.LFalse, lua.LNil}
+	case nil:
+		return []lua.LValue{lua.LTrue, lua.LNil}
+	default:
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").
+			WithKind(lua.Internal).WithRetryable(false)}
+	}
+}

--- a/service/terminal/host.go
+++ b/service/terminal/host.go
@@ -76,6 +76,9 @@ func (h *Host) OnStart(context.Context, pid.PID, process.Process) error { return
 // OnComplete implements scheduler.Lifecycle.
 func (h *Host) OnComplete(ctx context.Context, _ pid.PID, result *runtime.Result) {
 	h.logCtrl.RestoreBaseConfig(ctx)
+	if tc := terminalapi.GetTerminalContext(ctx); tc != nil && tc.Input != nil {
+		_ = tc.Input.Stop()
+	}
 	if h.raw != nil {
 		_ = h.raw.Reset()
 	}
@@ -247,6 +250,7 @@ func (h *Host) prepareContext(ctx context.Context, processID pid.PID, start *pro
 	pairs[1] = ctxapi.Pair{Key: runtime.FramePIDKey, Value: processID}
 	tc := terminalapi.NewTerminalContextWithArgs(os.Stdin, os.Stdout, os.Stderr, args)
 	tc.Raw = h.raw
+	tc.Input = NewInputReader(os.Stdin, h.raw, h.scheduler, processID)
 	pairs[2] = ctxapi.Pair{Key: terminalapi.Key(), Value: tc}
 	copy(pairs[3:], start.Context)
 

--- a/service/terminal/input.go
+++ b/service/terminal/input.go
@@ -1,0 +1,216 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/charmbracelet/x/input"
+	"github.com/charmbracelet/x/term"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/system/scheduler/actor"
+)
+
+// InputReader reads terminal input and delivers parsed events via the scheduler.
+type InputReader struct {
+	stdin        *os.File
+	raw          *RawManager
+	scheduler    *actor.Scheduler
+	targetPID    pid.PID
+	reader       *input.Reader
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
+	mu           sync.Mutex
+	started      bool
+	mouseEnabled bool
+}
+
+// NewInputReader creates an InputReader that delivers events to the given process.
+func NewInputReader(stdin *os.File, raw *RawManager, scheduler *actor.Scheduler, targetPID pid.PID) *InputReader {
+	return &InputReader{
+		stdin:     stdin,
+		raw:       raw,
+		scheduler: scheduler,
+		targetPID: targetPID,
+	}
+}
+
+// Start enables raw mode and spawns the read loop and SIGWINCH goroutine.
+func (r *InputReader) Start() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.started {
+		return errors.New("input reader already started")
+	}
+
+	if err := r.raw.Enable(); err != nil {
+		return err
+	}
+
+	termType := os.Getenv("TERM")
+	reader, err := input.NewReader(r.stdin, termType, 0)
+	if err != nil {
+		_ = r.raw.Disable()
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	r.reader = reader
+	r.started = true
+
+	// Send initial start event with terminal size
+	cols, rows, sizeErr := r.screenSize()
+	if sizeErr == nil {
+		r.sendEvent(&TTYEvent{
+			Type:   "start",
+			Width:  cols,
+			Height: rows,
+		})
+	}
+
+	r.wg.Add(2)
+	go r.readLoop(ctx, reader)
+	go r.sigwinchLoop(ctx)
+
+	return nil
+}
+
+// Stop cancels the read loop, waits for goroutines, and restores the terminal.
+func (r *InputReader) Stop() error {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return nil
+	}
+
+	r.started = false
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	if r.reader != nil {
+		r.reader.Cancel()
+	}
+	r.mu.Unlock()
+
+	r.wg.Wait()
+
+	r.mu.Lock()
+	if r.reader != nil {
+		_ = r.reader.Close()
+		r.reader = nil
+	}
+	r.mu.Unlock()
+
+	// Disable mouse tracking if it was enabled
+	if r.mouseEnabled {
+		_, _ = os.Stdout.Write([]byte("\033[?1006l\033[?1003l"))
+		r.mouseEnabled = false
+	}
+
+	return r.raw.Disable()
+}
+
+// EnableMouse enables mouse event tracking (SGR mode).
+func (r *InputReader) EnableMouse() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.mouseEnabled {
+		_, _ = os.Stdout.Write([]byte("\033[?1003h\033[?1006h"))
+		r.mouseEnabled = true
+	}
+}
+
+// DisableMouse disables mouse event tracking.
+func (r *InputReader) DisableMouse() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.mouseEnabled {
+		_, _ = os.Stdout.Write([]byte("\033[?1006l\033[?1003l"))
+		r.mouseEnabled = false
+	}
+}
+
+// ScreenSize returns the current terminal dimensions.
+func (r *InputReader) ScreenSize() (int, int, error) {
+	return r.screenSize()
+}
+
+func (r *InputReader) screenSize() (int, int, error) {
+	return term.GetSize(r.stdin.Fd())
+}
+
+func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader) {
+	defer r.wg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		events, err := reader.ReadEvents()
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				continue
+			}
+		}
+
+		for _, ev := range events {
+			ttyEv := ConvertInputEvent(ev)
+			if ttyEv != nil {
+				r.sendEvent(ttyEv)
+			}
+		}
+	}
+}
+
+func (r *InputReader) sigwinchLoop(ctx context.Context) {
+	defer r.wg.Done()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sigCh:
+			cols, rows, err := r.screenSize()
+			if err == nil {
+				r.sendEvent(&TTYEvent{
+					Type:   "resize",
+					Width:  cols,
+					Height: rows,
+				})
+			}
+		}
+	}
+}
+
+func (r *InputReader) sendEvent(ev *TTYEvent) {
+	pkg := &relay.Package{
+		Target: r.targetPID,
+	}
+	pkg.AddMessage(relay.Topic(TopicTTYEvents), payload.New(ev))
+	_ = r.scheduler.Send(pkg)
+}
+
+var _ ttyapi.InputController = (*InputReader)(nil)

--- a/service/terminal/input_event.go
+++ b/service/terminal/input_event.go
@@ -1,0 +1,143 @@
+package terminal
+
+import (
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/input"
+)
+
+// TopicTTYEvents is the relay topic for terminal input events.
+const TopicTTYEvents = "@tty/events"
+
+// TTYEvent is the abstract terminal input event sent via relay as payload.Golang.
+type TTYEvent struct {
+	Type    string // "start", "key", "mouse", "resize", "focus", "paste"
+	Key     string // rune(s) or keystroke string for key events
+	KeyType string // "runes", "enter", "tab", "esc", "up", "down", "f1", etc.
+	Action  string // key: "press", "release"; mouse: "press", "release", "motion", "wheel"
+	Button  string // mouse: "left", "right", "middle", "none"
+	Paste   string // paste event text
+	X, Y    int    // mouse position
+	Width   int    // resize/start: terminal columns
+	Height  int    // resize/start: terminal rows
+	Focused bool   // focus event
+	Alt     bool
+	Ctrl    bool
+	Shift   bool
+}
+
+// keyTypeName maps key codes to string names for Lua consumption.
+var keyTypeName = map[rune]string{
+	input.KeyEnter:     "enter",
+	input.KeyTab:       "tab",
+	input.KeyBackspace: "backspace",
+	input.KeyEscape:    "esc",
+	input.KeySpace:     "space",
+	input.KeyUp:        "up",
+	input.KeyDown:      "down",
+	input.KeyLeft:      "left",
+	input.KeyRight:     "right",
+	input.KeyHome:      "home",
+	input.KeyEnd:       "end",
+	input.KeyPgUp:      "pgup",
+	input.KeyPgDown:    "pgdown",
+	input.KeyInsert:    "insert",
+	input.KeyDelete:    "delete",
+	input.KeyF1:        "f1",
+	input.KeyF2:        "f2",
+	input.KeyF3:        "f3",
+	input.KeyF4:        "f4",
+	input.KeyF5:        "f5",
+	input.KeyF6:        "f6",
+	input.KeyF7:        "f7",
+	input.KeyF8:        "f8",
+	input.KeyF9:        "f9",
+	input.KeyF10:       "f10",
+	input.KeyF11:       "f11",
+	input.KeyF12:       "f12",
+}
+
+// mouseButtonName maps mouse buttons to string names.
+var mouseButtonName = map[ansi.MouseButton]string{
+	ansi.MouseNone:      "none",
+	ansi.MouseLeft:      "left",
+	ansi.MouseMiddle:    "middle",
+	ansi.MouseRight:     "right",
+	ansi.MouseWheelUp:   "wheel_up",
+	ansi.MouseWheelDown: "wheel_down",
+}
+
+// ConvertInputEvent converts a charmbracelet/x/input event to a TTYEvent.
+// Returns nil for unrecognized events.
+func ConvertInputEvent(ev input.Event) *TTYEvent {
+	switch e := ev.(type) {
+	case input.KeyPressEvent:
+		return convertKeyEvent(input.Key(e), "press")
+	case input.KeyReleaseEvent:
+		return convertKeyEvent(input.Key(e), "release")
+	case input.MouseClickEvent:
+		return convertMouseEvent(input.Mouse(e), "press")
+	case input.MouseReleaseEvent:
+		return convertMouseEvent(input.Mouse(e), "release")
+	case input.MouseMotionEvent:
+		return convertMouseEvent(input.Mouse(e), "motion")
+	case input.MouseWheelEvent:
+		return convertMouseEvent(input.Mouse(e), "wheel")
+	case input.WindowSizeEvent:
+		return &TTYEvent{
+			Type:   "resize",
+			Width:  e.Width,
+			Height: e.Height,
+		}
+	case input.FocusEvent:
+		return &TTYEvent{Type: "focus", Focused: true}
+	case input.BlurEvent:
+		return &TTYEvent{Type: "focus", Focused: false}
+	case input.PasteEvent:
+		return &TTYEvent{Type: "paste", Paste: string(e)}
+	default:
+		return nil
+	}
+}
+
+func convertKeyEvent(k input.Key, action string) *TTYEvent {
+	ev := &TTYEvent{
+		Type:   "key",
+		Action: action,
+		Alt:    k.Mod.Contains(input.ModAlt),
+		Ctrl:   k.Mod.Contains(input.ModCtrl),
+		Shift:  k.Mod.Contains(input.ModShift),
+	}
+
+	if name, ok := keyTypeName[k.Code]; ok {
+		ev.KeyType = name
+		ev.Key = name
+	} else if k.Text != "" {
+		ev.KeyType = "runes"
+		ev.Key = k.Text
+	} else if k.Code > 0 && k.Code < input.KeyExtended {
+		ev.KeyType = "runes"
+		ev.Key = string(k.Code)
+	} else {
+		ev.KeyType = "unknown"
+		ev.Key = k.Keystroke()
+	}
+
+	return ev
+}
+
+func convertMouseEvent(m input.Mouse, action string) *TTYEvent {
+	btn := "none"
+	if name, ok := mouseButtonName[m.Button]; ok {
+		btn = name
+	}
+	return &TTYEvent{
+		Type:   "mouse",
+		Action: action,
+		Button: btn,
+		X:      m.X,
+		Y:      m.Y,
+		Alt:    m.Mod.Contains(input.ModAlt),
+		Ctrl:   m.Mod.Contains(input.ModCtrl),
+		Shift:  m.Mod.Contains(input.ModShift),
+	}
+}

--- a/service/terminal/input_event_test.go
+++ b/service/terminal/input_event_test.go
@@ -1,0 +1,186 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/input"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertInputEvent_KeyPress_Runes(t *testing.T) {
+	ev := input.KeyPressEvent(input.Key{
+		Code: 'a',
+		Text: "a",
+	})
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "key", result.Type)
+	assert.Equal(t, "a", result.Key)
+	assert.Equal(t, "runes", result.KeyType)
+	assert.False(t, result.Ctrl)
+	assert.False(t, result.Alt)
+	assert.False(t, result.Shift)
+}
+
+func TestConvertInputEvent_KeyPress_SpecialKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    rune
+		keyType string
+	}{
+		{"enter", input.KeyEnter, "enter"},
+		{"tab", input.KeyTab, "tab"},
+		{"escape", input.KeyEscape, "esc"},
+		{"backspace", input.KeyBackspace, "backspace"},
+		{"up", input.KeyUp, "up"},
+		{"down", input.KeyDown, "down"},
+		{"left", input.KeyLeft, "left"},
+		{"right", input.KeyRight, "right"},
+		{"home", input.KeyHome, "home"},
+		{"end", input.KeyEnd, "end"},
+		{"pgup", input.KeyPgUp, "pgup"},
+		{"pgdown", input.KeyPgDown, "pgdown"},
+		{"delete", input.KeyDelete, "delete"},
+		{"insert", input.KeyInsert, "insert"},
+		{"f1", input.KeyF1, "f1"},
+		{"f12", input.KeyF12, "f12"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := input.KeyPressEvent(input.Key{Code: tt.code})
+			result := ConvertInputEvent(ev)
+			require.NotNil(t, result)
+			assert.Equal(t, "key", result.Type)
+			assert.Equal(t, tt.keyType, result.KeyType)
+			assert.Equal(t, tt.keyType, result.Key)
+		})
+	}
+}
+
+func TestConvertInputEvent_KeyPress_Modifiers(t *testing.T) {
+	ev := input.KeyPressEvent(input.Key{
+		Code: 'c',
+		Text: "c",
+		Mod:  input.ModCtrl | input.ModAlt,
+	})
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "key", result.Type)
+	assert.True(t, result.Ctrl)
+	assert.True(t, result.Alt)
+	assert.False(t, result.Shift)
+}
+
+func TestConvertInputEvent_MouseClick(t *testing.T) {
+	ev := input.MouseClickEvent(input.Mouse{
+		X:      10,
+		Y:      20,
+		Button: ansi.MouseLeft,
+	})
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "mouse", result.Type)
+	assert.Equal(t, "press", result.Action)
+	assert.Equal(t, "left", result.Button)
+	assert.Equal(t, 10, result.X)
+	assert.Equal(t, 20, result.Y)
+}
+
+func TestConvertInputEvent_MouseRelease(t *testing.T) {
+	ev := input.MouseReleaseEvent(input.Mouse{
+		X:      5,
+		Y:      3,
+		Button: ansi.MouseNone,
+	})
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "mouse", result.Type)
+	assert.Equal(t, "release", result.Action)
+	assert.Equal(t, "none", result.Button)
+}
+
+func TestConvertInputEvent_MouseWheel(t *testing.T) {
+	ev := input.MouseWheelEvent(input.Mouse{
+		Button: ansi.MouseWheelDown,
+	})
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "mouse", result.Type)
+	assert.Equal(t, "wheel", result.Action)
+	assert.Equal(t, "wheel_down", result.Button)
+}
+
+func TestConvertInputEvent_MouseMotion(t *testing.T) {
+	ev := input.MouseMotionEvent(input.Mouse{
+		X:      1,
+		Y:      2,
+		Button: ansi.MouseLeft,
+		Mod:    input.ModShift,
+	})
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "mouse", result.Type)
+	assert.Equal(t, "motion", result.Action)
+	assert.Equal(t, "left", result.Button)
+	assert.True(t, result.Shift)
+}
+
+func TestConvertInputEvent_WindowSize(t *testing.T) {
+	ev := input.WindowSizeEvent{Width: 80, Height: 24}
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "resize", result.Type)
+	assert.Equal(t, 80, result.Width)
+	assert.Equal(t, 24, result.Height)
+}
+
+func TestConvertInputEvent_Focus(t *testing.T) {
+	focus := ConvertInputEvent(input.FocusEvent{})
+	require.NotNil(t, focus)
+	assert.Equal(t, "focus", focus.Type)
+	assert.True(t, focus.Focused)
+
+	blur := ConvertInputEvent(input.BlurEvent{})
+	require.NotNil(t, blur)
+	assert.Equal(t, "focus", blur.Type)
+	assert.False(t, blur.Focused)
+}
+
+func TestConvertInputEvent_Paste(t *testing.T) {
+	ev := input.PasteEvent("pasted text")
+	result := ConvertInputEvent(ev)
+	require.NotNil(t, result)
+	assert.Equal(t, "paste", result.Type)
+	assert.Equal(t, "pasted text", result.Paste)
+}
+
+func TestConvertInputEvent_UnknownReturnsNil(t *testing.T) {
+	result := ConvertInputEvent("some unknown event")
+	assert.Nil(t, result)
+}
+
+func TestConvertInputEvent_MouseButtons(t *testing.T) {
+	tests := []struct {
+		button ansi.MouseButton
+		name   string
+	}{
+		{ansi.MouseNone, "none"},
+		{ansi.MouseLeft, "left"},
+		{ansi.MouseMiddle, "middle"},
+		{ansi.MouseRight, "right"},
+		{ansi.MouseWheelUp, "wheel_up"},
+		{ansi.MouseWheelDown, "wheel_down"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := input.MouseClickEvent(input.Mouse{Button: tt.button})
+			result := ConvertInputEvent(ev)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.name, result.Button)
+		})
+	}
+}

--- a/service/terminal/raw.go
+++ b/service/terminal/raw.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -39,6 +40,10 @@ func (r *RawManager) Enable() error {
 		}
 		r.state = state
 		r.active = true
+
+		// MakeRaw disables OPOST which turns off \n → \r\n translation.
+		// Re-enable output processing so terminal output renders correctly.
+		enableOutputProcessing(int(r.file.Fd()))
 	}
 	r.refs++
 	return nil
@@ -87,4 +92,16 @@ func (r *RawManager) Enabled() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.active
+}
+
+// enableOutputProcessing re-enables OPOST after MakeRaw so the kernel
+// translates \n to \r\n on output. Without this, line feeds in raw mode
+// move the cursor down without returning to column 0.
+func enableOutputProcessing(fd int) {
+	termios, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return
+	}
+	termios.Oflag |= unix.OPOST
+	_ = unix.IoctlSetTermios(fd, unix.TCSETS, termios)
 }

--- a/service/terminal/tty/dispatcher.go
+++ b/service/terminal/tty/dispatcher.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	errNoTerminalContext = errors.New("no terminal context")
-	errNoRawController   = errors.New("raw terminal control unavailable")
+	errNoTerminalContext  = errors.New("no terminal context")
+	errNoRawController    = errors.New("raw terminal control unavailable")
+	errNoInputController  = errors.New("input controller unavailable")
 )
 
 // Option configures a Dispatcher.
@@ -166,6 +167,56 @@ func (d *Dispatcher) execute(j job) {
 		}
 		j.receiver.CompleteYield(j.tag, true, nil)
 
+	case ttyapi.StartInputCmd:
+		if tc.Input == nil {
+			j.receiver.CompleteYield(j.tag, nil, errNoInputController)
+			return
+		}
+		if err := tc.Input.Start(); err != nil {
+			j.receiver.CompleteYield(j.tag, nil, err)
+			return
+		}
+		j.receiver.CompleteYield(j.tag, true, nil)
+
+	case ttyapi.StopInputCmd:
+		if tc.Input == nil {
+			j.receiver.CompleteYield(j.tag, nil, errNoInputController)
+			return
+		}
+		if err := tc.Input.Stop(); err != nil {
+			j.receiver.CompleteYield(j.tag, nil, err)
+			return
+		}
+		j.receiver.CompleteYield(j.tag, true, nil)
+
+	case ttyapi.ScreenSizeCmd:
+		if tc.Input == nil {
+			j.receiver.CompleteYield(j.tag, nil, errNoInputController)
+			return
+		}
+		cols, rows, err := tc.Input.ScreenSize()
+		if err != nil {
+			j.receiver.CompleteYield(j.tag, nil, err)
+			return
+		}
+		j.receiver.CompleteYield(j.tag, []int{cols, rows}, nil)
+
+	case ttyapi.EnableMouseCmd:
+		if tc.Input == nil {
+			j.receiver.CompleteYield(j.tag, nil, errNoInputController)
+			return
+		}
+		tc.Input.EnableMouse()
+		j.receiver.CompleteYield(j.tag, true, nil)
+
+	case ttyapi.DisableMouseCmd:
+		if tc.Input == nil {
+			j.receiver.CompleteYield(j.tag, nil, errNoInputController)
+			return
+		}
+		tc.Input.DisableMouse()
+		j.receiver.CompleteYield(j.tag, true, nil)
+
 	default:
 		j.receiver.CompleteYield(j.tag, nil, fmt.Errorf("unknown tty command: %T", j.cmd))
 	}
@@ -193,4 +244,9 @@ func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispat
 	register(ttyapi.ReadLine, h)
 	register(ttyapi.RawEnable, h)
 	register(ttyapi.RawDisable, h)
+	register(ttyapi.StartInput, h)
+	register(ttyapi.StopInput, h)
+	register(ttyapi.ScreenSize, h)
+	register(ttyapi.EnableMouse, h)
+	register(ttyapi.DisableMouse, h)
 }

--- a/service/terminal/tty/dispatcher_test.go
+++ b/service/terminal/tty/dispatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/service/terminal"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
@@ -130,6 +131,220 @@ func TestDispatcherRawEnable_NoController(t *testing.T) {
 	}
 	if !errors.Is(receiver.err, errNoRawController) {
 		t.Errorf("expected errNoRawController, got %v", receiver.err)
+	}
+}
+
+type stubInputController struct {
+	startCalls int
+	stopCalls  int
+	startErr   error
+	stopErr    error
+	cols       int
+	rows       int
+	sizeErr    error
+}
+
+func (s *stubInputController) Start() error {
+	s.startCalls++
+	return s.startErr
+}
+
+func (s *stubInputController) Stop() error {
+	s.stopCalls++
+	return s.stopErr
+}
+
+func (s *stubInputController) ScreenSize() (int, int, error) {
+	return s.cols, s.rows, s.sizeErr
+}
+
+func (s *stubInputController) EnableMouse()  {}
+func (s *stubInputController) DisableMouse() {}
+
+func TestDispatcherStartInput(t *testing.T) {
+	d := NewDispatcher()
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	tc := terminal.NewTerminalContext(bytes.NewBufferString(""), nil, nil)
+	input := &stubInputController{cols: 80, rows: 24}
+	tc.Input = input
+	_ = terminal.WithTerminalContext(ctx, tc)
+
+	receiver := &testReceiver{}
+	_ = d.handle(ctx, ttyapi.StartInputCmd{}, 1, receiver)
+	if receiver.err != nil {
+		t.Fatalf("unexpected error: %v", receiver.err)
+	}
+	if input.startCalls != 1 {
+		t.Fatalf("expected start called once, got %d", input.startCalls)
+	}
+	if receiver.data != true {
+		t.Fatalf("expected true, got %v", receiver.data)
+	}
+}
+
+func TestDispatcherStopInput(t *testing.T) {
+	d := NewDispatcher()
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	tc := terminal.NewTerminalContext(bytes.NewBufferString(""), nil, nil)
+	input := &stubInputController{}
+	tc.Input = input
+	_ = terminal.WithTerminalContext(ctx, tc)
+
+	receiver := &testReceiver{}
+	_ = d.handle(ctx, ttyapi.StopInputCmd{}, 1, receiver)
+	if receiver.err != nil {
+		t.Fatalf("unexpected error: %v", receiver.err)
+	}
+	if input.stopCalls != 1 {
+		t.Fatalf("expected stop called once, got %d", input.stopCalls)
+	}
+}
+
+func TestDispatcherScreenSize(t *testing.T) {
+	d := NewDispatcher()
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	tc := terminal.NewTerminalContext(bytes.NewBufferString(""), nil, nil)
+	input := &stubInputController{cols: 120, rows: 40}
+	tc.Input = input
+	_ = terminal.WithTerminalContext(ctx, tc)
+
+	receiver := &testReceiver{}
+	_ = d.handle(ctx, ttyapi.ScreenSizeCmd{}, 1, receiver)
+	if receiver.err != nil {
+		t.Fatalf("unexpected error: %v", receiver.err)
+	}
+	size, ok := receiver.data.([]int)
+	if !ok {
+		t.Fatalf("expected []int, got %T", receiver.data)
+	}
+	if size[0] != 120 || size[1] != 40 {
+		t.Errorf("expected [120, 40], got %v", size)
+	}
+}
+
+func TestDispatcherStartInput_NoController(t *testing.T) {
+	d := NewDispatcher()
+	ctx := withTerminalContext("input")
+	receiver := &testReceiver{}
+
+	_ = d.handle(ctx, ttyapi.StartInputCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error for missing input controller")
+	}
+	if !errors.Is(receiver.err, errNoInputController) {
+		t.Errorf("expected errNoInputController, got %v", receiver.err)
+	}
+}
+
+func TestDispatcherScreenSize_Error(t *testing.T) {
+	d := NewDispatcher()
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	tc := terminal.NewTerminalContext(bytes.NewBufferString(""), nil, nil)
+	input := &stubInputController{sizeErr: errors.New("not a terminal")}
+	tc.Input = input
+	_ = terminal.WithTerminalContext(ctx, tc)
+
+	receiver := &testReceiver{}
+	_ = d.handle(ctx, ttyapi.ScreenSizeCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDispatcherStopInput_NoController(t *testing.T) {
+	d := NewDispatcher()
+	ctx := withTerminalContext("input")
+	receiver := &testReceiver{}
+
+	_ = d.handle(ctx, ttyapi.StopInputCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error for missing input controller")
+	}
+	if !errors.Is(receiver.err, errNoInputController) {
+		t.Errorf("expected errNoInputController, got %v", receiver.err)
+	}
+}
+
+func TestDispatcherStartInput_Error(t *testing.T) {
+	d := NewDispatcher()
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	tc := terminal.NewTerminalContext(bytes.NewBufferString(""), nil, nil)
+	tc.Input = &stubInputController{startErr: errors.New("start failed")}
+	_ = terminal.WithTerminalContext(ctx, tc)
+
+	receiver := &testReceiver{}
+	_ = d.handle(ctx, ttyapi.StartInputCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error")
+	}
+	if receiver.err.Error() != "start failed" {
+		t.Errorf("expected 'start failed', got %v", receiver.err)
+	}
+}
+
+func TestDispatcherStopInput_Error(t *testing.T) {
+	d := NewDispatcher()
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	tc := terminal.NewTerminalContext(bytes.NewBufferString(""), nil, nil)
+	tc.Input = &stubInputController{stopErr: errors.New("stop failed")}
+	_ = terminal.WithTerminalContext(ctx, tc)
+
+	receiver := &testReceiver{}
+	_ = d.handle(ctx, ttyapi.StopInputCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error")
+	}
+	if receiver.err.Error() != "stop failed" {
+		t.Errorf("expected 'stop failed', got %v", receiver.err)
+	}
+}
+
+func TestDispatcherScreenSize_NoController(t *testing.T) {
+	d := NewDispatcher()
+	ctx := withTerminalContext("input")
+	receiver := &testReceiver{}
+
+	_ = d.handle(ctx, ttyapi.ScreenSizeCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error for missing input controller")
+	}
+	if !errors.Is(receiver.err, errNoInputController) {
+		t.Errorf("expected errNoInputController, got %v", receiver.err)
+	}
+}
+
+func TestDispatcherRawDisable_NoController(t *testing.T) {
+	d := NewDispatcher()
+	ctx := withTerminalContext("input")
+	receiver := &testReceiver{}
+
+	_ = d.handle(ctx, ttyapi.RawDisableCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error for missing raw controller")
+	}
+	if !errors.Is(receiver.err, errNoRawController) {
+		t.Errorf("expected errNoRawController, got %v", receiver.err)
+	}
+}
+
+type unknownCmd struct{}
+
+func (unknownCmd) CmdID() dispatcher.CommandID { return 999 }
+
+func TestDispatcherUnknownCommand(t *testing.T) {
+	d := NewDispatcher()
+	ctx := withTerminalContext("input")
+	receiver := &testReceiver{}
+
+	_ = d.handle(ctx, unknownCmd{}, 1, receiver)
+	if receiver.err == nil {
+		t.Fatal("expected error for unknown command")
 	}
 }
 

--- a/tests/tty-demo/src/_index.yaml
+++ b/tests/tty-demo/src/_index.yaml
@@ -1,0 +1,37 @@
+version: "1.0"
+namespace: demo
+
+entries:
+  - name: terminal
+    kind: terminal.host
+    meta:
+      comment: Terminal host for TTY demo
+    hide_logs: true
+    lifecycle:
+      auto_start: true
+
+  - name: tty_demo
+    kind: process.lua
+    meta:
+      comment: TTY toolkit demo
+      command:
+        name: tty-demo
+        short: Demonstrate the tty module toolkit
+    source: file://tty_demo.lua
+    method: main
+    modules:
+      - io
+      - tty
+
+  - name: norton
+    kind: process.lua
+    meta:
+      comment: Norton Commander file manager demo
+      command:
+        name: norton
+        short: Norton Commander-style dual-pane file manager
+    source: file://norton.lua
+    method: main
+    modules:
+      - io
+      - tty

--- a/tests/tty-demo/src/norton.lua
+++ b/tests/tty-demo/src/norton.lua
@@ -1,0 +1,454 @@
+-- Norton Commander-style dual-pane file manager demo.
+-- Showcases tty module: styles, borders, layout, key bindings, input events.
+
+local io = require("io")
+local tty = require("tty")
+
+local LEFT = tty.text.position.LEFT
+local CENTER = tty.text.position.CENTER
+local RIGHT = tty.text.position.RIGHT
+local TOP = tty.text.position.TOP
+
+local DOUBLE = tty.borders.DOUBLE
+
+-- ANSI sequences
+local ESC = "\027["
+local ALT_SCREEN_ON = "\027[?1049h"
+local ALT_SCREEN_OFF = "\027[?1049l"
+local CURSOR_HIDE = ESC .. "?25l"
+local CURSOR_SHOW = ESC .. "?25h"
+local CURSOR_HOME = ESC .. "H"
+local CLEAR_BELOW = ESC .. "J"
+
+-- Simulated filesystem
+type FsEntry = {name: string, size: integer, kind: string, date: string}
+
+local fs_tree: {[string]: {FsEntry}} = {
+    ["/"] = {
+        {name = "..",     size = 0,     kind = "up",  date = "2026-01-01 00:00"},
+        {name = "bin",    size = 4096,  kind = "dir", date = "2026-02-10 08:30"},
+        {name = "etc",    size = 4096,  kind = "dir", date = "2026-02-14 11:20"},
+        {name = "home",   size = 4096,  kind = "dir", date = "2026-01-28 09:45"},
+        {name = "usr",    size = 4096,  kind = "dir", date = "2026-02-01 14:00"},
+        {name = "var",    size = 4096,  kind = "dir", date = "2026-02-12 16:30"},
+        {name = "tmp",    size = 4096,  kind = "dir", date = "2026-02-16 10:00"},
+        {name = "LICENSE",      size = 1071,   kind = "file", date = "2025-06-15 12:00"},
+        {name = "README.md",    size = 3420,   kind = "file", date = "2026-02-10 09:15"},
+        {name = "Makefile",     size = 2180,   kind = "file", date = "2026-01-20 17:30"},
+    },
+    ["/home"] = {
+        {name = "..",           size = 0,      kind = "up",   date = "2026-01-01 00:00"},
+        {name = "user",         size = 4096,   kind = "dir",  date = "2026-02-15 20:00"},
+        {name = "guest",        size = 4096,   kind = "dir",  date = "2026-01-10 08:00"},
+        {name = ".bashrc",      size = 420,    kind = "file", date = "2026-02-01 10:00"},
+        {name = ".profile",     size = 180,    kind = "file", date = "2025-12-01 09:00"},
+    },
+    ["/home/user"] = {
+        {name = "..",           size = 0,      kind = "up",   date = "2026-01-01 00:00"},
+        {name = "Documents",    size = 4096,   kind = "dir",  date = "2026-02-14 18:00"},
+        {name = "Downloads",    size = 4096,   kind = "dir",  date = "2026-02-16 09:30"},
+        {name = "projects",     size = 4096,   kind = "dir",  date = "2026-02-15 21:00"},
+        {name = ".gitconfig",   size = 256,    kind = "file", date = "2026-01-05 11:00"},
+        {name = ".vimrc",       size = 1420,   kind = "file", date = "2026-02-08 14:30"},
+        {name = "notes.txt",    size = 8320,   kind = "file", date = "2026-02-16 08:45"},
+        {name = "todo.md",      size = 512,    kind = "file", date = "2026-02-15 19:00"},
+    },
+    ["/home/user/projects"] = {
+        {name = "..",           size = 0,      kind = "up",   date = "2026-01-01 00:00"},
+        {name = "wippy",        size = 4096,   kind = "dir",  date = "2026-02-16 10:00"},
+        {name = "scripts",      size = 4096,   kind = "dir",  date = "2026-02-10 15:00"},
+        {name = "go.mod",       size = 890,    kind = "file", date = "2026-02-16 09:00"},
+        {name = "go.sum",       size = 45200,  kind = "file", date = "2026-02-16 09:00"},
+        {name = "main.go",      size = 2340,   kind = "file", date = "2026-02-15 22:00"},
+        {name = "config.yaml",  size = 680,    kind = "file", date = "2026-02-14 16:00"},
+        {name = "Dockerfile",   size = 420,    kind = "file", date = "2026-02-12 11:30"},
+        {name = "Makefile",     size = 1560,   kind = "file", date = "2026-02-13 14:00"},
+        {name = "README.md",    size = 5120,   kind = "file", date = "2026-02-15 20:00"},
+    },
+    ["/etc"] = {
+        {name = "..",           size = 0,      kind = "up",   date = "2026-01-01 00:00"},
+        {name = "nginx",        size = 4096,   kind = "dir",  date = "2026-02-10 12:00"},
+        {name = "ssh",          size = 4096,   kind = "dir",  date = "2026-01-15 08:00"},
+        {name = "hosts",        size = 340,    kind = "file", date = "2025-11-01 00:00"},
+        {name = "passwd",       size = 2100,   kind = "file", date = "2026-02-01 10:00"},
+        {name = "resolv.conf",  size = 128,    kind = "file", date = "2026-02-10 08:00"},
+        {name = "fstab",        size = 560,    kind = "file", date = "2025-10-15 12:00"},
+    },
+    ["/usr"] = {
+        {name = "..",           size = 0,      kind = "up",   date = "2026-01-01 00:00"},
+        {name = "bin",          size = 4096,   kind = "dir",  date = "2026-02-10 08:30"},
+        {name = "lib",          size = 4096,   kind = "dir",  date = "2026-02-10 08:30"},
+        {name = "local",        size = 4096,   kind = "dir",  date = "2026-01-20 14:00"},
+        {name = "share",        size = 4096,   kind = "dir",  date = "2026-02-05 16:00"},
+    },
+}
+
+local default_listing: {FsEntry} = {
+    {name = "..", size = 0, kind = "up", date = "2026-01-01 00:00"},
+}
+
+local function get_listing(path: string): {FsEntry}
+    return fs_tree[path] or default_listing
+end
+
+local function parent_path(path)
+    if path == "/" then return "/" end
+    local parent = path:match("^(.+)/[^/]+$")
+    return parent or "/"
+end
+
+local function join_path(base, name)
+    if base == "/" then return "/" .. name end
+    return base .. "/" .. name
+end
+
+local function format_size(bytes)
+    if bytes >= 1048576 then
+        return string.format("%.1fM", bytes / 1048576)
+    elseif bytes >= 1024 then
+        return string.format("%.1fK", bytes / 1024)
+    end
+    return tostring(bytes)
+end
+
+-- Key bindings
+local keys = {
+    quit = tty.bind({
+        keys = {"f10", "ctrl+c"},
+        help = {key = "F10", desc = "quit"},
+    }),
+    nav_up = tty.bind({
+        keys = {"up", "k"},
+        help = {key = "up/k", desc = "up"},
+    }),
+    nav_down = tty.bind({
+        keys = {"down", "j"},
+        help = {key = "dn/j", desc = "down"},
+    }),
+    enter = tty.bind({
+        keys = {"enter"},
+        help = {key = "enter", desc = "open"},
+    }),
+    switch_panel = tty.bind({
+        keys = {"tab"},
+        help = {key = "tab", desc = "switch"},
+    }),
+    page_up = tty.bind({
+        keys = {"pgup"},
+        help = {key = "pgup", desc = "page up"},
+    }),
+    page_down = tty.bind({
+        keys = {"pgdown"},
+        help = {key = "pgdn", desc = "page down"},
+    }),
+    go_home = tty.bind({
+        keys = {"home"},
+        help = {key = "home", desc = "first"},
+    }),
+    go_end = tty.bind({
+        keys = {"end"},
+        help = {key = "end", desc = "last"},
+    }),
+}
+
+-- Panel state
+type Panel = {path: string, cursor: integer, scroll: integer, listing: {FsEntry}}
+
+local function new_panel(path: string): Panel
+    return {
+        path = path,
+        cursor = 1,
+        scroll = 0,
+        listing = get_listing(path),
+    }
+end
+
+-- State
+local width, height = 80, 24
+local running = true
+local active_panel = 1
+local panels = {
+    new_panel("/home/user"),
+    new_panel("/home/user/projects"),
+}
+
+-- Styles
+local nc_blue = "#000088"
+local nc_cyan = "#00AAAA"
+
+local s = {
+    panel_border   = tty.style():foreground(nc_cyan):background(nc_blue),
+    panel_title    = tty.style():foreground("#FFFFFF"):background(nc_blue):bold(),
+    file_normal    = tty.style():foreground(nc_cyan):background(nc_blue),
+    file_dir       = tty.style():foreground("#FFFFFF"):background(nc_blue):bold(),
+    file_exec      = tty.style():foreground("#00CC00"):background(nc_blue),
+    file_selected  = tty.style():foreground("#000000"):background(nc_cyan),
+    file_dir_sel   = tty.style():foreground("#000000"):background(nc_cyan):bold(),
+    header_bg      = tty.style():background(nc_blue):foreground(nc_cyan),
+    status_bar     = tty.style():foreground("#000000"):background(nc_cyan),
+    fn_key_num     = tty.style():foreground("#000000"):background(nc_cyan):bold(),
+    fn_key_label   = tty.style():foreground("#000000"):background(nc_cyan),
+    fn_key_gap     = tty.style():foreground(nc_cyan):background(nc_blue),
+    info_bar       = tty.style():foreground(nc_cyan):background(nc_blue),
+    menu_bar       = tty.style():foreground("#000000"):background(nc_cyan),
+    menu_item      = tty.style():foreground("#000000"):background(nc_cyan),
+    menu_hotkey    = tty.style():foreground("#FF0000"):background(nc_cyan):bold(),
+}
+
+-- Navigation
+local function panel_enter(panel: Panel)
+    local entry: FsEntry? = panel.listing[panel.cursor]
+    if not entry then return end
+    local target
+    if entry.kind == "up" then
+        target = parent_path(panel.path)
+    elseif entry.kind == "dir" then
+        target = join_path(panel.path, entry.name)
+    else
+        return
+    end
+    panel.path = target
+    panel.listing = get_listing(target)
+    panel.cursor = 1
+    panel.scroll = 0
+end
+
+local function panel_move(panel: Panel, delta: number, page_h: number)
+    local count = #panel.listing
+    if count == 0 then return end
+    panel.cursor = panel.cursor + delta
+    if panel.cursor < 1 then panel.cursor = 1 end
+    if panel.cursor > count then panel.cursor = count end
+    if panel.cursor < panel.scroll + 1 then
+        panel.scroll = panel.cursor - 1
+    end
+    if panel.cursor > panel.scroll + page_h then
+        panel.scroll = panel.cursor - page_h
+    end
+end
+
+-- Rendering
+local function render_panel(panel: Panel, pw: integer, ph: integer, is_active: boolean): string
+    local inner_w = pw - 2
+    local list_h = ph - 5
+
+    -- Path header
+    local title_style = is_active and s.panel_title or s.file_normal
+    local path_line = title_style:width(inner_w):align(tty.align.CENTER):render(panel.path)
+
+    -- Column header
+    local name_col_w = inner_w - 16
+    if name_col_w < 8 then name_col_w = 8 end
+    local hdr_line = tty.style():foreground("#FFCC00"):background(nc_blue):bold()
+        :width(inner_w)
+        :render("Name" .. string.rep(" ", name_col_w - 4)
+            .. string.format("%6s", "Size") .. "  Date")
+
+    -- File lines
+    local lines = {}
+    for i = panel.scroll + 1, math.min(panel.scroll + list_h, #panel.listing) do
+        local entry: FsEntry? = panel.listing[i]
+        if not entry then break end
+        local is_cursor = (i == panel.cursor)
+
+        local display_name = entry.name
+        if entry.kind == "dir" then
+            display_name = "/" .. display_name
+        elseif entry.kind == "up" then
+            display_name = "/.."
+        end
+
+        local size_str = entry.kind == "dir" and "<DIR>" or format_size(entry.size)
+        if entry.kind == "up" then size_str = "UP" end
+        local date_str = entry.date:sub(6, 10)
+
+        local padded_name = display_name
+        if #padded_name > name_col_w then
+            padded_name = padded_name:sub(1, name_col_w - 1) .. "~"
+        end
+        padded_name = padded_name .. string.rep(" ", name_col_w - #padded_name)
+
+        local row = padded_name .. string.format("%6s", size_str) .. "  " .. date_str
+
+        local row_style
+        if is_cursor and is_active then
+            row_style = (entry.kind == "dir" or entry.kind == "up") and s.file_dir_sel or s.file_selected
+        elseif entry.kind == "dir" or entry.kind == "up" then
+            row_style = s.file_dir
+        else
+            row_style = s.file_normal
+        end
+        lines[#lines + 1] = row_style:width(inner_w):render(row)
+    end
+
+    -- Pad remaining lines
+    local empty_line = s.file_normal:width(inner_w):render("")
+    for _ = #lines + 1, list_h do
+        lines[#lines + 1] = empty_line
+    end
+
+    -- Info line
+    local entry: FsEntry? = panel.listing[panel.cursor]
+    local info = ""
+    if entry then
+        info = entry.name
+        if entry.kind == "file" then
+            info = info .. "  " .. format_size(entry.size) .. "  " .. entry.date
+        end
+    end
+    local info_line = s.info_bar:width(inner_w):render(info)
+
+    -- Compose body and wrap with border
+    local body = tty.text.join_vertical(LEFT,
+        path_line, hdr_line, table.concat(lines, "\n"), info_line)
+
+    local border_fg = is_active and "#FFFFFF" or nc_cyan
+    return tty.style()
+        :foreground(nc_cyan)
+        :background(nc_blue)
+        :border(DOUBLE)
+        :border_foreground(border_fg)
+        :border_background(nc_blue)
+        :width(inner_w)
+        :render(body)
+end
+
+local function render_fn_bar(w: integer): string
+    local fn_items = {
+        {num = "1", label = "Help"},
+        {num = "2", label = "Menu"},
+        {num = "3", label = "View"},
+        {num = "4", label = "Edit"},
+        {num = "5", label = "Copy"},
+        {num = "6", label = "Move"},
+        {num = "7", label = "Mkdir"},
+        {num = "8", label = "Del"},
+        {num = "9", label = "Pull"},
+        {num = "10", label = "Quit"},
+    }
+    local parts = {}
+    local item_w = math.floor(w / #fn_items)
+    for _, f in ipairs(fn_items) do
+        local label_w = item_w - #f.num
+        if label_w < 1 then label_w = 1 end
+        local label = f.label
+        if #label > label_w then label = label:sub(1, label_w) end
+        label = label .. string.rep(" ", label_w - #label)
+        parts[#parts + 1] = s.fn_key_num:render(f.num) .. s.fn_key_label:render(label)
+    end
+    return table.concat(parts, "")
+end
+
+local function render_menu_bar(w: integer): string
+    local items = {
+        {hot = "L", rest = "eft"},
+        {hot = "F", rest = "ile"},
+        {hot = "C", rest = "ommand"},
+        {hot = "O", rest = "ptions"},
+        {hot = "R", rest = "ight"},
+    }
+    local parts = {}
+    for _, item in ipairs(items) do
+        parts[#parts + 1] = " " .. s.menu_hotkey:render(item.hot) .. s.menu_item:render(item.rest)
+    end
+    local menu_content = table.concat(parts, "")
+    local menu_w = tty.text.width(menu_content)
+    local pad = w - menu_w
+    if pad < 0 then pad = 0 end
+    return tty.style():foreground("#000000"):background(nc_cyan):width(w):render(menu_content .. string.rep(" ", pad))
+end
+
+local function render()
+    local pw = math.floor(width / 2)
+    local panel_h = height - 3
+
+    local left = render_panel(panels[1], pw, panel_h, active_panel == 1)
+    local right = render_panel(panels[2], width - pw, panel_h, active_panel == 2)
+    local dual = tty.text.join_horizontal(TOP, left, right)
+
+    local menu = render_menu_bar(width)
+    local fn_bar = render_fn_bar(width)
+
+    -- Prompt line
+    local prompt = s.info_bar:width(width):render(panels[active_panel].path .. ">")
+
+    local frame = tty.text.join_vertical(LEFT, menu, dual, prompt, fn_bar)
+    io.write(CURSOR_HOME .. frame .. CLEAR_BELOW)
+    io.flush()
+end
+
+-- Event handling
+local function handle_key(event: any)
+    local panel: Panel? = panels[active_panel]
+    if not panel then return end
+    local list_h = height - 8
+
+    if keys.quit:matches(event) then
+        running = false
+    elseif keys.switch_panel:matches(event) then
+        active_panel = active_panel == 1 and 2 or 1
+    elseif keys.nav_up:matches(event) then
+        panel_move(panel, -1, list_h)
+    elseif keys.nav_down:matches(event) then
+        panel_move(panel, 1, list_h)
+    elseif keys.enter:matches(event) then
+        panel_enter(panel)
+    elseif keys.page_up:matches(event) then
+        panel_move(panel, -list_h, list_h)
+    elseif keys.page_down:matches(event) then
+        panel_move(panel, list_h, list_h)
+    elseif keys.go_home:matches(event) then
+        panel_move(panel, -#panel.listing, list_h)
+    elseif keys.go_end:matches(event) then
+        panel_move(panel, #panel.listing, list_h)
+    end
+end
+
+local function handle_event(event: any)
+    if event.type == "key" and event.action ~= "release" then
+        handle_key(event)
+    elseif event.type == "resize" or event.type == "start" then
+        width = event.width
+        height = event.height
+    end
+end
+
+-- Main
+local function main()
+    local ok, err = tty.start()
+    if not ok then
+        io.print("tty.start failed: " .. tostring(err))
+        return
+    end
+
+    local cols, rows
+    cols, rows, err = tty.screen_size()
+    if cols then
+        width = cols
+        height = rows
+    end
+
+    local ch = tty.events()
+    if not ch then
+        tty.stop()
+        io.print("tty.events failed")
+        return
+    end
+
+    io.write(ALT_SCREEN_ON .. CURSOR_HIDE)
+    io.flush()
+    render()
+
+    while running do
+        local event = ch:receive()
+        if event == nil then break end
+        handle_event(event)
+        if running then render() end
+    end
+
+    io.write(CURSOR_SHOW .. ALT_SCREEN_OFF)
+    io.flush()
+    tty.stop()
+end
+
+return main

--- a/tests/tty-demo/src/tty_demo.lua
+++ b/tests/tty-demo/src/tty_demo.lua
@@ -1,0 +1,431 @@
+-- TTY Toolkit Interactive Demo
+-- Full-screen TUI exercising every function in the tty module.
+
+local io = require("io")
+local tty = require("tty")
+
+local LEFT = tty.text.position.LEFT
+local CENTER = tty.text.position.CENTER
+local TOP = tty.text.position.TOP
+local RIGHT = tty.text.position.RIGHT
+
+local ROUNDED = tty.borders.ROUNDED
+local NORMAL = tty.borders.NORMAL
+local THICK = tty.borders.THICK
+local DOUBLE = tty.borders.DOUBLE
+local HIDDEN = tty.borders.HIDDEN
+
+-- ANSI sequences
+local ESC = "\027["
+local ALT_SCREEN_ON = "\027[?1049h"
+local ALT_SCREEN_OFF = "\027[?1049l"
+local CURSOR_HIDE = ESC .. "?25l"
+local CURSOR_SHOW = ESC .. "?25h"
+local CURSOR_HOME = ESC .. "H"
+local CLEAR_BELOW = ESC .. "J"
+
+-- Reusable styles
+local theme = {
+    title    = tty.style():foreground("#FFCC00"):bold(),
+    label    = tty.style():foreground("#888888"),
+    value    = tty.style():foreground("#FFFFFF"):bold(),
+    ok       = tty.style():foreground("#00CC00"):bold(),
+    fail     = tty.style():foreground("#FF0000"):bold(),
+    muted    = tty.style():foreground("#555555"):italic(),
+    section  = tty.style():foreground("#AAAAAA"):bold(),
+    header   = tty.style():bold():foreground("#FFFFFF"):background("#FF6600"),
+    status   = tty.style():background("#222222"),
+}
+
+-- Key bindings
+local bindings = {
+    quit = tty.bind({
+        keys = {"q", "ctrl+c", "esc"},
+        help = {key = "q/esc", desc = "quit"},
+    }),
+    next_tab = tty.bind({
+        keys = {"tab", "l"},
+        help = {key = "tab/l", desc = "next tab"},
+    }),
+    prev_tab = tty.bind({
+        keys = {"shift+tab", "h"},
+        help = {key = "S-tab/h", desc = "prev tab"},
+    }),
+}
+
+-- State
+local width, height = 80, 24
+local events = {}
+local max_events = 100
+local mouse_x, mouse_y = 0, 0
+local key_count, mouse_count, resize_count = 0, 0, 0
+local running = true
+local tab_index = 1
+local tab_names = {"Events", "Styles", "Layout", "Bindings"}
+
+local function push_event(ev: any)
+    table.insert(events, 1, ev)
+    if #events > max_events then
+        table.remove(events)
+    end
+end
+
+local function format_event(ev)
+    if ev.type == "key" then
+        local mods = ""
+        if ev.ctrl then mods = mods .. "ctrl+" end
+        if ev.alt then mods = mods .. "alt+" end
+        if ev.shift then mods = mods .. "shift+" end
+        local k = ev.key_type ~= "runes" and ev.key_type or ev.key
+        local act = ev.action == "release" and " up" or ""
+        return "KEY " .. mods .. k .. act
+    elseif ev.type == "mouse" then
+        return "MOUSE " .. ev.action .. " " .. ev.button .. " @" .. ev.x .. "," .. ev.y
+    elseif ev.type == "resize" then
+        return "RESIZE " .. ev.width .. "x" .. ev.height
+    elseif ev.type == "focus" then
+        return "FOCUS " .. (ev.focused and "in" or "out")
+    elseif ev.type == "start" then
+        return "START " .. ev.width .. "x" .. ev.height
+    end
+    return ev.type
+end
+
+-- Tab: Events
+
+local function render_events_tab(w: integer, h: integer): string
+    local title = theme.title:copy():width(w):align(tty.align.CENTER):render("Live Event Stream")
+    local lines = {}
+    local visible = h - 3
+    for i = 1, math.min(#events, visible) do
+        local s = tty.style():foreground(i == 1 and "#00FF88" or "#666666")
+        if i == 1 then s = s:bold() end
+        lines[#lines + 1] = s:max_width(w):render("  " .. format_event(events[i]))
+    end
+    if #events == 0 then
+        lines[#lines + 1] = theme.muted:render("  waiting for events...")
+    end
+    return tty.text.join_vertical(LEFT, title, "", table.concat(lines, "\n"))
+end
+
+-- Tab: Styles
+
+local function render_styles_tab(w: integer, h: integer): string
+    local lbl = theme.label
+    local title = theme.title:copy():width(w):align(tty.align.CENTER):render("Style Showcase")
+
+    local fmt_line =
+        tty.style():bold():render("bold") .. "  " ..
+        tty.style():italic():render("italic") .. "  " ..
+        tty.style():underline():render("underline") .. "  " ..
+        tty.style():strikethrough():render("strike") .. "  " ..
+        tty.style():faint():render("faint") .. "  " ..
+        tty.style():reverse():render("reverse")
+
+    local colors = {"#FF0000", "#FF6600", "#FFCC00", "#00CC00", "#0066FF", "#6600CC", "#CC00CC"}
+    local fg_parts, bg_parts = {}, {}
+    for _, c in ipairs(colors) do
+        fg_parts[#fg_parts + 1] = tty.style():foreground(c):bold():render("@@")
+        bg_parts[#bg_parts + 1] = tty.style():background(c):foreground("#000000"):render("  ")
+    end
+    local fg_line = table.concat(fg_parts, " ")
+    local bg_line = table.concat(bg_parts, " ")
+
+    local bdr = tty.style():border_foreground("#666666"):foreground("#CCCCCC"):padding(0, 1)
+    local b_normal = bdr:copy():border(NORMAL):render(NORMAL)
+    local b_rounded = bdr:copy():border(ROUNDED):render(ROUNDED)
+    local b_thick = bdr:copy():border(THICK):render(THICK)
+    local b_double = bdr:copy():border(DOUBLE):render(DOUBLE)
+    local b_hidden = bdr:copy():border(HIDDEN):render(HIDDEN)
+    local border_row = tty.text.join_horizontal(CENTER, b_normal, b_rounded, b_thick)
+    local border_row2 = tty.text.join_horizontal(CENTER, b_double, b_hidden)
+
+    local partial = tty.style()
+        :border(ROUNDED, true, false, true, false)
+        :border_foreground("#FF6600"):border_background("#330000")
+        :padding(0, 1):render("top+bottom only")
+
+    local padded = tty.style()
+        :foreground("#00CC00"):background("#003300")
+        :padding(0, 2):render("padded")
+    local margined = tty.style()
+        :foreground("#0066FF"):margin(0, 1):render("margin")
+
+    local fixed_w = tty.style():width(20):foreground("#FFCC00"):render("width=20")
+    local max_w = tty.style():max_width(15):foreground("#00CCCC"):render("max_width=15 long")
+
+    local align_box = tty.text.join_vertical(LEFT,
+        tty.style():width(24):align(tty.align.LEFT):foreground("#888888"):render("left"),
+        tty.style():width(24):align(tty.align.CENTER):foreground("#CCCCCC"):render("center"),
+        tty.style():width(24):align(tty.align.RIGHT):foreground("#FFFFFF"):render("right"))
+
+    local inline_s = tty.style():inline():foreground("#00CC00"):render("inline removes\nnewlines")
+
+    local base = tty.style():foreground("#00CC00"):bold()
+    local derived = base:copy():foreground("#FF0000")
+    local copy_line = base:render("original") .. "  " .. derived:render("copy")
+
+    local multi = tty.style():foreground("#FFCC00"):render("hello", " ", "world", "!")
+
+    return tty.text.join_vertical(LEFT,
+        title, "",
+        "  " .. lbl:render("Formatting: ") .. fmt_line,
+        "  " .. lbl:render("FG colors:  ") .. fg_line,
+        "  " .. lbl:render("BG colors:  ") .. bg_line,
+        "  " .. lbl:render("Borders:"),
+        border_row,
+        border_row2,
+        "  " .. lbl:render("Partial:"),
+        partial,
+        "  " .. lbl:render("Spacing:    ") .. padded .. margined,
+        "  " .. lbl:render("Sizing:     ") .. fixed_w .. "  " .. max_w,
+        "  " .. lbl:render("Alignment:"),
+        align_box,
+        "  " .. lbl:render("Inline:     ") .. inline_s,
+        "  " .. lbl:render("Copy:       ") .. copy_line,
+        "  " .. lbl:render("Multi-arg:  ") .. multi)
+end
+
+-- Tab: Layout
+
+local function render_layout_tab(w: integer, h: integer): string
+    local lbl = theme.label
+    local val = theme.value
+    local title = theme.title:copy():width(w):align(tty.align.CENTER):render("Text Layout & Placement")
+
+    local sample = "Hello, World!"
+    local tw, th = tty.text.size("line1\nline2!")
+
+    local box_style = tty.style():border(ROUNDED):padding(0, 1)
+    local box_a = box_style:copy():foreground("#FF6600"):render("A")
+    local box_b = box_style:copy():foreground("#00CC00"):render("B")
+    local box_c = box_style:copy():foreground("#0066FF"):render("C")
+
+    local horiz = tty.text.join_horizontal(CENTER, box_a, box_b, box_c)
+    local vert = tty.text.join_vertical(CENTER, box_a, box_b)
+    local joined = tty.text.join_horizontal(TOP, horiz, "   ", vert)
+
+    local pw = math.min(30, w - 4)
+    local placed = tty.text.place(pw, 3, CENTER, CENTER, "centered")
+    local placed_box = tty.style():border(ROUNDED):border_foreground("#444444"):render(placed)
+
+    local ph = tty.text.place_horizontal(pw, RIGHT, "right-aligned")
+
+    local valign_box = tty.style()
+        :width(16):height(3)
+        :align(tty.align.CENTER):align_vertical(tty.align.CENTER)
+        :foreground("#FF6600"):border(ROUNDED):border_foreground("#333333")
+        :render("v-center")
+
+    return tty.text.join_vertical(LEFT,
+        title, "",
+        "  " .. lbl:render("width:      ") .. val:render(tostring(tty.text.width(sample))),
+        "  " .. lbl:render("height:     ") .. val:render(tostring(tty.text.height("a\nb\nc"))),
+        "  " .. lbl:render("size:       ") .. val:render(tw .. "x" .. th),
+        "  " .. lbl:render("max_width:  ") .. val:render(tostring(tty.text.max_width({"short", "a longer string", "mid"}))),
+        "  " .. lbl:render("max_height: ") .. val:render(tostring(tty.text.max_height({"one", "one\ntwo\nthree", "a"}))),
+        "",
+        "  " .. lbl:render("join_horizontal + join_vertical:"),
+        joined,
+        "",
+        "  " .. lbl:render("place (centered in box):"),
+        placed_box,
+        "",
+        "  " .. lbl:render("place_horizontal:"),
+        "  |" .. ph .. "|",
+        "",
+        "  " .. lbl:render("align_vertical:"),
+        valign_box)
+end
+
+-- Tab: Bindings
+
+local function render_bindings_tab(w: integer, h: integer): string
+    local lbl = theme.label
+    local val = theme.value
+    local sec = theme.section
+    local title = theme.title:copy():width(w):align(tty.align.CENTER):render("Key Bindings")
+
+    local help = bindings.quit:help()
+    local lines = {
+        "  " .. lbl:render("quit:    ") .. val:render(tostring(bindings.quit)),
+        "  " .. lbl:render("  key:   ") .. val:render(help.key),
+        "  " .. lbl:render("  desc:  ") .. val:render(help.desc),
+        "  " .. lbl:render("  on:    ") .. val:render(tostring(bindings.quit:is_enabled())),
+        "",
+        "  " .. lbl:render("tab:     ") .. val:render(tostring(bindings.next_tab)),
+        "",
+    }
+
+    lines[#lines + 1] = "  " .. sec:render("Match tests:")
+    local tests = {
+        {name = "q",          ev = {type = "key", key = "q",   key_type = "runes", ctrl = false, alt = false, shift = false}},
+        {name = "ctrl+c",     ev = {type = "key", key = "c",   key_type = "runes", ctrl = true,  alt = false, shift = false}},
+        {name = "esc",        ev = {type = "key", key = "esc", key_type = "esc",   ctrl = false, alt = false, shift = false}},
+        {name = "x (no)",     ev = {type = "key", key = "x",   key_type = "runes", ctrl = false, alt = false, shift = false}},
+        {name = "mouse (no)", ev = {type = "mouse", action = "press", button = "left"}},
+    }
+    for _, t in ipairs(tests) do
+        local m = bindings.quit:matches(t.ev)
+        local ind = m and theme.ok:render("[y]") or theme.fail:render("[n]")
+        lines[#lines + 1] = "    " .. ind .. " " .. lbl:render(t.name)
+    end
+
+    lines[#lines + 1] = ""
+    bindings.quit:set_enabled(false)
+    local dm = bindings.quit:matches(tests[1].ev)
+    bindings.quit:set_enabled(true)
+    local em = bindings.quit:matches(tests[1].ev)
+
+    lines[#lines + 1] = "  " .. sec:render("Enable/disable:")
+    lines[#lines + 1] = "    " .. lbl:render("disabled: ") .. (dm and theme.ok or theme.fail):render(tostring(dm))
+    lines[#lines + 1] = "    " .. lbl:render("enabled:  ") .. (em and theme.ok or theme.fail):render(tostring(em))
+    lines[#lines + 1] = ""
+
+    local nav_kb = tty.bind({
+        keys = {"esc", "alt+x", "shift+tab", "ctrl+alt+delete"},
+        help = {key = "esc", desc = "navigation"},
+    })
+    lines[#lines + 1] = "  " .. sec:render("Complex: ") .. val:render(tostring(nav_kb))
+
+    local empty_kb = tty.bind({keys = {}})
+    lines[#lines + 1] = "  " .. sec:render("Empty:   ") .. val:render(tostring(empty_kb))
+    local nhelp = tty.bind({keys = {"a"}}):help()
+    lines[#lines + 1] = "  " .. sec:render("No-help: ") .. "'" .. nhelp.key .. "'"
+    lines[#lines + 1] = ""
+
+    lines[#lines + 1] = "  " .. sec:render("Borders: ") ..
+        val:render(NORMAL .. " " .. ROUNDED .. " " .. THICK .. " " .. DOUBLE .. " " .. HIDDEN)
+    lines[#lines + 1] = "  " .. sec:render("Align:   ") ..
+        val:render("L=" .. tty.align.LEFT .. " C=" .. tty.align.CENTER .. " R=" .. tty.align.RIGHT)
+    lines[#lines + 1] = "  " .. sec:render("Pos:     ") ..
+        val:render("T=" .. TOP .. " L=" .. LEFT .. " C=" .. CENTER .. " B=" .. tty.text.position.BOTTOM .. " R=" .. RIGHT)
+
+    return tty.text.join_vertical(LEFT, title, "", table.concat(lines, "\n"))
+end
+
+-- Rendering
+
+local tab_renderers = {render_events_tab, render_styles_tab, render_layout_tab, render_bindings_tab}
+
+local function build_status_bar()
+    local left = tty.style():foreground("#888888")
+        :render(" " .. width .. "x" .. height
+            .. " keys:" .. key_count
+            .. " mouse:" .. mouse_count
+            .. " resize:" .. resize_count
+            .. " @" .. mouse_x .. "," .. mouse_y)
+
+    local help_parts = {}
+    for _, name in ipairs({"quit", "next_tab", "prev_tab"}) do
+        local h = bindings[name]:help()
+        help_parts[#help_parts + 1] = h.key .. ":" .. h.desc
+    end
+    local right = tty.style():foreground("#666666"):render(table.concat(help_parts, " ") .. " ")
+
+    local gap = width - tty.text.width(left) - tty.text.width(right)
+    if gap < 0 then gap = 0 end
+    return theme.status:copy():width(width):render(left .. string.rep(" ", gap) .. right)
+end
+
+local function render()
+    local header = theme.header:copy()
+        :width(width):align(tty.align.CENTER):padding(0, 1)
+        :render("TTY TOOLKIT DEMO")
+
+    local tab_parts: {string} = {}
+    for i, name in ipairs(tab_names) do
+        local ts
+        if i == tab_index then
+            ts = tty.style():bold():foreground("#FFFFFF"):background("#0066FF"):padding(0, 1)
+        else
+            ts = tty.style():foreground("#888888"):padding(0, 1)
+        end
+        tab_parts[#tab_parts + 1] = ts:render(name)
+    end
+    local tab_bar = table.concat(tab_parts, "")
+    tab_bar = tty.style():width(width):align(tty.align.CENTER):render(tab_bar)
+
+    local renderer = tab_renderers[tab_index]
+    local content: string = renderer and renderer(width, height - 4) or ""
+    local status = build_status_bar()
+
+    local frame = tty.text.join_vertical(LEFT, header, tab_bar, content)
+    io.write(CURSOR_HOME .. frame .. ESC .. height .. ";1H" .. status .. CLEAR_BELOW)
+    io.flush()
+end
+
+-- Event handling
+
+local function handle_key(event: any)
+    key_count = key_count + 1
+    if bindings.quit:matches(event) then
+        running = false
+    elseif bindings.next_tab:matches(event) then
+        tab_index = tab_index % #tab_names + 1
+    elseif bindings.prev_tab:matches(event) then
+        tab_index = (tab_index - 2) % #tab_names + 1
+    end
+end
+
+local function handle_event(event: any)
+    push_event(event)
+
+    if event.type == "key" and event.action ~= "release" then
+        handle_key(event)
+    elseif event.type == "mouse" then
+        mouse_count = mouse_count + 1
+        mouse_x = event.x
+        mouse_y = event.y
+    elseif event.type == "resize" then
+        resize_count = resize_count + 1
+        width = event.width
+        height = event.height
+    elseif event.type == "start" then
+        width = event.width
+        height = event.height
+    end
+end
+
+-- Main
+
+local function main()
+    local ok, err = tty.start()
+    if not ok then
+        io.print("tty.start failed: " .. tostring(err))
+        return
+    end
+
+    local cols, rows
+    cols, rows, err = tty.screen_size()
+    if cols then
+        width = cols
+        height = rows
+    end
+
+    local ch = tty.events()
+    if not ch then
+        tty.stop()
+        io.print("tty.events failed")
+        return
+    end
+
+    tty.mouse(true)
+    io.write(ALT_SCREEN_ON .. CURSOR_HIDE)
+    io.flush()
+    render()
+
+    while running do
+        local event = ch:receive()
+        if event == nil then break end
+        handle_event(event)
+        if running then render() end
+    end
+
+    io.write(CURSOR_SHOW .. ALT_SCREEN_OFF)
+    io.flush()
+    tty.mouse(false)
+    tty.stop()
+end
+
+return main

--- a/tests/tty-demo/wippy.lock
+++ b/tests/tty-demo/wippy.lock
@@ -1,0 +1,3 @@
+directories:
+    modules: .wippy
+    src: ./src


### PR DESCRIPTION
This pull request introduces a new Lua `tty` module providing terminal input events, screen size, mouse support, and key binding utilities for Lua scripts. It also adds a `cwd()` function to the `system.process` Lua API for retrieving the current working directory, and updates dependencies to support the new terminal features. The changes include new dispatcher commands, Go interfaces, and Lua module/component registration.

**Terminal Input and TTY Support for Lua:**

- Added a new `tty` Lua module with functions for starting/stopping terminal input, querying screen size, enabling/disabling mouse events, subscribing to terminal events, styling, and key binding utilities. (`runtime/lua/modules/tty/module.go` [[1]](diffhunk://#diff-056d88c9f0b3c5443cc480aede787f8b4245defad883f77b2b9f0ca34eabce74R1-R224) `runtime/lua/modules/tty/key_binding.go` [[2]](diffhunk://#diff-a9f8bc64475527d7721fe869ac97c8a1a9be40e516fdbe1282719ff345590e5bR1-R179) `runtime/lua/modules/tty/handler.go` [[3]](diffhunk://#diff-26afc57c9ed465384ef13a0c1e13cafc5c7119a8a69c763d1e031676bd8ba2f7R1-R57)
- Registered the new `tty` module as a boot component for Lua runtimes and defined its component name. (`boot/components/runtime/lua/tty.go` [[1]](diffhunk://#diff-bb0aba985332fdd686c446ddff9090df301b1181dc11ca3e602ebd305c431842R1-R27) `boot/components/runtime/lua/all.go` [[2]](diffhunk://#diff-9b2339bd58f21fb874b22c0de7f4899d43278953b9407c09ab9467259e680573R42) `boot/components/runtime/lua/constants.go` [[3]](diffhunk://#diff-9b0f1443bb0cb346b47e14ef7e8b526a2b3c764f652c03ddc7f8311dbfb33f65R38)

**Terminal Service and API Enhancements:**

- Introduced a `InputController` Go interface for managing terminal input events and mouse/screen size, and added it to the terminal context. (`api/tty/input.go` [[1]](diffhunk://#diff-729ad9dafd2d8e4f4d9fc9a124a04a4782f9783c9bcf5fd99102eac37da2ada5R1-R10) `api/service/terminal/context.go` [[2]](diffhunk://#diff-57fb17995174a64ef2dffabd1ff4e48ba138103a266ba1541e78c85c86bdd147R9) [[3]](diffhunk://#diff-57fb17995174a64ef2dffabd1ff4e48ba138103a266ba1541e78c85c86bdd147R22)
- Added new dispatcher commands and command structs for starting/stopping input, querying screen size, and toggling mouse tracking. (`api/tty/command.go` [[1]](diffhunk://#diff-d2019703598707978b4bab9a90e7492ef91c433da4fa5b74b805e92bcd0f2462L7-R11) [[2]](diffhunk://#diff-d2019703598707978b4bab9a90e7492ef91c433da4fa5b74b805e92bcd0f2462R21-R25) [[3]](diffhunk://#diff-d2019703598707978b4bab9a90e7492ef91c433da4fa5b74b805e92bcd0f2462R64-R103)

**Dependency Updates:**

- Added new dependencies for terminal and input handling from Charmbracelet (ansi, input, term). (`go.mod` [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R20-R22) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L103-R107)

**Lua System Module Improvements:**

- Added a `cwd()` function to the `system.process` Lua API for retrieving the working directory, with security checks and error handling. (`runtime/lua/modules/system/module.go` [[1]](diffhunk://#diff-ad5d0a2c438be51be94cadba15d6d7974f5660a9c6b9d24a9517507a90417447L79-R82) [[2]](diffhunk://#diff-ad5d0a2c438be51be94cadba15d6d7974f5660a9c6b9d24a9517507a90417447R333-R351) `runtime/lua/modules/system/types.go` [[3]](diffhunk://#diff-14d116c8f03e7d91e41b494739a7958a3371421ddf84db2966fddab4a3cd6e1cR61)
- Added a test for the new `cwd()` function. (`runtime/lua/modules/system/module_test.go` [runtime/lua/modules/system/module_test.goR269-R287](diffhunk://#diff-6d986f596b986e0e7eecbe0f965dbc074f32c632fa762a2891d078885ebe1edbR269-R287))