### PR TITLE
Fix/pack run loadstate

### DIFF
--- a/api/runtime/lua/config.go
+++ b/api/runtime/lua/config.go
@@ -25,6 +25,7 @@ const (
 	FunctionBytecode registry.Kind = "function.lua.bc"
 	LibraryBytecode  registry.Kind = "library.lua.bc"
 	ProcessBytecode  registry.Kind = "process.lua.bc"
+	WorkflowBytecode registry.Kind = "workflow.lua.bc"
 
 	// DefaultMaxSize defines how many concurrent executions are allowed in a flex pool by default
 	DefaultMaxSize = 100

--- a/api/service/env/config.go
+++ b/api/service/env/config.go
@@ -13,6 +13,7 @@ const (
 	StorageMemory registry.Kind = "env.storage.memory"
 	StorageFile   registry.Kind = "env.storage.file"
 	StorageOS     registry.Kind = "env.storage.os"
+	StorageStatic registry.Kind = "env.storage.static"
 	StorageRouter registry.Kind = "env.storage.router"
 	Variable      registry.Kind = "env.variable"
 )
@@ -34,6 +35,12 @@ type FileStorageConfig struct {
 // OSStorageConfig provides configuration for OS environment variable storage.
 type OSStorageConfig struct {
 	Meta attrs.Bag `json:"meta"`
+}
+
+// StaticStorageConfig provides configuration for static map-backed environment variable storage.
+type StaticStorageConfig struct {
+	Meta   attrs.Bag         `json:"meta"`
+	Values map[string]string `json:"values"`
 }
 
 // RouterStorageConfig provides configuration for routing environment variable requests across multiple storages.
@@ -68,6 +75,10 @@ func (c *FileStorageConfig) Validate() error {
 }
 
 func (c *OSStorageConfig) Validate() error {
+	return nil
+}
+
+func (c *StaticStorageConfig) Validate() error {
 	return nil
 }
 

--- a/api/service/env/config_test.go
+++ b/api/service/env/config_test.go
@@ -20,6 +20,7 @@ func TestKindConstants(t *testing.T) {
 		{"storage memory", StorageMemory, "env.storage.memory"},
 		{"storage file", StorageFile, "env.storage.file"},
 		{"storage os", StorageOS, "env.storage.os"},
+		{"storage static", StorageStatic, "env.storage.static"},
 		{"storage router", StorageRouter, "env.storage.router"},
 		{"variable", Variable, "env.variable"},
 	}
@@ -188,6 +189,52 @@ func TestOSStorageConfig_MarshalUnmarshal(t *testing.T) {
 
 func TestOSStorageConfig_Validate(t *testing.T) {
 	config := OSStorageConfig{}
+	assert.NoError(t, config.Validate())
+}
+
+func TestStaticStorageConfig_MarshalUnmarshal(t *testing.T) {
+	tests := []struct {
+		config  StaticStorageConfig
+		name    string
+		wantErr bool
+	}{
+		{
+			name: "with values",
+			config: StaticStorageConfig{
+				Meta: attrs.Bag{"type": "static"},
+				Values: map[string]string{
+					"PUBLIC_API_HOST": "https://example.test",
+					"APP_ENV":         "production",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty config",
+			config:  StaticStorageConfig{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(&tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			var decoded StaticStorageConfig
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+			assert.Equal(t, tt.config, decoded)
+		})
+	}
+}
+
+func TestStaticStorageConfig_Validate(t *testing.T) {
+	config := StaticStorageConfig{}
 	assert.NoError(t, config.Validate())
 }
 

--- a/boot/build/stages/bytecode.go
+++ b/boot/build/stages/bytecode.go
@@ -37,6 +37,7 @@ var kindMapping = map[registry.Kind]registry.Kind{
 	luaapi.Function: luaapi.FunctionBytecode,
 	luaapi.Library:  luaapi.LibraryBytecode,
 	luaapi.Process:  luaapi.ProcessBytecode,
+	luaapi.Workflow: luaapi.WorkflowBytecode,
 }
 
 type bytecodeStage struct {

--- a/boot/build/stages/bytecode_test.go
+++ b/boot/build/stages/bytecode_test.go
@@ -139,6 +139,40 @@ return { run = run }
 	assert.Equal(t, "run", data["method"])
 }
 
+func TestBytecode_CompileWorkflow(t *testing.T) {
+	ctx, _ := setupTestContext()
+	ClearBytecodeResource()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("app", "wf"),
+			Kind: luaapi.Workflow,
+			Data: payload.New(map[string]any{
+				"source": `
+local function main(ctx)
+    return { ok = true }
+end
+return { main = main }
+`,
+				"method": "main",
+			}),
+		},
+	}
+
+	stage := Bytecode()
+	err := stage.Execute(ctx, &entries)
+	require.NoError(t, err)
+
+	entry := entries[0]
+	assert.Equal(t, luaapi.WorkflowBytecode, entry.Kind)
+
+	data := entry.Data.Data().(map[string]any)
+	assert.Equal(t, BytecodeFSID, data["fs"])
+	assert.Equal(t, "app/wf.luac", data["path"])
+	assert.NotEmpty(t, data["hash"])
+	assert.Equal(t, "main", data["method"])
+}
+
 func TestBytecode_MultipleEntries(t *testing.T) {
 	ctx, _ := setupTestContext()
 	ClearBytecodeResource()

--- a/boot/components/env/all.go
+++ b/boot/components/env/all.go
@@ -7,6 +7,7 @@ func All() []boot.Component {
 		Memory(),
 		File(),
 		OS(),
+		Static(),
 		Composite(),
 		Variable(),
 	}

--- a/boot/components/env/constants.go
+++ b/boot/components/env/constants.go
@@ -6,6 +6,7 @@ const (
 	MemoryName    boot.Name = "env.memory"
 	FileName      boot.Name = "env.file"
 	OSName        boot.Name = "env.os"
+	StaticName    boot.Name = "env.static"
 	CompositeName boot.Name = "env.composite"
 	VariableName  boot.Name = "env.variable"
 )

--- a/boot/components/env/static.go
+++ b/boot/components/env/static.go
@@ -9,26 +9,26 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	bootpkg "github.com/wippyai/runtime/boot"
 	bootsys "github.com/wippyai/runtime/boot/components/system"
-	"github.com/wippyai/runtime/service/env/composite"
+	envstatic "github.com/wippyai/runtime/service/env/static"
 )
 
-func Composite() boot.Component {
+func Static() boot.Component {
 	return boot.New(boot.P{
-		Name:      CompositeName,
-		DependsOn: []boot.Name{MemoryName, FileName, OSName, StaticName, bootsys.EnvironmentName},
+		Name:      StaticName,
+		DependsOn: []boot.Name{bootsys.EnvironmentName},
 		Load: func(ctx context.Context) (context.Context, error) {
 			logger := logapi.GetLogger(ctx)
 			dtt := payload.GetTranscoder(ctx)
 			bus := event.GetBus(ctx)
 			handlers := bootpkg.GetHandlerRegistry(ctx)
 
-			manager := composite.NewManager(
+			manager := envstatic.NewManager(
 				bus,
 				dtt,
-				logger.Named("env.composite"),
+				logger.Named("env.static"),
 			)
 
-			handlers.RegisterListener("env.storage.router", manager)
+			handlers.RegisterListener("env.storage.static", manager)
 			return ctx, nil
 		},
 	})

--- a/boot/components/runtime/lua/engine.go
+++ b/boot/components/runtime/lua/engine.go
@@ -126,13 +126,13 @@ func Engine() boot.Component {
 			)
 			libraries := library.NewManager(logger.Named("lua.lib"), codeManager, fsReg)
 			processes := proclua.NewManager(logger.Named("lua.process"), codeManager, bus, fsReg, processFactory)
-			workflows := workflowlua.NewManager(logger.Named("lua.workflow"), codeManager, bus, processFactory)
+			workflows := workflowlua.NewManager(logger.Named("lua.workflow"), codeManager, bus, fsReg, processFactory)
 
 			handlers.Register(reghandler.NewTransactionHandler(codeManager))
 			handlers.Register(component.NewHandler("function.lua.**", funcs))
 			handlers.Register(component.NewHandler("library.lua.**", libraries))
 			handlers.Register(component.NewHandler("process.lua.**", processes))
-			handlers.Register(component.NewHandler("workflow.lua", workflows))
+			handlers.Register(component.NewHandler("workflow.lua.**", workflows))
 
 			return ctx, nil
 		},

--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -28,6 +28,7 @@ type ModuleConfig struct {
 	Include      []string            `yaml:"include,omitempty"`
 	Exclude      []string            `yaml:"exclude,omitempty"`
 	Embed        []string            `yaml:"embed,omitempty"`
+	Metadata     map[string]any      `yaml:"metadata,omitempty"`
 }
 
 func Load(dir string) (*ModuleConfig, error) {

--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -27,8 +27,8 @@ type ModuleConfig struct {
 	Authors      []string            `yaml:"authors,omitempty"`
 	Include      []string            `yaml:"include,omitempty"`
 	Exclude      []string            `yaml:"exclude,omitempty"`
-	Embed        []string            `yaml:"embed,omitempty"`
 	Metadata     map[string]any      `yaml:"metadata,omitempty"`
+	Embed        []string            `yaml:"embed,omitempty"`
 }
 
 func Load(dir string) (*ModuleConfig, error) {

--- a/boot/deps/config/config_test.go
+++ b/boot/deps/config/config_test.go
@@ -266,3 +266,28 @@ exclude:
 	assert.Equal(t, []string{"*.lua"}, cfg.Include)
 	assert.Equal(t, []string{"*.test.lua"}, cfg.Exclude)
 }
+
+func TestLoad_WithMetadata(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+organization: myorg
+module: mymod
+metadata:
+  runtime.lsp.enabled: true
+  runtime:
+    logger:
+      level: debug
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DefaultConfigFile), []byte(content), 0644))
+
+	cfg, err := Load(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Metadata)
+	assert.Equal(t, true, cfg.Metadata["runtime.lsp.enabled"])
+
+	runtimeMap, ok := cfg.Metadata["runtime"].(map[string]any)
+	require.True(t, ok)
+	loggerMap, ok := runtimeMap["logger"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "debug", loggerMap["level"])
+}

--- a/boot/deps/hub/download.go
+++ b/boot/deps/hub/download.go
@@ -2,8 +2,10 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +15,12 @@ import (
 	downloadv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/download/v1"
 	modulev1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1"
 	versionv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/version/v1"
+	"github.com/wippyai/runtime/api/supervisor"
+	"github.com/wippyai/runtime/internal/backoff"
+)
+
+const (
+	downloadMaxAttempts = 3
 )
 
 type DownloadInfo struct {
@@ -80,6 +88,43 @@ func (c *Client) GetDownloadURL(ctx context.Context, params *DownloadParams) (*D
 }
 
 func (c *Client) DownloadToFile(ctx context.Context, url, destPath string) error {
+	// Retry transient download failures with bounded exponential backoff.
+	retry := backoff.NewCalculator(supervisor.RetryPolicy{
+		MaxAttempts:   downloadMaxAttempts - 1, // intervals between attempts
+		InitialDelay:  150 * time.Millisecond,
+		BackoffFactor: 2.0,
+		MaxDelay:      time.Second,
+		Jitter:        0.2,
+	})
+
+	for attempt := 1; attempt <= downloadMaxAttempts; attempt++ {
+		err := c.downloadToFileOnce(ctx, url, destPath)
+		if err == nil {
+			return nil
+		}
+
+		if !isRetriableDownloadError(err) || attempt == downloadMaxAttempts {
+			return err
+		}
+
+		wait := retry.NextInterval()
+		if wait <= 0 {
+			return err
+		}
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return err
+		case <-timer.C:
+		}
+	}
+
+	return fmt.Errorf("download failed after retries")
+}
+
+func (c *Client) downloadToFileOnce(ctx context.Context, url, destPath string) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 		return fmt.Errorf("create directory: %w", err)
 	}
@@ -91,13 +136,16 @@ func (c *Client) DownloadToFile(ctx context.Context, url, destPath string) error
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("download failed: %w", err)
+		return &downloadRequestError{err: err}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
-		return fmt.Errorf("download failed with status %d: %s", resp.StatusCode, string(body))
+		return &downloadStatusError{
+			statusCode: resp.StatusCode,
+			body:       string(body),
+		}
 	}
 
 	f, err := os.Create(destPath)
@@ -118,4 +166,50 @@ func (c *Client) DownloadToFile(ctx context.Context, url, destPath string) error
 	}
 
 	return f.Close()
+}
+
+type downloadRequestError struct {
+	err error
+}
+
+func (e *downloadRequestError) Error() string {
+	return fmt.Sprintf("download failed: %v", e.err)
+}
+
+func (e *downloadRequestError) Unwrap() error {
+	return e.err
+}
+
+type downloadStatusError struct {
+	statusCode int
+	body       string
+}
+
+func (e *downloadStatusError) Error() string {
+	return fmt.Sprintf("download failed with status %d: %s", e.statusCode, e.body)
+}
+
+func isRetriableDownloadError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var statusErr *downloadStatusError
+	if errors.As(err, &statusErr) {
+		code := statusErr.statusCode
+		return code == http.StatusRequestTimeout ||
+			code == http.StatusTooManyRequests ||
+			code >= http.StatusInternalServerError
+	}
+
+	var reqErr *downloadRequestError
+	if errors.As(err, &reqErr) {
+		var netErr net.Error
+		if errors.As(reqErr, &netErr) {
+			return true
+		}
+		return true
+	}
+
+	return false
 }

--- a/boot/deps/hub/download.go
+++ b/boot/deps/hub/download.go
@@ -181,8 +181,8 @@ func (e *downloadRequestError) Unwrap() error {
 }
 
 type downloadStatusError struct {
-	statusCode int
 	body       string
+	statusCode int
 }
 
 func (e *downloadStatusError) Error() string {

--- a/boot/deps/hub/download_test.go
+++ b/boot/deps/hub/download_test.go
@@ -1,0 +1,60 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadToFileRetriesTransientStatus(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("temporary"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("payload"))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{
+		httpClient: server.Client(),
+	}
+
+	dest := filepath.Join(t.TempDir(), "cache", "module.wapp")
+	err := client.DownloadToFile(context.Background(), server.URL, dest)
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+
+	data, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(data))
+}
+
+func TestDownloadToFileDoesNotRetryForbidden(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{
+		httpClient: server.Client(),
+	}
+
+	dest := filepath.Join(t.TempDir(), "cache", "module.wapp")
+	err := client.DownloadToFile(context.Background(), server.URL, dest)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status 403")
+	require.Equal(t, 1, attempts)
+}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -71,7 +71,7 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 		return err
 	}
 
-	if err := loadEntriesToRegistry(ctx, entries, logger); err != nil {
+	if err := LoadEntriesToRegistry(ctx, entries, logger); err != nil {
 		return err // Already has context from registry
 	}
 
@@ -376,8 +376,8 @@ func loadEntriesFromWapp(path string, dtt payload.Transcoder) ([]regapi.Entry, e
 	return reader.GetEntries()
 }
 
-// loadEntriesToRegistry loads entries into the registry using LoadState to restore from history.
-func loadEntriesToRegistry(ctx context.Context, entries []regapi.Entry, logger *zap.Logger) error {
+// LoadEntriesToRegistry loads entries into the registry using LoadState to restore from history.
+func LoadEntriesToRegistry(ctx context.Context, entries []regapi.Entry, logger *zap.Logger) error {
 	if err := waitForListenerReadiness(ctx, logger); err != nil {
 		return err
 	}

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -26,8 +26,9 @@ If the lock file is missing, runs 'wippy init' followed by 'wippy update'.
 Modules are installed to the vendor directory specified in the lock file.
 
 When module names are provided as arguments, only those modules are processed.
-Use with --force or --repair to target specific modules:
-  wippy install --repair keeper/keeper wippy/relay`,
+Use with --refresh to re-download modules when cache might be stale:
+  wippy install --refresh
+  wippy install --refresh keeper/keeper wippy/relay`,
 	RunE: runInstall,
 }
 
@@ -35,8 +36,9 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 
 	installCmd.Flags().StringP("lock-file", "l", defaultLockFile, "path to lock file")
-	installCmd.Flags().Bool("force", false, "bypass cache and always download modules")
-	installCmd.Flags().Bool("repair", false, "verify entry hashes and re-download if mismatch")
+	installCmd.Flags().Bool("refresh", false, "re-download modules even if already cached")
+	installCmd.Flags().Bool("force", false, "alias for --refresh")
+	installCmd.Flags().Bool("repair", false, "alias for --refresh")
 	installCmd.Flags().String("registry", "", "registry URL (default: from credentials)")
 }
 
@@ -132,7 +134,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	vendorDir := filepath.Join(lockDir, vendorPath)
 	shouldUnpack := lockObj.ShouldUnpackModules()
 
-	force, _ := cmd.Flags().GetBool("force")
+	refresh := shouldBypassInstallCache(cmd)
+	if refresh {
+		logger.Info("refresh enabled, bypassing module cache")
+	}
 
 	installed := 0
 	cached := 0
@@ -150,7 +155,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 		dirPath := filepath.Join(vendorDir, lock.ModulePath(modName))
 
-		if !force {
+		if !refresh {
 			resolved := lock.ResolveModuleDir(vendorDir, modName, module.Version)
 			if resolved.IsWapp {
 				if shouldUnpack {
@@ -234,6 +239,25 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		zap.Int("total", len(modules)),
 	}
 	logger.Info(logMsg, logFields...)
+	if !refresh && installed == 0 && cached > 0 {
+		logger.Info("all modules were loaded from cache; use --refresh to re-download")
+	}
 
 	return nil
+}
+
+func shouldBypassInstallCache(cmd *cobra.Command) bool {
+	return getBoolFlag(cmd, "refresh") || getBoolFlag(cmd, "force") || getBoolFlag(cmd, "repair")
+}
+
+func getBoolFlag(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return false
+	}
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		return false
+	}
+	value, err := cmd.Flags().GetBool(name)
+	return err == nil && value
 }

--- a/cmd/wippy/cmd/install_test.go
+++ b/cmd/wippy/cmd/install_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestShouldBypassInstallCache(t *testing.T) {
+	t.Run("returns false when no flags exist", func(t *testing.T) {
+		c := &cobra.Command{Use: "test"}
+		if shouldBypassInstallCache(c) {
+			t.Fatal("expected cache bypass to be false")
+		}
+	})
+
+	t.Run("returns true for refresh", func(t *testing.T) {
+		c := &cobra.Command{Use: "test"}
+		c.Flags().Bool("refresh", false, "")
+		if err := c.Flags().Set("refresh", "true"); err != nil {
+			t.Fatalf("set refresh flag: %v", err)
+		}
+		if !shouldBypassInstallCache(c) {
+			t.Fatal("expected cache bypass to be true for --refresh")
+		}
+	})
+
+	t.Run("returns true for force alias", func(t *testing.T) {
+		c := &cobra.Command{Use: "test"}
+		c.Flags().Bool("force", false, "")
+		if err := c.Flags().Set("force", "true"); err != nil {
+			t.Fatalf("set force flag: %v", err)
+		}
+		if !shouldBypassInstallCache(c) {
+			t.Fatal("expected cache bypass to be true for --force")
+		}
+	})
+
+	t.Run("returns true for repair alias", func(t *testing.T) {
+		c := &cobra.Command{Use: "test"}
+		c.Flags().Bool("repair", false, "")
+		if err := c.Flags().Set("repair", "true"); err != nil {
+			t.Fatalf("set repair flag: %v", err)
+		}
+		if !shouldBypassInstallCache(c) {
+			t.Fatal("expected cache bypass to be true for --repair")
+		}
+	})
+}

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -402,6 +402,17 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 	if len(cfg.Authors) > 0 {
 		metadata["authors"] = cfg.Authors
 	}
+	for key, value := range cfg.Metadata {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		// Preserve canonical publish metadata fields.
+		if _, exists := metadata[trimmed]; exists {
+			continue
+		}
+		metadata[trimmed] = value
+	}
 
 	packWriter := wapp.NewWriter()
 

--- a/cmd/wippy/cmd/readme_test.go
+++ b/cmd/wippy/cmd/readme_test.go
@@ -35,8 +35,6 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 func TestPrintReadmeJSON(t *testing.T) {
-	t.Parallel()
-
 	ref := &moduleRef{Org: "wippy", Module: "terminal"}
 	info := &hub.ReadmeInfo{
 		Content:  "# Terminal",
@@ -59,8 +57,6 @@ func TestPrintReadmeJSON(t *testing.T) {
 }
 
 func TestPrintReadmeText_WithMetadata(t *testing.T) {
-	t.Parallel()
-
 	ref := &moduleRef{Org: "wippy", Module: "terminal"}
 	info := &hub.ReadmeInfo{
 		Content:  "# Heading\nline\n",
@@ -80,8 +76,6 @@ func TestPrintReadmeText_WithMetadata(t *testing.T) {
 }
 
 func TestPrintReadmeText_AddsTrailingNewlineWhenMissing(t *testing.T) {
-	t.Parallel()
-
 	ref := &moduleRef{Org: "wippy", Module: "terminal"}
 	info := &hub.ReadmeInfo{Content: "no newline"}
 

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -80,6 +80,7 @@ func init() {
 type commandMeta struct {
 	Name  string `json:"name"`
 	Short string `json:"short"`
+	Main  bool   `json:"main"`
 }
 
 // runApp is the primary `wippy run` execution flow.
@@ -262,6 +263,13 @@ func resolveCommandToEntry(ctx context.Context, name string) (string, error) {
 // 2) CLI logger/event-stream overrides,
 // 3) explicit -o override fields.
 func loadRuntimeConfig(cmd *cobra.Command, logger *zap.Logger) (boot.Config, error) {
+	return loadRuntimeConfigWithDefaults(cmd, logger, nil)
+}
+
+// loadRuntimeConfigWithDefaults resolves runtime configuration like
+// loadRuntimeConfig, but first seeds it with optional runtime defaults.
+// Defaults are applied with lower precedence than file and CLI settings.
+func loadRuntimeConfigWithDefaults(cmd *cobra.Command, logger *zap.Logger, runtimeDefaults boot.Config) (boot.Config, error) {
 	cfg, err := loadBootConfig()
 	if err != nil {
 		return nil, err
@@ -269,6 +277,10 @@ func loadRuntimeConfig(cmd *cobra.Command, logger *zap.Logger) (boot.Config, err
 
 	if cfg == nil {
 		cfg = createDefaultConfig()
+	}
+
+	if runtimeDefaults != nil {
+		cfg = bootconfig.Merge(runtimeDefaults, cfg)
 	}
 
 	cfg = applyCLIOverrides(cfg)
@@ -312,7 +324,8 @@ func extractCommandMeta(meta map[string]any) *commandMeta {
 	}
 
 	short, _ := cmdMap["short"].(string)
-	return &commandMeta{Name: name, Short: short}
+	main, _ := cmdMap["main"].(bool)
+	return &commandMeta{Name: name, Short: short, Main: main}
 }
 
 // runList prints all command-enabled process entries from resolved lock modules.

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -307,7 +307,15 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string) error {
 
 	logger.Info("loading pack file", zap.String("file", packFile), zap.String("memory_limit", formatBytes(memLimit)))
 
-	ctx, loader, runLogger, embedReg, err := bootstrapPackRuntime(cmd, logger)
+	runtimeDefaults, err := loadPackRuntimeDefaults(packFile, logger)
+	if err != nil {
+		return fmt.Errorf("failed to load runtime defaults from pack metadata: %w", err)
+	}
+	if runtimeDefaults != nil {
+		logger.Info("applied runtime defaults from pack metadata", zap.Int("setting_count", len(runtimeDefaults.Keys())))
+	}
+
+	ctx, loader, runLogger, embedReg, err := bootstrapPackRuntimeWithDefaults(cmd, logger, runtimeDefaults)
 	if err != nil {
 		return err
 	}
@@ -358,7 +366,15 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string) err
 
 	logger.Info("loading pack files", zap.Strings("files", packFiles), zap.String("memory_limit", formatBytes(memLimit)))
 
-	ctx, loader, runLogger, embedReg, err := bootstrapPackRuntime(cmd, logger)
+	runtimeDefaults, err := loadPackRuntimeDefaultsFromFiles(packFiles, logger)
+	if err != nil {
+		return fmt.Errorf("failed to load runtime defaults from pack metadata: %w", err)
+	}
+	if runtimeDefaults != nil {
+		logger.Info("applied runtime defaults from pack metadata", zap.Int("setting_count", len(runtimeDefaults.Keys())))
+	}
+
+	ctx, loader, runLogger, embedReg, err := bootstrapPackRuntimeWithDefaults(cmd, logger, runtimeDefaults)
 	if err != nil {
 		return err
 	}

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -29,7 +29,7 @@ import (
 var hubModulePattern = regexp.MustCompile(`^([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)(?:@(.+))?$`)
 
 // findPackCommand finds a command entry in the pack.
-// If commandName is empty, returns the first available command (preferring "run").
+// If commandName is empty, it only auto-selects a command marked as main.
 func findPackCommand(ctx context.Context, commandName string) (string, error) {
 	reg := registry.GetRegistry(ctx)
 	if reg == nil {
@@ -44,10 +44,11 @@ func findPackCommand(ctx context.Context, commandName string) (string, error) {
 	var commands []struct {
 		name    string
 		entryID string
+		main    bool
 	}
 
 	for _, e := range allEntries {
-		if !strings.HasPrefix(e.Kind, "process.lua") {
+		if !isProcessKind(e.Kind) {
 			continue
 		}
 
@@ -59,9 +60,18 @@ func findPackCommand(ctx context.Context, commandName string) (string, error) {
 		commands = append(commands, struct {
 			name    string
 			entryID string
-		}{name: cmdMeta.Name, entryID: e.ID.String()})
+			main    bool
+		}{name: cmdMeta.Name, entryID: e.ID.String(), main: cmdMeta.Main})
 	}
 
+	return selectPackCommand(commands, commandName)
+}
+
+func selectPackCommand(commands []struct {
+	name    string
+	entryID string
+	main    bool
+}, commandName string) (string, error) {
 	if len(commands) == 0 {
 		return "", nil
 	}
@@ -75,13 +85,24 @@ func findPackCommand(ctx context.Context, commandName string) (string, error) {
 		return "", fmt.Errorf("command %q not found in pack", commandName)
 	}
 
+	var mainCommands []string
+	var mainEntryID string
 	for _, c := range commands {
-		if c.name == "run" {
-			return c.entryID, nil
+		if !c.main {
+			continue
 		}
+		mainCommands = append(mainCommands, c.name)
+		mainEntryID = c.entryID
 	}
 
-	return commands[0].entryID, nil
+	switch len(mainCommands) {
+	case 0:
+		return "", nil
+	case 1:
+		return mainEntryID, nil
+	default:
+		return "", fmt.Errorf("multiple commands marked as main in pack: %s", strings.Join(mainCommands, ", "))
+	}
 }
 
 // isHubModuleRef identifies inputs that should be treated as hub references
@@ -396,17 +417,7 @@ func runPackEntries(
 		return NewStartComponentsError(err)
 	}
 
-	reg := registry.GetRegistry(appCtx)
-	if reg == nil {
-		return ErrRegistryNotFound
-	}
-
-	resolver := registry.GetResolver(appCtx)
-	if resolver == nil {
-		return ErrDependencyResolverNotFound
-	}
-
-	if err := entries.ApplyToRegistry(appCtx, packEntries, resolver, reg, logger); err != nil {
+	if err := entries.LoadEntriesToRegistry(appCtx, packEntries, logger); err != nil {
 		return err
 	}
 

--- a/cmd/wippy/cmd/run_pack_bootstrap.go
+++ b/cmd/wippy/cmd/run_pack_bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+	"github.com/wippyai/runtime/api/boot"
 	logapi "github.com/wippyai/runtime/api/logs"
 	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
 	bootpkg "github.com/wippyai/runtime/boot"
@@ -15,7 +16,13 @@ import (
 // It keeps boot sequencing and config resolution (including CLI overrides) identical
 // for both single-pack and multi-pack execution.
 func bootstrapPackRuntime(cmd *cobra.Command, baseLogger *zap.Logger) (context.Context, *bootpkg.Loader, *zap.Logger, *embedpkg.Registry, error) {
-	cfg, err := loadRuntimeConfig(cmd, baseLogger)
+	return bootstrapPackRuntimeWithDefaults(cmd, baseLogger, nil)
+}
+
+// bootstrapPackRuntimeWithDefaults initializes runtime context for pack execution,
+// seeding runtime config with optional defaults extracted from pack metadata.
+func bootstrapPackRuntimeWithDefaults(cmd *cobra.Command, baseLogger *zap.Logger, runtimeDefaults boot.Config) (context.Context, *bootpkg.Loader, *zap.Logger, *embedpkg.Registry, error) {
+	cfg, err := loadRuntimeConfigWithDefaults(cmd, baseLogger, runtimeDefaults)
 	if err != nil {
 		baseLogger.Error("failed to resolve runtime config", zap.Error(err))
 		return nil, nil, nil, nil, err

--- a/cmd/wippy/cmd/run_pack_metadata.go
+++ b/cmd/wippy/cmd/run_pack_metadata.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/cmd/internal/bootconfig"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+const runtimeMetadataPrefix = "runtime."
+
+// loadPackRuntimeDefaults reads runtime defaults from a single pack metadata.
+func loadPackRuntimeDefaults(packPath string, logger *zap.Logger) (boot.Config, error) {
+	file, err := os.Open(packPath)
+	if err != nil {
+		return nil, fmt.Errorf("open pack metadata %s: %w", packPath, err)
+	}
+	defer file.Close()
+
+	reader, err := wapp.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("read pack metadata %s: %w", packPath, err)
+	}
+
+	metadata, err := reader.GetMetadata()
+	if err != nil {
+		return nil, fmt.Errorf("read pack metadata %s: %w", packPath, err)
+	}
+
+	return runtimeConfigFromPackMetadata(metadata, logger), nil
+}
+
+// loadPackRuntimeDefaultsFromFiles reads and merges runtime defaults from pack files.
+// Later packs override earlier ones for overlapping keys.
+func loadPackRuntimeDefaultsFromFiles(packFiles []string, logger *zap.Logger) (boot.Config, error) {
+	var merged boot.Config
+
+	for _, packPath := range packFiles {
+		if filepath.Ext(packPath) != ".wapp" {
+			continue
+		}
+
+		cfg, err := loadPackRuntimeDefaults(packPath, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		if cfg != nil {
+			merged = bootconfig.Merge(merged, cfg)
+		}
+	}
+
+	return merged, nil
+}
+
+// runtimeConfigFromPackMetadata extracts runtime.* metadata keys and builds a boot config.
+// Example supported keys: runtime.lsp.enabled=true
+func runtimeConfigFromPackMetadata(metadata wapp.Metadata, logger *zap.Logger) boot.Config {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	flatRuntime := make(map[string]any)
+	for key, val := range metadata {
+		switch {
+		case key == "runtime":
+			flattenRuntimeMetadata(flatRuntime, "", val)
+		case strings.HasPrefix(key, runtimeMetadataPrefix):
+			runtimeKey := strings.Trim(strings.TrimPrefix(key, runtimeMetadataPrefix), ".")
+			if runtimeKey == "" {
+				continue
+			}
+			flatRuntime[runtimeKey] = normalizeRuntimeMetadataValue(val)
+		}
+	}
+
+	if len(flatRuntime) == 0 {
+		return nil
+	}
+
+	sections := make(map[string]map[string]any)
+	for key, val := range flatRuntime {
+		section, subKey, ok := strings.Cut(key, ".")
+		if !ok || section == "" || subKey == "" {
+			if logger != nil {
+				logger.Debug("ignoring pack runtime metadata without section key", zap.String("key", key))
+			}
+			continue
+		}
+
+		if sections[section] == nil {
+			sections[section] = make(map[string]any)
+		}
+		sections[section][subKey] = normalizeRuntimeMetadataValue(val)
+	}
+
+	if len(sections) == 0 {
+		return nil
+	}
+
+	opts := make([]boot.ConfigOption, 0, len(sections))
+	for section, values := range sections {
+		opts = append(opts, boot.WithSection(section, values))
+	}
+
+	return boot.NewConfig(opts...)
+}
+
+func flattenRuntimeMetadata(dst map[string]any, prefix string, value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			if key == "" {
+				continue
+			}
+			next := key
+			if prefix != "" {
+				next = prefix + "." + key
+			}
+			flattenRuntimeMetadata(dst, next, nested)
+		}
+	case map[any]any:
+		for key, nested := range typed {
+			strKey, ok := key.(string)
+			if !ok || strKey == "" {
+				continue
+			}
+			next := strKey
+			if prefix != "" {
+				next = prefix + "." + strKey
+			}
+			flattenRuntimeMetadata(dst, next, nested)
+		}
+	default:
+		if prefix != "" {
+			dst[prefix] = normalizeRuntimeMetadataValue(value)
+		}
+	}
+}
+
+func normalizeRuntimeMetadataValue(value any) any {
+	switch typed := value.(type) {
+	case string:
+		s := strings.TrimSpace(typed)
+		switch strings.ToLower(s) {
+		case "true":
+			return true
+		case "false":
+			return false
+		}
+
+		if i, err := strconv.Atoi(s); err == nil {
+			return i
+		}
+		return s
+	case int8:
+		return int(typed)
+	case int16:
+		return int(typed)
+	case int32:
+		return int(typed)
+	case int64:
+		maxInt := int64(^uint(0) >> 1)
+		minInt := -maxInt - 1
+		if typed > maxInt || typed < minInt {
+			return value
+		}
+		return int(typed)
+	case uint8:
+		return int(typed)
+	case uint16:
+		return int(typed)
+	case uint32:
+		return int(typed)
+	case uint64:
+		maxInt := uint64(^uint(0) >> 1)
+		if typed > maxInt {
+			return value
+		}
+		return int(typed)
+	default:
+		return value
+	}
+}

--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+func TestRuntimeConfigFromPackMetadata_DottedKeys(t *testing.T) {
+	cfg := runtimeConfigFromPackMetadata(wapp.Metadata{
+		"runtime.lsp.enabled":           true,
+		"runtime.lsp.max_message_bytes": "2048",
+		"runtime.logger.level":          "debug",
+	}, zap.NewNop())
+
+	require.NotNil(t, cfg)
+	require.True(t, cfg.GetBool("lsp.enabled", false))
+	require.Equal(t, 2048, cfg.GetInt("lsp.max_message_bytes", 0))
+	require.Equal(t, "debug", cfg.GetString("logger.level", ""))
+}
+
+func TestRuntimeConfigFromPackMetadata_NestedRuntimeMap(t *testing.T) {
+	cfg := runtimeConfigFromPackMetadata(wapp.Metadata{
+		"runtime": map[string]any{
+			"lsp": map[string]any{
+				"enabled": "true",
+			},
+			"logger": map[string]any{
+				"encoding": "console",
+			},
+		},
+	}, zap.NewNop())
+
+	require.NotNil(t, cfg)
+	require.True(t, cfg.GetBool("lsp.enabled", false))
+	require.Equal(t, "console", cfg.GetString("logger.encoding", ""))
+}
+
+func TestLoadPackRuntimeDefaultsFromFiles_MergeOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	basePack := filepath.Join(tmpDir, "base.wapp")
+	require.NoError(t, writeTestPack(basePack, wapp.Metadata{
+		"runtime.lsp.enabled":  true,
+		"runtime.logger.level": "info",
+	}))
+
+	overridePack := filepath.Join(tmpDir, "override.wapp")
+	require.NoError(t, writeTestPack(overridePack, wapp.Metadata{
+		"runtime.lsp.enabled": false,
+	}))
+
+	cfg, err := loadPackRuntimeDefaultsFromFiles([]string{basePack, overridePack}, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.False(t, cfg.GetBool("lsp.enabled", true))
+	require.Equal(t, "info", cfg.GetString("logger.level", ""))
+}
+
+func writeTestPack(path string, metadata wapp.Metadata) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	writer := wapp.NewWriter()
+	if err := writer.PackEntries(metadata, nil, file); err != nil {
+		_ = file.Close()
+		return err
+	}
+
+	return file.Close()
+}

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/cmd/internal/shutdown"
+	"go.uber.org/zap"
+)
+
+func TestRunPackEntries_LoadStatePathSkipsDependencyExpansion(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+	})
+
+	ctx, loader, logger, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("bootstrap pack runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = embedReg.Close()
+	})
+	t.Cleanup(func() {
+		_ = shutdown.Perform(ctx, loader, logger, true)
+	})
+
+	// This malformed ns.dependency entry fails if dependency expansion runs.
+	// For pack execution we expect baseline LoadState behavior.
+	packEntries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("app", "deps"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{
+				"component": "",
+			}),
+		},
+		{
+			ID:   regapi.NewID("app", "runner"),
+			Kind: "process.lua",
+			Meta: map[string]any{
+				"command": map[string]any{
+					"name": "run",
+				},
+			},
+			Data: payload.New(map[string]any{
+				"source": "return {}",
+			}),
+		},
+	}
+
+	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"})
+	if err == nil {
+		t.Fatal("expected command lookup error")
+	}
+
+	errText := err.Error()
+	if !strings.Contains(errText, `command "missing" not found in pack`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(errText, "failed to expand changeset") {
+		t.Fatalf("unexpected dependency expansion error: %v", err)
+	}
+}
+
+func TestIsProcessKind(t *testing.T) {
+	tests := []struct {
+		name string
+		kind regapi.Kind
+		want bool
+	}{
+		{name: "lua process", kind: "process.lua", want: true},
+		{name: "lua bytecode process", kind: "process.lua.bc", want: true},
+		{name: "wasm process", kind: "process.wasm", want: true},
+		{name: "lua function", kind: "function.lua", want: false},
+		{name: "wasm function", kind: "function.wasm", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isProcessKind(tc.kind); got != tc.want {
+				t.Fatalf("isProcessKind(%q) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/cmd/internal/shutdown"
@@ -94,4 +95,74 @@ func TestIsProcessKind(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBootstrapPackRuntimeWithDefaults_Harness(t *testing.T) {
+	t.Run("applies runtime defaults when config key is missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+		if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		prevConfigFile := configFile
+		configFile = cfgPath
+		t.Cleanup(func() {
+			configFile = prevConfigFile
+		})
+
+		runtimeDefaults := boot.NewConfig(boot.WithSection("lsp", map[string]any{
+			"enabled": true,
+		}))
+
+		ctx, _, _, embedReg, err := bootstrapPackRuntimeWithDefaults(nil, zap.NewNop(), runtimeDefaults)
+		if err != nil {
+			t.Fatalf("bootstrap pack runtime: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = embedReg.Close()
+		})
+
+		cfg := boot.GetConfig(ctx)
+		if cfg == nil {
+			t.Fatal("missing boot config in context")
+		}
+		if got := cfg.GetBool("lsp.enabled", false); !got {
+			t.Fatalf("lsp.enabled = %v, want true", got)
+		}
+	})
+
+	t.Run("config file overrides runtime defaults", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+		if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\nlsp:\n  enabled: false\n"), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		prevConfigFile := configFile
+		configFile = cfgPath
+		t.Cleanup(func() {
+			configFile = prevConfigFile
+		})
+
+		runtimeDefaults := boot.NewConfig(boot.WithSection("lsp", map[string]any{
+			"enabled": true,
+		}))
+
+		ctx, _, _, embedReg, err := bootstrapPackRuntimeWithDefaults(nil, zap.NewNop(), runtimeDefaults)
+		if err != nil {
+			t.Fatalf("bootstrap pack runtime: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = embedReg.Close()
+		})
+
+		cfg := boot.GetConfig(ctx)
+		if cfg == nil {
+			t.Fatal("missing boot config in context")
+		}
+		if got := cfg.GetBool("lsp.enabled", true); got {
+			t.Fatalf("lsp.enabled = %v, want false", got)
+		}
+	})
 }

--- a/cmd/wippy/cmd/run_test.go
+++ b/cmd/wippy/cmd/run_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
 	"go.uber.org/zap"
 )
 
@@ -80,4 +81,52 @@ func TestLoadRuntimeConfigAppliesOverridesAndCLISettings(t *testing.T) {
 	overrideCfg := cfg.Sub("override")
 	require.NotNil(t, overrideCfg)
 	require.Equal(t, "true", overrideCfg.GetString("app:test:enabled", ""))
+}
+
+func TestLoadRuntimeConfigWithDefaultsAppliesPackDefaultsWhenFileMissingKey(t *testing.T) {
+	tempDir := t.TempDir()
+	cfgPath := filepath.Join(tempDir, "wippy.yaml")
+	cfgBody := []byte("version: \"1.0\"\n")
+	require.NoError(t, os.WriteFile(cfgPath, cfgBody, 0o644))
+
+	prevConfigFile := configFile
+	prevProfiler := profiler
+	configFile = cfgPath
+	profiler = false
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+		profiler = prevProfiler
+	})
+
+	runtimeDefaults := boot.NewConfig(boot.WithSection("lsp", map[string]any{
+		"enabled": true,
+	}))
+
+	cfg, err := loadRuntimeConfigWithDefaults(nil, zap.NewNop(), runtimeDefaults)
+	require.NoError(t, err)
+	require.True(t, cfg.GetBool("lsp.enabled", false))
+}
+
+func TestLoadRuntimeConfigWithDefaultsFileOverridesPackDefaults(t *testing.T) {
+	tempDir := t.TempDir()
+	cfgPath := filepath.Join(tempDir, "wippy.yaml")
+	cfgBody := []byte("version: \"1.0\"\nlsp:\n  enabled: false\n")
+	require.NoError(t, os.WriteFile(cfgPath, cfgBody, 0o644))
+
+	prevConfigFile := configFile
+	prevProfiler := profiler
+	configFile = cfgPath
+	profiler = false
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+		profiler = prevProfiler
+	})
+
+	runtimeDefaults := boot.NewConfig(boot.WithSection("lsp", map[string]any{
+		"enabled": true,
+	}))
+
+	cfg, err := loadRuntimeConfigWithDefaults(nil, zap.NewNop(), runtimeDefaults)
+	require.NoError(t, err)
+	require.False(t, cfg.GetBool("lsp.enabled", true))
 }

--- a/runtime/lua/component/workflow/manager.go
+++ b/runtime/lua/component/workflow/manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/wippyai/runtime/api/event"
+	fsapi "github.com/wippyai/runtime/api/fs"
 	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/registry"
 	api "github.com/wippyai/runtime/api/runtime/lua"
@@ -19,32 +20,108 @@ import (
 	"go.uber.org/zap"
 )
 
+// configEntry holds config for either source or bytecode workflow.
+type configEntry struct {
+	source   *api.WorkflowConfig
+	bytecode *api.BytecodeWorkflowConfig
+	method   string
+}
+
 // Manager handles Lua workflow components for engine2.
 // Workflows have restricted module access compared to processes.
 type Manager struct {
 	log     *zap.Logger
 	code    *code.Manager
 	bus     event.Bus
+	fsReg   fsapi.Registry
 	factory engine.CompiledFactory
-	configs sync.Map // map[registry.ID]*api.WorkflowConfig
+	configs sync.Map // map[registry.ID]*configEntry
 }
 
 // NewManager creates a new workflow manager.
-func NewManager(log *zap.Logger, code *code.Manager, bus event.Bus, factory engine.CompiledFactory) *Manager {
+func NewManager(
+	log *zap.Logger,
+	code *code.Manager,
+	bus event.Bus,
+	fsReg fsapi.Registry,
+	factory engine.CompiledFactory,
+) *Manager {
 	return &Manager{
 		log:     log,
 		code:    code,
 		bus:     bus,
+		fsReg:   fsReg,
 		factory: factory,
 	}
 }
 
 // Add implements registry.EntryListener.
 func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
-	if entry.Kind != api.Workflow {
+	switch entry.Kind {
+	case api.Workflow:
+		return m.addSource(ctx, entry)
+	case api.WorkflowBytecode:
+		return m.addBytecode(ctx, entry)
+	default:
 		return runtimelua.NewInvalidEntryKindError(entry.Kind, api.Workflow)
 	}
+}
 
+// Update implements registry.EntryListener.
+func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
+	switch entry.Kind {
+	case api.Workflow:
+		return m.updateSource(ctx, entry)
+	case api.WorkflowBytecode:
+		return m.updateBytecode(ctx, entry)
+	default:
+		return runtimelua.NewInvalidEntryKindError(entry.Kind, api.Workflow)
+	}
+}
+
+// Delete implements registry.EntryListener.
+func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
+	switch entry.Kind {
+	case api.Workflow, api.WorkflowBytecode:
+		if err := m.code.DeleteNode(ctx, entry.ID); err != nil {
+			return runtimelua.NewDeleteNodeError("workflow", err)
+		}
+		m.configs.Delete(entry.ID)
+		m.unregisterFactory(ctx, entry.ID)
+		m.log.Debug("deleted workflow", zap.String("id", entry.ID.String()))
+		return nil
+	default:
+		return runtimelua.NewInvalidEntryKindError(entry.Kind, api.Workflow)
+	}
+}
+
+// Invalidate handles code invalidation for hot reload.
+func (m *Manager) Invalidate(ctx context.Context, ids []registry.ID) {
+	for _, id := range ids {
+		cfgAny, exists := m.configs.Load(id)
+		if !exists {
+			continue
+		}
+		cfg := cfgAny.(*configEntry)
+
+		m.log.Debug("invalidating workflow", zap.String("id", id.String()))
+
+		// For bytecode, verify the file is still valid.
+		if cfg.bytecode != nil {
+			if _, err := component.LoadAndVerifyBytecode(m.fsReg, cfg.bytecode.FS, cfg.bytecode.Path, cfg.bytecode.Hash); err != nil {
+				m.log.Error("failed to reload bytecode workflow", zap.Error(err))
+				continue
+			}
+		}
+
+		if err := m.registerFactory(ctx, id, cfg.method); err != nil {
+			m.log.Error("failed to invalidate workflow", zap.Error(err))
+		}
+	}
+}
+
+// addSource adds a source-based workflow.
+func (m *Manager) addSource(ctx context.Context, entry registry.Entry) error {
 	cfg, err := component.UnpackConfig[api.WorkflowConfig](ctx, entry)
 	if err != nil {
 		return runtimelua.NewUnpackConfigError("workflow", err)
@@ -61,7 +138,10 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 		return runtimelua.NewAddNodeError("workflow", err)
 	}
 
-	m.configs.Store(entry.ID, cfg)
+	m.configs.Store(entry.ID, &configEntry{
+		source: cfg,
+		method: cfg.Method,
+	})
 
 	if err := m.registerFactory(ctx, entry.ID, cfg.Method); err != nil {
 		_ = m.code.DeleteNode(ctx, entry.ID)
@@ -73,12 +153,49 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 	return nil
 }
 
-// Update implements registry.EntryListener.
-func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
-	if entry.Kind != api.Workflow {
-		return runtimelua.NewInvalidEntryKindError(entry.Kind, api.Workflow)
+// addBytecode adds a bytecode-based workflow.
+func (m *Manager) addBytecode(ctx context.Context, entry registry.Entry) error {
+	cfg, err := component.UnpackConfig[api.BytecodeWorkflowConfig](ctx, entry)
+	if err != nil {
+		return runtimelua.NewUnpackConfigError("workflow", err)
 	}
 
+	proto, err := component.LoadAndVerifyBytecode(m.fsReg, cfg.FS, cfg.Path, cfg.Hash)
+	if err != nil {
+		return runtimelua.NewLoadBytecodeError(err)
+	}
+
+	node := code.Node{
+		ID:     entry.ID,
+		Kind:   api.WorkflowBytecode,
+		Method: cfg.Method,
+	}
+
+	if err := m.code.AddNodeWithProto(ctx, node, component.BuildImports(cfg.Imports, cfg.Modules), proto); err != nil {
+		return runtimelua.NewAddNodeError("workflow", err)
+	}
+
+	m.configs.Store(entry.ID, &configEntry{
+		bytecode: cfg,
+		method:   cfg.Method,
+	})
+
+	if err := m.registerFactory(ctx, entry.ID, cfg.Method); err != nil {
+		_ = m.code.DeleteNode(ctx, entry.ID)
+		m.configs.Delete(entry.ID)
+		return runtimelua.NewRegisterFactoryError(err)
+	}
+
+	m.log.Debug("added bytecode workflow",
+		zap.String("id", entry.ID.String()),
+		zap.String("fs", cfg.FS),
+		zap.String("path", cfg.Path),
+	)
+	return nil
+}
+
+// updateSource updates a source-based workflow.
+func (m *Manager) updateSource(ctx context.Context, entry registry.Entry) error {
 	cfg, err := component.UnpackConfig[api.WorkflowConfig](ctx, entry)
 	if err != nil {
 		return runtimelua.NewUnpackConfigError("workflow", err)
@@ -95,7 +212,10 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 		return runtimelua.NewUpdateNodeError("workflow", err)
 	}
 
-	m.configs.Store(entry.ID, cfg)
+	m.configs.Store(entry.ID, &configEntry{
+		source: cfg,
+		method: cfg.Method,
+	})
 
 	if err := m.registerFactory(ctx, entry.ID, cfg.Method); err != nil {
 		return runtimelua.NewUpdateFactoryError(err)
@@ -105,38 +225,39 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 	return nil
 }
 
-// Delete implements registry.EntryListener.
-func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
-	if entry.Kind != api.Workflow {
-		return runtimelua.NewInvalidEntryKindError(entry.Kind, api.Workflow)
+// updateBytecode updates a bytecode-based workflow.
+func (m *Manager) updateBytecode(ctx context.Context, entry registry.Entry) error {
+	cfg, err := component.UnpackConfig[api.BytecodeWorkflowConfig](ctx, entry)
+	if err != nil {
+		return runtimelua.NewUnpackConfigError("workflow", err)
 	}
 
-	if err := m.code.DeleteNode(ctx, entry.ID); err != nil {
-		return runtimelua.NewDeleteNodeError("workflow", err)
+	proto, err := component.LoadAndVerifyBytecode(m.fsReg, cfg.FS, cfg.Path, cfg.Hash)
+	if err != nil {
+		return runtimelua.NewLoadBytecodeError(err)
 	}
 
-	m.configs.Delete(entry.ID)
-	m.unregisterFactory(ctx, entry.ID)
+	node := code.Node{
+		ID:     entry.ID,
+		Kind:   api.WorkflowBytecode,
+		Method: cfg.Method,
+	}
 
-	m.log.Debug("deleted workflow", zap.String("id", entry.ID.String()))
+	if err := m.code.UpdateNodeWithProto(ctx, node, component.BuildImports(cfg.Imports, cfg.Modules), proto); err != nil {
+		return runtimelua.NewUpdateNodeError("workflow", err)
+	}
+
+	m.configs.Store(entry.ID, &configEntry{
+		bytecode: cfg,
+		method:   cfg.Method,
+	})
+
+	if err := m.registerFactory(ctx, entry.ID, cfg.Method); err != nil {
+		return runtimelua.NewUpdateFactoryError(err)
+	}
+
+	m.log.Debug("updated bytecode workflow", zap.String("id", entry.ID.String()))
 	return nil
-}
-
-// Invalidate handles code invalidation for hot reload.
-func (m *Manager) Invalidate(ctx context.Context, ids []registry.ID) {
-	for _, id := range ids {
-		cfgAny, exists := m.configs.Load(id)
-		if !exists {
-			continue
-		}
-		cfg := cfgAny.(*api.WorkflowConfig)
-
-		m.log.Debug("invalidating workflow", zap.String("id", id.String()))
-
-		if err := m.registerFactory(ctx, id, cfg.Method); err != nil {
-			m.log.Error("failed to invalidate workflow", zap.Error(err))
-		}
-	}
 }
 
 // registerFactory registers a workflow factory with the factory registry.

--- a/runtime/lua/component/workflow/manager_test.go
+++ b/runtime/lua/component/workflow/manager_test.go
@@ -84,7 +84,7 @@ func TestNewManager(t *testing.T) {
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
 
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	assert.NotNil(t, manager)
 	assert.Equal(t, log, manager.log)
@@ -98,7 +98,7 @@ func TestManager_Add_InvalidKind(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	entry := registry.Entry{
 		Kind: invalid,
@@ -114,7 +114,7 @@ func TestManager_Add_InvalidConfig(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	testData := `{"source": "test", "invalid": }`
 
@@ -139,7 +139,7 @@ func TestManager_Update_InvalidKind(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	entry := registry.Entry{
 		Kind: invalid,
@@ -155,7 +155,7 @@ func TestManager_Delete_InvalidKind(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	entry := registry.Entry{
 		Kind: invalid,
@@ -171,7 +171,7 @@ func TestManager_Invalidate_NoConfig(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockTrackingFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	ids := []registry.ID{{Name: "test1"}, {Name: "test2"}}
 	manager.Invalidate(context.Background(), ids)
@@ -185,14 +185,17 @@ func TestManager_Invalidate_WithConfig(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockTrackingFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	id := registry.NewID("test", "workflow")
 	cfg := &api.WorkflowConfig{
 		Source: "return {}",
 		Method: "main",
 	}
-	manager.configs.Store(id, cfg)
+	manager.configs.Store(id, &configEntry{
+		source: cfg,
+		method: cfg.Method,
+	})
 
 	manager.Invalidate(context.Background(), []registry.ID{id})
 
@@ -205,7 +208,7 @@ func TestManager_Update_InvalidConfig(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	testData := `{"source": "test", "invalid": }`
 	payloadData := payload.NewPayload(testData, payload.JSON)
@@ -229,7 +232,7 @@ func TestManager_ConfigStoreLoad(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	id := registry.NewID("test", "config")
 	cfg := &api.WorkflowConfig{
@@ -238,15 +241,19 @@ func TestManager_ConfigStoreLoad(t *testing.T) {
 	}
 
 	// Store config
-	manager.configs.Store(id, cfg)
+	manager.configs.Store(id, &configEntry{
+		source: cfg,
+		method: cfg.Method,
+	})
 
 	// Load config
 	loaded, ok := manager.configs.Load(id)
 	require.True(t, ok)
 
-	loadedCfg := loaded.(*api.WorkflowConfig)
-	assert.Equal(t, cfg.Source, loadedCfg.Source)
-	assert.Equal(t, cfg.Method, loadedCfg.Method)
+	loadedCfg := loaded.(*configEntry)
+	require.NotNil(t, loadedCfg.source)
+	assert.Equal(t, cfg.Source, loadedCfg.source.Source)
+	assert.Equal(t, cfg.Method, loadedCfg.method)
 
 	// Delete config
 	manager.configs.Delete(id)
@@ -261,7 +268,7 @@ func TestManager_unregisterFactory_SendsEvent(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	id := registry.NewID("test", "unregister")
 	manager.unregisterFactory(context.Background(), id)
@@ -288,7 +295,7 @@ func TestManager_Concurrency(_ *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	done := make(chan struct{})
 
@@ -297,7 +304,9 @@ func TestManager_Concurrency(_ *testing.T) {
 		for i := 0; i < 100; i++ {
 			id := registry.NewID("test", "concurrent")
 			cfg := &api.WorkflowConfig{Source: "test"}
-			manager.configs.Store(id, cfg)
+			manager.configs.Store(id, &configEntry{
+				source: cfg,
+			})
 			manager.configs.Load(id)
 			manager.configs.Delete(id)
 		}
@@ -324,7 +333,7 @@ func TestManager_registerFactory_PreparesBeforeSend(t *testing.T) {
 	codeManager := &code.Manager{}
 	bus := &mockEventBus{}
 	factory := &mockCompiledFactory{}
-	manager := NewManager(log, codeManager, bus, factory)
+	manager := NewManager(log, codeManager, bus, nil, factory)
 
 	awaitSvc := &mockPrepareAwaitService{
 		result: event.AwaitResult{Accepted: true},

--- a/service/env/static/manager.go
+++ b/service/env/static/manager.go
@@ -1,0 +1,123 @@
+package static
+
+import (
+	"context"
+	"sync"
+
+	"github.com/wippyai/runtime/api/env"
+	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/registry"
+	envsvc "github.com/wippyai/runtime/api/service/env"
+	entryutil "github.com/wippyai/runtime/internal/entry"
+	envos "github.com/wippyai/runtime/service/env/os"
+	sysenv "github.com/wippyai/runtime/system/env"
+	"go.uber.org/zap"
+)
+
+// Manager handles static storage lifecycle and registry integration.
+type Manager struct {
+	dtt      payload.Transcoder
+	bus      event.Bus
+	log      *zap.Logger
+	storages map[registry.ID]env.Storage
+	mu       sync.RWMutex
+}
+
+// NewManager creates a new static storage manager.
+func NewManager(
+	bus event.Bus,
+	dtt payload.Transcoder,
+	log *zap.Logger,
+) *Manager {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &Manager{
+		log:      log,
+		dtt:      dtt,
+		bus:      bus,
+		storages: make(map[registry.ID]env.Storage),
+	}
+}
+
+// Add registers a new static storage from registry entry.
+func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
+	if entry.Kind != envsvc.StorageStatic {
+		return sysenv.NewUnsupportedKindError(entry.Kind)
+	}
+
+	cfg, err := entryutil.DecodeEntryConfig[envsvc.StaticStorageConfig](ctx, m.dtt, entry)
+	if err != nil {
+		return sysenv.NewDecodeConfigError(err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return sysenv.NewInvalidConfigError(err)
+	}
+
+	storage := envos.NewStaticStorage(cfg.Values)
+
+	m.mu.Lock()
+	m.storages[entry.ID] = storage
+	m.mu.Unlock()
+
+	// Register directly in the central registry for synchronous access.
+	if reg := env.GetRegistry(ctx); reg != nil {
+		reg.RegisterStorage(entry.ID, storage)
+	}
+
+	m.bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.StorageRegister,
+		Path:   entry.ID.String(),
+		Data:   storage,
+	})
+
+	m.log.Info("registered static environment storage",
+		zap.String("id", entry.ID.String()),
+		zap.Int("value_count", len(cfg.Values)))
+
+	return nil
+}
+
+// Update updates an existing static storage (recreates it).
+func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
+	return m.Add(ctx, entry)
+}
+
+// Delete removes a static storage.
+func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
+	if entry.Kind != envsvc.StorageStatic {
+		return sysenv.NewUnsupportedKindError(entry.Kind)
+	}
+
+	m.mu.Lock()
+	_, exists := m.storages[entry.ID]
+	if !exists {
+		m.mu.Unlock()
+		return sysenv.NewStorageNotExistsError(entry.ID.String())
+	}
+	delete(m.storages, entry.ID)
+	m.mu.Unlock()
+
+	m.bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.StorageDelete,
+		Path:   entry.ID.String(),
+	})
+
+	m.log.Info("deleted static environment storage",
+		zap.String("id", entry.ID.String()))
+
+	return nil
+}
+
+// GetStorage retrieves a storage by ID.
+func (m *Manager) GetStorage(id registry.ID) (env.Storage, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	storage, exists := m.storages[id]
+	return storage, exists
+}

--- a/service/env/static/manager_test.go
+++ b/service/env/static/manager_test.go
@@ -1,0 +1,261 @@
+package static
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/env"
+	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/registry"
+	envsvc "github.com/wippyai/runtime/api/service/env"
+	"go.uber.org/zap"
+)
+
+type mockBus struct {
+	events []event.Event
+}
+
+func (m *mockBus) Send(_ context.Context, e event.Event) {
+	m.events = append(m.events, e)
+}
+
+func (m *mockBus) Subscribe(context.Context, event.System, chan<- event.Event) (event.SubscriberID, error) {
+	return "", nil
+}
+
+func (m *mockBus) SubscribeP(context.Context, event.System, event.Kind, chan<- event.Event) (event.SubscriberID, error) {
+	return "", nil
+}
+
+func (m *mockBus) Unsubscribe(context.Context, event.SubscriberID) {}
+
+type mockTranscoder struct {
+	config     *envsvc.StaticStorageConfig
+	shouldFail bool
+}
+
+func (m *mockTranscoder) Unmarshal(_ payload.Payload, out any) error {
+	if m.shouldFail {
+		return assert.AnError
+	}
+	if cfg, ok := out.(*envsvc.StaticStorageConfig); ok && m.config != nil {
+		*cfg = *m.config
+	}
+	return nil
+}
+
+func (m *mockTranscoder) Transcode(p payload.Payload, _ payload.Format) (payload.Payload, error) {
+	return p, nil
+}
+
+func TestNewManager(t *testing.T) {
+	bus := &mockBus{}
+	dtt := &mockTranscoder{}
+	log := zap.NewNop()
+
+	mgr := NewManager(bus, dtt, log)
+
+	assert.NotNil(t, mgr)
+	assert.NotNil(t, mgr.storages)
+}
+
+func TestManager_Add(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bus := &mockBus{}
+		dtt := &mockTranscoder{
+			config: &envsvc.StaticStorageConfig{
+				Values: map[string]string{
+					"PUBLIC_API_HOST": "https://example.test",
+					"APP_ENV":         "production",
+				},
+			},
+		}
+		log := zap.NewNop()
+		mgr := NewManager(bus, dtt, log)
+
+		entry := registry.Entry{
+			ID:   registry.ID{NS: "app", Name: "static1"},
+			Kind: envsvc.StorageStatic,
+			Meta: attrs.NewBag(),
+			Data: payload.New(nil),
+		}
+
+		err := mgr.Add(context.Background(), entry)
+		require.NoError(t, err)
+
+		require.Len(t, bus.events, 1)
+		assert.Equal(t, env.StorageRegister, bus.events[0].Kind)
+
+		storage, ok := mgr.GetStorage(entry.ID)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		value, err := storage.Get(context.Background(), "PUBLIC_API_HOST")
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.test", value)
+
+		list, err := storage.List(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"PUBLIC_API_HOST": "https://example.test",
+			"APP_ENV":         "production",
+		}, list)
+	})
+
+	t.Run("wrong kind", func(t *testing.T) {
+		bus := &mockBus{}
+		dtt := &mockTranscoder{}
+		log := zap.NewNop()
+		mgr := NewManager(bus, dtt, log)
+
+		entry := registry.Entry{
+			ID:   registry.ID{NS: "app", Name: "memory1"},
+			Kind: envsvc.StorageMemory,
+		}
+
+		err := mgr.Add(context.Background(), entry)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported entry kind")
+	})
+
+	t.Run("decode error", func(t *testing.T) {
+		bus := &mockBus{}
+		dtt := &mockTranscoder{shouldFail: true}
+		log := zap.NewNop()
+		mgr := NewManager(bus, dtt, log)
+
+		entry := registry.Entry{
+			ID:   registry.ID{NS: "app", Name: "static1"},
+			Kind: envsvc.StorageStatic,
+			Data: payload.New(nil),
+		}
+
+		err := mgr.Add(context.Background(), entry)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode configuration")
+	})
+}
+
+func TestManager_Update(t *testing.T) {
+	bus := &mockBus{}
+	dtt := &mockTranscoder{
+		config: &envsvc.StaticStorageConfig{
+			Values: map[string]string{
+				"KEY": "value",
+			},
+		},
+	}
+	log := zap.NewNop()
+	mgr := NewManager(bus, dtt, log)
+
+	entry := registry.Entry{
+		ID:   registry.ID{NS: "app", Name: "static1"},
+		Kind: envsvc.StorageStatic,
+		Meta: attrs.NewBag(),
+		Data: payload.New(nil),
+	}
+
+	err := mgr.Update(context.Background(), entry)
+	require.NoError(t, err)
+}
+
+func TestManager_Delete(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bus := &mockBus{}
+		dtt := &mockTranscoder{
+			config: &envsvc.StaticStorageConfig{
+				Values: map[string]string{
+					"KEY": "value",
+				},
+			},
+		}
+		log := zap.NewNop()
+		mgr := NewManager(bus, dtt, log)
+
+		entry := registry.Entry{
+			ID:   registry.ID{NS: "app", Name: "static1"},
+			Kind: envsvc.StorageStatic,
+			Meta: attrs.NewBag(),
+			Data: payload.New(nil),
+		}
+
+		err := mgr.Add(context.Background(), entry)
+		require.NoError(t, err)
+
+		bus.events = nil
+
+		err = mgr.Delete(context.Background(), entry)
+		require.NoError(t, err)
+
+		require.Len(t, bus.events, 1)
+		assert.Equal(t, env.StorageDelete, bus.events[0].Kind)
+
+		_, ok := mgr.GetStorage(entry.ID)
+		assert.False(t, ok)
+	})
+
+	t.Run("wrong kind", func(t *testing.T) {
+		bus := &mockBus{}
+		dtt := &mockTranscoder{}
+		log := zap.NewNop()
+		mgr := NewManager(bus, dtt, log)
+
+		entry := registry.Entry{
+			ID:   registry.ID{NS: "app", Name: "memory1"},
+			Kind: envsvc.StorageMemory,
+		}
+
+		err := mgr.Delete(context.Background(), entry)
+		require.Error(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		bus := &mockBus{}
+		dtt := &mockTranscoder{}
+		log := zap.NewNop()
+		mgr := NewManager(bus, dtt, log)
+
+		entry := registry.Entry{
+			ID:   registry.ID{NS: "app", Name: "missing"},
+			Kind: envsvc.StorageStatic,
+		}
+
+		err := mgr.Delete(context.Background(), entry)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "storage does not exist")
+	})
+}
+
+func TestManager_GetStorage(t *testing.T) {
+	bus := &mockBus{}
+	dtt := &mockTranscoder{
+		config: &envsvc.StaticStorageConfig{
+			Values: map[string]string{
+				"KEY": "value",
+			},
+		},
+	}
+	log := zap.NewNop()
+	mgr := NewManager(bus, dtt, log)
+
+	entry := registry.Entry{
+		ID:   registry.ID{NS: "app", Name: "static1"},
+		Kind: envsvc.StorageStatic,
+		Meta: attrs.NewBag(),
+		Data: payload.New(nil),
+	}
+
+	err := mgr.Add(context.Background(), entry)
+	require.NoError(t, err)
+
+	storage, ok := mgr.GetStorage(entry.ID)
+	assert.True(t, ok)
+	assert.NotNil(t, storage)
+
+	_, ok = mgr.GetStorage(registry.ID{NS: "app", Name: "nonexistent"})
+	assert.False(t, ok)
+}


### PR DESCRIPTION
 - Added new env storage kind: env.storage.static.
  - Added static env config model (values: map[string]string) and validation/tests.
  - Added static env boot component and wiring into env component set.
  - Updated env composite dependency graph to include static storage component.
  - Added workflow bytecode support:
      - New kind: workflow.lua.bc.
      - Build bytecode stage now compiles workflow.lua entries.
      - Lua runtime workflow manager now loads/updates/deletes both source and bytecode workflows.
      - Lua workflow handler registration now uses wildcard workflow.lua.**.
  - Exported registry loader helper for pack/load-state reuse: LoadEntriesToRegistry.
  - Added/updated tests across env config, static manager, workflow manager, and bytecode stage.