### PR TITLE
Fix/pack flow canonicalization

### DIFF
--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -308,7 +308,8 @@ type ModuleLoadPath struct {
 }
 
 // GetModuleLoadPaths returns load paths annotated with module ownership.
-// App source and replacement paths have empty Module/Version fields.
+// App source has empty Module/Version.
+// Replacement paths carry Module from replacement "from" and empty Version.
 func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 	lockDir := filepath.Dir(l.path)
 	paths := make([]ModuleLoadPath, 0, 1+len(l.data.Replacements)+len(l.data.Modules))

--- a/boot/deps/lock/module_load_paths_test.go
+++ b/boot/deps/lock/module_load_paths_test.go
@@ -1,0 +1,96 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLock_GetModuleLoadPaths(t *testing.T) {
+	t.Run("includes src replacement and non-replaced module with metadata", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockPath := filepath.Join(tmpDir, DefaultFilename)
+
+		l, err := New(lockPath)
+		if err != nil {
+			t.Fatalf("New failed: %v", err)
+		}
+
+		l.SetDirectories(Directories{
+			Modules: ".wippy",
+			Src:     "app",
+		})
+		l.SetReplacement(Replacement{
+			From: "userspace/users",
+			To:   "local/users",
+		})
+		l.SetModule(Module{
+			Name:    "userspace/users",
+			Version: "v1.2.3",
+		})
+		l.SetModule(Module{
+			Name:    "demo/sql",
+			Version: "v2.0.0",
+		})
+
+		paths := l.GetModuleLoadPaths()
+		if len(paths) != 3 {
+			t.Fatalf("path count = %d, want 3", len(paths))
+		}
+
+		if got := paths[0]; got.Path != filepath.Join(tmpDir, "app") || got.Module != "" || got.Version != "" {
+			t.Fatalf("src path = %+v, want app path with empty module/version", got)
+		}
+
+		if got := paths[1]; got.Path != filepath.Join(tmpDir, "local/users") || got.Module != "userspace/users" || got.Version != "" {
+			t.Fatalf("replacement path = %+v, want replacement module and empty version", got)
+		}
+
+		if got := paths[2]; got.Path != filepath.Join(tmpDir, ".wippy", "vendor", "demo", "sql") || got.Module != "demo/sql" || got.Version != "v2.0.0" {
+			t.Fatalf("module path = %+v, want vendor module path with metadata", got)
+		}
+	})
+
+	t.Run("uses .wapp path when module is not unpacked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockPath := filepath.Join(tmpDir, DefaultFilename)
+
+		l, err := New(lockPath)
+		if err != nil {
+			t.Fatalf("New failed: %v", err)
+		}
+
+		l.SetDirectories(Directories{
+			Modules: ".wippy",
+			Src:     ".",
+		})
+		l.SetModule(Module{
+			Name:    "userspace/users",
+			Version: "v1.2.3",
+		})
+
+		wappPath := filepath.Join(tmpDir, ".wippy", "vendor", "userspace", "users-v1.2.3.wapp")
+		if err := os.MkdirAll(filepath.Dir(wappPath), 0o755); err != nil {
+			t.Fatalf("mkdir vendor path: %v", err)
+		}
+		if err := os.WriteFile(wappPath, []byte("pack"), 0o644); err != nil {
+			t.Fatalf("write wapp file: %v", err)
+		}
+
+		paths := l.GetModuleLoadPaths()
+		if len(paths) != 2 {
+			t.Fatalf("path count = %d, want 2", len(paths))
+		}
+
+		got := paths[1]
+		if got.Path != wappPath {
+			t.Fatalf("module path = %q, want %q", got.Path, wappPath)
+		}
+		if got.Module != "userspace/users" {
+			t.Fatalf("module = %q, want userspace/users", got.Module)
+		}
+		if got.Version != "v1.2.3" {
+			t.Fatalf("version = %q, want v1.2.3", got.Version)
+		}
+	})
+}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -274,6 +274,16 @@ func LoadEntriesFromPaths(ctx context.Context, paths []string, logger *zap.Logge
 	return entries, nil
 }
 
+// LoadEntriesFromModuleLoadPaths loads entries from lock module paths with module metadata.
+// Module-owned entries are tagged with meta.module/meta.module_version before pipeline stages.
+func LoadEntriesFromModuleLoadPaths(
+	ctx context.Context,
+	modulePaths []lock.ModuleLoadPath,
+	logger *zap.Logger,
+) ([]regapi.Entry, error) {
+	return loadEntriesWithModuleMeta(ctx, modulePaths, logger)
+}
+
 // loadEntriesWithModuleMeta loads entries from annotated paths and tags module entries
 // with their owning module name and version. App source entries remain untagged.
 func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoadPath, logger *zap.Logger) ([]regapi.Entry, error) {

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -15,7 +15,9 @@ import (
 	regapi "github.com/wippyai/runtime/api/registry"
 	bootpkg "github.com/wippyai/runtime/boot"
 	"github.com/wippyai/runtime/boot/components/core"
+	"github.com/wippyai/runtime/boot/deps/lock"
 	transcoder "github.com/wippyai/runtime/system/payload"
+	yamlpayload "github.com/wippyai/runtime/system/payload/yaml"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
@@ -174,6 +176,7 @@ func setupTestContext(t *testing.T) context.Context {
 	ctx = logapi.WithLogger(ctx, logger)
 
 	dtt := transcoder.GlobalTranscoder()
+	yamlpayload.Register(dtt)
 	ctx = payload.WithTranscoder(ctx, dtt)
 
 	loaderComponent := core.Loader()
@@ -554,6 +557,86 @@ func TestLoadEntriesFromPathsMultipleWappsWithDifferentKinds(t *testing.T) {
 	}
 	if kinds["myapp:run"] != "process.lua" {
 		t.Errorf("myapp:run kind = %v, want process.lua", kinds["myapp:run"])
+	}
+}
+
+func TestLoadEntriesFromModuleLoadPaths_ResolvesRequirementByModuleMeta(t *testing.T) {
+	ctx := setupTestContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	moduleDir := filepath.Join(tmpDir, "module")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatalf("mkdir module dir: %v", err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: userspace.user
+entries:
+  - name: public_router
+    kind: ns.requirement
+    targets:
+      - entry: login.endpoint
+        path: meta.router
+  - name: login.endpoint
+    kind: http.endpoint
+    meta:
+      router: public_router
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+
+	appDir := filepath.Join(tmpDir, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatalf("mkdir app dir: %v", err)
+	}
+	appYAML := `version: "1.0"
+namespace: app.deps
+entries:
+  - name: users
+    kind: ns.dependency
+    component: userspace/users
+    parameters:
+      - name: public_router
+        value: app:api.public
+`
+	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(appYAML), 0o644); err != nil {
+		t.Fatalf("write app _index.yaml: %v", err)
+	}
+
+	flatEntries, err := LoadEntriesFromPaths(ctx, []string{appDir, moduleDir}, logger)
+	if err != nil {
+		t.Fatalf("LoadEntriesFromPaths failed: %v", err)
+	}
+
+	routerFlat := ""
+	for _, entry := range flatEntries {
+		if entry.ID.String() != "userspace.user:login.endpoint" {
+			continue
+		}
+		routerFlat = entry.Meta.GetString("router", "")
+	}
+	if routerFlat != "public_router" {
+		t.Fatalf("flat load router = %q, want unresolved alias", routerFlat)
+	}
+
+	moduleAwareEntries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: appDir},
+		{Path: moduleDir, Module: "userspace/users", Version: "1.0.0"},
+	}, logger)
+	if err != nil {
+		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
+	}
+
+	routerResolved := ""
+	for _, entry := range moduleAwareEntries {
+		if entry.ID.String() != "userspace.user:login.endpoint" {
+			continue
+		}
+		routerResolved = entry.Meta.GetString("router", "")
+	}
+	if routerResolved != "app:api.public" {
+		t.Fatalf("module-aware load router = %q, want app:api.public", routerResolved)
 	}
 }
 

--- a/cmd/wippy/cmd/load_entries.go
+++ b/cmd/wippy/cmd/load_entries.go
@@ -13,6 +13,6 @@ func loadEntriesFromLockPaths(ctx context.Context, lockObj *lock.Lock, logger *z
 	if lockObj == nil {
 		return nil, nil
 	}
-	paths := lockObj.GetLoadPaths()
-	return entries.LoadEntriesFromPaths(ctx, paths, logger)
+	modulePaths := lockObj.GetModuleLoadPaths()
+	return entries.LoadEntriesFromModuleLoadPaths(ctx, modulePaths, logger)
 }

--- a/cmd/wippy/cmd/load_entries_test.go
+++ b/cmd/wippy/cmd/load_entries_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	contextapi "github.com/wippyai/runtime/api/context"
+	logapi "github.com/wippyai/runtime/api/logs"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/boot/components/core"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	transcoder "github.com/wippyai/runtime/system/payload"
+	yamlpayload "github.com/wippyai/runtime/system/payload/yaml"
+	"go.uber.org/zap"
+)
+
+func TestLoadEntriesFromLockPaths_NilLock(t *testing.T) {
+	loaded, err := loadEntriesFromLockPaths(context.Background(), nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("loadEntriesFromLockPaths returned error: %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("expected nil entries for nil lock, got %d", len(loaded))
+	}
+}
+
+func TestLoadEntriesFromLockPaths_ResolvesRequirementByModuleMeta(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	appDir := filepath.Join(tmpDir, "app")
+	moduleDir := filepath.Join(tmpDir, ".wippy", "vendor", "userspace", "users")
+
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatalf("mkdir app dir: %v", err)
+	}
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatalf("mkdir module dir: %v", err)
+	}
+
+	appYAML := `version: "1.0"
+namespace: app.deps
+entries:
+  - name: users
+    kind: ns.dependency
+    component: userspace/users
+    parameters:
+      - name: public_router
+        value: app:api.public
+`
+	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(appYAML), 0o644); err != nil {
+		t.Fatalf("write app _index.yaml: %v", err)
+	}
+
+	moduleYAML := `version: "1.0"
+namespace: userspace.user
+entries:
+  - name: public_router
+    kind: ns.requirement
+    targets:
+      - entry: login.endpoint
+        path: meta.router
+  - name: login.endpoint
+    kind: http.endpoint
+    meta:
+      router: public_router
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+
+	lockPath := filepath.Join(tmpDir, lock.DefaultFilename)
+	lockObj, err := lock.New(lockPath)
+	if err != nil {
+		t.Fatalf("create lock: %v", err)
+	}
+	lockObj.SetDirectories(lock.Directories{
+		Modules: ".wippy",
+		Src:     "app",
+	})
+	lockObj.SetModule(lock.Module{
+		Name:    "userspace/users",
+		Version: "v1.0.0",
+	})
+	if err := lockObj.Write(); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+
+	loaded, err := loadEntriesFromLockPaths(ctx, lockObj, logger)
+	if err != nil {
+		t.Fatalf("loadEntriesFromLockPaths failed: %v", err)
+	}
+
+	router := ""
+	module := ""
+	moduleVersion := ""
+	for _, entry := range loaded {
+		if entry.ID.String() != "userspace.user:login.endpoint" {
+			continue
+		}
+		router = entry.Meta.GetString("router", "")
+		module = entry.Meta.GetString("module", "")
+		moduleVersion = entry.Meta.GetString("module_version", "")
+	}
+
+	if router != "app:api.public" {
+		t.Fatalf("router = %q, want app:api.public", router)
+	}
+	if module != "userspace/users" {
+		t.Fatalf("module = %q, want userspace/users", module)
+	}
+	if moduleVersion != "v1.0.0" {
+		t.Fatalf("module_version = %q, want v1.0.0", moduleVersion)
+	}
+}
+
+func setupLoaderContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx := context.Background()
+	appCtx := contextapi.NewAppContext()
+	ctx = contextapi.WithAppContext(ctx, appCtx)
+
+	logger := zap.NewNop()
+	ctx = logapi.WithLogger(ctx, logger)
+
+	dtt := transcoder.GlobalTranscoder()
+	yamlpayload.Register(dtt)
+	ctx = payload.WithTranscoder(ctx, dtt)
+
+	loaderComponent := core.Loader()
+	loadedCtx, err := loaderComponent.Load(ctx)
+	if err != nil {
+		t.Fatalf("loader component load failed: %v", err)
+	}
+
+	return loadedCtx
+}

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
-	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	bootpkg "github.com/wippyai/runtime/boot"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
@@ -321,30 +320,10 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string) error {
 	}
 	defer embedReg.Close()
 
-	transcoder := payload.GetTranscoder(ctx)
-	if transcoder == nil {
-		return ErrTranscoderNotFound
-	}
-
-	file, err := os.Open(packFile)
+	packEntries, err := loadPackEntries([]string{packFile}, embedReg)
 	if err != nil {
-		return NewOpenPackFileError(packFile, err)
-	}
-
-	packReader, err := entries.NewPackReader(file, transcoder)
-	if err != nil {
-		file.Close()
-		return NewCreatePackReaderError(packFile, err)
-	}
-
-	if err := embedReg.Register(packFile, packReader.Reader(), file); err != nil {
-		file.Close()
-		return fmt.Errorf("register embed resources: %w", err)
-	}
-
-	packEntries, err := packReader.GetEntries()
-	if err != nil {
-		return NewReadEntriesError(packFile, err)
+		runLogger.Error("failed to load entries from pack", zap.Error(err))
+		return NewLoadEntriesError(packFile, err)
 	}
 
 	runLogger.Info("loaded entries from pack", zap.Int("count", len(packEntries)))
@@ -380,32 +359,10 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string) err
 	}
 	defer embedReg.Close()
 
-	packEntries, err := entries.LoadEntriesFromPaths(ctx, packFiles, runLogger)
+	packEntries, err := loadPackEntries(packFiles, embedReg)
 	if err != nil {
 		runLogger.Error("failed to load entries from packs", zap.Error(err))
 		return NewLoadEntriesError("pack files", err)
-	}
-
-	// Register .wapp pack readers with embed registry for fs.embed support.
-	for _, pf := range packFiles {
-		if filepath.Ext(pf) != ".wapp" {
-			continue
-		}
-		f, err := os.Open(pf)
-		if err != nil {
-			return fmt.Errorf("open pack for embed: %w", err)
-		}
-
-		reader, err := wapp.NewReader(f)
-		if err != nil {
-			f.Close()
-			return fmt.Errorf("read pack for embed: %w", err)
-		}
-
-		if err := embedReg.Register(pf, reader, f); err != nil {
-			f.Close()
-			return fmt.Errorf("register embed resources: %w", err)
-		}
 	}
 
 	runLogger.Info("loaded entries from packs", zap.Int("count", len(packEntries)))
@@ -433,7 +390,7 @@ func runPackEntries(
 		return NewStartComponentsError(err)
 	}
 
-	if err := entries.LoadEntriesToRegistry(appCtx, packEntries, logger); err != nil {
+	if err := applyPackEntries(appCtx, packEntries, logger); err != nil {
 		return err
 	}
 
@@ -469,4 +426,49 @@ func runPackEntries(
 	}
 
 	return nil
+}
+
+// applyPackEntries restores packed entries as baseline state.
+// Pack execution uses snapshot semantics and does not perform dependency expansion.
+func applyPackEntries(ctx context.Context, packEntries []registry.Entry, logger *zap.Logger) error {
+	return entries.LoadEntriesToRegistry(ctx, packEntries, logger)
+}
+
+type packReaderRegistry interface {
+	Register(packPath string, reader *wapp.Reader, file *os.File) error
+}
+
+func loadPackEntries(packFiles []string, embedReg packReaderRegistry) ([]registry.Entry, error) {
+	packEntries := make([]registry.Entry, 0)
+
+	for _, packFile := range packFiles {
+		if filepath.Ext(packFile) != ".wapp" {
+			return nil, fmt.Errorf("unsupported pack format %q", packFile)
+		}
+
+		file, err := os.Open(packFile)
+		if err != nil {
+			return nil, fmt.Errorf("open pack %s: %w", packFile, err)
+		}
+
+		packReader, err := entries.NewPackReader(file, nil)
+		if err != nil {
+			file.Close()
+			return nil, fmt.Errorf("read pack %s: %w", packFile, err)
+		}
+
+		if err := embedReg.Register(packFile, packReader.Reader(), file); err != nil {
+			file.Close()
+			return nil, fmt.Errorf("register embed resources for %s: %w", packFile, err)
+		}
+
+		entries, err := packReader.GetEntries()
+		if err != nil {
+			return nil, fmt.Errorf("read entries from %s: %w", packFile, err)
+		}
+
+		packEntries = append(packEntries, entries...)
+	}
+
+	return packEntries, nil
 }

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -107,7 +107,7 @@ func selectPackCommand(commands []struct {
 // isHubModuleRef identifies inputs that should be treated as hub references
 // instead of local files/paths.
 func isHubModuleRef(s string) bool {
-	if strings.HasSuffix(s, ".wapp") {
+	if hasWappExtension(s) {
 		return false
 	}
 
@@ -116,6 +116,10 @@ func isHubModuleRef(s string) bool {
 	}
 
 	return hubModulePattern.MatchString(s)
+}
+
+func hasWappExtension(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".wapp")
 }
 
 // downloadHubModule resolves dependency graph for a hub reference, downloads
@@ -442,7 +446,7 @@ func loadPackEntries(packFiles []string, embedReg packReaderRegistry) ([]registr
 	packEntries := make([]registry.Entry, 0)
 
 	for _, packFile := range packFiles {
-		if filepath.Ext(packFile) != ".wapp" {
+		if !hasWappExtension(packFile) {
 			return nil, fmt.Errorf("unsupported pack format %q", packFile)
 		}
 

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,8 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/cmd/internal/shutdown"
+	embedpkg "github.com/wippyai/runtime/service/fs/embed"
+	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
 
@@ -72,6 +75,48 @@ func TestRunPackEntries_LoadStatePathSkipsDependencyExpansion(t *testing.T) {
 	}
 	if strings.Contains(errText, "failed to expand changeset") {
 		t.Fatalf("unexpected dependency expansion error: %v", err)
+	}
+}
+
+func TestRunFromPackFiles_SnapshotLoadPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+	})
+
+	packPath := createTestPackFile(t, tmpDir, "snapshot", []wapp.Entry{
+		{
+			ID:   wapp.NewID("test", "broken.requirement"),
+			Kind: regapi.NamespaceRequirement,
+			Data: "not-a-requirement-definition",
+		},
+		{
+			ID:   wapp.NewID("app", "runner"),
+			Kind: "process.lua",
+			Meta: wapp.Metadata{
+				"command": map[string]any{"name": "run"},
+			},
+			Data: map[string]any{"source": "return {}"},
+		},
+	})
+
+	err := runFromPackFiles(nil, []string{packPath}, []string{"missing"})
+	if err == nil {
+		t.Fatal("expected command lookup error")
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, `command "missing" not found in pack`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(errText, "failed to execute pipeline") || strings.Contains(errText, "failed to decode requirement") {
+		t.Fatalf("unexpected re-link/pipeline error: %v", err)
 	}
 }
 
@@ -165,4 +210,96 @@ func TestBootstrapPackRuntimeWithDefaults_Harness(t *testing.T) {
 			t.Fatalf("lsp.enabled = %v, want false", got)
 		}
 	})
+}
+
+func TestLoadPackEntries_RawLoadSkipsLinkPipeline(t *testing.T) {
+	tmpDir := t.TempDir()
+	packPath := createTestPackFile(t, tmpDir, "raw-load", []wapp.Entry{
+		{
+			ID:   wapp.NewID("test", "broken.requirement"),
+			Kind: regapi.NamespaceRequirement,
+			Data: "not-a-requirement-definition",
+		},
+		{
+			ID:   wapp.NewID("app", "runner"),
+			Kind: "process.lua",
+			Meta: wapp.Metadata{
+				"command": map[string]any{"name": "run"},
+			},
+			Data: map[string]any{"source": "return {}"},
+		},
+	})
+
+	embedReg := embedpkg.NewRegistry()
+	defer func() { _ = embedReg.Close() }()
+
+	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	if err != nil {
+		t.Fatalf("loadPackEntries failed: %v", err)
+	}
+	if len(packEntries) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(packEntries))
+	}
+}
+
+func TestLoadPackEntries_MultiPackOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	depPack := createTestPackFile(t, tmpDir, "dep", []wapp.Entry{
+		{
+			ID:   wapp.NewID("app", "config"),
+			Kind: "state",
+			Data: map[string]any{"value": "dep"},
+		},
+	})
+	mainPack := createTestPackFile(t, tmpDir, "main", []wapp.Entry{
+		{
+			ID:   wapp.NewID("app", "config"),
+			Kind: "state",
+			Data: map[string]any{"value": "main"},
+		},
+	})
+
+	embedReg := embedpkg.NewRegistry()
+	defer func() { _ = embedReg.Close() }()
+
+	packEntries, err := loadPackEntries([]string{depPack, mainPack}, embedReg)
+	if err != nil {
+		t.Fatalf("loadPackEntries failed: %v", err)
+	}
+	if len(packEntries) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(packEntries))
+	}
+
+	first, ok := packEntries[0].Data.Data().(map[string]any)
+	if !ok {
+		t.Fatalf("first data type = %T, want map[string]any", packEntries[0].Data.Data())
+	}
+	second, ok := packEntries[1].Data.Data().(map[string]any)
+	if !ok {
+		t.Fatalf("second data type = %T, want map[string]any", packEntries[1].Data.Data())
+	}
+
+	if first["value"] != "dep" {
+		t.Fatalf("first entry value = %v, want dep", first["value"])
+	}
+	if second["value"] != "main" {
+		t.Fatalf("second entry value = %v, want main", second["value"])
+	}
+}
+
+func createTestPackFile(t *testing.T, dir, name string, entries []wapp.Entry) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := wapp.NewWriter()
+	if err := writer.PackEntries(wapp.Metadata{"name": name}, entries, &buf); err != nil {
+		t.Fatalf("pack entries: %v", err)
+	}
+
+	path := filepath.Join(dir, name+".wapp")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write pack file: %v", err)
+	}
+
+	return path
 }

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,6 +143,12 @@ func TestIsProcessKind(t *testing.T) {
 	}
 }
 
+func TestIsHubModuleRef_WithUppercaseWappExtension(t *testing.T) {
+	if got := isHubModuleRef("dockerio.WAPP"); got {
+		t.Fatalf("isHubModuleRef returned true for .WAPP path")
+	}
+}
+
 func TestBootstrapPackRuntimeWithDefaults_Harness(t *testing.T) {
 	t.Run("applies runtime defaults when config key is missing", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -242,6 +249,70 @@ func TestLoadPackEntries_RawLoadSkipsLinkPipeline(t *testing.T) {
 	}
 }
 
+func TestLoadPackEntries_RejectsUnsupportedExtension(t *testing.T) {
+	embedReg := embedpkg.NewRegistry()
+	defer func() { _ = embedReg.Close() }()
+
+	_, err := loadPackEntries([]string{"./not-a-pack.yaml"}, embedReg)
+	if err == nil {
+		t.Fatal("expected error for unsupported pack extension")
+	}
+	if !strings.Contains(err.Error(), `unsupported pack format "./not-a-pack.yaml"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadPackEntries_AcceptsUppercaseExtension(t *testing.T) {
+	tmpDir := t.TempDir()
+	packPath := createTestPackFile(t, tmpDir, "uppercase-ext", []wapp.Entry{
+		{
+			ID:   wapp.NewID("app", "runner"),
+			Kind: "process.lua",
+			Meta: wapp.Metadata{
+				"command": map[string]any{"name": "run"},
+			},
+			Data: map[string]any{"source": "return {}"},
+		},
+	})
+	upperPath := filepath.Join(tmpDir, "UPPER.WAPP")
+	if err := os.Rename(packPath, upperPath); err != nil {
+		t.Fatalf("rename pack file: %v", err)
+	}
+
+	embedReg := embedpkg.NewRegistry()
+	defer func() { _ = embedReg.Close() }()
+
+	packEntries, err := loadPackEntries([]string{upperPath}, embedReg)
+	if err != nil {
+		t.Fatalf("loadPackEntries failed: %v", err)
+	}
+	if len(packEntries) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(packEntries))
+	}
+}
+
+func TestLoadPackEntries_RegisterErrorIncludesPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	packPath := createTestPackFile(t, tmpDir, "register-failure", []wapp.Entry{
+		{
+			ID:   wapp.NewID("app", "runner"),
+			Kind: "process.lua",
+			Data: map[string]any{"source": "return {}"},
+		},
+	})
+
+	_, err := loadPackEntries([]string{packPath}, failingPackRegistry{err: errors.New("boom")})
+	if err == nil {
+		t.Fatal("expected register error")
+	}
+	if !strings.Contains(err.Error(), "register embed resources for") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), packPath) {
+		t.Fatalf("error does not include pack path: %v", err)
+	}
+}
+
 func TestLoadPackEntries_MultiPackOrder(t *testing.T) {
 	tmpDir := t.TempDir()
 	depPack := createTestPackFile(t, tmpDir, "dep", []wapp.Entry{
@@ -302,4 +373,12 @@ func createTestPackFile(t *testing.T, dir, name string, entries []wapp.Entry) st
 	}
 
 	return path
+}
+
+type failingPackRegistry struct {
+	err error
+}
+
+func (f failingPackRegistry) Register(_ string, _ *wapp.Reader, _ *os.File) error {
+	return f.err
 }


### PR DESCRIPTION
This pull request introduces improvements to module-aware entry loading and refines pack snapshot loading behavior. The changes enhance how entries are tagged with module metadata, ensure correct resolution of requirements, and simplify pack file loading for snapshot semantics. Comprehensive tests have been added to verify these behaviors.

**Module-aware entry loading improvements:**

* Added `LoadEntriesFromModuleLoadPaths` to `cmd/internal/entries/loader.go`, enabling loading entries from annotated module paths and tagging them with module metadata.
* Updated `boot/deps/lock/lock.go` to clarify module metadata semantics for app source and replacement paths in `GetModuleLoadPaths`.
* Changed `cmd/wippy/cmd/load_entries.go` to use module-aware entry loading, ensuring entries are tagged and resolved correctly.
* Added tests in `boot/deps/lock/module_load_paths_test.go` and `cmd/wippy/cmd/load_entries_test.go` to verify module metadata tagging and requirement resolution. [[1]](diffhunk://#diff-b841d9815e72908ebd00cb8324cf1f5c6f493f14bb7e659823a2106b3071fd6eR1-R96) [[2]](diffhunk://#diff-9b52a422bc4013894f872b51c12dc41903ea291140a958bd5bb13405a2310ad5R1-R141)

**Pack snapshot loading and execution:**

* Refactored pack loading in `cmd/wippy/cmd/run_pack.go` to use `loadPackEntries`, enforcing snapshot semantics and avoiding dependency expansion. Introduced `applyPackEntries` for restoring baseline state. [[1]](diffhunk://#diff-3b2b2550ff613446c69d9133c5f327a2868c8c468a10cfb15c05c486be911327L324-R330) [[2]](diffhunk://#diff-3b2b2550ff613446c69d9133c5f327a2868c8c468a10cfb15c05c486be911327L383-L410) [[3]](diffhunk://#diff-3b2b2550ff613446c69d9133c5f327a2868c8c468a10cfb15c05c486be911327L436-R397) [[4]](diffhunk://#diff-3b2b2550ff613446c69d9133c5f327a2868c8c468a10cfb15c05c486be911327R434-R478)
* Improved pack file extension handling with `hasWappExtension` to support case-insensitive `.wapp` detection. [[1]](diffhunk://#diff-3b2b2550ff613446c69d9133c5f327a2868c8c468a10cfb15c05c486be911327L111-R110) [[2]](diffhunk://#diff-3b2b2550ff613446c69d9133c5f327a2868c8c468a10cfb15c05c486be911327R121-R124)
* Added tests in `cmd/wippy/cmd/run_pack_test.go` to verify snapshot loading behavior and `.wapp` extension handling. [[1]](diffhunk://#diff-5546cac7ce99999392f73951d11faaadbcf0a3c4eedc7a036257b210a435718fR82-R123) [[2]](diffhunk://#diff-5546cac7ce99999392f73951d11faaadbcf0a3c4eedc7a036257b210a435718fR146-R151)

**Test and setup enhancements:**

* Registered YAML payload transcoder in loader test setup to ensure proper decoding of module and app entries.
* Added imports and setup functions for new test cases across affected files. [[1]](diffhunk://#diff-0ea4c93c7e459fb22154c6550675cc7e5c71989c1ecd08f7944f4a2baec2c924R18-R20) [[2]](diffhunk://#diff-5546cac7ce99999392f73951d11faaadbcf0a3c4eedc7a036257b210a435718fR15-R16)

These changes collectively improve module metadata handling, ensure correct requirement resolution, and simplify pack file loading for snapshot execution.