### PR TITLE
cli: honor logger.encoding json from .wippy.yaml in bootstrap logger

### DIFF
--- a/cmd/internal/logger/logger.go
+++ b/cmd/internal/logger/logger.go
@@ -52,6 +52,10 @@ type Config struct {
 	VeryVerbose  bool
 	Console      bool
 	Silent       bool
+	// Encoding selects the zap encoder. "" | "console" (default, humanized)
+	// or "json" for machine-parseable structured logs. The --console CLI
+	// flag and encoding from .wippy.yaml logger.encoding both feed into this.
+	Encoding string
 }
 
 func consoleTimeEncoder(startTime time.Time) zapcore.TimeEncoder {
@@ -95,7 +99,11 @@ func CreateLogger(cfg Config) (*zap.Logger, error) {
 
 	var zapCfg zap.Config
 
-	if cfg.Console {
+	// Console flag takes precedence (legacy -c behavior); otherwise
+	// honor Encoding from config. Empty Encoding falls back to
+	// development console output for readability.
+	switch {
+	case cfg.Console:
 		zapCfg = zap.Config{
 			Level:       zap.NewAtomicLevelAt(zapcore.InfoLevel),
 			Development: true,
@@ -116,7 +124,18 @@ func CreateLogger(cfg Config) (*zap.Logger, error) {
 			OutputPaths:      []string{"stdout"},
 			ErrorOutputPaths: []string{"stderr"},
 		}
-	} else {
+	case cfg.Encoding == "json":
+		zapCfg = zap.NewProductionConfig()
+		zapCfg.EncoderConfig.TimeKey = "ts"
+		zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		zapCfg.EncoderConfig.EncodeLevel = zapcore.LowercaseLevelEncoder
+		zapCfg.EncoderConfig.EncodeCaller = nil
+		zapCfg.EncoderConfig.CallerKey = ""
+		zapCfg.DisableCaller = true
+		zapCfg.DisableStacktrace = true
+		zapCfg.OutputPaths = []string{"stdout"}
+		zapCfg.ErrorOutputPaths = []string{"stderr"}
+	default:
 		zapCfg = zap.NewDevelopmentConfig()
 		zapCfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.DateTime)
 		zapCfg.DisableCaller = true

--- a/cmd/internal/logger/logger.go
+++ b/cmd/internal/logger/logger.go
@@ -48,14 +48,14 @@ var (
 
 type Config struct {
 	AppStartTime time.Time
-	Verbose      bool
-	VeryVerbose  bool
-	Console      bool
-	Silent       bool
 	// Encoding selects the zap encoder. "" | "console" (default, humanized)
 	// or "json" for machine-parseable structured logs. The --console CLI
 	// flag and encoding from .wippy.yaml logger.encoding both feed into this.
-	Encoding string
+	Encoding    string
+	Verbose     bool
+	VeryVerbose bool
+	Console     bool
+	Silent      bool
 }
 
 func consoleTimeEncoder(startTime time.Time) zapcore.TimeEncoder {

--- a/cmd/wippy/cmd/logger_helpers.go
+++ b/cmd/wippy/cmd/logger_helpers.go
@@ -4,11 +4,17 @@ package cmd
 
 import (
 	clilogger "github.com/wippyai/runtime/cmd/internal/logger"
+	"github.com/wippyai/runtime/cmd/internal/bootconfig"
 	"go.uber.org/zap"
 )
 
 // createCommandLogger is the single logger-construction path for command
 // execution flows. It keeps CLI flags -> logger config mapping consistent.
+//
+// Logger encoding resolution (highest precedence first):
+//  1. --console / -c flag (humanized console)
+//  2. logger.encoding from .wippy.yaml (canonical config)
+//  3. development console default
 func createCommandLogger() (*zap.Logger, error) {
 	return clilogger.CreateLogger(clilogger.Config{
 		Verbose:      verbose,
@@ -16,5 +22,22 @@ func createCommandLogger() (*zap.Logger, error) {
 		Console:      console,
 		Silent:       silentLogs,
 		AppStartTime: appStartTime,
+		Encoding:     preloadLoggerEncoding(),
 	})
+}
+
+// preloadLoggerEncoding peeks the config file (if present) for the
+// logger.encoding key so the CLI bootstrap logger can emit structured
+// JSON from the first line. Returns "" on any failure — the caller
+// falls back to the humanized development encoder.
+func preloadLoggerEncoding() string {
+	path := configFile
+	if path == "" {
+		path = defaultConfigFile
+	}
+	cfg, err := bootconfig.Load(path)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.GetString("logger.encoding", "")
 }

--- a/cmd/wippy/cmd/logger_helpers.go
+++ b/cmd/wippy/cmd/logger_helpers.go
@@ -3,8 +3,8 @@
 package cmd
 
 import (
-	clilogger "github.com/wippyai/runtime/cmd/internal/logger"
 	"github.com/wippyai/runtime/cmd/internal/bootconfig"
+	clilogger "github.com/wippyai/runtime/cmd/internal/logger"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
## Summary

- Canonical config key `logger.encoding` was parsed into `boot.Config` but never read by the CLI bootstrap logger — all startup output (registry load, bootloader, service init) was console text regardless of config
- Bootstrap logger now reads `logger.encoding` from `.wippy.yaml` via `bootconfig.Load(configFile)` before `CreateLogger` runs, and switches to a JSON encoder when `encoding: json`
- `--console`/`-c` still wins (humanized elapsed-time format for interactive use). `--silent`/`-s` unchanged. Default remains development console

## Why

Structured-log consumers (test harnesses, log shippers, eval/GRPO pipelines) need machine-parseable boot output from line one. Until now you could set `logger.encoding: json` and nothing would happen — the key was dead. This wires it end-to-end.

Verified locally: `logger.encoding: json` in `.wippy.yaml` now produces zap JSON lines like:

```json
{"level":"info","ts":"2026-04-14T18:27:13.708-0400","msg":"initializing runtime","memory_limit":"1.0GB"}
{"level":"info","ts":"2026-04-14T18:27:13.708-0400","logger":"run","msg":"infrastructure initialized"}
```

Level is lowercase, timestamps are ISO8601, structured fields flow through from `zap.Field` calls (e.g. `error`, `operation`, `serviceID`).

## Test plan

- [x] Local smoke: `.wippy.yaml` with `encoding: json` → JSON lines from first log onward
- [x] Local smoke: `.wippy.yaml` with `encoding: console` (or unset) → unchanged human output
- [x] `-c` flag still produces humanized elapsed-time console
- [x] `-s` still suppresses all output
- [x] Consumed downstream by a structured log parser (eval harness) — boot errors parsed with stable `level`/`logger`/`msg`/`error` fields
- [ ] CI tests green on target branch