### PR TITLE
Fix frame ownership and scheduler/temporal race paths

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,18 @@ linters:
           - gosec
         text: "G602"
       - linters:
+          - gosec
+        text: "G117"
+      - linters:
+          - gosec
+        text: "G703"
+      - linters:
+          - gosec
+        text: "G704"
+      - linters:
+          - gosec
+        text: "G705"
+      - linters:
           - revive
         text: "unexported-return"
       - linters:
@@ -161,7 +173,6 @@ linters:
     paths:
       - .github
       - .git
-      - 
       - third_party$
       - builtin$
       - examples$

--- a/api/boot/config.go
+++ b/api/boot/config.go
@@ -125,8 +125,13 @@ func (c *config) GetDuration(key string, def time.Duration) time.Duration {
 	if !ok {
 		return def
 	}
-	if d, ok := v.(time.Duration); ok {
+	switch d := v.(type) {
+	case time.Duration:
 		return d
+	case string:
+		if parsed, err := time.ParseDuration(d); err == nil {
+			return parsed
+		}
 	}
 	return def
 }

--- a/api/context/framecontext.go
+++ b/api/context/framecontext.go
@@ -4,6 +4,7 @@ package context
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 )
@@ -38,67 +39,149 @@ type FrameContext interface {
 	// IsSealed returns true if this frame is sealed.
 	IsSealed() bool
 
-	// IncRef increments reference count. Returns Closer to decrement when done.
-	// Call before spawning async work, defer the returned Closer in the goroutine.
-	IncRef() Closer
-
 	// Close decrements refcount and releases frame when zero.
 	Close() error
 }
 
-// frameContext is designed for single-threaded access before sealing.
-// Do NOT access from multiple goroutines until Seal() is called.
-// After sealing, concurrent reads are safe (values become immutable).
+type frameValues map[any]any
+
+// frameContext stores values as immutable snapshots.
+// Reads stay lock-free; writes clone and swap the snapshot.
 type frameContext struct {
-	values   map[any]any
-	parent   *frameContext
-	sealed   atomic.Bool
-	refcount atomic.Int32
+	values atomic.Pointer[frameValues]
+	parent *frameContext
+	// generation increments whenever the frame lifecycle changes.
+	// Context values carry the generation to reject stale frame references.
+	generation atomic.Uint64
+	refcount   atomic.Int32
+	sealed     atomic.Bool
+	writers    atomic.Int32
+}
+
+type frameContextRef struct {
+	frame      *frameContext
+	generation uint64
 }
 
 var frameContextPool = sync.Pool{
 	New: func() any {
-		return &frameContext{values: make(map[any]any, 8)}
+		f := &frameContext{}
+		values := make(frameValues, 8)
+		f.values.Store(&values)
+		return f
 	},
 }
 
+func cloneValues(src frameValues, extra int) frameValues {
+	if extra < 0 {
+		extra = 0
+	}
+	dst := make(frameValues, len(src)+extra)
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func (f *frameContext) valuesSnapshot() frameValues {
+	valuesPtr := f.values.Load()
+	if valuesPtr == nil {
+		return nil
+	}
+	return *valuesPtr
+}
+
+func (f *frameContext) beginWrite() bool {
+	if f.sealed.Load() {
+		return false
+	}
+	f.writers.Add(1)
+	if f.sealed.Load() {
+		f.writers.Add(-1)
+		return false
+	}
+	return true
+}
+
+func (f *frameContext) endWrite() {
+	f.writers.Add(-1)
+}
+
 func (f *frameContext) Get(key any) (any, bool) {
-	val, exists := f.values[key]
+	values := f.valuesSnapshot()
+	val, exists := values[key]
 	return val, exists
 }
 
 func (f *frameContext) Set(key any, value any) error {
-	if f.sealed.Load() {
+	if !f.beginWrite() {
 		return NewFrameSealedError(key)
 	}
-	f.values[key] = value
-	return nil
+	defer f.endWrite()
+
+	for {
+		currentPtr := f.values.Load()
+		var current frameValues
+		if currentPtr != nil {
+			current = *currentPtr
+		}
+
+		next := cloneValues(current, 1)
+		next[key] = value
+		nextPtr := &next
+		if f.values.CompareAndSwap(currentPtr, nextPtr) {
+			return nil
+		}
+
+		if f.sealed.Load() {
+			return NewFrameSealedError(key)
+		}
+	}
 }
 
 func (f *frameContext) SetMultiple(pairs ...Pair) error {
-	if f.sealed.Load() {
+	if !f.beginWrite() {
 		return ErrFrameSealed
 	}
-	for _, p := range pairs {
-		f.values[p.Key] = p.Value
+	defer f.endWrite()
+
+	for {
+		currentPtr := f.values.Load()
+		var current frameValues
+		if currentPtr != nil {
+			current = *currentPtr
+		}
+
+		next := cloneValues(current, len(pairs))
+		for _, p := range pairs {
+			next[p.Key] = p.Value
+		}
+		nextPtr := &next
+		if f.values.CompareAndSwap(currentPtr, nextPtr) {
+			return nil
+		}
+
+		if f.sealed.Load() {
+			return ErrFrameSealed
+		}
 	}
-	return nil
 }
 
 func (f *frameContext) Has(key any) bool {
-	_, exists := f.values[key]
+	values := f.valuesSnapshot()
+	_, exists := values[key]
 	return exists
 }
 
 func (f *frameContext) Iterate(fn func(key any, value any)) {
-	for k, v := range f.values {
+	for k, v := range f.valuesSnapshot() {
 		fn(k, v)
 	}
 }
 
 func (f *frameContext) InheritablePairs() []Pair {
 	var pairs []Pair
-	for k, v := range f.values {
+	for k, v := range f.valuesSnapshot() {
 		if ctxKey, ok := k.(*Key); ok && ctxKey.Inherit {
 			pairs = append(pairs, Pair{Key: k, Value: v})
 		}
@@ -107,19 +190,18 @@ func (f *frameContext) InheritablePairs() []Pair {
 }
 
 func (f *frameContext) Seal() {
-	f.sealed.Store(true)
+	if f.sealed.Swap(true) {
+		return
+	}
+
+	// Wait until in-flight writers that entered before seal complete.
+	for f.writers.Load() != 0 {
+		runtime.Gosched()
+	}
 }
 
 func (f *frameContext) IsSealed() bool {
 	return f.sealed.Load()
-}
-
-func (f *frameContext) IncRef() Closer {
-	f.refcount.Add(1)
-	return CloserFunc(func() error {
-		releaseFrame(f)
-		return nil
-	})
 }
 
 func (f *frameContext) Close() error {
@@ -129,13 +211,38 @@ func (f *frameContext) Close() error {
 
 // WithFrameContext attaches FrameContext to the provided context.
 func WithFrameContext(ctx context.Context, fc FrameContext) context.Context {
+	if f, ok := fc.(*frameContext); ok {
+		ref := frameContextRef{
+			frame:      f,
+			generation: f.generation.Load(),
+		}
+		return context.WithValue(ctx, frameContextKey, ref)
+	}
 	return context.WithValue(ctx, frameContextKey, fc)
 }
 
 // FrameFromContext extracts FrameContext from context.
 func FrameFromContext(ctx context.Context) FrameContext {
-	if fc, ok := ctx.Value(frameContextKey).(FrameContext); ok {
-		return fc
+	switch v := ctx.Value(frameContextKey).(type) {
+	case frameContextRef:
+		if v.frame == nil {
+			return nil
+		}
+		if v.generation != v.frame.generation.Load() {
+			return nil
+		}
+		if v.frame.refcount.Load() <= 0 {
+			return nil
+		}
+		return v.frame
+	case *frameContext:
+		// Backward compatibility for contexts created before frameContextRef.
+		if v == nil || v.refcount.Load() <= 0 {
+			return nil
+		}
+		return v
+	case FrameContext:
+		return v
 	}
 	return nil
 }
@@ -180,23 +287,42 @@ func ReleaseFrameContext(fc FrameContext) {
 	releaseFrame(f)
 }
 
+// tryIncRef atomically increments refcount only if the frame is still alive (refcount > 0).
+// Returns false if the frame has already been released, preventing use-after-pool races.
+func tryIncRef(f *frameContext) bool {
+	for {
+		current := f.refcount.Load()
+		if current <= 0 {
+			return false
+		}
+		if f.refcount.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
 func releaseFrame(f *frameContext) {
 	newCount := f.refcount.Add(-1)
-	if newCount > 0 {
+	if newCount != 0 {
 		return
 	}
 
+	// Invalidate all context-bound references before clearing/repooling.
+	f.generation.Add(1)
+
 	// refcount == 0 means exclusive access, no lock needed
 	var closers []Closer
-	for _, v := range f.values {
+	for _, v := range f.valuesSnapshot() {
 		if closer, ok := v.(Closer); ok {
 			closers = append(closers, closer)
 		}
 	}
-	clear(f.values)
+	values := make(frameValues, 8)
+	f.values.Store(&values)
 	parent := f.parent
 	f.parent = nil
 	f.sealed.Store(false)
+	f.writers.Store(0)
 
 	for _, closer := range closers {
 		_ = closer.Close()
@@ -226,42 +352,59 @@ func OpenFrameContext(ctx context.Context) (context.Context, FrameContext) {
 // Uses reference counting to ensure parent frame stays alive while child iterates.
 func OpenFrameContextOn(targetCtx context.Context, parentCtx context.Context) (context.Context, FrameContext) {
 	parentFC, _ := FrameFromContext(parentCtx).(*frameContext)
+	if parentFC != nil && !parentFC.IsSealed() {
+		// Forking implies immutable parent snapshot for safe copy-on-fork.
+		parentFC.Seal()
+	}
 	return forkFrameContext(targetCtx, parentFC)
 }
 
 func newFrameContext(parent context.Context) (context.Context, FrameContext) {
 	fc := frameContextPool.Get().(*frameContext)
+	fc.generation.Add(1)
 	fc.sealed.Store(false)
 	fc.refcount.Store(1)
+	fc.writers.Store(0)
 	fc.parent = nil
+	values := make(frameValues, 8)
+	fc.values.Store(&values)
 	return WithFrameContext(parent, fc), fc
 }
 
 // forkFrameContext creates a new child frame from a parent frame.
-// Increments parent refcount to keep parent alive until child releases.
+// Uses CAS to increment parent refcount only if still alive, preventing
+// a race where FrameFromContext returns a frame that is concurrently released.
 // Parent is always sealed when forking, so no lock needed for copying.
 func forkFrameContext(ctx context.Context, parent *frameContext) (context.Context, *frameContext) {
 	if parent != nil {
-		parent.refcount.Add(1)
+		if !tryIncRef(parent) {
+			parent = nil
+		}
 	}
 
 	fc := frameContextPool.Get().(*frameContext)
+	fc.generation.Add(1)
 	fc.sealed.Store(false)
 	fc.refcount.Store(1)
+	fc.writers.Store(0)
 	fc.parent = parent
+	values := make(frameValues, 8)
 
 	// Parent is sealed (checked in OpenFrameContext), safe to read without lock
 	if parent != nil {
-		for k, v := range parent.values {
+		parentValues := parent.valuesSnapshot()
+		values = make(frameValues, len(parentValues))
+		for k, v := range parentValues {
 			if ctxKey, ok := k.(*Key); ok && ctxKey.Inherit {
 				if cloner, ok := v.(Cloner); ok {
-					fc.values[k] = cloner.Clone()
+					values[k] = cloner.Clone()
 				} else {
-					fc.values[k] = v
+					values[k] = v
 				}
 			}
 		}
 	}
+	fc.values.Store(&values)
 
 	return WithFrameContext(ctx, fc), fc
 }

--- a/api/context/framecontext.go
+++ b/api/context/framecontext.go
@@ -359,6 +359,11 @@ func OpenFrameContextOn(targetCtx context.Context, parentCtx context.Context) (c
 	return forkFrameContext(targetCtx, parentFC)
 }
 
+// ForkFrameContext creates a new frame on ctx inheriting from the frame in ctx.
+func ForkFrameContext(ctx context.Context) (context.Context, FrameContext) {
+	return OpenFrameContextOn(ctx, ctx)
+}
+
 func newFrameContext(parent context.Context) (context.Context, FrameContext) {
 	fc := frameContextPool.Get().(*frameContext)
 	fc.generation.Add(1)

--- a/api/context/framecontext_test.go
+++ b/api/context/framecontext_test.go
@@ -6,7 +6,9 @@ package context
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestNewFrameContext(t *testing.T) {
@@ -179,6 +181,100 @@ func TestFrameContext_ConcurrentReadsAfterSeal(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestFrameContext_ConcurrentReadWriteBeforeSeal(t *testing.T) {
+	_, cc := newFrameContext(context.Background())
+	key := &Key{Name: "test.concurrent"}
+
+	const writeWorkers = 4
+	const readWorkers = 4
+	const iterations = 2000
+
+	var wg sync.WaitGroup
+
+	for writer := 0; writer < writeWorkers; writer++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if err := cc.Set(key, id*iterations+i); err != nil {
+					t.Errorf("unexpected set error: %v", err)
+					return
+				}
+			}
+		}(writer)
+	}
+
+	for reader := 0; reader < readWorkers; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_, _ = cc.Get(key)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if _, ok := cc.Get(key); !ok {
+		t.Fatal("expected key to exist after concurrent writes")
+	}
+}
+
+func TestFrameContext_SealRejectsWritersUnderContention(t *testing.T) {
+	_, cc := newFrameContext(context.Background())
+	key := &Key{Name: "test.seal.concurrent"}
+
+	const writers = 8
+
+	var started sync.WaitGroup
+	var wg sync.WaitGroup
+	var postSealSuccess atomic.Bool
+	var sealed atomic.Bool
+	stop := make(chan struct{})
+
+	started.Add(writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			started.Done()
+
+			n := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				err := cc.Set(key, id*100000+n)
+				if sealed.Load() && err == nil {
+					postSealSuccess.Store(true)
+					return
+				}
+				n++
+			}
+		}(i)
+	}
+
+	started.Wait()
+	cc.Seal()
+	sealed.Store(true)
+
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if postSealSuccess.Load() {
+		t.Fatal("write succeeded after seal")
+	}
+
+	if err := cc.Set(key, "after-seal"); err == nil {
+		t.Fatal("expected set to fail after seal")
+	}
 }
 
 func TestWithFrameContext(t *testing.T) {
@@ -370,6 +466,50 @@ func TestOpenFrameContext_NilFrame(t *testing.T) {
 	}
 	if newCtx == ctx {
 		t.Error("OpenFrameContext should return new context when creating frame")
+	}
+}
+
+func TestFrameFromContext_StaleReferenceInvalidated(t *testing.T) {
+	staleCtx, fc := OpenFrameContext(context.Background())
+	key := &Key{Name: "test.key"}
+	_ = fc.Set(key, "value")
+	ReleaseFrameContext(fc)
+
+	if got := FrameFromContext(staleCtx); got != nil {
+		t.Fatal("stale context should not expose released frame")
+	}
+
+	freshCtx, freshFC := OpenFrameContext(staleCtx)
+	defer ReleaseFrameContext(freshFC)
+
+	if got := FrameFromContext(staleCtx); got != nil {
+		t.Fatal("stale context should remain invalid after frame pool reuse")
+	}
+	if got := FrameFromContext(freshCtx); got == nil {
+		t.Fatal("fresh context should expose active frame")
+	}
+}
+
+func TestOpenFrameContextOn_SealsParentForSafeFork(t *testing.T) {
+	parentCtx, parent := OpenFrameContext(context.Background())
+	defer ReleaseFrameContext(parent)
+
+	inheritKey := &Key{Name: "test.inherit", Inherit: true}
+	_ = parent.Set(inheritKey, "user123")
+
+	_, child := OpenFrameContextOn(context.Background(), parentCtx)
+	defer ReleaseFrameContext(child)
+
+	if !parent.IsSealed() {
+		t.Fatal("parent should be sealed after OpenFrameContextOn")
+	}
+	if err := parent.Set(&Key{Name: "test.after_fork"}, "x"); err == nil {
+		t.Fatal("sealed parent should reject post-fork writes")
+	}
+
+	val, ok := child.Get(inheritKey)
+	if !ok || val != "user123" {
+		t.Fatalf("child should inherit sealed parent values, got %v (ok=%v)", val, ok)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/tree-sitter/tree-sitter-php v0.24.2
 	github.com/tree-sitter/tree-sitter-python v0.25.0
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
-	github.com/wippyai/go-lua v1.5.11
+	github.com/wippyai/go-lua v1.5.12
 	github.com/wippyai/module-registry-proto-go v0.0.1
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaO
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/wippyai/go-lua v1.5.11 h1:mbelTIrfqVlxytKDkVOa4PBSnhDYToymR2biPcER8V0=
-github.com/wippyai/go-lua v1.5.11/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
+github.com/wippyai/go-lua v1.5.12 h1:oGwN9tXo57/Mv4geuvE5WPSP/Zs70BROP5jlt5/3HOM=
+github.com/wippyai/go-lua v1.5.12/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/module-registry-proto-go v0.0.1 h1:EYnW8MTrI/gs7TJ0ilTVgJal3e0NWmXQigeamrXu0mk=
 github.com/wippyai/module-registry-proto-go v0.0.1/go.mod h1:p4ihYQKRQuqRVLxaH1YL0IEnkz4zKdyfVADOwvA5Tno=
 github.com/wippyai/tree-sitter-markdown v0.0.3 h1:u6e53+hzPSS848Xhm+I48SwtvWQHrC21wDrogdwCwuc=

--- a/runtime/lua/component/function/lifecycle.go
+++ b/runtime/lua/component/function/lifecycle.go
@@ -90,8 +90,8 @@ func (m *Manager) Execute(ctx context.Context, task runtime.Task) (*runtime.Resu
 	if len(task.Context) > 0 {
 		fc := ctxapi.FrameFromContext(ctx)
 		if fc != nil {
-			for _, pair := range task.Context {
-				_ = fc.Set(pair.Key, pair.Value)
+			if err := fc.SetMultiple(task.Context...); err != nil {
+				return nil, runtimelua.NewOperationError("set task context", err)
 			}
 		}
 	}

--- a/runtime/lua/engine/process.go
+++ b/runtime/lua/engine/process.go
@@ -265,9 +265,8 @@ func (p *Process) Init(ctx context.Context, method string, input payload.Payload
 	// Create and store resource.Store in FrameContext
 	store := resource.NewStore()
 	if err := resource.SetStore(ctx, store); err != nil {
-		if p.state != nil {
-			p.state.Close()
-		}
+		// Process owns LState lifecycle and always releases it in Close().
+		// Do not close here to avoid duplicate pool returns on init failures.
 		return runtimelua.NewStoreResourcesError(err)
 	}
 
@@ -326,11 +325,9 @@ func (p *Process) Init(ctx context.Context, method string, input payload.Payload
 			var err error
 			fn, err = p.state.Load(strings.NewReader(p.script), p.scriptName)
 			if err != nil {
-				p.state.Close()
 				return runtimelua.NewLoadScriptError(err)
 			}
 		} else {
-			p.state.Close()
 			return luaapi.ErrNoScriptOrProto
 		}
 	}

--- a/runtime/lua/evalhost/host.go
+++ b/runtime/lua/evalhost/host.go
@@ -142,19 +142,9 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 	}
 	defer proc.Close()
 
-	// Create isolated frame context for eval execution.
-	existingFC := ctxapi.FrameFromContext(ctx)
-	evalCtx, fc := ctxapi.OpenFrameContext(ctx)
-	owned := fc != existingFC
-	if !owned && fc != nil {
-		// If caller passed an unsealed frame, seal and fork so eval owns lifecycle.
-		fc.Seal()
-		evalCtx, fc = ctxapi.OpenFrameContext(evalCtx)
-		owned = true
-	}
-	if owned {
-		defer ctxapi.ReleaseFrameContext(fc)
-	}
+	// Eval always owns an isolated execution frame.
+	evalCtx, fc := ctxapi.ForkFrameContext(ctx)
+	defer ctxapi.ReleaseFrameContext(fc)
 
 	// Apply caller-provided context values
 	if len(cmd.Context) > 0 {
@@ -245,23 +235,15 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 			}
 
 			// Freeze parent frame for concurrent yield handlers.
-			if frame := ctxapi.FrameFromContext(evalCtx); frame != nil {
-				frame.Seal()
-			}
+			fc.Seal()
 
 			// Create collector with exact count and dispatch
 			collector := newYieldCollector(len(validYields))
 			for _, y := range validYields {
 				handler := disp.Dispatch(y.Cmd)
-				yieldCtx := evalCtx
-				var yieldFC ctxapi.FrameContext
-				if ctxapi.FrameFromContext(evalCtx) != nil {
-					yieldCtx, yieldFC = ctxapi.OpenFrameContext(evalCtx)
-				}
+				yieldCtx, yieldFC := ctxapi.ForkFrameContext(evalCtx)
 				go func(tag uint64, c dispatcher.Command, h dispatcher.Handler, callCtx context.Context, callFC ctxapi.FrameContext) {
-					if callFC != nil {
-						defer ctxapi.ReleaseFrameContext(callFC)
-					}
+					defer ctxapi.ReleaseFrameContext(callFC)
 					err := h.Handle(callCtx, c, tag, collector)
 					if err != nil {
 						collector.CompleteYield(tag, nil, err)

--- a/runtime/lua/evalhost/host.go
+++ b/runtime/lua/evalhost/host.go
@@ -142,9 +142,19 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 	}
 	defer proc.Close()
 
-	// Create fresh frame context for the eval process
+	// Create isolated frame context for eval execution.
+	existingFC := ctxapi.FrameFromContext(ctx)
 	evalCtx, fc := ctxapi.OpenFrameContext(ctx)
-	defer ctxapi.ReleaseFrameContext(fc)
+	owned := fc != existingFC
+	if !owned && fc != nil {
+		// If caller passed an unsealed frame, seal and fork so eval owns lifecycle.
+		fc.Seal()
+		evalCtx, fc = ctxapi.OpenFrameContext(evalCtx)
+		owned = true
+	}
+	if owned {
+		defer ctxapi.ReleaseFrameContext(fc)
+	}
 
 	// Apply caller-provided context values
 	if len(cmd.Context) > 0 {
@@ -234,16 +244,29 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 				continue
 			}
 
+			// Freeze parent frame for concurrent yield handlers.
+			if frame := ctxapi.FrameFromContext(evalCtx); frame != nil {
+				frame.Seal()
+			}
+
 			// Create collector with exact count and dispatch
 			collector := newYieldCollector(len(validYields))
 			for _, y := range validYields {
 				handler := disp.Dispatch(y.Cmd)
-				go func(tag uint64, c dispatcher.Command, h dispatcher.Handler) {
-					err := h.Handle(evalCtx, c, tag, collector)
+				yieldCtx := evalCtx
+				var yieldFC ctxapi.FrameContext
+				if ctxapi.FrameFromContext(evalCtx) != nil {
+					yieldCtx, yieldFC = ctxapi.OpenFrameContext(evalCtx)
+				}
+				go func(tag uint64, c dispatcher.Command, h dispatcher.Handler, callCtx context.Context, callFC ctxapi.FrameContext) {
+					if callFC != nil {
+						defer ctxapi.ReleaseFrameContext(callFC)
+					}
+					err := h.Handle(callCtx, c, tag, collector)
 					if err != nil {
 						collector.CompleteYield(tag, nil, err)
 					}
-				}(y.Tag, y.Cmd, handler)
+				}(y.Tag, y.Cmd, handler, yieldCtx, yieldFC)
 			}
 
 			// Wait for all yields to complete

--- a/runtime/wasm/component/function/lifecycle.go
+++ b/runtime/wasm/component/function/lifecycle.go
@@ -4,6 +4,7 @@ package function
 
 import (
 	"context"
+	"fmt"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/registry"
@@ -72,8 +73,8 @@ func (m *Manager) Execute(ctx context.Context, task runtime.Task) (*runtime.Resu
 	if len(task.Context) > 0 {
 		fc := ctxapi.FrameFromContext(ctx)
 		if fc != nil {
-			for _, pair := range task.Context {
-				_ = fc.Set(pair.Key, pair.Value)
+			if err := fc.SetMultiple(task.Context...); err != nil {
+				return nil, fmt.Errorf("set task context: %w", err)
 			}
 		}
 	}

--- a/runtime/wasm/engine/process.go
+++ b/runtime/wasm/engine/process.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/dispatcher"
 	envapi "github.com/wippyai/runtime/api/env"
 	fsapi "github.com/wippyai/runtime/api/fs"
@@ -83,6 +84,9 @@ func (p *Process) Init(ctx context.Context, method string, input payload.Payload
 	p.pendingTag = 0
 	p.waitingYield = false
 	p.done = false
+	if fc := ctxapi.FrameFromContext(ctx); fc != nil {
+		fc.Seal()
+	}
 	return nil
 }
 

--- a/service/host/host.go
+++ b/service/host/host.go
@@ -100,6 +100,9 @@ func (h *Host) Run(ctx context.Context, start *process.Start) (pid.PID, error) {
 
 	if _, err = h.scheduler.Submit(frameCtx, processID, proc, method, start.Input); err != nil {
 		proc.Close()
+		if fc := ctxapi.FrameFromContext(frameCtx); fc != nil {
+			ctxapi.ReleaseFrameContext(fc)
+		}
 
 		// Handle spawn-or-signal: if name taken, route messages to existing process
 		if errors.Is(err, topology.ErrNameAlreadyRegistered) {

--- a/service/http/middleware/wsrelay/conn.go
+++ b/service/http/middleware/wsrelay/conn.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	contextapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/process"
@@ -28,6 +29,7 @@ type Connection struct {
 	connectedAt         time.Time
 	ctx                 context.Context
 	closeReason         atomic.Value
+	frameCtx            contextapi.FrameContext
 	host                relay.AttachableReceiver
 	node                relay.Node
 	topo                topology.Topology
@@ -50,6 +52,7 @@ type Connection struct {
 // NewConnection creates a new WebSocket connection relay
 func NewConnection(
 	appCtx context.Context,
+	fc contextapi.FrameContext,
 	wsConn *websocket.Conn,
 	targetPID pid.PID,
 	config RelayCommand,
@@ -95,6 +98,7 @@ func NewConnection(
 	// Create the connection instance
 	conn := &Connection{
 		ctx:                 ctx,
+		frameCtx:            fc,
 		cancelCtx:           cancel,
 		conn:                wsConn,
 		wsPID:               wsPID,
@@ -626,6 +630,11 @@ func (c *Connection) cleanup() {
 
 	// Close message channel to prevent leaks
 	close(c.msgCh)
+
+	// Release frame context to return it to pool
+	if c.frameCtx != nil {
+		contextapi.ReleaseFrameContext(c.frameCtx)
+	}
 
 	c.logger.Debug("websocket connection closed")
 }

--- a/service/http/middleware/wsrelay/manager.go
+++ b/service/http/middleware/wsrelay/manager.go
@@ -212,7 +212,7 @@ func (m *RelayManager) middlewareHandler(h http.Handler, originPatterns []string
 		}
 
 		// Always fork a per-connection frame from app context.
-		wsCtx, wsFC := contextapi.OpenFrameContextOn(m.appCtx, m.appCtx)
+		wsCtx, wsFC := contextapi.ForkFrameContext(m.appCtx)
 		if err := wsFC.Set(httpapi.ServerIDKey(), serverID); err != nil {
 			logger.Error("Failed to set server ID in frame context", zap.Error(err))
 			contextapi.ReleaseFrameContext(wsFC)

--- a/service/http/middleware/wsrelay/manager.go
+++ b/service/http/middleware/wsrelay/manager.go
@@ -211,15 +211,18 @@ func (m *RelayManager) middlewareHandler(h http.Handler, originPatterns []string
 			return
 		}
 
-		wsCtx, wsFC := contextapi.OpenFrameContext(m.appCtx)
+		// Always fork a per-connection frame from app context.
+		wsCtx, wsFC := contextapi.OpenFrameContextOn(m.appCtx, m.appCtx)
 		if err := wsFC.Set(httpapi.ServerIDKey(), serverID); err != nil {
 			logger.Error("Failed to set server ID in frame context", zap.Error(err))
+			contextapi.ReleaseFrameContext(wsFC)
 			_ = conn.Close(websocket.StatusInternalError, "Failed to set server ID")
 			return
 		}
 
 		wsConn, err := NewConnection(
 			wsCtx,
+			wsFC,
 			conn,
 			targetPID,
 			config,
@@ -234,6 +237,7 @@ func (m *RelayManager) middlewareHandler(h http.Handler, originPatterns []string
 		)
 		if err != nil {
 			logger.Error("Error creating WebSocket connection", zap.Error(err))
+			contextapi.ReleaseFrameContext(wsFC)
 			_ = conn.Close(websocket.StatusInternalError, err.Error())
 			return
 		}

--- a/service/http/server.go
+++ b/service/http/server.go
@@ -225,8 +225,8 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 
 	// Wrap handler with per-request FrameContext creation
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Create unsealed FrameContext for each HTTP request
-		ctx, fc := contextapi.OpenFrameContext(r.Context())
+		// Always fork a dedicated request frame from the inbound context.
+		ctx, fc := contextapi.OpenFrameContextOn(r.Context(), r.Context())
 		defer contextapi.ReleaseFrameContext(fc)
 
 		// Set all HTTP-specific metadata in FrameContext in one place

--- a/service/http/server.go
+++ b/service/http/server.go
@@ -226,7 +226,7 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 	// Wrap handler with per-request FrameContext creation
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always fork a dedicated request frame from the inbound context.
-		ctx, fc := contextapi.OpenFrameContextOn(r.Context(), r.Context())
+		ctx, fc := contextapi.ForkFrameContext(r.Context())
 		defer contextapi.ReleaseFrameContext(fc)
 
 		// Set all HTTP-specific metadata in FrameContext in one place

--- a/service/queue/consumer/consumer.go
+++ b/service/queue/consumer/consumer.go
@@ -63,6 +63,10 @@ func (c *Consumer) Start(ctx context.Context) (<-chan any, error) {
 
 	// Create worker context
 	c.workerCtx, c.workerCancel = context.WithCancel(ctx)
+	if fc := ctxapi.FrameFromContext(c.workerCtx); fc != nil {
+		// Workers share c.workerCtx across goroutines, so freeze it once.
+		fc.Seal()
+	}
 
 	// Attach to driver to receive deliveries
 	cancel, err := c.driver.Attach(ctx, c.queueID, c.deliveries)

--- a/service/temporal/peer/receiver.go
+++ b/service/temporal/peer/receiver.go
@@ -162,7 +162,7 @@ func (r *Receiver) signalWorkflow(from, target pid.PID, msg *relay.Message) erro
 	ctx := r.ctx
 	var fc ctxapi.FrameContext
 	if from.Node != "" || from.Host != "" || from.UniqID != "" {
-		ctx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+		ctx, fc = ctxapi.ForkFrameContext(ctx)
 		values, err := ctxapi.GetOrCreateValues(ctx)
 		if err == nil {
 			values.Set(temporalprop.SignalFromValueKey, from.String())

--- a/service/temporal/propagator/propagator.go
+++ b/service/temporal/propagator/propagator.go
@@ -282,7 +282,7 @@ func MergeActivityContext(appCtx context.Context, activityCtx context.Context) (
 		return appCtx, func() {}, nil
 	}
 
-	execCtx, fc := ctxapi.OpenFrameContextOn(appCtx, appCtx)
+	execCtx, fc := ctxapi.ForkFrameContext(appCtx)
 	release := func() { ctxapi.ReleaseFrameContext(fc) }
 
 	if len(ctxValues) > 0 {

--- a/service/temporal/worker/host.go
+++ b/service/temporal/worker/host.go
@@ -42,7 +42,7 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 	execCtx := ctx
 	var fc ctxapi.FrameContext
 	if len(start.Context) > 0 {
-		execCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+		execCtx, fc = ctxapi.ForkFrameContext(ctx)
 		if err := fc.SetMultiple(start.Context...); err != nil {
 			ctxapi.ReleaseFrameContext(fc)
 			return pid.PID{}, fmt.Errorf("failed to set workflow context: %w", err)
@@ -250,7 +250,7 @@ func withSignalSender(ctx context.Context, sender pid.PID) (context.Context, ctx
 	var fc ctxapi.FrameContext
 
 	if sender.Node != "" || sender.Host != "" || sender.UniqID != "" {
-		signalCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+		signalCtx, fc = ctxapi.ForkFrameContext(ctx)
 		values, err := ctxapi.GetOrCreateValues(signalCtx)
 		if err == nil {
 			values.Set(temporalprop.SignalFromValueKey, sender.String())

--- a/service/temporal/worker/host.go
+++ b/service/temporal/worker/host.go
@@ -26,11 +26,12 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 	if w.closed.Load() {
 		return pid.PID{}, fmt.Errorf("worker is closed")
 	}
-	if w.temporalClient == nil {
+	runtimeState := w.loadRuntime()
+	if runtimeState == nil || runtimeState.temporalClient == nil {
 		return pid.PID{}, fmt.Errorf("temporal client not available")
 	}
 
-	taskQueue := w.taskQueue
+	taskQueue := runtimeState.taskQueue
 	if taskQueue == "" {
 		taskQueue = w.config.TaskQueue
 	}
@@ -97,11 +98,11 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 
 	firstSignalIdx, firstSignal := firstSignalMessage(start.Messages)
 	if firstSignal != nil {
-		run, err := w.signalWithStartMessage(execCtx, workflowID, workflowName, opts, start, firstSignal)
+		run, err := w.signalWithStartMessage(execCtx, runtimeState, workflowID, workflowName, opts, start, firstSignal)
 		if err != nil {
 			var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
 			if errors.As(err, &alreadyStarted) && shouldUseExistingOnAlreadyStarted(opts) {
-				w.publishRunHandoff(start, workflowID, alreadyStarted.RunId)
+				w.publishRunHandoff(runtimeState.ctx, start, workflowID, alreadyStarted.RunId)
 				if err := w.signalMessages(execCtx, workflowID, start.Messages, start); err != nil {
 					return pid.PID{}, err
 				}
@@ -110,7 +111,7 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 			return pid.PID{}, err
 		}
 		if run != nil {
-			w.publishRunHandoff(start, workflowID, run.GetRunID())
+			w.publishRunHandoff(runtimeState.ctx, start, workflowID, run.GetRunID())
 		}
 		if err := w.signalMessages(execCtx, workflowID, start.Messages[firstSignalIdx+1:], start); err != nil {
 			return pid.PID{}, err
@@ -118,17 +119,17 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 		return workflowPID, nil
 	}
 
-	run, err := w.temporalClient.ExecuteWorkflow(execCtx, opts, workflowName, start.Input)
+	run, err := runtimeState.temporalClient.ExecuteWorkflow(execCtx, opts, workflowName, start.Input)
 	if err != nil {
 		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
 		if errors.As(err, &alreadyStarted) && shouldUseExistingOnAlreadyStarted(opts) {
-			w.publishRunHandoff(start, workflowID, alreadyStarted.RunId)
+			w.publishRunHandoff(runtimeState.ctx, start, workflowID, alreadyStarted.RunId)
 			return workflowPID, nil
 		}
 		return pid.PID{}, err
 	}
 	if run != nil {
-		w.publishRunHandoff(start, workflowID, run.GetRunID())
+		w.publishRunHandoff(runtimeState.ctx, start, workflowID, run.GetRunID())
 	}
 
 	return workflowPID, nil
@@ -154,16 +155,22 @@ func shouldUseExistingOnAlreadyStarted(opts client.StartWorkflowOptions) bool {
 
 // Terminate stops a running Temporal workflow.
 func (w *Worker) Terminate(ctx context.Context, target pid.PID) error {
-	if w.temporalClient == nil {
+	runtimeState := w.loadRuntime()
+	if runtimeState == nil || runtimeState.temporalClient == nil {
 		return fmt.Errorf("temporal client not available")
 	}
 	if target.UniqID == "" {
 		return fmt.Errorf("target workflow ID is empty")
 	}
-	return w.temporalClient.TerminateWorkflow(ctx, target.UniqID, "", "process.terminate")
+	return runtimeState.temporalClient.TerminateWorkflow(ctx, target.UniqID, "", "process.terminate")
 }
 
 func (w *Worker) signalMessages(ctx context.Context, workflowID string, messages []*relay.Message, start *process.Start) error {
+	runtimeState := w.loadRuntime()
+	if runtimeState == nil || runtimeState.temporalClient == nil {
+		return fmt.Errorf("temporal client not available")
+	}
+
 	if len(messages) == 0 {
 		return nil
 	}
@@ -173,7 +180,7 @@ func (w *Worker) signalMessages(ctx context.Context, workflowID string, messages
 			continue
 		}
 		signalCtx, fc := withSignalSender(ctx, sender)
-		err := w.temporalClient.SignalWorkflow(signalCtx, workflowID, "", msg.Topic, signalArg(msg))
+		err := runtimeState.temporalClient.SignalWorkflow(signalCtx, workflowID, "", msg.Topic, signalArg(msg))
 		releaseSignalFrame(fc)
 		if err != nil {
 			return err
@@ -184,6 +191,7 @@ func (w *Worker) signalMessages(ctx context.Context, workflowID string, messages
 
 func (w *Worker) signalWithStartMessage(
 	ctx context.Context,
+	runtimeState *workerRuntime,
 	workflowID string,
 	workflowName string,
 	opts client.StartWorkflowOptions,
@@ -194,7 +202,7 @@ func (w *Worker) signalWithStartMessage(
 	signalCtx, fc := withSignalSender(ctx, sender)
 	defer releaseSignalFrame(fc)
 
-	return w.temporalClient.SignalWithStartWorkflow(
+	return runtimeState.temporalClient.SignalWithStartWorkflow(
 		signalCtx,
 		workflowID,
 		msg.Topic,
@@ -309,15 +317,15 @@ func shouldPublishRunHandoff(start *process.Start) bool {
 	return false
 }
 
-func (w *Worker) publishRunHandoff(start *process.Start, workflowID, runID string) {
+func (w *Worker) publishRunHandoff(runtimeCtx context.Context, start *process.Start, workflowID, runID string) {
 	if !shouldPublishRunHandoff(start) || workflowID == "" || runID == "" {
 		return
 	}
-	if w.ctx == nil || w.config == nil {
+	if runtimeCtx == nil || w.config == nil {
 		return
 	}
 
-	registry := temporalapi.GetWorkflowRunHandoff(w.ctx)
+	registry := temporalapi.GetWorkflowRunHandoff(runtimeCtx)
 	if registry == nil {
 		return
 	}

--- a/service/temporal/worker/worker.go
+++ b/service/temporal/worker/worker.go
@@ -53,11 +53,12 @@ type Worker struct {
 	worker         worker.Worker
 	dtt            payload.Transcoder
 	clientResource resource.Resource[any]
-	log            *zap.Logger
 	cancel         context.CancelFunc
+	log            *zap.Logger
 	activities     map[string]*activityRegistration
 	workflows      map[string]*workflowRegistration
 	config         *api.WorkerConfig
+	runtimeState   atomic.Pointer[workerRuntime]
 	id             registry.ID
 	clientNodeID   pid.NodeID
 	workflowPrefix string
@@ -65,6 +66,17 @@ type Worker struct {
 	interceptors   []interceptor.WorkerInterceptor
 	mu             sync.RWMutex
 	closed         atomic.Bool
+}
+
+// workerRuntime is the published runtime snapshot used by hot paths.
+// It is replaced atomically on Start/Stop boundaries.
+type workerRuntime struct {
+	worker         worker.Worker
+	temporalClient client.Client
+	funcRegistry   function.Registry
+	clientResource resource.Resource[any]
+	ctx            context.Context
+	taskQueue      string
 }
 
 // activityRegistration represents a registered activity
@@ -120,13 +132,20 @@ func (w *Worker) Start(ctx context.Context) (<-chan any, error) {
 	// Create status channel
 	statusCh := make(chan any, 1)
 
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.runtimeState.Load() != nil {
+		statusCh <- supervisor.StatusFailed
+		return statusCh, fmt.Errorf("worker is already started")
+	}
+
 	// Acquire client resource
 	clientRes, err := w.resourceReg.Acquire(ctx, w.config.Client, resource.ModeNormal)
 	if err != nil {
 		statusCh <- supervisor.StatusFailed
 		return statusCh, fmt.Errorf("failed to acquire client: %w", err)
 	}
-	w.clientResource = clientRes
 
 	// Get temporal client resource
 	clientAny, err := clientRes.Get()
@@ -149,7 +168,6 @@ func (w *Worker) Start(ctx context.Context) (<-chan any, error) {
 		statusCh <- supervisor.StatusFailed
 		return statusCh, fmt.Errorf("temporal client is nil")
 	}
-	w.temporalClient = temporalClient
 
 	// Apply task queue prefix from client
 	taskQueue := temporalRes.GetTaskQueueName(w.config.TaskQueue)
@@ -158,11 +176,10 @@ func (w *Worker) Start(ctx context.Context) (<-chan any, error) {
 			zap.String("original", w.config.TaskQueue),
 			zap.String("prefixed", taskQueue))
 	}
-	w.taskQueue = taskQueue
 
 	// Get function registry from context
-	w.funcRegistry = function.GetRegistry(ctx)
-	if w.funcRegistry == nil {
+	funcRegistry := function.GetRegistry(ctx)
+	if funcRegistry == nil {
 		clientRes.Release()
 		statusCh <- supervisor.StatusFailed
 		return statusCh, fmt.Errorf("function registry not found in context")
@@ -170,8 +187,8 @@ func (w *Worker) Start(ctx context.Context) (<-chan any, error) {
 
 	// Store application context with Temporal routing identity.
 	// Client ID identifies the Temporal node; worker ID identifies host-level PID identity.
-	w.ctx = api.WithClientID(ctx, w.config.Client.String())
-	w.ctx = api.WithWorkerID(w.ctx, w.id.String())
+	appCtx := api.WithClientID(ctx, w.config.Client.String())
+	appCtx = api.WithWorkerID(appCtx, w.id.String())
 
 	// Create worker options
 	options := worker.Options{
@@ -238,31 +255,53 @@ func (w *Worker) Start(ctx context.Context) (<-chan any, error) {
 	options.DisableRegistrationAliasing = w.config.WorkerOptions.DisableRegistrationAliasing
 
 	// Create Temporal SDK worker
-	w.worker = worker.New(temporalClient, taskQueue, options)
+	sdkWorker := worker.New(temporalClient, taskQueue, options)
+	runtimeState := &workerRuntime{
+		worker:         sdkWorker,
+		temporalClient: temporalClient,
+		funcRegistry:   funcRegistry,
+		clientResource: clientRes,
+		ctx:            appCtx,
+		taskQueue:      taskQueue,
+	}
+
+	// Keep legacy fields synchronized for tests that manually wire dependencies.
+	w.clientResource = clientRes
+	w.temporalClient = temporalClient
+	w.taskQueue = taskQueue
+	w.funcRegistry = funcRegistry
+	w.ctx = appCtx
+	w.worker = sdkWorker
 
 	// Register system activities
-	w.registerRelaySendActivity(ctx)
+	w.registerRelaySendActivity(runtimeState)
 
 	// Re-register all existing activities and workflows
-	w.mu.RLock()
 	for _, act := range w.activities {
 		if act.local {
-			w.registerLocalActivity(ctx, act)
+			w.registerLocalActivity(runtimeState, act)
 		} else {
-			w.registerActivity(ctx, act)
+			w.registerActivity(runtimeState, act)
 		}
 	}
 	for _, wf := range w.workflows {
-		w.registerWorkflow(ctx, wf)
+		w.registerWorkflow(runtimeState, wf)
 	}
-	w.mu.RUnlock()
 
 	// Start worker
-	if err := w.worker.Start(); err != nil {
+	if err := runtimeState.worker.Start(); err != nil {
+		w.clientResource = nil
+		w.temporalClient = nil
+		w.taskQueue = ""
+		w.funcRegistry = nil
+		w.ctx = nil
+		w.worker = nil
 		clientRes.Release()
 		statusCh <- supervisor.StatusFailed
 		return statusCh, fmt.Errorf("failed to start worker: %w", err)
 	}
+
+	w.runtimeState.Store(runtimeState)
 
 	w.log.Info("worker started",
 		zap.String("task_queue", w.config.TaskQueue),
@@ -282,15 +321,40 @@ func (w *Worker) Stop(ctx context.Context) error {
 
 	w.log.Info("stopping temporal worker", zap.String("id", w.id.String()))
 
-	if w.cancel != nil {
-		w.cancel()
+	w.mu.Lock()
+	runtimeState := w.runtimeState.Load()
+	w.runtimeState.Store(nil)
+
+	cancel := w.cancel
+	w.cancel = nil
+
+	workerInstance := w.worker
+	if runtimeState != nil && runtimeState.worker != nil {
+		workerInstance = runtimeState.worker
 	}
 
-	if w.worker != nil {
+	clientRes := w.clientResource
+	if runtimeState != nil && runtimeState.clientResource != nil {
+		clientRes = runtimeState.clientResource
+	}
+
+	w.worker = nil
+	w.clientResource = nil
+	w.temporalClient = nil
+	w.funcRegistry = nil
+	w.ctx = nil
+	w.taskQueue = ""
+	w.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	if workerInstance != nil {
 		// Stop worker in goroutine to respect context timeout
 		done := make(chan struct{})
 		go func() {
-			w.worker.Stop()
+			workerInstance.Stop()
 			close(done)
 		}()
 
@@ -302,8 +366,8 @@ func (w *Worker) Stop(ctx context.Context) error {
 		}
 	}
 
-	if w.clientResource != nil {
-		w.clientResource.Release()
+	if clientRes != nil {
+		clientRes.Release()
 	}
 
 	w.log.Info("temporal worker stopped", zap.String("id", w.id.String()))
@@ -311,7 +375,7 @@ func (w *Worker) Stop(ctx context.Context) error {
 }
 
 // RegisterActivity registers an activity with this worker
-func (w *Worker) RegisterActivity(ctx context.Context, name string, funcID registry.ID) error {
+func (w *Worker) RegisterActivity(_ context.Context, name string, funcID registry.ID) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -327,8 +391,8 @@ func (w *Worker) RegisterActivity(ctx context.Context, name string, funcID regis
 	w.activities[name] = reg
 
 	// If worker is already running, register immediately
-	if w.worker != nil {
-		w.registerActivity(ctx, reg)
+	if runtimeState := w.runtimeState.Load(); runtimeState != nil && runtimeState.worker != nil {
+		w.registerActivity(runtimeState, reg)
 	}
 
 	w.log.Debug("activity registered",
@@ -339,7 +403,7 @@ func (w *Worker) RegisterActivity(ctx context.Context, name string, funcID regis
 }
 
 // RegisterLocalActivity registers a local activity with this worker
-func (w *Worker) RegisterLocalActivity(ctx context.Context, name string, funcID registry.ID) error {
+func (w *Worker) RegisterLocalActivity(_ context.Context, name string, funcID registry.ID) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -356,8 +420,8 @@ func (w *Worker) RegisterLocalActivity(ctx context.Context, name string, funcID 
 	w.activities[name] = reg
 
 	// If worker is already running, register immediately
-	if w.worker != nil {
-		w.registerLocalActivity(ctx, reg)
+	if runtimeState := w.runtimeState.Load(); runtimeState != nil && runtimeState.worker != nil {
+		w.registerLocalActivity(runtimeState, reg)
 	}
 
 	w.log.Debug("local activity registered",
@@ -383,7 +447,7 @@ func (w *Worker) UnregisterActivity(name string) error {
 }
 
 // RegisterWorkflow registers a workflow with this worker
-func (w *Worker) RegisterWorkflow(ctx context.Context, name string, handler any) error {
+func (w *Worker) RegisterWorkflow(_ context.Context, name string, handler any) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -399,8 +463,8 @@ func (w *Worker) RegisterWorkflow(ctx context.Context, name string, handler any)
 	w.workflows[name] = reg
 
 	// If worker is already running, register immediately
-	if w.worker != nil {
-		w.registerWorkflow(ctx, reg)
+	if runtimeState := w.runtimeState.Load(); runtimeState != nil && runtimeState.worker != nil {
+		w.registerWorkflow(runtimeState, reg)
 	}
 
 	w.log.Debug("workflow registered",
@@ -425,40 +489,40 @@ func (w *Worker) UnregisterWorkflow(name string) error {
 }
 
 // registerActivity registers an activity with the Temporal SDK worker
-func (w *Worker) registerActivity(ctx context.Context, reg *activityRegistration) {
-	handler := w.createActivityHandler(ctx, reg.function)
-	w.worker.RegisterActivityWithOptions(handler, activity.RegisterOptions{
+func (w *Worker) registerActivity(runtimeState *workerRuntime, reg *activityRegistration) {
+	handler := w.createActivityHandler(runtimeState, reg.function)
+	runtimeState.worker.RegisterActivityWithOptions(handler, activity.RegisterOptions{
 		Name: reg.name,
 	})
 }
 
 // registerLocalActivity registers a local activity with the Temporal SDK worker
-func (w *Worker) registerLocalActivity(ctx context.Context, reg *activityRegistration) {
-	handler := w.createActivityHandler(ctx, reg.function)
-	w.worker.RegisterActivityWithOptions(handler, activity.RegisterOptions{
+func (w *Worker) registerLocalActivity(runtimeState *workerRuntime, reg *activityRegistration) {
+	handler := w.createActivityHandler(runtimeState, reg.function)
+	runtimeState.worker.RegisterActivityWithOptions(handler, activity.RegisterOptions{
 		Name: reg.name,
 	})
 }
 
 // registerWorkflow registers a workflow with the Temporal SDK worker
-func (w *Worker) registerWorkflow(_ context.Context, reg *workflowRegistration) {
+func (w *Worker) registerWorkflow(runtimeState *workerRuntime, reg *workflowRegistration) {
 	// Support DefinitionFactory with WithContext method
 	handler := reg.handler
 	if cwf, ok := handler.(interface{ WithContext(context.Context) any }); ok {
-		handler = cwf.WithContext(w.ctx)
+		handler = cwf.WithContext(runtimeState.ctx)
 	}
 
 	// Register directly with Temporal SDK
-	w.worker.RegisterWorkflowWithOptions(handler, workflow.RegisterOptions{
+	runtimeState.worker.RegisterWorkflowWithOptions(handler, workflow.RegisterOptions{
 		Name: reg.name,
 	})
 }
 
 // registerRelaySendActivity registers the system activity for routing messages to local processes.
-func (w *Worker) registerRelaySendActivity(_ context.Context) {
+func (w *Worker) registerRelaySendActivity(runtimeState *workerRuntime) {
 	handler := func(_ context.Context, pkg *relay.Package) error {
 		// Get router from application context
-		router := relay.GetRouter(w.ctx)
+		router := relay.GetRouter(runtimeState.ctx)
 		if router == nil {
 			return fmt.Errorf("relay router not available")
 		}
@@ -471,13 +535,13 @@ func (w *Worker) registerRelaySendActivity(_ context.Context) {
 		return router.Send(pkg)
 	}
 
-	w.worker.RegisterActivityWithOptions(handler, activity.RegisterOptions{
+	runtimeState.worker.RegisterActivityWithOptions(handler, activity.RegisterOptions{
 		Name: relaySendActivityName,
 	})
 }
 
 // createActivityHandler creates an activity handler that executes a function through the registry
-func (w *Worker) createActivityHandler(_ context.Context, funcID registry.ID) func(context.Context, []payload.Payload) ([]payload.Payload, error) {
+func (w *Worker) createActivityHandler(runtimeState *workerRuntime, funcID registry.ID) func(context.Context, []payload.Payload) ([]payload.Payload, error) {
 	return func(activityCtx context.Context, input []payload.Payload) ([]payload.Payload, error) {
 		info := activity.GetInfo(activityCtx)
 		w.log.Debug("executing activity",
@@ -489,10 +553,10 @@ func (w *Worker) createActivityHandler(_ context.Context, funcID registry.ID) fu
 		)
 
 		// Use application context (has wippy components) but respect activity cancellation
-		execCtx := w.ctx
+		execCtx := runtimeState.ctx
 		if activityCtx.Done() != nil {
 			var cancel context.CancelFunc
-			execCtx, cancel = context.WithCancel(w.ctx)
+			execCtx, cancel = context.WithCancel(runtimeState.ctx)
 			defer cancel()
 
 			go func() {
@@ -508,7 +572,7 @@ func (w *Worker) createActivityHandler(_ context.Context, funcID registry.ID) fu
 			defer release()
 		}
 
-		result, err := w.funcRegistry.Call(execCtx, runtime.Task{
+		result, err := runtimeState.funcRegistry.Call(execCtx, runtime.Task{
 			ID:       funcID,
 			Payloads: input,
 			Context: []ctxapi.Pair{
@@ -547,12 +611,47 @@ func (w *Worker) createActivityHandler(_ context.Context, funcID registry.ID) fu
 	}
 }
 
+// loadRuntime returns the currently running snapshot.
+// It falls back to legacy fields for tests that manually configure a worker.
+func (w *Worker) loadRuntime() *workerRuntime {
+	if runtimeState := w.runtimeState.Load(); runtimeState != nil {
+		return runtimeState
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if w.temporalClient == nil {
+		return nil
+	}
+
+	ctx := w.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	taskQueue := w.taskQueue
+	if taskQueue == "" && w.config != nil {
+		taskQueue = w.config.TaskQueue
+	}
+
+	return &workerRuntime{
+		worker:         w.worker,
+		temporalClient: w.temporalClient,
+		funcRegistry:   w.funcRegistry,
+		clientResource: w.clientResource,
+		ctx:            ctx,
+		taskQueue:      taskQueue,
+	}
+}
+
 // Send implements relay.Receiver by translating relay packages to Temporal signals.
 func (w *Worker) Send(pkg *relay.Package) error {
 	if w.closed.Load() {
 		return fmt.Errorf("worker is closed")
 	}
-	if w.temporalClient == nil {
+
+	runtimeState := w.loadRuntime()
+	if runtimeState == nil || runtimeState.temporalClient == nil {
 		return fmt.Errorf("temporal client not available")
 	}
 
@@ -579,7 +678,7 @@ func (w *Worker) Send(pkg *relay.Package) error {
 			zap.String("signal", msg.Topic),
 			zap.Int("payloads", len(msg.Payloads)))
 
-		ctx := w.ctx
+		ctx := runtimeState.ctx
 		var frame ctxapi.FrameContext
 		if pkg.Source.Node != "" || pkg.Source.Host != "" || pkg.Source.UniqID != "" {
 			ctx, frame = ctxapi.OpenFrameContextOn(ctx, ctx)
@@ -590,7 +689,7 @@ func (w *Worker) Send(pkg *relay.Package) error {
 			ctx = withContextValuesFallback(ctx)
 		}
 
-		err := w.temporalClient.SignalWorkflow(ctx, workflowID, "", msg.Topic, signalArg)
+		err := runtimeState.temporalClient.SignalWorkflow(ctx, workflowID, "", msg.Topic, signalArg)
 		if frame != nil {
 			ctxapi.ReleaseFrameContext(frame)
 		}

--- a/service/temporal/worker/worker.go
+++ b/service/temporal/worker/worker.go
@@ -681,7 +681,7 @@ func (w *Worker) Send(pkg *relay.Package) error {
 		ctx := runtimeState.ctx
 		var frame ctxapi.FrameContext
 		if pkg.Source.Node != "" || pkg.Source.Host != "" || pkg.Source.UniqID != "" {
-			ctx, frame = ctxapi.OpenFrameContextOn(ctx, ctx)
+			ctx, frame = ctxapi.ForkFrameContext(ctx)
 			values, err := ctxapi.GetOrCreateValues(ctx)
 			if err == nil {
 				values.Set(temporalprop.SignalFromValueKey, pkg.Source.String())

--- a/service/temporal/workflow/definition.go
+++ b/service/temporal/workflow/definition.go
@@ -161,7 +161,7 @@ func (d *Definition) Execute(env bindings.WorkflowEnvironment, header *commonpb.
 		UniqID: env.WorkflowInfo().WorkflowExecution.ID,
 	}
 
-	execCtx, fc := ctxapi.OpenFrameContextOn(d.ctx, d.ctx)
+	execCtx, fc := ctxapi.ForkFrameContext(d.ctx)
 	keepFrame := false
 	defer func() {
 		if !keepFrame {

--- a/service/temporal/workflow/definition.go
+++ b/service/temporal/workflow/definition.go
@@ -93,6 +93,7 @@ type Definition struct {
 	env        bindings.WorkflowEnvironment
 	dc         converter.DataConverter
 	proc       process.Process
+	frameCtx   ctxapi.FrameContext
 	ctx        context.Context
 	execCtx    context.Context
 	log        *zap.Logger
@@ -119,6 +120,11 @@ type Definition struct {
 
 // Execute implements WorkflowDefinition.Execute.
 func (d *Definition) Execute(env bindings.WorkflowEnvironment, header *commonpb.Header, input *commonpb.Payloads) {
+	if d.frameCtx != nil {
+		ctxapi.ReleaseFrameContext(d.frameCtx)
+		d.frameCtx = nil
+	}
+
 	d.env = env
 	d.dc = env.GetDataConverter()
 	d.replayLog = propagator.NewReplayLogger(d.log, env.IsReplaying)
@@ -156,6 +162,12 @@ func (d *Definition) Execute(env bindings.WorkflowEnvironment, header *commonpb.
 	}
 
 	execCtx, fc := ctxapi.OpenFrameContextOn(d.ctx, d.ctx)
+	keepFrame := false
+	defer func() {
+		if !keepFrame {
+			ctxapi.ReleaseFrameContext(fc)
+		}
+	}()
 	pairs := []ctxapi.Pair{
 		{Key: runtime.FrameIDKey, Value: d.id},
 		{Key: runtime.FramePIDKey, Value: processPID},
@@ -203,8 +215,6 @@ func (d *Definition) Execute(env bindings.WorkflowEnvironment, header *commonpb.
 		return
 	}
 
-	d.execCtx = execCtx
-
 	env.RegisterCancelHandler(d.handleCancel)
 	env.RegisterSignalHandler(d.handleSignal)
 	env.RegisterQueryHandler(d.handleQuery)
@@ -223,6 +233,10 @@ func (d *Definition) Execute(env bindings.WorkflowEnvironment, header *commonpb.
 		d.env.Complete(nil, fmt.Errorf("failed to start workflow: %w", err))
 		return
 	}
+
+	d.execCtx = execCtx
+	d.frameCtx = fc
+	keepFrame = true
 }
 
 func (d *Definition) resolveClientID() string {
@@ -325,5 +339,9 @@ func (d *Definition) StackTrace() string {
 func (d *Definition) Close() {
 	if d.proc != nil {
 		d.proc.Close()
+	}
+	if d.frameCtx != nil {
+		ctxapi.ReleaseFrameContext(d.frameCtx)
+		d.frameCtx = nil
 	}
 }

--- a/service/temporal/workflow/handler_process.go
+++ b/service/temporal/workflow/handler_process.go
@@ -179,7 +179,7 @@ func (d *Definition) executeProcessSpawn(cmd *process.SpawnCmd, tag uint64) erro
 		params.TaskQueueName = cmd.Start.HostID
 	}
 	if len(cmd.Start.Context) > 0 {
-		spawnCtx, fc := ctxapi.OpenFrameContextOn(d.execCtx, d.execCtx)
+		spawnCtx, fc := ctxapi.ForkFrameContext(d.execCtx)
 		if err := fc.SetMultiple(cmd.Start.Context...); err != nil {
 			ctxapi.ReleaseFrameContext(fc)
 			d.resumeProcess(tag, process.SpawnResult{Error: fmt.Errorf("failed to apply spawn context: %w", err)}, nil)

--- a/service/terminal/host.go
+++ b/service/terminal/host.go
@@ -150,6 +150,10 @@ func (h *Host) Run(ctx context.Context, start *process.Start) (pid.PID, error) {
 	}
 
 	if _, err = h.scheduler.Submit(frameCtx, processID, proc, method, start.Input); err != nil {
+		proc.Close()
+		if fc := ctxapi.FrameFromContext(frameCtx); fc != nil {
+			ctxapi.ReleaseFrameContext(fc)
+		}
 		return pid.PID{}, err
 	}
 

--- a/service/websocket/registry.go
+++ b/service/websocket/registry.go
@@ -20,7 +20,7 @@ import (
 // TypeWsConn is the type ID for WebSocket connections in the resource table.
 const TypeWsConn uint32 = 0x20
 
-// registryKey is the FrameContext key for caching the websocket Registry.
+// registryKey caches websocket Registry in FrameContext for request/process lifetime.
 var registryKey = &ctxapi.Key{Name: "websocket.registry", Inherit: false}
 
 // connEntry holds an active WebSocket connection with its message channel.
@@ -190,25 +190,23 @@ func (r *Registry) Close(id uint64, code int, reason string) error {
 // Returns nil if no resource table is available.
 func GetRegistry(ctx context.Context) *Registry {
 	fc := ctxapi.FrameFromContext(ctx)
-	if fc == nil {
-		table := resource.GetTable(ctx)
-		if table == nil {
-			return nil
+	if fc != nil {
+		if cached, ok := fc.Get(registryKey); ok {
+			if reg, ok := cached.(*Registry); ok {
+				return reg
+			}
 		}
-		return NewRegistry(table, nil)
-	}
-
-	if val, ok := fc.Get(registryKey); ok {
-		return val.(*Registry)
 	}
 
 	table := resource.GetTable(ctx)
 	if table == nil {
 		return nil
 	}
+
 	reg := NewRegistry(table, nil)
-	if err := fc.Set(registryKey, reg); err != nil {
-		reg.log.Debug("failed to cache registry in frame context", zap.Error(err))
+	if fc != nil {
+		// Frame may already be sealed; caching is best-effort only.
+		_ = fc.Set(registryKey, reg)
 	}
 	return reg
 }

--- a/system/contract/dispatcher.go
+++ b/system/contract/dispatcher.go
@@ -56,16 +56,10 @@ func (d *Dispatcher) handleOpen(ctx context.Context, cmd dispatcher.Command, tag
 		return nil
 	}
 
-	callCtx := ctx
-	var fc ctxapi.FrameContext
-	if ctxapi.FrameFromContext(ctx) != nil {
-		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
-	}
+	callCtx, fc := ctxapi.ForkFrameContext(ctx)
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
-		if callFC != nil {
-			defer ctxapi.ReleaseFrameContext(callFC)
-		}
+		defer ctxapi.ReleaseFrameContext(callFC)
 		instance, err := instantiator.Instantiate(callCtx, openCmd.BindingID, openCmd.Scope)
 		if callCtx.Err() != nil {
 			receiver.CompleteYield(tag, contract.OpenResult{Error: callCtx.Err()}, nil)
@@ -89,16 +83,10 @@ func (d *Dispatcher) handleCall(ctx context.Context, cmd dispatcher.Command, tag
 		return nil
 	}
 
-	callCtx := ctx
-	var fc ctxapi.FrameContext
-	if ctxapi.FrameFromContext(ctx) != nil {
-		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
-	}
+	callCtx, fc := ctxapi.ForkFrameContext(ctx)
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
-		if callFC != nil {
-			defer ctxapi.ReleaseFrameContext(callFC)
-		}
+		defer ctxapi.ReleaseFrameContext(callFC)
 		result, err := callCmd.Instance.Call(callCtx, callCmd.Method, callCmd.Args)
 		if callCtx.Err() != nil {
 			receiver.CompleteYield(tag, contract.CallResult{Error: callCtx.Err()}, nil)
@@ -148,16 +136,10 @@ func (d *Dispatcher) handleAsyncCall(ctx context.Context, cmd dispatcher.Command
 	args := asyncCmd.Args
 	logger := d.logger
 
-	callCtx := ctx
-	var fc ctxapi.FrameContext
-	if ctxapi.FrameFromContext(ctx) != nil {
-		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
-	}
+	callCtx, fc := ctxapi.ForkFrameContext(ctx)
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
-		if callFC != nil {
-			defer ctxapi.ReleaseFrameContext(callFC)
-		}
+		defer ctxapi.ReleaseFrameContext(callFC)
 		result, err := instance.Call(callCtx, method, args)
 
 		resultPayload := resultToPayload(result, err)

--- a/system/contract/dispatcher.go
+++ b/system/contract/dispatcher.go
@@ -5,6 +5,7 @@ package contract
 import (
 	"context"
 
+	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/contract"
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/payload"
@@ -55,10 +56,19 @@ func (d *Dispatcher) handleOpen(ctx context.Context, cmd dispatcher.Command, tag
 		return nil
 	}
 
-	go func() {
-		instance, err := instantiator.Instantiate(ctx, openCmd.BindingID, openCmd.Scope)
-		if ctx.Err() != nil {
-			receiver.CompleteYield(tag, contract.OpenResult{Error: ctx.Err()}, nil)
+	callCtx := ctx
+	var fc ctxapi.FrameContext
+	if ctxapi.FrameFromContext(ctx) != nil {
+		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+	}
+
+	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
+		if callFC != nil {
+			defer ctxapi.ReleaseFrameContext(callFC)
+		}
+		instance, err := instantiator.Instantiate(callCtx, openCmd.BindingID, openCmd.Scope)
+		if callCtx.Err() != nil {
+			receiver.CompleteYield(tag, contract.OpenResult{Error: callCtx.Err()}, nil)
 			return
 		}
 		if err != nil {
@@ -66,7 +76,7 @@ func (d *Dispatcher) handleOpen(ctx context.Context, cmd dispatcher.Command, tag
 			return
 		}
 		receiver.CompleteYield(tag, contract.OpenResult{Instance: instance}, nil)
-	}()
+	}(callCtx, fc)
 
 	return nil
 }
@@ -79,10 +89,19 @@ func (d *Dispatcher) handleCall(ctx context.Context, cmd dispatcher.Command, tag
 		return nil
 	}
 
-	go func() {
-		result, err := callCmd.Instance.Call(ctx, callCmd.Method, callCmd.Args)
-		if ctx.Err() != nil {
-			receiver.CompleteYield(tag, contract.CallResult{Error: ctx.Err()}, nil)
+	callCtx := ctx
+	var fc ctxapi.FrameContext
+	if ctxapi.FrameFromContext(ctx) != nil {
+		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+	}
+
+	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
+		if callFC != nil {
+			defer ctxapi.ReleaseFrameContext(callFC)
+		}
+		result, err := callCmd.Instance.Call(callCtx, callCmd.Method, callCmd.Args)
+		if callCtx.Err() != nil {
+			receiver.CompleteYield(tag, contract.CallResult{Error: callCtx.Err()}, nil)
 			return
 		}
 		if err != nil {
@@ -98,7 +117,7 @@ func (d *Dispatcher) handleCall(ctx context.Context, cmd dispatcher.Command, tag
 		} else {
 			receiver.CompleteYield(tag, contract.CallResult{}, nil)
 		}
-	}()
+	}(callCtx, fc)
 
 	return nil
 }
@@ -129,8 +148,17 @@ func (d *Dispatcher) handleAsyncCall(ctx context.Context, cmd dispatcher.Command
 	args := asyncCmd.Args
 	logger := d.logger
 
-	go func() {
-		result, err := instance.Call(ctx, method, args)
+	callCtx := ctx
+	var fc ctxapi.FrameContext
+	if ctxapi.FrameFromContext(ctx) != nil {
+		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+	}
+
+	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
+		if callFC != nil {
+			defer ctxapi.ReleaseFrameContext(callFC)
+		}
+		result, err := instance.Call(callCtx, method, args)
 
 		resultPayload := resultToPayload(result, err)
 		if err := sendAsyncResult(node, framePID, topic, resultPayload); err != nil {
@@ -139,7 +167,7 @@ func (d *Dispatcher) handleAsyncCall(ctx context.Context, cmd dispatcher.Command
 				zap.String("target", framePID.String()),
 				zap.Error(err))
 		}
-	}()
+	}(callCtx, fc)
 
 	receiver.CompleteYield(tag, contract.AsyncCallResult{}, nil)
 	return nil

--- a/system/function/dispatcher.go
+++ b/system/function/dispatcher.go
@@ -70,16 +70,10 @@ func (d *Dispatcher) handleCall(ctx context.Context, cmd dispatcher.Command, tag
 		return nil
 	}
 
-	callCtx := ctx
-	var fc ctxapi.FrameContext
-	if ctxapi.FrameFromContext(ctx) != nil {
-		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
-	}
+	callCtx, fc := ctxapi.ForkFrameContext(ctx)
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
-		if callFC != nil {
-			defer ctxapi.ReleaseFrameContext(callFC)
-		}
+		defer ctxapi.ReleaseFrameContext(callFC)
 		result, err := registry.Call(callCtx, callCmd.Task)
 		if callErr := extractCallError(callCtx, result, err); callErr != nil {
 			receiver.CompleteYield(tag, function.CallResult{Error: callErr}, nil)
@@ -116,16 +110,10 @@ func (d *Dispatcher) handleAsyncStart(ctx context.Context, cmd dispatcher.Comman
 	task := startCmd.Task
 	logger := d.logger
 
-	callCtx := ctx
-	var fc ctxapi.FrameContext
-	if ctxapi.FrameFromContext(ctx) != nil {
-		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
-	}
+	callCtx, fc := ctxapi.ForkFrameContext(ctx)
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
-		if callFC != nil {
-			defer ctxapi.ReleaseFrameContext(callFC)
-		}
+		defer ctxapi.ReleaseFrameContext(callFC)
 		result, err := registry.Call(callCtx, task)
 
 		resultPayload := resultToPayload(result, err)

--- a/system/function/dispatcher.go
+++ b/system/function/dispatcher.go
@@ -47,14 +47,6 @@ func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispat
 	register(function.AsyncCancel, dispatcher.HandlerFunc(d.handleAsyncCancel))
 }
 
-// acquireCloser gets a frame closer if available.
-func acquireCloser(ctx context.Context) ctxapi.Closer {
-	if fc := ctxapi.FrameFromContext(ctx); fc != nil {
-		return fc.IncRef()
-	}
-	return nil
-}
-
 // extractCallError returns the first non-nil error from context, err, or result.
 func extractCallError(ctx context.Context, result *runtime.Result, err error) error {
 	if ctx.Err() != nil {
@@ -78,18 +70,23 @@ func (d *Dispatcher) handleCall(ctx context.Context, cmd dispatcher.Command, tag
 		return nil
 	}
 
-	closer := acquireCloser(ctx)
-	go func() {
-		if closer != nil {
-			defer func() { _ = closer.Close() }()
+	callCtx := ctx
+	var fc ctxapi.FrameContext
+	if ctxapi.FrameFromContext(ctx) != nil {
+		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+	}
+
+	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
+		if callFC != nil {
+			defer ctxapi.ReleaseFrameContext(callFC)
 		}
-		result, err := registry.Call(ctx, callCmd.Task)
-		if callErr := extractCallError(ctx, result, err); callErr != nil {
+		result, err := registry.Call(callCtx, callCmd.Task)
+		if callErr := extractCallError(callCtx, result, err); callErr != nil {
 			receiver.CompleteYield(tag, function.CallResult{Error: callErr}, nil)
 			return
 		}
 		receiver.CompleteYield(tag, function.CallResult{Value: result.Value}, nil)
-	}()
+	}(callCtx, fc)
 
 	return nil
 }
@@ -118,13 +115,18 @@ func (d *Dispatcher) handleAsyncStart(ctx context.Context, cmd dispatcher.Comman
 	node := d.node
 	task := startCmd.Task
 	logger := d.logger
-	closer := acquireCloser(ctx)
 
-	go func() {
-		if closer != nil {
-			defer func() { _ = closer.Close() }()
+	callCtx := ctx
+	var fc ctxapi.FrameContext
+	if ctxapi.FrameFromContext(ctx) != nil {
+		callCtx, fc = ctxapi.OpenFrameContextOn(ctx, ctx)
+	}
+
+	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
+		if callFC != nil {
+			defer ctxapi.ReleaseFrameContext(callFC)
 		}
-		result, err := registry.Call(ctx, task)
+		result, err := registry.Call(callCtx, task)
 
 		resultPayload := resultToPayload(result, err)
 		if err := sendAsyncResult(node, framePID, topic, resultPayload); err != nil {
@@ -133,7 +135,7 @@ func (d *Dispatcher) handleAsyncStart(ctx context.Context, cmd dispatcher.Comman
 				zap.String("target", framePID.String()),
 				zap.Error(err))
 		}
-	}()
+	}(callCtx, fc)
 
 	receiver.CompleteYield(tag, function.AsyncStartResult{}, nil)
 	return nil

--- a/system/function/functions.go
+++ b/system/function/functions.go
@@ -202,13 +202,13 @@ func (f *Registry) Call(ctx context.Context, task runtimeapi.Task) (*runtimeapi.
 // This is called as the final step in the interceptor chain or directly if no chain exists.
 // PID is generated with Host set to the function ID - each function is its own mini-host.
 func (f *Registry) executor(ctx context.Context, handler function.Func, task runtimeapi.Task) (*runtimeapi.Result, error) {
-	// Open frame context with inheritance from sealed parent (actor, scope, etc.)
-	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	// Always fork an execution-local frame to prevent shared mutable maps across calls.
+	ctx, fc := ctxapi.OpenFrameContextOn(ctx, ctx)
+	defer ctxapi.ReleaseFrameContext(fc)
 
 	// Generate PID with function ID as Host - function is its own host for message routing
 	gen := process.GetPIDGenerator(ctx)
 	if gen == nil {
-		ctxapi.ReleaseFrameContext(fc)
 		return nil, function.ErrPIDGeneratorNotFound
 	}
 	pid := gen.Generate(task.ID.String())
@@ -222,15 +222,11 @@ func (f *Registry) executor(ctx context.Context, handler function.Func, task run
 	pairs = append(pairs, task.Context...)
 
 	if err := fc.SetMultiple(pairs...); err != nil {
-		ctxapi.ReleaseFrameContext(fc)
 		return nil, NewFrameContextError(err)
 	}
 
 	// Execute function handler
 	result, err := handler(ctx, task)
-
-	// Release frame back to pool
-	ctxapi.ReleaseFrameContext(fc)
 
 	return result, err
 }

--- a/system/function/functions.go
+++ b/system/function/functions.go
@@ -203,7 +203,7 @@ func (f *Registry) Call(ctx context.Context, task runtimeapi.Task) (*runtimeapi.
 // PID is generated with Host set to the function ID - each function is its own mini-host.
 func (f *Registry) executor(ctx context.Context, handler function.Func, task runtimeapi.Task) (*runtimeapi.Result, error) {
 	// Always fork an execution-local frame to prevent shared mutable maps across calls.
-	ctx, fc := ctxapi.OpenFrameContextOn(ctx, ctx)
+	ctx, fc := ctxapi.ForkFrameContext(ctx)
 	defer ctxapi.ReleaseFrameContext(fc)
 
 	// Generate PID with function ID as Host - function is its own host for message routing

--- a/system/registry/topology/state_builder_test.go
+++ b/system/registry/topology/state_builder_test.go
@@ -111,14 +111,14 @@ func formatState(state registry.State) string {
 	var result strings.Builder
 	result.WriteString("\n")
 	for _, entry := range state {
-		result.WriteString(fmt.Sprintf("  {NS: %s, Alias: %s, Kind: %s, Data: %v, DependsOn: %v, Groups: %v}\n",
+		_, _ = fmt.Fprintf(&result, "  {NS: %s, Alias: %s, Kind: %s, Data: %v, DependsOn: %v, Groups: %v}\n",
 			entry.ID.NS,
 			entry.ID.Name,
 			entry.Kind,
 			entry.Data.Data(),
 			entry.Meta[registry.TagDependsOn],
 			entry.Meta[registry.TagGroups],
-		))
+		)
 	}
 	return result.String()
 }
@@ -128,12 +128,12 @@ func formatDelta(cs registry.ChangeSet) string {
 	var result strings.Builder
 	result.WriteString("\n")
 	for _, op := range cs {
-		result.WriteString(fmt.Sprintf("  %s {NS: %s, Alias: %s} (deps: %v)\n",
+		_, _ = fmt.Fprintf(&result, "  %s {NS: %s, Alias: %s} (deps: %v)\n",
 			op.Kind,
 			op.Entry.ID.NS,
 			op.Entry.ID.Name,
 			op.Entry.Meta[registry.TagDependsOn],
-		))
+		)
 	}
 	return result.String()
 }

--- a/system/scheduler/actor/edge_cases_test.go
+++ b/system/scheduler/actor/edge_cases_test.go
@@ -246,7 +246,7 @@ func TestUpgradeSuccess(t *testing.T) {
 			return &ImmediateProcess{}, &process.Meta{Method: "run"}, nil
 		},
 	})
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	pid := pidapi.PID{UniqID: "upgrade-success"}
@@ -263,6 +263,43 @@ func TestUpgradeSuccess(t *testing.T) {
 
 	if result.Error != nil {
 		t.Fatalf("unexpected error: %v", result.Error)
+	}
+}
+
+// TestUpgradeSuccess_Stress guards against missed wakeup regressions by repeatedly
+// executing upgrade flow on a single-worker scheduler.
+func TestUpgradeSuccess_Stress(t *testing.T) {
+	reg := scheduler.NewRegistry()
+	te := newTestExecutorWithRegistry(1, reg)
+	te.Start()
+	defer te.Stop()
+
+	appCtx := ctxapi.NewAppContext()
+	ctx := ctxapi.WithAppContext(context.Background(), appCtx)
+	process.WithFactory(ctx, &mockFactory{
+		createFunc: func(_ registry.ID) (process.Process, *process.Meta, error) {
+			return &ImmediateProcess{}, &process.Meta{Method: "run"}, nil
+		},
+	})
+
+	const runs = 300
+	for i := 0; i < runs; i++ {
+		runCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		p := pidapi.PID{UniqID: fmt.Sprintf("upgrade-stress-%d", i)}
+		proc := &UpgradeProcess{
+			upgradeReq: &process.UpgradeRequest{
+				Source: registry.ID{Name: "test"},
+			},
+		}
+
+		result, err := te.Execute(runCtx, p, proc, "", nil)
+		cancel()
+		if err != nil {
+			t.Fatalf("run %d execute error: %v", i, err)
+		}
+		if result.Error != nil {
+			t.Fatalf("run %d unexpected error: %v", i, result.Error)
+		}
 	}
 }
 

--- a/system/scheduler/actor/scheduler.go
+++ b/system/scheduler/actor/scheduler.go
@@ -192,10 +192,7 @@ func (s *Scheduler) Stop(ctx context.Context) {
 
 func (s *Scheduler) wakeAny() {
 	for _, w := range s.workers {
-		if w.parkMu.TryLock() {
-			w.notified.Store(true)
-			w.parkCond.Signal()
-			w.parkMu.Unlock()
+		if w.signal() {
 			return
 		}
 	}
@@ -203,7 +200,7 @@ func (s *Scheduler) wakeAny() {
 
 func (s *Scheduler) wakeAll() {
 	for _, w := range s.workers {
-		w.signal()
+		_ = w.signal()
 	}
 }
 

--- a/system/scheduler/actor/worker.go
+++ b/system/scheduler/actor/worker.go
@@ -78,7 +78,6 @@ func (w *Worker) park() {
 	s := w.scheduler
 	w.parkMu.Lock()
 	for {
-		w.notified.Store(false)
 		if proc := w.findWork(); proc != nil {
 			shouldWake := s.global.Len() > 0
 			w.parkMu.Unlock()
@@ -93,7 +92,9 @@ func (w *Worker) park() {
 			w.parkMu.Unlock()
 			return
 		}
-		if w.notified.Load() {
+
+		// Consume one pending wake token without sleeping.
+		if w.notified.Swap(false) {
 			continue
 		}
 		w.parkCond.Wait()
@@ -111,11 +112,17 @@ func (w *Worker) drain() {
 	}
 }
 
-func (w *Worker) signal() {
-	w.notified.Store(true)
+func (w *Worker) signal() bool {
+	// Coalesce wakeups with a CAS token. This prevents missed wake races where
+	// a worker is transitioning into park() while work is enqueued.
+	if !w.notified.CompareAndSwap(false, true) {
+		return false
+	}
+
 	w.parkMu.Lock()
 	w.parkCond.Signal()
 	w.parkMu.Unlock()
+	return true
 }
 
 func (w *Worker) findWork() *Processor {

--- a/system/supervisor/controller.go
+++ b/system/supervisor/controller.go
@@ -66,8 +66,8 @@ func NewController(
 		ops:           make(chan ctrlOp, 10),
 	}
 
-	// Create FrameContext for this service lifecycle
-	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	// Create isolated FrameContext for this service lifecycle.
+	ctx, fc := ctxapi.OpenFrameContextOn(ctx, ctx)
 
 	if config.Security != nil {
 		ctx = securitysys.WithSecurityConfig(ctx, config.Security)
@@ -78,7 +78,10 @@ func NewController(
 
 	ctrl.ctx, ctrl.cancel = context.WithCancel(ctx)
 
-	go ctrl.supervise()
+	go func() {
+		defer ctxapi.ReleaseFrameContext(fc)
+		ctrl.supervise()
+	}()
 	return ctrl
 }
 

--- a/system/supervisor/controller.go
+++ b/system/supervisor/controller.go
@@ -67,7 +67,7 @@ func NewController(
 	}
 
 	// Create isolated FrameContext for this service lifecycle.
-	ctx, fc := ctxapi.OpenFrameContextOn(ctx, ctx)
+	ctx, fc := ctxapi.ForkFrameContext(ctx)
 
 	if config.Security != nil {
 		ctx = securitysys.WithSecurityConfig(ctx, config.Security)


### PR DESCRIPTION
This pull request introduces a major refactor and enhancement of the `framecontext` implementation in the context package, focusing on improved concurrency safety, immutability, and lifecycle management for frame contexts. The changes ensure safe concurrent access and mutation, robust sealing and forking semantics, and eliminate potential races and use-after-release bugs. Additional test coverage is provided to validate these concurrency and lifecycle guarantees.

Key changes include:

**FrameContext: Concurrency and Immutability Improvements**
- Refactored `frameContext` to use atomic operations and immutable snapshots for storing values, ensuring lock-free concurrent reads and safe concurrent writes before sealing. Writes now clone and swap the entire snapshot, and sealing a frame waits for all in-flight writers to finish. (`api/context/framecontext.go` [[1]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3L41-R184) [[2]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3L110-R204)
- Added robust reference counting and generation tracking to prevent use-after-release and stale context access, including a new `frameContextRef` type for context storage. (`api/context/framecontext.go` [[1]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R214-R245) [[2]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R290-R325)
- Improved frame forking and sealing: parent frames are automatically sealed before forking to guarantee immutability, and reference counting is now atomic and safe against races. (`api/context/framecontext.go` [api/context/framecontext.goR355-R407](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R355-R407))

**API and Usage Updates**
- Updated context attachment and extraction logic to use new reference semantics, ensuring only live frames are accessible from contexts. (`api/context/framecontext.go` [api/context/framecontext.goR214-R245](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R214-R245))
- Updated `SetMultiple` usage in runtime task execution to use the new atomic batch setter, improving efficiency and error handling. (`runtime/lua/component/function/lifecycle.go` [[1]](diffhunk://#diff-690b7ce94fe3e4242837042f72e480c4da887a045b435103e136470840a08a9cL93-R94) `runtime/wasm/component/function/lifecycle.go` [[2]](diffhunk://#diff-20b047ee31e3f72bae4849eff96affddf92f3b4fd08aa29610be552bc80fa488L75-R77)

**Lifecycle and Resource Management**
- Improved frame context lifecycle handling in process initialization, evaluation hosts, and service hosts to ensure correct sealing, forking, and releasing of frame contexts, preventing resource leaks and double releases. (`runtime/lua/engine/process.go` [[1]](diffhunk://#diff-08a8ed8892ca6269e66eaa36ad59de56260f18e8e4dc057b1643dd8795952425L268-R269) [[2]](diffhunk://#diff-08a8ed8892ca6269e66eaa36ad59de56260f18e8e4dc057b1643dd8795952425L329-L333) `runtime/lua/evalhost/host.go` [[3]](diffhunk://#diff-dabd9b6de83f343ab78abdf78f5c279b0f59365a75f2acda4db17f897ac7cd78L145-R157) [[4]](diffhunk://#diff-dabd9b6de83f343ab78abdf78f5c279b0f59365a75f2acda4db17f897ac7cd78R247-R269) `runtime/wasm/engine/process.go` [[5]](diffhunk://#diff-38ea6a1cbff7aaca817745c1b6428f75d7935957258503ede4e5a99df42b8783R87-R89) `service/host/host.go` [[6]](diffhunk://#diff-31ccdbbe4c39d59b8575e3c7fa14a36d7e899f688ce9972d0264b275d80f435eR103-R105)

**Testing: Concurrency and Lifecycle Coverage**
- Added comprehensive tests for concurrent read/write before sealing, sealing under contention, stale reference invalidation, and parent sealing during forking, ensuring correctness under concurrent and edge-case scenarios. (`api/context/framecontext_test.go` [[1]](diffhunk://#diff-93a4808bc1163bf12bd333465422dc151d72b82d80085a9d518a4985f6cae3deR186-R279) [[2]](diffhunk://#diff-93a4808bc1163bf12bd333465422dc151d72b82d80085a9d518a4985f6cae3deR472-R515)

**Dependency Update**
- Bumped `github.com/wippyai/go-lua` dependency from v1.5.11 to v1.5.12. (`go.mod` [go.modL54-R54](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L54-R54))

These changes significantly improve the safety, reliability, and clarity of context management throughout the codebase.

---

**FrameContext concurrency and lifecycle (core changes):**
- Refactored `frameContext` to use atomic immutable snapshots for values, added atomic reference counting and generation tracking, and ensured sealing waits for in-flight writers. (`api/context/framecontext.go` [[1]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3L41-R184) [[2]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3L110-R204) [[3]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R290-R325) [[4]](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R355-R407)
- Updated context attachment/extraction to use new reference semantics, preventing access to released or stale frames. (`api/context/framecontext.go` [api/context/framecontext.goR214-R245](diffhunk://#diff-8f8a921dbc0ba6fc405b180f59f11aaf189c959e4928e430f1add72b31a308f3R214-R245))

**API and usage updates:**
- Updated `SetMultiple` usage for batch context setting in runtime task execution, improving efficiency and error handling. (`runtime/lua/component/function/lifecycle.go` [[1]](diffhunk://#diff-690b7ce94fe3e4242837042f72e480c4da887a045b435103e136470840a08a9cL93-R94) `runtime/wasm/component/function/lifecycle.go` [[2]](diffhunk://#diff-20b047ee31e3f72bae4849eff96affddf92f3b4fd08aa29610be552bc80fa488L75-R77)

**Lifecycle/resource management:**
- Improved sealing, forking, and releasing of frame contexts in process and host logic to prevent resource leaks and ensure correct ownership. (`runtime/lua/engine/process.go` [[1]](diffhunk://#diff-08a8ed8892ca6269e66eaa36ad59de56260f18e8e4dc057b1643dd8795952425L268-R269) [[2]](diffhunk://#diff-08a8ed8892ca6269e66eaa36ad59de56260f18e8e4dc057b1643dd8795952425L329-L333) `runtime/lua/evalhost/host.go` [[3]](diffhunk://#diff-dabd9b6de83f343ab78abdf78f5c279b0f59365a75f2acda4db17f897ac7cd78L145-R157) [[4]](diffhunk://#diff-dabd9b6de83f343ab78abdf78f5c279b0f59365a75f2acda4db17f897ac7cd78R247-R269) `runtime/wasm/engine/process.go` [[5]](diffhunk://#diff-38ea6a1cbff7aaca817745c1b6428f75d7935957258503ede4e5a99df42b8783R87-R89) `service/host/host.go` [[6]](diffhunk://#diff-31ccdbbe4c39d59b8575e3c7fa14a36d7e899f688ce9972d0264b275d80f435eR103-R105)

**Testing:**
- Added new tests for concurrent read/write, sealing under contention, stale reference invalidation, and parent sealing on fork. (`api/context/framecontext_test.go` [[1]](diffhunk://#diff-93a4808bc1163bf12bd333465422dc151d72b82d80085a9d518a4985f6cae3deR186-R279) [[2]](diffhunk://#diff-93a4808bc1163bf12bd333465422dc151d72b82d80085a9d518a4985f6cae3deR472-R515)

**Dependencies:**
- Updated `go-lua` to v1.5.12. (`go.mod` [go.modL54-R54](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L54-R54))