### PR TITLE
Split terminal raw mode and signal handling into platform-specific files

### DIFF
--- a/service/terminal/input.go
+++ b/service/terminal/input.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 
 	"github.com/charmbracelet/x/input"
 	"github.com/charmbracelet/x/term"
@@ -181,27 +179,14 @@ func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader) {
 	}
 }
 
-func (r *InputReader) sigwinchLoop(ctx context.Context) {
-	defer r.wg.Done()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGWINCH)
-	defer signal.Stop(sigCh)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-sigCh:
-			cols, rows, err := r.screenSize()
-			if err == nil {
-				r.sendEvent(&TTYEvent{
-					Type:   "resize",
-					Width:  cols,
-					Height: rows,
-				})
-			}
-		}
+func (r *InputReader) emitResize() {
+	cols, rows, err := r.screenSize()
+	if err == nil {
+		r.sendEvent(&TTYEvent{
+			Type:   "resize",
+			Width:  cols,
+			Height: rows,
+		})
 	}
 }
 

--- a/service/terminal/raw.go
+++ b/service/terminal/raw.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -41,7 +40,7 @@ func (r *RawManager) Enable() error {
 		r.state = state
 		r.active = true
 
-		// MakeRaw disables OPOST which turns off \n → \r\n translation.
+		// MakeRaw disables OPOST which turns off \n -> \r\n translation.
 		// Re-enable output processing so terminal output renders correctly.
 		enableOutputProcessing(int(r.file.Fd()))
 	}
@@ -92,16 +91,4 @@ func (r *RawManager) Enabled() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.active
-}
-
-// enableOutputProcessing re-enables OPOST after MakeRaw so the kernel
-// translates \n to \r\n on output. Without this, line feeds in raw mode
-// move the cursor down without returning to column 0.
-func enableOutputProcessing(fd int) {
-	termios, err := unix.IoctlGetTermios(fd, unix.TCGETS)
-	if err != nil {
-		return
-	}
-	termios.Oflag |= unix.OPOST
-	_ = unix.IoctlSetTermios(fd, unix.TCSETS, termios)
 }

--- a/service/terminal/raw_darwin.go
+++ b/service/terminal/raw_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+func enableOutputProcessing(fd int) {
+	termios, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		return
+	}
+	termios.Oflag |= unix.OPOST
+	_ = unix.IoctlSetTermios(fd, unix.TIOCSETA, termios)
+}

--- a/service/terminal/raw_linux.go
+++ b/service/terminal/raw_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+func enableOutputProcessing(fd int) {
+	termios, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return
+	}
+	termios.Oflag |= unix.OPOST
+	_ = unix.IoctlSetTermios(fd, unix.TCSETS, termios)
+}

--- a/service/terminal/raw_windows.go
+++ b/service/terminal/raw_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package terminal
+
+// Windows console does not use POSIX termios; output processing
+// is handled by the console subsystem.
+func enableOutputProcessing(fd int) {}

--- a/service/terminal/signal_unix.go
+++ b/service/terminal/signal_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func (r *InputReader) sigwinchLoop(ctx context.Context) {
+	defer r.wg.Done()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sigCh:
+			r.emitResize()
+		}
+	}
+}

--- a/service/terminal/signal_windows.go
+++ b/service/terminal/signal_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package terminal
+
+import "context"
+
+func (r *InputReader) sigwinchLoop(ctx context.Context) {
+	defer r.wg.Done()
+	<-ctx.Done()
+}


### PR DESCRIPTION
TCGETS/TCSETS are Linux-only ioctl constants; macOS uses TIOCGETA/TIOCSETA. SIGWINCH is unavailable on Windows. Extract enableOutputProcessing into raw_linux.go, raw_darwin.go, raw_windows.go and sigwinchSignal into signal_unix.go, signal_windows.go to allow cross-compilation.