### PR TITLE
Fix duplicate SIGTERM causing exit code 1 on process completion

### DIFF
--- a/api/supervisor/shutdown.go
+++ b/api/supervisor/shutdown.go
@@ -14,7 +14,8 @@ import (
 var (
 	signalChannelKey = &ctxapi.Key{Name: "supervisor.signal"}
 	// exitCode is stored atomically since it's set at runtime during shutdown
-	exitCode atomic.Int32
+	exitCode    atomic.Int32
+	shutdownSent atomic.Bool
 )
 
 func setExitCode(code int) {
@@ -52,9 +53,13 @@ func getSignalChannel(ctx context.Context) chan<- os.Signal {
 }
 
 // TriggerShutdown sets the exit code and sends a SIGTERM signal to trigger
-// graceful application shutdown.
+// graceful application shutdown. Only the first call sends the signal;
+// subsequent calls update the exit code but do not send duplicate signals.
 func TriggerShutdown(ctx context.Context, code int) {
 	setExitCode(code)
+	if !shutdownSent.CompareAndSwap(false, true) {
+		return
+	}
 	if ch := getSignalChannel(ctx); ch != nil {
 		ch <- syscall.SIGTERM
 	}

--- a/api/supervisor/shutdown.go
+++ b/api/supervisor/shutdown.go
@@ -14,7 +14,7 @@ import (
 var (
 	signalChannelKey = &ctxapi.Key{Name: "supervisor.signal"}
 	// exitCode is stored atomically since it's set at runtime during shutdown
-	exitCode    atomic.Int32
+	exitCode     atomic.Int32
 	shutdownSent atomic.Bool
 )
 

--- a/api/supervisor/supervisor_test.go
+++ b/api/supervisor/supervisor_test.go
@@ -236,7 +236,8 @@ func TestShutdownContext(t *testing.T) {
 	})
 
 	t.Run("TriggerShutdown_WithChannel", func(t *testing.T) {
-		setExitCode(0) // reset
+		setExitCode(0)
+		shutdownSent.Store(false)
 		appCtx := ctxapi.NewAppContext()
 		ctx := ctxapi.WithAppContext(context.Background(), appCtx)
 
@@ -252,17 +253,37 @@ func TestShutdownContext(t *testing.T) {
 		default:
 			t.Fatal("expected signal to be sent")
 		}
-		setExitCode(0) // reset
+		setExitCode(0)
+		shutdownSent.Store(false)
 	})
 
 	t.Run("TriggerShutdown_NoChannel", func(t *testing.T) {
-		setExitCode(0) // reset
+		setExitCode(0)
+		shutdownSent.Store(false)
 		appCtx := ctxapi.NewAppContext()
 		ctx := ctxapi.WithAppContext(context.Background(), appCtx)
 
 		TriggerShutdown(ctx, 2)
 
 		assert.Equal(t, 2, GetExitCode())
-		setExitCode(0) // reset
+		setExitCode(0)
+		shutdownSent.Store(false)
+	})
+
+	t.Run("TriggerShutdown_OnlyFirstCallSendsSignal", func(t *testing.T) {
+		setExitCode(0)
+		shutdownSent.Store(false)
+		appCtx := ctxapi.NewAppContext()
+		ctx := ctxapi.WithAppContext(context.Background(), appCtx)
+
+		ch := make(chan os.Signal, 2)
+		SetSignalChannel(ctx, ch)
+
+		TriggerShutdown(ctx, 0)
+		TriggerShutdown(ctx, 0)
+
+		assert.Equal(t, 1, len(ch))
+		setExitCode(0)
+		shutdownSent.Store(false)
 	})
 }


### PR DESCRIPTION
## Summary
- `TriggerShutdown` now sends SIGTERM only once via `shutdownSent` atomic flag
- When multiple processes complete (e.g. test runner + background process), duplicate SIGTERMs no longer hit the force-exit goroutine in `waitForShutdownSignal`
- This caused `wippy run test` to exit with code 1 even when all tests passed, breaking CI for framework modules (facade, llm, relay)

## Root cause
`terminal/host.go:OnComplete` calls `TriggerShutdown` for every process that completes. The first SIGTERM unblocks `waitForShutdownSignal`. The second SIGTERM is received by the force-exit goroutine which calls `os.Exit(1)`.

## Test plan
- Added `TriggerShutdown_OnlyFirstCallSendsSignal` test verifying only one signal is sent on duplicate calls
- Verified `wippy run test` exits 0 for facade, llm, relay modules locally