### PR TITLE
Map MySQL registry kind to "mysql" driver name

### DIFF
--- a/service/sql/conn.go
+++ b/service/sql/conn.go
@@ -185,9 +185,9 @@ func buildDSN(kind registry.Kind, cfg *config.DBConfig) (string, error) {
 func getDriver(kind registry.Kind) string {
 	switch kind {
 	case config.Postgres:
-
 		return "postgres"
-
+	case config.MySQL:
+		return "mysql"
 	default:
 		return kind
 	}

--- a/service/sql/conn_test.go
+++ b/service/sql/conn_test.go
@@ -364,7 +364,7 @@ func TestBuildOptionsString(t *testing.T) {
 
 func TestGetDriver(t *testing.T) {
 	assert.Equal(t, "postgres", getDriver(apiconfig.Postgres))
-	assert.Equal(t, apiconfig.MySQL, getDriver(apiconfig.MySQL))
+	assert.Equal(t, "mysql", getDriver(apiconfig.MySQL))
 	assert.Equal(t, "unknown", getDriver("unknown"))
 }
 


### PR DESCRIPTION
## Summary
- `getDriver()` in `service/sql/conn.go` only mapped `db.sql.postgres` to a real Go `database/sql` driver name (`"postgres"`); all other kinds (MySQL, MSSQL, Oracle) fell through to the default case and returned the kind string itself.
- Opening a `db.sql.mysql` pool therefore failed with `sql: unknown driver "db.sql.mysql" (forgotten import?)`, even though `go-sql-driver/mysql` is blank-imported in `cmd/wippy/main.go` and registers itself as `"mysql"`.
- Adds the `MySQL` case so `sql.Open` receives `"mysql"`. SQLite is unaffected — it goes through `CreateSQLitePool` which hardcodes `"sqlite3"`.
- Updates `TestGetDriver`, which had been locking in the buggy behavior.

## Test plan
- [x] `go test ./service/sql/...` passes locally
- [ ] Verify a real `db.sql.mysql` entry connects end-to-end after rebuild