### PR TITLE
Add options support to contract call system

### DIFF
--- a/api/contract/command.go
+++ b/api/contract/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/runtime"
 	secapi "github.com/wippyai/runtime/api/security"
 )
 
@@ -62,8 +63,9 @@ type OpenResult struct {
 
 // CallCmd calls a method on a contract instance.
 type CallCmd struct {
-	Instance Instance
 	Method   string
+	Instance Instance
+	Options  runtime.Options
 	Args     payload.Payloads
 }
 
@@ -76,6 +78,7 @@ func (c *CallCmd) Release() {
 	c.Instance = nil
 	c.Method = ""
 	c.Args = nil
+	c.Options = nil
 	callCmdPool.Put(c)
 }
 
@@ -87,9 +90,10 @@ type CallResult struct {
 
 // AsyncCallCmd calls a method asynchronously.
 type AsyncCallCmd struct {
-	Instance Instance
 	Method   string
 	Topic    string
+	Instance Instance
+	Options  runtime.Options
 	Args     payload.Payloads
 }
 
@@ -103,6 +107,7 @@ func (c *AsyncCallCmd) Release() {
 	c.Method = ""
 	c.Args = nil
 	c.Topic = ""
+	c.Options = nil
 	asyncCallCmdPool.Put(c)
 }
 

--- a/api/contract/contract.go
+++ b/api/contract/contract.go
@@ -110,6 +110,6 @@ type (
 		Implements() []Contract
 
 		// Call invokes a method on this instance synchronously.
-		Call(ctx context.Context, method string, input payload.Payloads) (*runtime.Result, error)
+		Call(ctx context.Context, method string, input payload.Payloads, options runtime.Options) (*runtime.Result, error)
 	}
 )

--- a/api/contract/contract_test.go
+++ b/api/contract/contract_test.go
@@ -406,6 +406,7 @@ func TestCommandPools(t *testing.T) {
 		assert.Equal(t, Call, cmd.CmdID())
 
 		cmd.Method = "testMethod"
+		cmd.Options = attrs.Bag{"retry": map[string]any{"max_attempts": 3}}
 
 		cmd.Release()
 
@@ -414,6 +415,7 @@ func TestCommandPools(t *testing.T) {
 		assert.Equal(t, "", cmd2.Method)
 		assert.Nil(t, cmd2.Instance)
 		assert.Nil(t, cmd2.Args)
+		assert.Nil(t, cmd2.Options)
 	})
 
 	t.Run("AsyncCallCmd", func(t *testing.T) {
@@ -423,6 +425,7 @@ func TestCommandPools(t *testing.T) {
 
 		cmd.Method = "asyncMethod"
 		cmd.Topic = "result-topic"
+		cmd.Options = attrs.Bag{"retry": map[string]any{"max_attempts": 5}}
 
 		cmd.Release()
 
@@ -432,6 +435,7 @@ func TestCommandPools(t *testing.T) {
 		assert.Equal(t, "", cmd2.Topic)
 		assert.Nil(t, cmd2.Instance)
 		assert.Nil(t, cmd2.Args)
+		assert.Nil(t, cmd2.Options)
 	})
 
 	t.Run("AsyncCancelCmd", func(t *testing.T) {

--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -736,7 +736,7 @@ func TestIntegration_Concurrent(t *testing.T) {
 	wg.Wait()
 }
 
-func TestIntegration_WithOptions_OptionsReachFunction(t *testing.T) {
+func TestIntegration_WithOptions_ConfigPermutations(t *testing.T) {
 	tc := setupIntegrationTest(t, 4)
 	defer tc.Close(t)
 
@@ -763,34 +763,163 @@ func TestIntegration_WithOptions_OptionsReachFunction(t *testing.T) {
 		}},
 	})
 
-	script := `
-		local c, err = contract.get("test:opts_check_contract")
-		if err then error(tostring(err)) end
+	run := func(t *testing.T, script string) (string, runtime.Options) {
+		t.Helper()
+		capturedOptions = nil
+		frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+		proc := newLuaProcess(t, script)
+		result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+		require.NoError(t, err, "scheduler error")
+		require.NotNil(t, result, "result is nil")
+		if result.Error != nil {
+			t.Fatalf("result.Error: %v", result.Error)
+		}
+		if result.Value == nil {
+			t.Fatal("result.Value is nil (Lua returned nothing)")
+		}
+		s, ok := result.Value.Data().(lua.LString)
+		require.True(t, ok, "expected LString, got %T: %v", result.Value.Data(), result.Value.Data())
+		return string(s), capturedOptions
+	}
 
-		local instance, err = c
-			:with_options({retry = {max_attempts = 5, initial_delay = 1}})
-			:open("test:opts_check_binding")
-		if err then error(tostring(err)) end
+	hasRetry := func(t *testing.T, opts runtime.Options) {
+		t.Helper()
+		require.NotNil(t, opts, "options should not be nil")
+		bag, ok := opts.(runtime.Bag)
+		require.True(t, ok)
+		_, exists := bag["retry"]
+		assert.True(t, exists, "retry key should exist")
+	}
 
-		local result, err = instance:check()
-		if err then error(tostring(err)) end
-		return result
-	`
+	t.Run("wrapper with_options then open", func(t *testing.T) {
+		val, opts := run(t, `
+			local c, err = contract.get("test:opts_check_contract")
+			if err then error("get: " .. tostring(err)) end
+			local inst, err = c:with_options({retry = {max_attempts = 3}}):open("test:opts_check_binding")
+			if err then error("open: " .. tostring(err)) end
+			local result, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return result
+		`)
+		assert.Equal(t, "has_options", val)
+		hasRetry(t, opts)
+	})
 
-	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
-	proc := newLuaProcess(t, script)
+	t.Run("contract.open with empty scope and options", func(t *testing.T) {
+		val, opts := run(t, `
+			local inst, err = contract.open("test:opts_check_binding", {}, {retry = {max_attempts = 3}})
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "has_options", val)
+		hasRetry(t, opts)
+	})
 
-	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
-	require.NoError(t, err)
-	require.Nil(t, result.Error, "result.Error: %v", result.Error)
-	require.NotNil(t, result.Value)
-	assert.Equal(t, "has_options", string(result.Value.Data().(lua.LString)))
+	t.Run("contract.open with nil scope and options", func(t *testing.T) {
+		val, opts := run(t, `
+			local inst, err = contract.open("test:opts_check_binding", nil, {retry = {max_attempts = 3}})
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "has_options", val)
+		hasRetry(t, opts)
+	})
 
-	require.NotNil(t, capturedOptions)
-	bag, ok := capturedOptions.(runtime.Bag)
-	require.True(t, ok, "options should be attrs.Bag, got %T", capturedOptions)
-	_, exists := bag["retry"]
-	assert.True(t, exists, "retry key should exist in options")
+	t.Run("contract.open with scope and options", func(t *testing.T) {
+		val, opts := run(t, `
+			local inst, err = contract.open("test:opts_check_binding", {key = "val"}, {retry = {max_attempts = 3}})
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "has_options", val)
+		hasRetry(t, opts)
+	})
+
+	t.Run("contract.open without options", func(t *testing.T) {
+		val, opts := run(t, `
+			local inst, err = contract.open("test:opts_check_binding")
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "no_options", val)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("contract.open with scope only", func(t *testing.T) {
+		val, opts := run(t, `
+			local inst, err = contract.open("test:opts_check_binding", {key = "val"})
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "no_options", val)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("wrapper with_options chains with with_context", func(t *testing.T) {
+		val, opts := run(t, `
+			local c, err = contract.get("test:opts_check_contract")
+			if err then error(tostring(err)) end
+			local inst, err = c:with_context({k = "v"}):with_options({retry = {max_attempts = 3}}):open("test:opts_check_binding")
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "has_options", val)
+		hasRetry(t, opts)
+	})
+
+	t.Run("wrapper with_options then with_context preserves options", func(t *testing.T) {
+		val, opts := run(t, `
+			local c, err = contract.get("test:opts_check_contract")
+			if err then error(tostring(err)) end
+			local inst, err = c:with_options({retry = {max_attempts = 3}}):with_context({k = "v"}):open("test:opts_check_binding")
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "has_options", val)
+		hasRetry(t, opts)
+	})
+
+	t.Run("wrapper without options", func(t *testing.T) {
+		val, opts := run(t, `
+			local c, err = contract.get("test:opts_check_contract")
+			if err then error(tostring(err)) end
+			local inst, err = c:open("test:opts_check_binding")
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "no_options", val)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("wrapper with empty options", func(t *testing.T) {
+		val, opts := run(t, `
+			local c, err = contract.get("test:opts_check_contract")
+			if err then error(tostring(err)) end
+			local inst, err = c:with_options({}):open("test:opts_check_binding")
+			if err then error(tostring(err)) end
+			local r, err = inst:check()
+			if err then error("check: " .. tostring(err)) end
+			return r
+		`)
+		assert.Equal(t, "has_options", val)
+		require.NotNil(t, opts)
+	})
 }
 
 func TestIntegration_WithOptions_RetryOnFailure(t *testing.T) {

--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -17,6 +17,7 @@ import (
 	ctxapi "github.com/wippyai/runtime/api/context"
 	apicontract "github.com/wippyai/runtime/api/contract"
 	"github.com/wippyai/runtime/api/dispatcher"
+	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/function"
 	"github.com/wippyai/runtime/api/payload"
@@ -32,6 +33,8 @@ import (
 	syscontract "github.com/wippyai/runtime/system/contract"
 	"github.com/wippyai/runtime/system/eventbus"
 	sysfunction "github.com/wippyai/runtime/system/function"
+	"github.com/wippyai/runtime/system/function/interceptor"
+	"github.com/wippyai/runtime/system/function/interceptor/retry"
 	sysrelay "github.com/wippyai/runtime/system/relay"
 	"github.com/wippyai/runtime/system/scheduler"
 	"github.com/wippyai/runtime/system/scheduler/actor"
@@ -121,6 +124,36 @@ type integrationTestContext struct {
 }
 
 func setupIntegrationTest(t *testing.T, numWorkers int) *integrationTestContext {
+	// Configure error metadata extractor so Lua errors preserve kind/retryable from apierror
+	lua.SetErrorMetadataExtractor(func(err error) *lua.ErrorMetadata {
+		chain := apierror.BuildChain(err)
+		if chain == nil {
+			return nil
+		}
+		root := chain.Root()
+		if root == nil {
+			return nil
+		}
+		meta := &lua.ErrorMetadata{}
+		if root.Kind != "" {
+			meta.Kind = lua.Kind(root.Kind)
+		}
+		if root.Retryable != nil {
+			b := *root.Retryable
+			meta.Retryable = &b
+		}
+		if len(root.Details) > 0 {
+			meta.Details = make(map[string]any, len(root.Details))
+			for k, v := range root.Details {
+				meta.Details[k] = v
+			}
+		}
+		if meta.Kind == "" && meta.Retryable == nil && meta.Details == nil {
+			return nil
+		}
+		return meta
+	})
+
 	logger := zap.NewNop()
 	bus := eventbus.NewBus()
 
@@ -130,10 +163,14 @@ func setupIntegrationTest(t *testing.T, numWorkers int) *integrationTestContext 
 	functionRegistry := sysfunction.NewFunctionRegistry(bus, logger)
 	instantiator := syscontract.NewContractInstantiator(contractRegistry, functionRegistry)
 
+	interceptorRegistry := interceptor.NewRegistry(logger)
+	require.NoError(t, interceptorRegistry.Register("retry", retry.New(), 20))
+
 	ctx := security.SetStrictMode(ctxapi.NewRootContext(), false)
 	ctx = relay.WithNode(ctx, node)
 	ctx = apicontract.WithContracts(ctx, contractRegistry, instantiator)
 	ctx = function.WithRegistry(ctx, functionRegistry)
+	ctx = function.WithInterceptorRegistry(ctx, interceptorRegistry)
 
 	// Set up PID generator for function calls
 	uniqGen := uniqid.NewGenerator()
@@ -697,4 +734,259 @@ func TestIntegration_Concurrent(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestIntegration_WithOptions_OptionsReachFunction(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	var capturedOptions runtime.Options
+	funcID := registry.NewID("test", "capture_opts")
+	tc.registerFunction(t, funcID, func(_ context.Context, task runtime.Task) (*runtime.Result, error) {
+		capturedOptions = task.Options
+		if capturedOptions != nil {
+			return &runtime.Result{Value: payload.New("has_options")}, nil
+		}
+		return &runtime.Result{Value: payload.New("no_options")}, nil
+	})
+
+	contractID := registry.NewID("test", "opts_check_contract")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "check"}},
+	})
+
+	bindingID := registry.NewID("test", "opts_check_binding")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{{
+			Contract: contractID,
+			Methods:  map[string]registry.ID{"check": funcID},
+		}},
+	})
+
+	script := `
+		local c, err = contract.get("test:opts_check_contract")
+		if err then error(tostring(err)) end
+
+		local instance, err = c
+			:with_options({retry = {max_attempts = 5, initial_delay = 1}})
+			:open("test:opts_check_binding")
+		if err then error(tostring(err)) end
+
+		local result, err = instance:check()
+		if err then error(tostring(err)) end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcess(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error, "result.Error: %v", result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "has_options", string(result.Value.Data().(lua.LString)))
+
+	require.NotNil(t, capturedOptions)
+	bag, ok := capturedOptions.(runtime.Bag)
+	require.True(t, ok, "options should be attrs.Bag, got %T", capturedOptions)
+	_, exists := bag["retry"]
+	assert.True(t, exists, "retry key should exist in options")
+}
+
+func TestIntegration_WithOptions_RetryOnFailure(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	var callCount atomic.Int64
+	funcID := registry.NewID("test", "flaky_func")
+	tc.registerFunction(t, funcID, func(_ context.Context, _ runtime.Task) (*runtime.Result, error) {
+		n := callCount.Add(1)
+		if n < 3 {
+			return nil, apierror.New(apierror.Unavailable, "temporary failure").WithRetryable(apierror.True)
+		}
+		return &runtime.Result{Value: payload.New("success_after_retries")}, nil
+	})
+
+	contractID := registry.NewID("test", "retry_contract")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "call"}},
+	})
+
+	bindingID := registry.NewID("test", "retry_binding")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{{
+			Contract: contractID,
+			Methods:  map[string]registry.ID{"call": funcID},
+		}},
+	})
+
+	script := `
+		local c, err = contract.get("test:retry_contract")
+		if err then return nil, tostring(err) end
+
+		local instance, err = c
+			:with_options({retry = {max_attempts = 5, initial_delay = 1}})
+			:open("test:retry_binding")
+		if err then return nil, tostring(err) end
+
+		local result, err = instance:call()
+		if err then return nil, tostring(err) end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcess(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "success_after_retries", string(result.Value.Data().(lua.LString)))
+	assert.Equal(t, int64(3), callCount.Load())
+}
+
+func TestIntegration_WithOptions_DirectOpen(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	var callCount atomic.Int64
+	funcID := registry.NewID("test", "flaky_direct")
+	tc.registerFunction(t, funcID, func(_ context.Context, _ runtime.Task) (*runtime.Result, error) {
+		n := callCount.Add(1)
+		if n < 2 {
+			return nil, apierror.New(apierror.Unavailable, "temporary").WithRetryable(apierror.True)
+		}
+		return &runtime.Result{Value: payload.New("ok")}, nil
+	})
+
+	contractID := registry.NewID("test", "direct_retry_contract")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "run"}},
+	})
+
+	bindingID := registry.NewID("test", "direct_retry_binding")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{{
+			Contract: contractID,
+			Methods:  map[string]registry.ID{"run": funcID},
+		}},
+	})
+
+	script := `
+		local instance, err = contract.open("test:direct_retry_binding", {}, {
+			retry = {max_attempts = 3, initial_delay = 1}
+		})
+		if err then return nil, tostring(err) end
+
+		local result, err = instance:run()
+		if err then return nil, tostring(err) end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcess(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "ok", string(result.Value.Data().(lua.LString)))
+	assert.Equal(t, int64(2), callCount.Load())
+}
+
+func TestIntegration_WithOptions_NonRetryableError(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	var callCount atomic.Int64
+	funcID := registry.NewID("test", "permanent_fail")
+	tc.registerFunction(t, funcID, func(_ context.Context, _ runtime.Task) (*runtime.Result, error) {
+		callCount.Add(1)
+		return nil, apierror.New(apierror.PermissionDenied, "not allowed").WithRetryable(apierror.False)
+	})
+
+	contractID := registry.NewID("test", "noretry_contract")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "forbidden"}},
+	})
+
+	bindingID := registry.NewID("test", "noretry_binding")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{{
+			Contract: contractID,
+			Methods:  map[string]registry.ID{"forbidden": funcID},
+		}},
+	})
+
+	script := `
+		local c, err = contract.get("test:noretry_contract")
+		if err then return nil, tostring(err) end
+
+		local instance, err = c
+			:with_options({retry = {max_attempts = 5, initial_delay = 1}})
+			:open("test:noretry_binding")
+		if err then return nil, tostring(err) end
+
+		local result, err = instance:forbidden()
+		if err then
+			return err:kind()
+		end
+		return "should_not_reach"
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcess(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "PermissionDenied", string(result.Value.Data().(lua.LString)))
+	assert.Equal(t, int64(1), callCount.Load())
+}
+
+func TestIntegration_WithOptions_NoRetryWithoutOptions(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	var callCount atomic.Int64
+	funcID := registry.NewID("test", "always_fail")
+	tc.registerFunction(t, funcID, func(_ context.Context, _ runtime.Task) (*runtime.Result, error) {
+		callCount.Add(1)
+		return nil, apierror.New(apierror.Unavailable, "fail").WithRetryable(apierror.True)
+	})
+
+	contractID := registry.NewID("test", "noopts_contract")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "fail"}},
+	})
+
+	bindingID := registry.NewID("test", "noopts_binding")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{{
+			Contract: contractID,
+			Methods:  map[string]registry.ID{"fail": funcID},
+		}},
+	})
+
+	script := `
+		local instance, err = contract.open("test:noopts_binding")
+		if err then return nil, tostring(err) end
+
+		local result, err = instance:fail()
+		if err then
+			return "failed:" .. err:kind()
+		end
+		return "should_not_reach"
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcess(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "failed:Unavailable", string(result.Value.Data().(lua.LString)))
+	assert.Equal(t, int64(1), callCount.Load())
 }

--- a/runtime/lua/modules/contract/module.go
+++ b/runtime/lua/modules/contract/module.go
@@ -44,6 +44,7 @@ func init() {
 		"with_context":    contractWithContext,
 		"with_actor":      contractWithActor,
 		"with_scope":      contractWithScope,
+		"with_options":    contractWithOptions,
 	})
 
 	// Register instance type with dynamic method access via __index
@@ -89,14 +90,18 @@ type Wrapper struct {
 	registry   contract.Registry
 	scope      secapi.Scope
 	values     contextapi.Values
+	options    attrs.Bag
 	actor      secapi.Actor
 	hasActor   bool
 	hasScope   bool
+	hasOptions bool
 }
 
-// InstanceWrapper holds an opened contract instance.
+// InstanceWrapper holds an opened contract instance with optional call options.
 type InstanceWrapper struct {
-	instance contract.Instance
+	instance   contract.Instance
+	options    attrs.Bag
+	hasOptions bool
 }
 
 // parseBindingID parses a binding ID with optional query parameters.
@@ -219,9 +224,24 @@ func openBinding(l *lua.LState) int {
 		}
 	}
 
+	// Parse optional options table (third argument)
+	var options attrs.Bag
+	var hasOptions bool
+	if l.GetTop() >= 3 && l.Get(3).Type() == lua.LTTable {
+		options = attrs.NewBag()
+		l.CheckTable(3).ForEach(func(k, v lua.LValue) {
+			if key, ok := k.(lua.LString); ok {
+				options.Set(string(key), value.ToGoAny(v))
+			}
+		})
+		hasOptions = true
+	}
+
 	yield := AcquireOpenYield()
 	yield.BindingID = registry.ParseID(baseID)
 	yield.Scope = scope
+	yield.options = options
+	yield.hasOptions = hasOptions
 
 	l.Push(yield)
 	return -1
@@ -448,6 +468,8 @@ func contractOpen(l *lua.LState) int {
 	yield.HasActor = wrapper.hasActor
 	yield.SecurityScope = wrapper.scope
 	yield.HasScope = wrapper.hasScope
+	yield.options = wrapper.options
+	yield.hasOptions = wrapper.hasOptions
 
 	l.Push(yield)
 	return -1
@@ -489,10 +511,12 @@ func contractWithContext(l *lua.LState) int {
 		definition: wrapper.definition,
 		registry:   wrapper.registry,
 		values:     newValues,
+		options:    wrapper.options,
 		actor:      wrapper.actor,
 		hasActor:   wrapper.hasActor,
-		scope:      wrapper.scope,
 		hasScope:   wrapper.hasScope,
+		hasOptions: wrapper.hasOptions,
+		scope:      wrapper.scope,
 	}
 
 	value.PushTypedUserData(l, newWrapper, contractTypeName)
@@ -532,10 +556,12 @@ func contractWithActor(l *lua.LState) int {
 		definition: wrapper.definition,
 		registry:   wrapper.registry,
 		values:     wrapper.values,
+		options:    wrapper.options,
 		actor:      actor,
 		hasActor:   true,
-		scope:      wrapper.scope,
 		hasScope:   wrapper.hasScope,
+		hasOptions: wrapper.hasOptions,
+		scope:      wrapper.scope,
 	}
 
 	value.PushTypedUserData(l, newWrapper, contractTypeName)
@@ -575,10 +601,44 @@ func contractWithScope(l *lua.LState) int {
 		definition: wrapper.definition,
 		registry:   wrapper.registry,
 		values:     wrapper.values,
+		options:    wrapper.options,
 		actor:      wrapper.actor,
 		hasActor:   wrapper.hasActor,
-		scope:      scope,
 		hasScope:   true,
+		hasOptions: wrapper.hasOptions,
+		scope:      scope,
+	}
+
+	value.PushTypedUserData(l, newWrapper, contractTypeName)
+	return 1
+}
+
+func contractWithOptions(l *lua.LState) int {
+	ud := l.CheckUserData(1)
+	wrapper, ok := ud.Value.(*Wrapper)
+	if !ok {
+		l.ArgError(1, "Contract expected")
+		return 0
+	}
+
+	optionsTable := l.CheckTable(2)
+	options := attrs.NewBag()
+	optionsTable.ForEach(func(k, v lua.LValue) {
+		if key, ok := k.(lua.LString); ok {
+			options.Set(string(key), value.ToGoAny(v))
+		}
+	})
+
+	newWrapper := &Wrapper{
+		definition: wrapper.definition,
+		registry:   wrapper.registry,
+		values:     wrapper.values,
+		options:    options,
+		actor:      wrapper.actor,
+		hasActor:   wrapper.hasActor,
+		hasScope:   wrapper.hasScope,
+		hasOptions: true,
+		scope:      wrapper.scope,
 	}
 
 	value.PushTypedUserData(l, newWrapper, contractTypeName)
@@ -647,6 +707,9 @@ func callMethodSync(l *lua.LState, wrapper *InstanceWrapper, method string, args
 	yield.Instance = wrapper.instance
 	yield.Method = method
 	yield.Args = args
+	if wrapper.hasOptions {
+		yield.Options = wrapper.options
+	}
 
 	l.Push(yield)
 	return -1
@@ -683,6 +746,9 @@ func callMethodAsync(l *lua.LState, wrapper *InstanceWrapper, method string, arg
 	yield.Args = args
 	yield.Topic = topic
 	yield.Future = f
+	if wrapper.hasOptions {
+		yield.Options = wrapper.options
+	}
 
 	l.Push(yield)
 	return -1

--- a/runtime/lua/modules/contract/module_test.go
+++ b/runtime/lua/modules/contract/module_test.go
@@ -3,6 +3,7 @@
 package contract
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,19 @@ import (
 	"github.com/wippyai/runtime/api/contract"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/runtime"
 )
+
+type mockInstanceForTest struct {
+	id        registry.ID
+	contracts []contract.Contract
+}
+
+func (m *mockInstanceForTest) ID() registry.ID                 { return m.id }
+func (m *mockInstanceForTest) Implements() []contract.Contract { return m.contracts }
+func (m *mockInstanceForTest) Call(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
+	return nil, nil
+}
 
 func TestModule_Info(t *testing.T) {
 	info := Module.Info()
@@ -39,12 +52,16 @@ func TestOpenYield_Pool(t *testing.T) {
 
 	y.BindingID = registry.ParseID("test/binding")
 	y.Scope = attrs.NewBagFrom(map[string]any{"key": "value"})
+	y.options = attrs.Bag{"retry": map[string]any{"max_attempts": 3}}
+	y.hasOptions = true
 
 	ReleaseOpenYield(y)
 
 	y2 := AcquireOpenYield()
 	assert.Equal(t, registry.ID{}, y2.BindingID)
 	assert.Nil(t, y2.Scope)
+	assert.Nil(t, y2.options)
+	assert.False(t, y2.hasOptions)
 	ReleaseOpenYield(y2)
 }
 
@@ -205,6 +222,32 @@ func TestOpenYield_HandleResult(t *testing.T) {
 	require.Len(t, results, 2)
 	assert.Equal(t, lua.LNil, results[0])
 	assert.NotEqual(t, lua.LNil, results[1])
+}
+
+func TestOpenYield_HandleResult_WithOptions(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireOpenYield()
+	defer ReleaseOpenYield(y)
+
+	y.options = attrs.Bag{"retry": map[string]any{"max_attempts": 3}}
+	y.hasOptions = true
+
+	mockInst := &mockInstanceForTest{id: registry.NewID("test", "binding")}
+	results := y.HandleResult(l, contract.OpenResult{Instance: mockInst}, nil)
+	require.Len(t, results, 2)
+	assert.Equal(t, lua.LNil, results[1])
+
+	ud, ok := results[0].(*lua.LUserData)
+	require.True(t, ok)
+	wrapper, ok := ud.Value.(*InstanceWrapper)
+	require.True(t, ok)
+	assert.True(t, wrapper.hasOptions)
+	retryVal, exists := wrapper.options["retry"]
+	require.True(t, exists)
+	retryMap := retryVal.(map[string]any)
+	assert.Equal(t, 3, retryMap["max_attempts"])
 }
 
 func TestCallYield_HandleResult(t *testing.T) {

--- a/runtime/lua/modules/contract/types.go
+++ b/runtime/lua/modules/contract/types.go
@@ -31,10 +31,11 @@ func init() {
 		{Name: "methods", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewArray(methodDefinitionType)).Build()},
 		{Name: "method", Type: typ.Func().Param("self", typ.Self).Param("name", typ.String).Returns(methodDefinitionType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "implementations", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewArray(typ.String), typ.NewOptional(typ.LuaError)).Build()},
-		{Name: "open", Type: typ.Func().Param("self", typ.Self).OptParam("name", typ.String).OptParam("options", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "open", Type: typ.Func().Param("self", typ.Self).OptParam("name", typ.String).OptParam("scope", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "with_context", Type: typ.Func().Param("self", typ.Self).Param("ctx", typ.Any).Returns(typ.Self).Build()},
 		{Name: "with_actor", Type: typ.Func().Param("self", typ.Self).Param("actor", typ.Any).Returns(typ.Self).Build()},
 		{Name: "with_scope", Type: typ.Func().Param("self", typ.Self).Param("scope", typ.Any).Returns(typ.Self).Build()},
+		{Name: "with_options", Type: typ.Func().Param("self", typ.Self).Param("options", typ.Any).Returns(typ.Self).Build()},
 	})
 }
 
@@ -47,7 +48,7 @@ func ModuleTypes() *io.Manifest {
 
 	moduleType := typ.NewInterface("contract", []typ.Method{
 		{Name: "get", Type: typ.Func().Param("name", typ.String).Returns(contractType, typ.NewOptional(typ.LuaError)).Build()},
-		{Name: "open", Type: typ.Func().Param("name", typ.String).OptParam("options", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "open", Type: typ.Func().Param("name", typ.String).OptParam("scope", typ.Any).OptParam("options", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "find_implementations", Type: typ.Func().Param("name", typ.String).Returns(typ.NewArray(typ.String), typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "is", Type: typ.Func().Param("value", typ.Any).Param("name", typ.String).Returns(typ.Boolean).Build()},
 	})

--- a/runtime/lua/modules/contract/yields.go
+++ b/runtime/lua/modules/contract/yields.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/contract"
 	"github.com/wippyai/runtime/api/dispatcher"
 	luaconv "github.com/wippyai/runtime/runtime/lua/engine/payload"
@@ -16,6 +17,8 @@ import (
 // OpenYield wraps OpenCmd for Lua.
 type OpenYield struct {
 	*contract.OpenCmd
+	options    attrs.Bag
+	hasOptions bool
 }
 
 var openYieldPool = sync.Pool{New: func() any { return &OpenYield{} }}
@@ -31,6 +34,8 @@ func ReleaseOpenYield(y *OpenYield) {
 		y.OpenCmd.Release()
 		y.OpenCmd = nil
 	}
+	y.options = nil
+	y.hasOptions = false
 	openYieldPool.Put(y)
 }
 
@@ -68,7 +73,9 @@ func (y *OpenYield) HandleResult(l *lua.LState, data any, err error) []lua.LValu
 
 	// Wrap instance in userdata
 	wrapper := &InstanceWrapper{
-		instance: resp.Instance,
+		instance:   resp.Instance,
+		options:    y.options,
+		hasOptions: y.hasOptions,
 	}
 	return []lua.LValue{value.NewTypedUserData(l, wrapper, instanceTypeName), lua.LNil}
 }

--- a/system/contract/dispatcher.go
+++ b/system/contract/dispatcher.go
@@ -87,7 +87,7 @@ func (d *Dispatcher) handleCall(ctx context.Context, cmd dispatcher.Command, tag
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
 		defer ctxapi.ReleaseFrameContext(callFC)
-		result, err := callCmd.Instance.Call(callCtx, callCmd.Method, callCmd.Args)
+		result, err := callCmd.Instance.Call(callCtx, callCmd.Method, callCmd.Args, callCmd.Options)
 		if callCtx.Err() != nil {
 			receiver.CompleteYield(tag, contract.CallResult{Error: callCtx.Err()}, nil)
 			return
@@ -134,13 +134,14 @@ func (d *Dispatcher) handleAsyncCall(ctx context.Context, cmd dispatcher.Command
 	instance := asyncCmd.Instance
 	method := asyncCmd.Method
 	args := asyncCmd.Args
+	options := asyncCmd.Options
 	logger := d.logger
 
 	callCtx, fc := ctxapi.ForkFrameContext(ctx)
 
 	go func(callCtx context.Context, callFC ctxapi.FrameContext) {
 		defer ctxapi.ReleaseFrameContext(callFC)
-		result, err := instance.Call(callCtx, method, args)
+		result, err := instance.Call(callCtx, method, args, options)
 
 		resultPayload := resultToPayload(result, err)
 		if err := sendAsyncResult(node, framePID, topic, resultPayload); err != nil {

--- a/system/contract/dispatcher_test.go
+++ b/system/contract/dispatcher_test.go
@@ -115,7 +115,7 @@ func TestOpenHandler_Error(t *testing.T) {
 func TestCallHandler(t *testing.T) {
 	d := NewDispatcher(nil, nil)
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("result")}, nil
 		},
 	}
@@ -135,6 +135,44 @@ func TestCallHandler(t *testing.T) {
 	case result := <-done:
 		assert.Nil(t, result.Error)
 		assert.NotNil(t, result.Value)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestCallHandler_WithOptions(t *testing.T) {
+	d := NewDispatcher(nil, nil)
+
+	var receivedOptions runtime.Options
+	mockInstance := &mockInstance{
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, opts runtime.Options) (*runtime.Result, error) {
+			receivedOptions = opts
+			return &runtime.Result{Value: payload.New("result")}, nil
+		},
+	}
+
+	ctx := setupDispatcherTestContext(nil)
+	cmd := contract.AcquireCallCmd()
+	cmd.Instance = mockInstance
+	cmd.Method = "test_method"
+	cmd.Options = attrs.Bag{
+		"retry": map[string]any{"max_attempts": 3},
+	}
+
+	done := make(chan contract.CallResult, 1)
+	err := d.handleCall(ctx, cmd, 0, &testReceiver{cb: func(data any, _ error) {
+		done <- data.(contract.CallResult)
+	}})
+
+	require.NoError(t, err)
+	select {
+	case result := <-done:
+		assert.Nil(t, result.Error)
+		assert.NotNil(t, result.Value)
+		bag, ok := receivedOptions.(attrs.Bag)
+		require.True(t, ok)
+		_, exists := bag["retry"]
+		assert.True(t, exists)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for result")
 	}
@@ -161,7 +199,7 @@ func TestCallHandler_Error(t *testing.T) {
 	d := NewDispatcher(nil, nil)
 	expectedErr := errors.New("call error")
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return nil, expectedErr
 		},
 	}
@@ -189,7 +227,7 @@ func TestCallHandler_ResultError(t *testing.T) {
 	d := NewDispatcher(nil, nil)
 	expectedErr := errors.New("result error")
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Error: expectedErr}, nil
 		},
 	}
@@ -217,7 +255,7 @@ func TestAsyncCallHandler(t *testing.T) {
 	mockNode := &mockRelayNode{packages: make(chan *relay.Package, 10)}
 	d := NewDispatcher(mockNode, nil)
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("async result")}, nil
 		},
 	}
@@ -329,7 +367,7 @@ func TestCallHandler_Stress(t *testing.T) {
 
 	d := NewDispatcher(nil, nil)
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("result")}, nil
 		},
 	}
@@ -367,7 +405,7 @@ func TestCallHandler_Stress(t *testing.T) {
 func BenchmarkCallHandler(b *testing.B) {
 	d := NewDispatcher(nil, nil)
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("result")}, nil
 		},
 	}
@@ -387,7 +425,7 @@ func BenchmarkCallHandler(b *testing.B) {
 func BenchmarkCallHandler_Parallel(b *testing.B) {
 	d := NewDispatcher(nil, nil)
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("result")}, nil
 		},
 	}
@@ -420,7 +458,7 @@ func (m *mockInstantiator) Instantiate(ctx context.Context, bindingID registry.I
 }
 
 type mockInstance struct {
-	callFn    func(context.Context, string, payload.Payloads) (*runtime.Result, error)
+	callFn    func(context.Context, string, payload.Payloads, runtime.Options) (*runtime.Result, error)
 	id        registry.ID
 	contracts []contract.Contract
 }
@@ -429,9 +467,9 @@ func (m *mockInstance) ID() registry.ID { return m.id }
 
 func (m *mockInstance) Implements() []contract.Contract { return m.contracts }
 
-func (m *mockInstance) Call(ctx context.Context, method string, input payload.Payloads) (*runtime.Result, error) {
+func (m *mockInstance) Call(ctx context.Context, method string, input payload.Payloads, options runtime.Options) (*runtime.Result, error) {
 	if m.callFn != nil {
-		return m.callFn(ctx, method, input)
+		return m.callFn(ctx, method, input, options)
 	}
 	return nil, contract.ErrInstanceNil
 }
@@ -504,7 +542,7 @@ func TestOpenHandler_ContextCanceled(t *testing.T) {
 func TestCallHandler_ContextCanceled(t *testing.T) {
 	d := NewDispatcher(nil, nil)
 	mockInstance := &mockInstance{
-		callFn: func(ctx context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(ctx context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		},
@@ -538,7 +576,7 @@ func TestAsyncCallHandler_NoPID(t *testing.T) {
 	d := NewDispatcher(mockNode, nil)
 
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("result")}, nil
 		},
 	}
@@ -599,7 +637,7 @@ func TestAsyncCallHandler_NoNode(t *testing.T) {
 	d := NewDispatcher(nil, nil)
 
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Value: payload.New("result")}, nil
 		},
 	}
@@ -652,7 +690,7 @@ func TestAsyncCallHandler_CallError(t *testing.T) {
 
 	callErr := errors.New("call failed")
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return nil, callErr
 		},
 	}
@@ -690,7 +728,7 @@ func TestAsyncCallHandler_ResultError(t *testing.T) {
 
 	resultErr := errors.New("result error")
 	mockInstance := &mockInstance{
-		callFn: func(_ context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+		callFn: func(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 			return &runtime.Result{Error: resultErr}, nil
 		},
 	}

--- a/system/contract/instantiator.go
+++ b/system/contract/instantiator.go
@@ -70,7 +70,7 @@ func (i *instanceImpl) ID() registry.ID {
 	return i.id
 }
 
-func (i *instanceImpl) Call(ctx context.Context, method string, args payload.Payloads) (*runtime.Result, error) {
+func (i *instanceImpl) Call(ctx context.Context, method string, args payload.Payloads, options runtime.Options) (*runtime.Result, error) {
 	// Find the bound contract and method
 	var funcID registry.ID
 	var boundContract contract.BoundContract
@@ -94,10 +94,11 @@ func (i *instanceImpl) Call(ctx context.Context, method string, args payload.Pay
 		return nil, err
 	}
 
-	// Create task with payloads.
+	// Create task with payloads and options.
 	task := runtime.Task{
 		ID:       funcID,
 		Payloads: args,
+		Options:  options,
 	}
 
 	// Merge scope values into task.Context for downstream consumers.

--- a/system/contract/instantiator_test.go
+++ b/system/contract/instantiator_test.go
@@ -230,7 +230,7 @@ func TestInstanceImpl_ScopeValidation(t *testing.T) {
 			instance, err := instantiator.Instantiate(ctx, bindingID, tt.instanceScope)
 			require.NoError(t, err)
 
-			_, err = instance.Call(ctx, "validateMethod", payload.Payloads{})
+			_, err = instance.Call(ctx, "validateMethod", payload.Payloads{}, nil)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)
@@ -347,15 +347,130 @@ func TestInstanceImpl_Call_Integration(t *testing.T) {
 	instance, err := instantiator.Instantiate(ctx, bindingID, attrs.Bag{})
 	require.NoError(t, err)
 
-	result, err := instance.Call(ctx, "testMethod", payload.Payloads{payload.New("test_input")})
+	result, err := instance.Call(ctx, "testMethod", payload.Payloads{payload.New("test_input")}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "function_result", result.Value.Data().(string))
 
 	// Test method not bound
-	_, err = instance.Call(ctx, "unknownMethod", payload.Payloads{})
+	_, err = instance.Call(ctx, "unknownMethod", payload.Payloads{}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "method 'unknownMethod' not bound")
+}
+
+func TestInstanceImpl_Call_WithOptions(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	ctx = relayapi.WithNode(ctx, relay.NewNode("test"))
+
+	uniqGen := uniqid.NewGenerator()
+	pidGen := uniqid.NewPIDGenerator(uniqGen, "")
+	ctx = process.WithPIDGenerator(ctx, pidGen)
+
+	instantiator, bus, contractRegistry, functionRegistry := setupInstantiatorTest()
+
+	require.NoError(t, contractRegistry.Start(ctx))
+	require.NoError(t, functionRegistry.Start(ctx))
+	defer func() {
+		err := contractRegistry.Stop()
+		require.NoError(t, err)
+		err = functionRegistry.Stop()
+		require.NoError(t, err)
+	}()
+
+	var wg sync.WaitGroup
+
+	contractSub, err := eventbus.NewSubscriber(ctx, bus, contract.System, "contract.*", func(evt event.Event) {
+		if evt.Kind == contract.ContractAccept {
+			wg.Done()
+		}
+	})
+	require.NoError(t, err)
+	defer contractSub.Close()
+
+	functionSub, err := eventbus.NewSubscriber(ctx, bus, function.System, "function.*", func(evt event.Event) {
+		if evt.Kind == function.FunctionAccept {
+			wg.Done()
+		}
+	})
+	require.NoError(t, err)
+	defer functionSub.Close()
+
+	// Register function that captures task options
+	funcID := registry.NewID("test", "options_func")
+	var capturedOptions runtime.Options
+	testFunc := function.Func(func(_ context.Context, task runtime.Task) (*runtime.Result, error) {
+		capturedOptions = task.Options
+		return &runtime.Result{Value: payload.New("ok")}, nil
+	})
+
+	wg.Add(1)
+	bus.Send(ctx, event.Event{
+		System: function.System,
+		Kind:   function.FunctionRegister,
+		Path:   funcID.String(),
+		Data:   &function.FuncEntry{Handler: testFunc},
+	})
+	wg.Wait()
+
+	// Register contract and binding
+	contractID := registry.NewID("test", "options_contract")
+	wg.Add(1)
+	bus.Send(ctx, event.Event{
+		System: contract.System,
+		Kind:   contract.RegisterDefinition,
+		Path:   contractID.String(),
+		Data:   &contract.Definition{Methods: []contract.MethodDef{{Name: "run"}}},
+	})
+	wg.Wait()
+
+	bindingID := registry.NewID("test", "options_binding")
+	wg.Add(1)
+	bus.Send(ctx, event.Event{
+		System: contract.System,
+		Kind:   contract.RegisterBinding,
+		Path:   bindingID.String(),
+		Data: &contract.Binding{
+			Contracts: []contract.BoundContract{{
+				Contract: contractID,
+				Methods:  map[string]registry.ID{"run": funcID},
+			}},
+		},
+	})
+	wg.Wait()
+
+	instance, err := instantiator.Instantiate(ctx, bindingID, attrs.Bag{})
+	require.NoError(t, err)
+
+	t.Run("nil options pass through as nil", func(t *testing.T) {
+		capturedOptions = attrs.Bag{"should": "be overwritten"}
+		result, err := instance.Call(ctx, "run", payload.Payloads{}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "ok", result.Value.Data().(string))
+		assert.Nil(t, capturedOptions)
+	})
+
+	t.Run("options pass through to function task", func(t *testing.T) {
+		capturedOptions = nil
+		opts := attrs.Bag{
+			"retry": map[string]any{
+				"max_attempts":   3,
+				"initial_delay":  100,
+				"backoff_factor": 2.0,
+			},
+		}
+		result, err := instance.Call(ctx, "run", payload.Payloads{}, opts)
+		require.NoError(t, err)
+		assert.Equal(t, "ok", result.Value.Data().(string))
+
+		bag, ok := capturedOptions.(attrs.Bag)
+		require.True(t, ok)
+		retryVal, exists := bag["retry"]
+		require.True(t, exists)
+		retryMap := retryVal.(map[string]any)
+		assert.Equal(t, 3, retryMap["max_attempts"])
+		assert.Equal(t, 100, retryMap["initial_delay"])
+		assert.Equal(t, 2.0, retryMap["backoff_factor"])
+	})
 }
 
 func TestInstanceImpl_ContextMerging(t *testing.T) {
@@ -469,7 +584,7 @@ func TestInstanceImpl_ContextMerging(t *testing.T) {
 	instanceNil, err := instantiator.Instantiate(ctx, bindingID, nil)
 	require.NoError(t, err)
 
-	result, err := instanceNil.Call(ctx, "contextMethod", payload.Payloads{})
+	result, err := instanceNil.Call(ctx, "contextMethod", payload.Payloads{}, nil)
 	require.NoError(t, err)
 
 	values := result.Value.Data().(map[string]any)
@@ -490,7 +605,7 @@ func TestInstanceImpl_ContextMerging(t *testing.T) {
 	err = ctxapi.SetValues(callCtx, existing)
 	require.NoError(t, err)
 
-	result, err = instance.Call(callCtx, "contextMethod", payload.Payloads{})
+	result, err = instance.Call(callCtx, "contextMethod", payload.Payloads{}, nil)
 	require.NoError(t, err)
 
 	values = result.Value.Data().(map[string]any)
@@ -605,7 +720,7 @@ func TestInstanceImpl_ScopeContextBehavior(t *testing.T) {
 		instance, err := instantiator.Instantiate(ctx, bindingID, attrs.Bag{})
 		require.NoError(t, err)
 
-		result, err := instance.Call(ctx, "captureMethod", payload.Payloads{})
+		result, err := instance.Call(ctx, "captureMethod", payload.Payloads{}, nil)
 		require.NoError(t, err)
 
 		captured := result.Value.Data().(map[string]any)
@@ -628,7 +743,7 @@ func TestInstanceImpl_ScopeContextBehavior(t *testing.T) {
 		instance, err := instantiator.Instantiate(ctx, bindingID, scope)
 		require.NoError(t, err)
 
-		result, err := instance.Call(ctx, "captureMethod", payload.Payloads{})
+		result, err := instance.Call(ctx, "captureMethod", payload.Payloads{}, nil)
 		require.NoError(t, err)
 
 		captured := result.Value.Data().(map[string]any)
@@ -657,7 +772,7 @@ func TestInstanceImpl_ScopeContextBehavior(t *testing.T) {
 		err = ctxapi.SetValues(callCtx, existing)
 		require.NoError(t, err)
 
-		result, err := instance.Call(callCtx, "captureMethod", payload.Payloads{})
+		result, err := instance.Call(callCtx, "captureMethod", payload.Payloads{}, nil)
 		require.NoError(t, err)
 
 		captured := result.Value.Data().(map[string]any)
@@ -776,7 +891,7 @@ func TestInstanceImpl_ContextValidationIssue(t *testing.T) {
 		require.NoError(t, err, "Instantiation should succeed")
 
 		// Try to call method - this should NOW SUCCEED validation with the fix
-		result, err := instance.Call(callCtx, "requiresOriginId", payload.Payloads{})
+		result, err := instance.Call(callCtx, "requiresOriginId", payload.Payloads{}, nil)
 		require.NoError(t, err, "Call should succeed - validation finds origin_id in Go context")
 
 		// Function should execute and return result
@@ -793,7 +908,7 @@ func TestInstanceImpl_ContextValidationIssue(t *testing.T) {
 		require.NoError(t, err, "Instantiation should succeed")
 
 		// Try to call method - should succeed
-		result, err := instance.Call(callCtx, "requiresOriginId", payload.Payloads{})
+		result, err := instance.Call(callCtx, "requiresOriginId", payload.Payloads{}, nil)
 		require.NoError(t, err, "Call should succeed - validation finds origin_id in scope")
 
 		// Function should execute and return result
@@ -813,7 +928,7 @@ func TestInstanceImpl_ContextValidationIssue(t *testing.T) {
 		require.NoError(t, err, "Instantiation should succeed")
 
 		// Try to call method - should succeed
-		result, err := instance.Call(callCtx, "requiresOriginId", payload.Payloads{})
+		result, err := instance.Call(callCtx, "requiresOriginId", payload.Payloads{}, nil)
 		require.NoError(t, err, "Call should succeed - validation finds origin_id in both places")
 
 		// Function should execute and return result
@@ -830,7 +945,7 @@ func TestInstanceImpl_ContextValidationIssue(t *testing.T) {
 		require.NoError(t, err, "Instantiation should succeed")
 
 		// Try to call method - should fail validation
-		_, err = instance.Call(callCtx, "requiresOriginId", payload.Payloads{})
+		_, err = instance.Call(callCtx, "requiresOriginId", payload.Payloads{}, nil)
 		require.Error(t, err, "Call should fail when origin_id is missing from both places")
 		assert.Contains(t, err.Error(), "missing required context keys: [origin_id]")
 	})

--- a/system/function/interceptor/retry/interceptor.go
+++ b/system/function/interceptor/retry/interceptor.go
@@ -143,6 +143,8 @@ func parsePolicy(opts map[string]any) supervisor.RetryPolicy {
 		switch val := v.(type) {
 		case int:
 			policy.MaxAttempts = val
+		case int64:
+			policy.MaxAttempts = int(val)
 		case float64:
 			policy.MaxAttempts = int(val)
 		}
@@ -179,6 +181,8 @@ func toFloat(v any) float64 {
 		return val
 	case int:
 		return float64(val)
+	case int64:
+		return float64(val)
 	}
 	return 0
 }
@@ -186,6 +190,8 @@ func toFloat(v any) float64 {
 func toDuration(v any) time.Duration {
 	switch val := v.(type) {
 	case int:
+		return time.Duration(val) * time.Millisecond
+	case int64:
 		return time.Duration(val) * time.Millisecond
 	case float64:
 		return time.Duration(val) * time.Millisecond

--- a/tests/app/src/test/contract/_index.yaml
+++ b/tests/app/src/test/contract/_index.yaml
@@ -221,3 +221,69 @@ entries:
       assert2: app.lib:assert
     modules:
       - contract
+
+  # Flaky contract for retry testing
+  - name: flaky
+    kind: contract.definition
+    meta:
+      comment: Contract with flaky and permanent-fail methods for retry testing
+    methods:
+      - name: flaky_call
+        description: Fails first 2 times, succeeds on 3rd
+      - name: permanent_fail
+        description: Always fails with non-retryable error
+      - name: always_fail
+        description: Always fails with retryable error
+
+  - name: flaky_call_func
+    kind: function.lua
+    meta:
+      comment: Flaky function implementation
+    source: file://flaky_call.lua
+    method: main
+    modules:
+      - store
+
+  - name: permanent_fail_func
+    kind: function.lua
+    meta:
+      comment: Always fails with non-retryable PermissionDenied
+    source: file://permanent_fail.lua
+    method: main
+    modules:
+      - store
+
+  - name: always_fail_func
+    kind: function.lua
+    meta:
+      comment: Always fails with retryable Unavailable
+    source: file://always_fail.lua
+    method: main
+    modules:
+      - store
+
+  - name: flaky_impl
+    kind: contract.binding
+    meta:
+      comment: Flaky contract binding for retry testing
+    contracts:
+      - contract: app.test.contract:flaky
+        default: true
+        methods:
+          flaky_call: app.test.contract:flaky_call_func
+          permanent_fail: app.test.contract:permanent_fail_func
+          always_fail: app.test.contract:always_fail_func
+
+  - name: with_options
+    kind: function.lua
+    meta:
+      type: test
+      suite: contract
+      description: contract with_options and retry behavior
+    source: file://with_options.lua
+    method: main
+    imports:
+      assert2: app.lib:assert
+    modules:
+      - contract
+      - store

--- a/tests/app/src/test/contract/always_fail.lua
+++ b/tests/app/src/test/contract/always_fail.lua
@@ -1,0 +1,22 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+local store = require("store")
+
+local function main()
+	local s, err = store.get("app.test.store:memory")
+	if err then
+		return nil, err
+	end
+
+	local count = s:get("always_fail_count") or 0
+	count = count + 1
+	s:set("always_fail_count", count)
+
+	return nil, errors.new({
+		message = "always fails (attempt " .. count .. ")",
+		kind = errors.UNAVAILABLE,
+		retryable = true,
+	})
+end
+
+return { main = main }

--- a/tests/app/src/test/contract/flaky_call.lua
+++ b/tests/app/src/test/contract/flaky_call.lua
@@ -1,0 +1,26 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+local store = require("store")
+
+local function main()
+	local s, err = store.get("app.test.store:memory")
+	if err then
+		return nil, err
+	end
+
+	local count = s:get("flaky_call_count") or 0
+	count = count + 1
+	s:set("flaky_call_count", count)
+
+	if count < 3 then
+		return nil, errors.new({
+			message = "temporary failure (attempt " .. count .. ")",
+			kind = errors.UNAVAILABLE,
+			retryable = true,
+		})
+	end
+
+	return "success_after_" .. count .. "_attempts"
+end
+
+return { main = main }

--- a/tests/app/src/test/contract/permanent_fail.lua
+++ b/tests/app/src/test/contract/permanent_fail.lua
@@ -1,0 +1,22 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+local store = require("store")
+
+local function main()
+	local s, err = store.get("app.test.store:memory")
+	if err then
+		return nil, err
+	end
+
+	local count = s:get("permanent_fail_count") or 0
+	count = count + 1
+	s:set("permanent_fail_count", count)
+
+	return nil, errors.new({
+		message = "permission denied",
+		kind = errors.PERMISSION_DENIED,
+		retryable = false,
+	})
+end
+
+return { main = main }

--- a/tests/app/src/test/contract/with_options.lua
+++ b/tests/app/src/test/contract/with_options.lua
@@ -1,0 +1,135 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+local assert = require("assert2")
+local contract = require("contract")
+local store = require("store")
+
+local function main()
+	local s, err = store.get("app.test.store:memory")
+	assert.is_nil(err, "store.get no error")
+
+	local c, err = contract.get("app.test.contract:flaky")
+	assert.is_nil(err, "get flaky contract no error")
+
+	-- 1. Retry succeeds after transient failures (wrapper with_options)
+	s:set("flaky_call_count", 0)
+
+	local inst, err = c
+		:with_options({retry = {max_attempts = 5, initial_delay = 1}})
+		:open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "open with retry options no error")
+
+	local result, err = inst:flaky_call()
+	assert.is_nil(err, "flaky_call succeeds after retries")
+	assert.eq(result, "success_after_3_attempts", "correct result after retry")
+	assert.eq(s:get("flaky_call_count"), 3, "called 3 times via retry")
+
+	-- 2. No options means no retry
+	s:set("flaky_call_count", 0)
+
+	local plain, err = contract.open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "open without options no error")
+
+	local result2, err2 = plain:flaky_call()
+	assert.not_nil(err2, "fails without retry")
+	assert.is_nil(result2, "no result on failure")
+	assert.eq(err2:kind(), "Unavailable", "error kind preserved")
+	assert.eq(err2:retryable(), true, "error is retryable")
+	assert.eq(s:get("flaky_call_count"), 1, "called once without retry")
+
+	-- 3. Non-retryable error skips retry despite options
+	s:set("permanent_fail_count", 0)
+
+	local result3, err3 = inst:permanent_fail()
+	assert.not_nil(err3, "permanent_fail returns error")
+	assert.is_nil(result3, "no result on permanent failure")
+	assert.eq(err3:kind(), "PermissionDenied", "non-retryable kind preserved")
+	assert.eq(err3:retryable(), false, "error marked non-retryable")
+	assert.eq(s:get("permanent_fail_count"), 1, "non-retryable called once")
+
+	-- 4. Exhausted retries surface the last error
+	s:set("always_fail_count", 0)
+
+	local inst2, err = c
+		:with_options({retry = {max_attempts = 3, initial_delay = 1}})
+		:open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "open for exhausted test no error")
+
+	local result4, err4 = inst2:always_fail()
+	assert.not_nil(err4, "always_fail returns error after exhausting retries")
+	assert.is_nil(result4, "no result when retries exhausted")
+	assert.eq(s:get("always_fail_count"), 3, "called max_attempts times before giving up")
+
+	-- 5. max_attempts = 1 behaves like no retry
+	s:set("always_fail_count", 0)
+
+	local inst3, err = c
+		:with_options({retry = {max_attempts = 1, initial_delay = 1}})
+		:open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "open with max_attempts=1 no error")
+
+	local result5, err5 = inst3:always_fail()
+	assert.not_nil(err5, "max_attempts=1 fails immediately")
+	assert.eq(s:get("always_fail_count"), 1, "max_attempts=1 called only once")
+
+	-- 6. Empty options table does not crash, no retry
+	s:set("flaky_call_count", 0)
+
+	local inst4, err = c
+		:with_options({})
+		:open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "open with empty options no error")
+
+	local result6, err6 = inst4:flaky_call()
+	assert.not_nil(err6, "empty options means no retry")
+	assert.eq(s:get("flaky_call_count"), 1, "empty options called once")
+
+	-- 7. contract.open direct with options as third arg
+	s:set("flaky_call_count", 0)
+
+	local inst5, err = contract.open("app.test.contract:flaky_impl", {}, {
+		retry = {max_attempts = 5, initial_delay = 1}
+	})
+	assert.is_nil(err, "direct open with options no error")
+
+	local result7, err7 = inst5:flaky_call()
+	assert.is_nil(err7, "direct open retry succeeds")
+	assert.eq(result7, "success_after_3_attempts", "direct open correct result")
+	assert.eq(s:get("flaky_call_count"), 3, "direct open retried 3 times")
+
+	-- 8. Options apply to multiple method calls on same instance
+	s:set("flaky_call_count", 0)
+	s:set("always_fail_count", 0)
+
+	local inst6, err = c
+		:with_options({retry = {max_attempts = 5, initial_delay = 1}})
+		:open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "open for multi-method no error")
+
+	local r8a, err8a = inst6:flaky_call()
+	assert.is_nil(err8a, "first method retries and succeeds")
+	assert.eq(r8a, "success_after_3_attempts", "first method result correct")
+	assert.eq(s:get("flaky_call_count"), 3, "first method retried")
+
+	local r8b, err8b = inst6:always_fail()
+	assert.not_nil(err8b, "second method exhausts retries")
+	assert.eq(s:get("always_fail_count"), 5, "second method used all 5 attempts")
+
+	-- 9. with_options chains with with_context
+	s:set("flaky_call_count", 0)
+
+	local inst7, err = c
+		:with_context({some_key = "some_value"})
+		:with_options({retry = {max_attempts = 5, initial_delay = 1}})
+		:open("app.test.contract:flaky_impl")
+	assert.is_nil(err, "chained with_context + with_options no error")
+
+	local r9, err9 = inst7:flaky_call()
+	assert.is_nil(err9, "chained options retry works")
+	assert.eq(r9, "success_after_3_attempts", "chained result correct")
+	assert.eq(s:get("flaky_call_count"), 3, "chained retried correctly")
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/contract/with_options.lua
+++ b/tests/app/src/test/contract/with_options.lua
@@ -84,7 +84,7 @@ local function main()
 	assert.not_nil(err6, "empty options means no retry")
 	assert.eq(s:get("flaky_call_count"), 1, "empty options called once")
 
-	-- 7. contract.open direct with options as third arg
+	-- 7. contract.open direct with options as third arg (empty scope)
 	s:set("flaky_call_count", 0)
 
 	local inst5, err = contract.open("app.test.contract:flaky_impl", {}, {
@@ -96,6 +96,19 @@ local function main()
 	assert.is_nil(err7, "direct open retry succeeds")
 	assert.eq(result7, "success_after_3_attempts", "direct open correct result")
 	assert.eq(s:get("flaky_call_count"), 3, "direct open retried 3 times")
+
+	-- 7b. contract.open direct with nil scope and options
+	s:set("flaky_call_count", 0)
+
+	local inst5b, err = contract.open("app.test.contract:flaky_impl", nil, {
+		retry = {max_attempts = 5, initial_delay = 1}
+	})
+	assert.is_nil(err, "direct open nil scope with options no error")
+
+	local result7b, err7b = inst5b:flaky_call()
+	assert.is_nil(err7b, "direct open nil scope retry succeeds")
+	assert.eq(result7b, "success_after_3_attempts", "direct open nil scope correct result")
+	assert.eq(s:get("flaky_call_count"), 3, "direct open nil scope retried 3 times")
 
 	-- 8. Options apply to multiple method calls on same instance
 	s:set("flaky_call_count", 0)


### PR DESCRIPTION
Wire runtime options (retry, etc.) through the contract call path so interceptors run on contract method calls the same way they do on direct function calls.

API: Instance.Call accepts runtime.Options, CallCmd/AsyncCallCmd carry Options field, Wrapper gets with_options (mirrors with_context pattern), contract.open accepts options as third arg.

Fix retry interceptor parsePolicy to handle int64 from Lua integers.

<!-- SPDX-License-Identifier: MPL-2.0 -->