### PR TITLE
wippy auth login --ssh + clearer private-module errors

### DIFF
--- a/boot/deps/auth/ssh.go
+++ b/boot/deps/auth/ssh.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wippyai/runtime/api/version"
+	"golang.org/x/crypto/ssh"
+)
+
+// EnvSSHKey lets the user point publish/install/run flows at a private SSH
+// key without first running 'wippy auth login'. Useful for ephemeral CI
+// runners that already have a deploy key on disk.
+const EnvSSHKey = "WIPPY_SSH_KEY"
+
+// SSHAuthEndpoint is the runtime CLI's view of the hub's SSH challenge
+// endpoint. The hub forwards the result to the auth-service and returns a
+// short-lived JWT (1h TTL).
+const SSHAuthEndpoint = "/api/v1/ssh/auth"
+
+// defaultSSHKeyCandidates lists the conventional locations that
+// 'wippy auth login --ssh' probes when the user does not pass --key.
+// Order matters: ed25519 first (modern default), then ecdsa, then rsa.
+var defaultSSHKeyCandidates = []string{
+	"id_ed25519",
+	"id_ecdsa",
+	"id_rsa",
+}
+
+// SSHKeyFromEnv returns the value of WIPPY_SSH_KEY, expanding ~ to the
+// user's home directory.
+func SSHKeyFromEnv() string {
+	return expandHome(os.Getenv(EnvSSHKey))
+}
+
+// FindDefaultSSHKey returns the first existing key under ~/.ssh that the CLI
+// will probe automatically. The empty string means "no usable key found".
+func FindDefaultSSHKey() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	for _, name := range defaultSSHKeyCandidates {
+		path := filepath.Join(home, ".ssh", name)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// PassphrasePrompter resolves a passphrase for an encrypted private key.
+// Implementations typically read from the controlling terminal.
+type PassphrasePrompter func(keyPath string) ([]byte, error)
+
+// SSHSigner pairs a parsed private key with its public-key fingerprint.
+type SSHSigner struct {
+	signer      ssh.Signer
+	fingerprint string
+	keyPath     string
+}
+
+// LoadSSHSigner reads and decodes an SSH private key. Encrypted keys trigger
+// the prompter (which is allowed to be nil — in that case encrypted keys
+// fail with an explanatory error). The returned signer can sign arbitrary
+// challenges for the hub's /api/v1/ssh/auth handshake.
+func LoadSSHSigner(keyPath string, prompter PassphrasePrompter) (*SSHSigner, error) {
+	keyPath = expandHome(keyPath)
+	pemBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ssh key %q: %w", keyPath, err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(pemBytes)
+	if err == nil {
+		return newSSHSigner(signer, keyPath), nil
+	}
+
+	var passErr *ssh.PassphraseMissingError
+	if !errors.As(err, &passErr) {
+		return nil, fmt.Errorf("parse ssh key %q: %w", keyPath, err)
+	}
+
+	if prompter == nil {
+		return nil, fmt.Errorf("ssh key %q is encrypted; pass a passphrase prompter", keyPath)
+	}
+
+	pass, err := prompter(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read passphrase for %q: %w", keyPath, err)
+	}
+
+	signer, err = ssh.ParsePrivateKeyWithPassphrase(pemBytes, pass)
+	if err != nil {
+		return nil, fmt.Errorf("parse encrypted ssh key %q: %w", keyPath, err)
+	}
+	return newSSHSigner(signer, keyPath), nil
+}
+
+func newSSHSigner(signer ssh.Signer, keyPath string) *SSHSigner {
+	return &SSHSigner{
+		signer:      signer,
+		fingerprint: sshFingerprint(signer.PublicKey()),
+		keyPath:     keyPath,
+	}
+}
+
+// Fingerprint returns the SHA256 fingerprint of the public key in the
+// canonical openssh form ("SHA256:<base64>"). The hub indexes registered
+// keys by this value.
+func (s *SSHSigner) Fingerprint() string { return s.fingerprint }
+
+// KeyPath returns the absolute path the signer was loaded from.
+func (s *SSHSigner) KeyPath() string { return s.keyPath }
+
+// SSHAuthResult is the runtime CLI's view of /api/v1/ssh/auth's response.
+type SSHAuthResult struct {
+	ExpiresAt time.Time
+	Token     string
+}
+
+// ExchangeSSHForToken performs a challenge-response handshake against the
+// hub's SSH auth endpoint and returns the resulting Bearer JWT.
+//
+// The challenge is a random 32-byte payload prefixed with a length-tagged
+// "wippy-ssh-auth\0" domain separator and the current Unix timestamp, so
+// the auth-service can reject stale challenges if it ever wants to (today
+// it doesn't, but the format leaves room).
+func ExchangeSSHForToken(ctx context.Context, registryURL string, signer *SSHSigner) (*SSHAuthResult, error) {
+	if signer == nil {
+		return nil, errors.New("ssh signer is nil")
+	}
+	if err := requireHTTPS(registryURL); err != nil {
+		return nil, err
+	}
+
+	challenge, err := buildChallenge()
+	if err != nil {
+		return nil, fmt.Errorf("build challenge: %w", err)
+	}
+
+	sig, err := signer.signer.Sign(rand.Reader, challenge)
+	if err != nil {
+		return nil, fmt.Errorf("sign challenge: %w", err)
+	}
+
+	body := map[string]string{
+		"fingerprint": signer.fingerprint,
+		"signature":   base64.StdEncoding.EncodeToString(ssh.Marshal(sig)),
+		"challenge":   base64.StdEncoding.EncodeToString(challenge),
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	endpoint := strings.TrimSuffix(registryURL, "/") + SSHAuthEndpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "wippy-cli/"+version.Version)
+
+	resp, err := sshClientForRequest().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ssh auth request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("read ssh auth response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		msg := strings.TrimSpace(string(respBody))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("ssh auth failed (status %d): %s", resp.StatusCode, msg)
+	}
+
+	var parsed struct {
+		Token     string `json:"token"`
+		ExpiresIn int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("decode ssh auth response: %w", err)
+	}
+	if parsed.Token == "" {
+		return nil, errors.New("ssh auth response missing token")
+	}
+
+	expiresAt := time.Time{}
+	if parsed.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
+	}
+	return &SSHAuthResult{Token: parsed.Token, ExpiresAt: expiresAt}, nil
+}
+
+func sshFingerprint(pub ssh.PublicKey) string {
+	sum := sha256.Sum256(pub.Marshal())
+	return "SHA256:" + base64.RawStdEncoding.EncodeToString(sum[:])
+}
+
+// buildChallenge produces 32 bytes of random material framed with a domain
+// separator and a Unix timestamp. The hub treats it as opaque bytes today;
+// the framing keeps the door open to add freshness/replay checks server-side
+// without breaking older clients.
+func buildChallenge() ([]byte, error) {
+	const tag = "wippy-ssh-auth\x00"
+	now := time.Now().Unix()
+
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 0, len(tag)+8+len(nonce))
+	buf = append(buf, tag...)
+	buf = binary.BigEndian.AppendUint64(buf, uint64(now))
+	buf = append(buf, nonce...)
+	return buf, nil
+}
+
+func requireHTTPS(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid registry URL %q: %w", rawURL, err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	host := u.Hostname()
+	if u.Scheme == "http" && (host == "localhost" || host == "127.0.0.1") {
+		return nil
+	}
+	return fmt.Errorf("registry %q must use HTTPS for ssh auth", rawURL)
+}
+
+func sshHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: clientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		},
+	}
+}
+
+// sshClientForRequest is the seam tests swap so they can talk to an
+// httptest.NewTLSServer (whose self-signed cert is only trusted by its
+// associated client). Production code keeps using sshHTTPClient.
+var sshClientForRequest = sshHTTPClient
+
+func expandHome(path string) string {
+	if path == "" || !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}

--- a/boot/deps/auth/ssh_test.go
+++ b/boot/deps/auth/ssh_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// writeUnencryptedED25519Key writes a fresh ed25519 OpenSSH-format private
+// key to disk and returns the path plus its expected SHA256 fingerprint.
+func writeUnencryptedED25519Key(t *testing.T) (string, string) {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	pemBlock, err := ssh.MarshalPrivateKey(priv, "")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(pemBlock), 0600))
+
+	signer, err := ssh.ParsePrivateKey(pem.EncodeToMemory(pemBlock))
+	require.NoError(t, err)
+	return keyPath, sshFingerprint(signer.PublicKey())
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, home, expandHome("~"))
+	assert.Equal(t, filepath.Join(home, ".ssh", "id_rsa"), expandHome("~/.ssh/id_rsa"))
+	assert.Equal(t, "/etc/passwd", expandHome("/etc/passwd"))
+	assert.Equal(t, "", expandHome(""))
+}
+
+func TestRequireHTTPS(t *testing.T) {
+	assert.NoError(t, requireHTTPS("https://hub.wippy.ai"))
+	assert.NoError(t, requireHTTPS("http://localhost:8080"))
+	assert.NoError(t, requireHTTPS("http://127.0.0.1:8080"))
+	assert.Error(t, requireHTTPS("http://hub.wippy.ai"))
+	assert.Error(t, requireHTTPS("ftp://hub.wippy.ai"))
+}
+
+func TestBuildChallenge_FormatAndUniqueness(t *testing.T) {
+	first, err := buildChallenge()
+	require.NoError(t, err)
+	second, err := buildChallenge()
+	require.NoError(t, err)
+
+	// 15 bytes "wippy-ssh-auth\0" + 8 bytes timestamp + 32 bytes nonce.
+	assert.Equal(t, 15+8+32, len(first))
+	assert.True(t, strings.HasPrefix(string(first), "wippy-ssh-auth\x00"))
+	assert.NotEqual(t, first, second, "challenge nonce must differ between calls")
+}
+
+func TestLoadSSHSigner(t *testing.T) {
+	keyPath, fingerprint := writeUnencryptedED25519Key(t)
+
+	signer, err := LoadSSHSigner(keyPath, nil)
+	require.NoError(t, err)
+	assert.Equal(t, fingerprint, signer.Fingerprint())
+	assert.Equal(t, keyPath, signer.KeyPath())
+}
+
+func TestLoadSSHSigner_FileMissing(t *testing.T) {
+	_, err := LoadSSHSigner(filepath.Join(t.TempDir(), "missing"), nil)
+	require.Error(t, err)
+}
+
+func TestExchangeSSHForToken_HappyPath(t *testing.T) {
+	keyPath, fingerprint := writeUnencryptedED25519Key(t)
+
+	var receivedFingerprint string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != SSHAuthEndpoint {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var body struct {
+			Fingerprint string `json:"fingerprint"`
+			Signature   string `json:"signature"`
+			Challenge   string `json:"challenge"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		receivedFingerprint = body.Fingerprint
+
+		// Verify the signature with the registered public key — exactly what
+		// the auth-service does on the production path.
+		serverSigner, err := parseSignerForTest(keyPath)
+		require.NoError(t, err)
+
+		challenge, err := base64.StdEncoding.DecodeString(body.Challenge)
+		require.NoError(t, err)
+		sigBytes, err := base64.StdEncoding.DecodeString(body.Signature)
+		require.NoError(t, err)
+
+		var sig ssh.Signature
+		require.NoError(t, ssh.Unmarshal(sigBytes, &sig))
+		require.NoError(t, serverSigner.PublicKey().Verify(challenge, &sig))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "issued-jwt",
+			"expires_in": 3600,
+		})
+	}))
+	defer srv.Close()
+
+	signer, err := LoadSSHSigner(keyPath, nil)
+	require.NoError(t, err)
+
+	res, err := exchangeWithClient(context.Background(), srv.URL, signer, srv.Client())
+	require.NoError(t, err)
+	assert.Equal(t, "issued-jwt", res.Token)
+	assert.WithinDuration(t, time.Now().Add(time.Hour), res.ExpiresAt, 5*time.Second)
+	assert.Equal(t, fingerprint, receivedFingerprint)
+}
+
+func TestExchangeSSHForToken_Unauthorized(t *testing.T) {
+	keyPath, _ := writeUnencryptedED25519Key(t)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	signer, err := LoadSSHSigner(keyPath, nil)
+	require.NoError(t, err)
+
+	_, err = exchangeWithClient(context.Background(), srv.URL, signer, srv.Client())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func parseSignerForTest(path string) (ssh.Signer, error) {
+	pemBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.ParsePrivateKey(pemBytes)
+}
+
+// exchangeWithClient swaps the ssh-auth HTTP client for the duration of the
+// call so tests can talk to httptest.NewTLSServer's in-memory cert.
+func exchangeWithClient(ctx context.Context, registryURL string, signer *SSHSigner, client *http.Client) (*SSHAuthResult, error) {
+	prev := sshClientForRequest
+	sshClientForRequest = func() *http.Client { return client }
+	defer func() { sshClientForRequest = prev }()
+	return ExchangeSSHForToken(ctx, registryURL, signer)
+}

--- a/boot/deps/auth/store.go
+++ b/boot/deps/auth/store.go
@@ -3,6 +3,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// refreshSkew is the safety margin applied when checking JWT expiry: we
+// refresh the token if it expires within this window so a /resolve→/download
+// pair doesn't straddle the boundary.
+const refreshSkew = 30 * time.Second
+
 // StoredCredential is the on-disk representation of a credential.
 type StoredCredential struct {
 	ExpiresAt time.Time `yaml:"expires_at,omitempty"`
@@ -22,7 +28,12 @@ type StoredCredential struct {
 	UserID    string    `yaml:"user_id,omitempty"`
 	Username  string    `yaml:"username,omitempty"`
 	Scope     string    `yaml:"scope,omitempty"`
-	Orgs      []string  `yaml:"orgs,omitempty"`
+	// SSHKeyPath records the SSH private key used to mint a short-lived JWT.
+	// Set when the credential came from 'wippy auth login --ssh' so the store
+	// can transparently refresh the token on expiry instead of forcing the
+	// user to re-authenticate every hour.
+	SSHKeyPath string   `yaml:"ssh_key_path,omitempty"`
+	Orgs       []string `yaml:"orgs,omitempty"`
 }
 
 // ToCredential converts to the api/auth.Credential type.
@@ -71,13 +82,15 @@ func NewStore(cfg *Config) *Store {
 }
 
 // Get returns the credential for the registry.
-// Resolution: env → local → global.
+// Resolution: env → local → global. When a stored credential carries an
+// SSH key reference and is expired (or about to expire), Get transparently
+// refreshes the token by replaying the SSH challenge handshake.
 func (s *Store) Get(registry string) (*auth.Credential, error) {
 	if registry == "" {
 		registry = s.DefaultRegistry()
 	}
 
-	// Environment override
+	// Environment override — explicit token wins.
 	if token := TokenFromEnv(); token != "" {
 		return &auth.Credential{
 			Token:    token,
@@ -85,27 +98,126 @@ func (s *Store) Get(registry string) (*auth.Credential, error) {
 		}, nil
 	}
 
+	// Environment override — SSH key. Mint a fresh JWT on every call; the
+	// token is never persisted because the env-driven flow is for ephemeral
+	// runners that have no writable home directory anyway.
+	if keyPath := SSHKeyFromEnv(); keyPath != "" {
+		cred, err := s.refreshFromSSH(context.Background(), registry, keyPath)
+		if err == nil {
+			return cred, nil
+		}
+		// Fall through to disk-based credentials so a misconfigured env var
+		// doesn't lock the user out when valid credentials still exist.
+	}
+
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	cred, path, stored := s.loadStoredCredential(registry)
+	s.mu.RUnlock()
 
-	// Local credentials
-	if cred := s.loadCredential(s.config.LocalPath(), registry); cred != nil {
-		return cred, nil
+	if cred == nil {
+		return nil, auth.ErrNotAuthenticated
 	}
 
-	// Global credentials
-	if cred := s.loadCredential(s.config.GlobalPath(), registry); cred != nil {
-		return cred, nil
+	if needsRefresh(stored) {
+		refreshed, err := s.refreshFromStored(context.Background(), registry, path, stored)
+		if err == nil {
+			return refreshed, nil
+		}
+		if !cred.IsExpired() {
+			// Refresh failed but the cached token is still technically valid —
+			// hand it out and let the caller decide if the eventual 401 is fatal.
+			return cred, nil
+		}
+		return nil, fmt.Errorf("refresh ssh credential for %s: %w", registry, err)
+	}
+	return cred, nil
+}
+
+// loadStoredCredential walks local→global and returns the first match
+// alongside the file path it was loaded from (so callers can write back).
+func (s *Store) loadStoredCredential(registry string) (*auth.Credential, string, *StoredCredential) {
+	for _, path := range []string{s.config.LocalPath(), s.config.GlobalPath()} {
+		file, err := s.loadFile(path)
+		if err != nil || file == nil {
+			continue
+		}
+		stored, ok := file.Credentials[registry]
+		if !ok || stored == nil {
+			continue
+		}
+		return stored.ToCredential(), path, stored
+	}
+	return nil, "", nil
+}
+
+func needsRefresh(stored *StoredCredential) bool {
+	if stored == nil || stored.SSHKeyPath == "" || stored.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().Add(refreshSkew).After(stored.ExpiresAt)
+}
+
+func (s *Store) refreshFromStored(ctx context.Context, registry, path string, stored *StoredCredential) (*auth.Credential, error) {
+	signer, err := LoadSSHSigner(stored.SSHKeyPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := ExchangeSSHForToken(ctx, registry, signer)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, auth.ErrNotAuthenticated
+	cred := &auth.Credential{
+		Token:     result.Token,
+		Registry:  registry,
+		UserID:    stored.UserID,
+		Username:  stored.Username,
+		Scope:     auth.Scope(stored.Scope),
+		Orgs:      stored.Orgs,
+		ExpiresAt: result.ExpiresAt,
+	}
+
+	// Persist refresh so concurrent commands don't all redial.
+	updated := FromCredential(cred)
+	updated.SSHKeyPath = stored.SSHKeyPath
+	updated.CreatedAt = stored.CreatedAt
+	if err := s.writeStored(path, updated); err != nil {
+		return cred, fmt.Errorf("persist refreshed token: %w", err)
+	}
+	return cred, nil
+}
+
+// refreshFromSSH performs an unstored SSH→JWT exchange driven entirely by
+// env vars. Used when WIPPY_SSH_KEY is set.
+func (s *Store) refreshFromSSH(ctx context.Context, registry, keyPath string) (*auth.Credential, error) {
+	signer, err := LoadSSHSigner(keyPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := ExchangeSSHForToken(ctx, registry, signer)
+	if err != nil {
+		return nil, err
+	}
+	return &auth.Credential{
+		Token:     result.Token,
+		Registry:  registry,
+		ExpiresAt: result.ExpiresAt,
+	}, nil
 }
 
 // Set stores a credential.
 func (s *Store) Set(cred *auth.Credential, global bool) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	return s.set(cred, "", global)
+}
 
+// SetWithSSHKey stores a credential together with the SSH private key path
+// that produced it. The path is persisted so future commands can refresh
+// the short-lived JWT transparently when it expires.
+func (s *Store) SetWithSSHKey(cred *auth.Credential, sshKeyPath string, global bool) error {
+	return s.set(cred, sshKeyPath, global)
+}
+
+func (s *Store) set(cred *auth.Credential, sshKeyPath string, global bool) error {
 	path := s.config.LocalPath()
 	if global {
 		path = s.config.GlobalPath()
@@ -115,25 +227,9 @@ func (s *Store) Set(cred *auth.Credential, global bool) error {
 		return fmt.Errorf("credentials path not configured")
 	}
 
-	file, err := s.loadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("load credentials: %w", err)
-	}
-
-	if file == nil {
-		file = &CredentialsFile{
-			Version:     "1.0",
-			Credentials: make(map[string]*StoredCredential),
-		}
-	}
-
-	file.Credentials[cred.Registry] = FromCredential(cred)
-
-	if file.Default == "" {
-		file.Default = cred.Registry
-	}
-
-	return s.saveFile(path, file)
+	stored := FromCredential(cred)
+	stored.SSHKeyPath = sshKeyPath
+	return s.writeStored(path, stored)
 }
 
 // Remove removes a credential.
@@ -187,17 +283,35 @@ func (s *Store) DefaultRegistry() string {
 	return DefaultRegistry
 }
 
-func (s *Store) loadCredential(path, registry string) *auth.Credential {
+// writeStored merges a single StoredCredential into the credentials file at
+// path, taking the lock so concurrent refreshes don't corrupt the YAML.
+func (s *Store) writeStored(path string, stored *StoredCredential) error {
+	if path == "" {
+		return fmt.Errorf("credentials path not configured")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	file, err := s.loadFile(path)
-	if err != nil || file == nil {
-		return nil
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("load credentials: %w", err)
+	}
+	if file == nil {
+		file = &CredentialsFile{
+			Version:     "1.0",
+			Credentials: make(map[string]*StoredCredential),
+		}
+	}
+	if file.Credentials == nil {
+		file.Credentials = make(map[string]*StoredCredential)
 	}
 
-	if stored := file.Credentials[registry]; stored != nil {
-		return stored.ToCredential()
+	file.Credentials[stored.Registry] = stored
+	if file.Default == "" {
+		file.Default = stored.Registry
 	}
-
-	return nil
+	return s.saveFile(path, file)
 }
 
 func (s *Store) loadFile(path string) (*CredentialsFile, error) {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -52,6 +52,9 @@ type DependencyHandler struct {
 	vendorDir       string
 	resolveTimeout  time.Duration
 	downloadTimeout time.Duration
+	// hasToken records whether the underlying hub client was built with
+	// credentials, so that auth-related errors get a more actionable hint.
+	hasToken bool
 }
 
 // HubClient defines the hub operations required for dependency handling.
@@ -88,12 +91,14 @@ func NewDependencyHandler(opts DependencyHandlerOptions) (*DependencyHandler, er
 	}
 
 	client := opts.Hub
+	hasToken := false
 	if client == nil {
-		hubClient, err := newHubClientFromAuth()
+		hubClient, gotToken, err := newHubClientFromAuth()
 		if err != nil {
 			return nil, err
 		}
 		client = hubClient
+		hasToken = gotToken
 	}
 
 	lockPath := opts.LockPath
@@ -121,6 +126,7 @@ func NewDependencyHandler(opts DependencyHandlerOptions) (*DependencyHandler, er
 		vendorDir:       vendorDir,
 		resolveTimeout:  opts.ResolveTimeout,
 		downloadTimeout: opts.DownloadTimeout,
+		hasToken:        hasToken,
 	}, nil
 }
 
@@ -304,7 +310,7 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 
 	result, err := Resolve(resolveCtx, h.hub, roots, nil)
 	if err != nil {
-		return nil, NewDependencyResolutionError(err)
+		return nil, NewDependencyResolutionError(DecorateAuthError(err, h.hasToken))
 	}
 	if len(result.Errors) > 0 {
 		return nil, NewDependencyResolutionErrors(result.Errors)
@@ -380,7 +386,7 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 			Version: mod.Version,
 		})
 		if err != nil {
-			return "", NewDependencyDownloadError(modKey(mod), err)
+			return "", NewDependencyDownloadError(modKey(mod), DecorateAuthError(err, h.hasToken))
 		}
 		url = info.URL
 		if expectedDigest == "" {
@@ -730,7 +736,11 @@ func formatResolutionErrors(errs []ResolutionError) string {
 	return msg
 }
 
-func newHubClientFromAuth() (*Client, error) {
+// newHubClientFromAuth builds a hub client using the user's stored credentials.
+// The second return reports whether a token was actually loaded — callers use
+// it to render more specific errors when an anonymous request hits a private
+// module (the server returns NotFound to hide existence).
+func newHubClientFromAuth() (*Client, bool, error) {
 	projectDir, _ := os.Getwd()
 	authCfg := auth.NewConfig(projectDir)
 	store := auth.NewStore(authCfg)
@@ -748,9 +758,9 @@ func newHubClientFromAuth() (*Client, error) {
 		Token:   token,
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return client, nil
+	return client, token != "", nil
 }
 
 var (

--- a/boot/deps/hub/errors.go
+++ b/boot/deps/hub/errors.go
@@ -4,6 +4,7 @@ package hub
 
 import (
 	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
 )
@@ -18,6 +19,30 @@ var (
 	ErrUploadExpired     = errors.New("upload URL expired")
 	ErrPublishInProgress = errors.New("publish already in progress")
 )
+
+// DecorateAuthError adds an actionable hint when an error is likely caused
+// by missing or invalid credentials. The hub deliberately returns NotFound
+// for private modules the caller can't see, so an unauthenticated NotFound
+// is almost always a permission issue rather than a typo.
+//
+// hasToken should be true when the caller had a credential available — this
+// distinguishes "you forgot to log in" from "your account doesn't have
+// access".
+func DecorateAuthError(err error, hasToken bool) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ErrModuleNotFound) && !hasToken:
+		return fmt.Errorf("%w (if this module is private, run 'wippy auth login')", err)
+	case errors.Is(err, ErrNotAuthenticated):
+		return fmt.Errorf("%w (token missing or invalid; run 'wippy auth login')", err)
+	case errors.Is(err, ErrOrgAccessDenied):
+		return fmt.Errorf("%w (your account does not have access to this organization)", err)
+	default:
+		return err
+	}
+}
 
 func MapConnectError(err error) error {
 	if err == nil {

--- a/boot/deps/hub/errors_test.go
+++ b/boot/deps/hub/errors_test.go
@@ -126,3 +126,38 @@ func TestSearchSubstring(t *testing.T) {
 	assert.False(t, searchSubstring("abc", "xyz"))
 	assert.True(t, searchSubstring("abc", ""))
 }
+
+func TestDecorateAuthError_Nil(t *testing.T) {
+	assert.Nil(t, DecorateAuthError(nil, false))
+	assert.Nil(t, DecorateAuthError(nil, true))
+}
+
+func TestDecorateAuthError_NotFoundAnonymous(t *testing.T) {
+	out := DecorateAuthError(ErrModuleNotFound, false)
+	assert.True(t, errors.Is(out, ErrModuleNotFound))
+	assert.Contains(t, out.Error(), "wippy auth login")
+}
+
+func TestDecorateAuthError_NotFoundAuthenticated(t *testing.T) {
+	// With a token, NotFound is more likely a typo than a permission issue.
+	out := DecorateAuthError(ErrModuleNotFound, true)
+	assert.Equal(t, ErrModuleNotFound, out)
+}
+
+func TestDecorateAuthError_NotAuthenticated(t *testing.T) {
+	out := DecorateAuthError(ErrNotAuthenticated, true)
+	assert.True(t, errors.Is(out, ErrNotAuthenticated))
+	assert.Contains(t, out.Error(), "wippy auth login")
+}
+
+func TestDecorateAuthError_OrgAccessDenied(t *testing.T) {
+	out := DecorateAuthError(ErrOrgAccessDenied, true)
+	assert.True(t, errors.Is(out, ErrOrgAccessDenied))
+	assert.Contains(t, out.Error(), "does not have access")
+}
+
+func TestDecorateAuthError_Passthrough(t *testing.T) {
+	other := errors.New("network unreachable")
+	assert.Equal(t, other, DecorateAuthError(other, true))
+	assert.Equal(t, other, DecorateAuthError(other, false))
+}

--- a/cmd/wippy/cmd/add.go
+++ b/cmd/wippy/cmd/add.go
@@ -106,10 +106,14 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	info, err := client.GetDownloadURL(ctx, params)
 	if err != nil {
-		return NewAddResolveError(moduleRef, registryURL, err)
+		return NewAddResolveError(moduleRef, registryURL, hub.DecorateAuthError(err, token != ""))
 	}
 
-	fmt.Printf("%s %s\n", labelStyle.Render("Resolved:"), infoStyle.Render(info.Version))
+	resolved := info.Version
+	if info.Protected {
+		resolved += " (private)"
+	}
+	fmt.Printf("%s %s\n", labelStyle.Render("Resolved:"), infoStyle.Render(resolved))
 
 	moduleName := fmt.Sprintf("%s/%s", ref.Org, ref.Module)
 	mod := lock.Module{

--- a/cmd/wippy/cmd/auth.go
+++ b/cmd/wippy/cmd/auth.go
@@ -82,9 +82,24 @@ var authLogoutCmd = &cobra.Command{
 }
 
 var authStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show authentication status",
-	RunE:  runAuthStatus,
+	Use:     "status",
+	Aliases: []string{"whoami"},
+	Short:   "Show authentication status",
+	RunE:    runAuthStatus,
+}
+
+var authTokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Print the stored token (for use in scripts and Docker secrets)",
+	Long: `Print the stored access token for the configured registry.
+
+Resolution order matches every other auth-aware command:
+WIPPY_TOKEN env > project-local credentials > global credentials.
+
+Examples:
+  wippy auth token                    # Print token to stdout
+  wippy auth token --registry https://hub.example.com`,
+	RunE: runAuthToken,
 }
 
 func init() {
@@ -92,6 +107,7 @@ func init() {
 	authCmd.AddCommand(authLoginCmd)
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authStatusCmd)
+	authCmd.AddCommand(authTokenCmd)
 
 	authLoginCmd.Flags().String("token", "", "API token")
 	authLoginCmd.Flags().String("registry", "", "registry URL")
@@ -101,6 +117,8 @@ func init() {
 	authLogoutCmd.Flags().Bool("local", false, "remove from project config")
 
 	authStatusCmd.Flags().Bool("json", false, "output as JSON")
+
+	authTokenCmd.Flags().String("registry", "", "registry URL")
 }
 
 func runAuthLogin(cmd *cobra.Command, _ []string) error {
@@ -249,6 +267,26 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 	}
 
 	return printStatusTable(registry, cred, nil, isConsole)
+}
+
+func runAuthToken(cmd *cobra.Command, _ []string) error {
+	registry, _ := cmd.Flags().GetString("registry")
+
+	projectDir, _ := os.Getwd()
+	cfg := bootauth.NewConfig(projectDir)
+	store := bootauth.NewStore(cfg)
+
+	if registry == "" {
+		registry = store.DefaultRegistry()
+	}
+
+	cred, err := store.Get(registry)
+	if err != nil || cred == nil || cred.Token == "" {
+		return bootauth.NewTokenReadError(fmt.Errorf("no token stored for %s", registry))
+	}
+
+	fmt.Println(cred.Token)
+	return nil
 }
 
 func readTokenInteractive(registry string) (string, error) {

--- a/cmd/wippy/cmd/auth.go
+++ b/cmd/wippy/cmd/auth.go
@@ -60,9 +60,11 @@ Examples:
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Authenticate with the registry",
-	Long: `Authenticate with the wippy registry using an API token.
+	Long: `Authenticate with the wippy registry using an API token or SSH key.
 
-Tokens can be created at https://modules.wippy.ai/settings/tokens
+API tokens can be created at https://modules.wippy.ai/settings/tokens.
+SSH keys can be registered under Account > SSH Keys; the same key used for
+'git push' works for 'wippy publish'.
 
 By default, credentials are stored globally in ~/.config/wippy/credentials.yaml.
 Use --local to store credentials in the current project's .wippy/ directory.
@@ -70,6 +72,8 @@ Use --local to store credentials in the current project's .wippy/ directory.
 Examples:
   wippy auth login                           # Interactive token prompt
   wippy auth login --token wpy_xxx           # Use token from flag
+  wippy auth login --ssh                     # SSH key (default key in ~/.ssh)
+  wippy auth login --ssh --key ~/.ssh/wippy  # Specific SSH key
   wippy auth login --registry https://...    # Use custom registry
   wippy auth login --local                   # Store in project config`,
 	RunE: runAuthLogin,
@@ -112,6 +116,8 @@ func init() {
 	authLoginCmd.Flags().String("token", "", "API token")
 	authLoginCmd.Flags().String("registry", "", "registry URL")
 	authLoginCmd.Flags().Bool("local", false, "store in project config")
+	authLoginCmd.Flags().Bool("ssh", false, "authenticate using a registered SSH key")
+	authLoginCmd.Flags().String("key", "", "path to SSH private key (default: ~/.ssh/id_ed25519, id_ecdsa, id_rsa)")
 
 	authLogoutCmd.Flags().String("registry", "", "registry URL")
 	authLogoutCmd.Flags().Bool("local", false, "remove from project config")
@@ -123,6 +129,13 @@ func init() {
 
 func runAuthLogin(cmd *cobra.Command, _ []string) error {
 	isConsole := console
+
+	useSSH, _ := cmd.Flags().GetBool("ssh")
+	keyPath, _ := cmd.Flags().GetString("key")
+	if keyPath != "" && !useSSH {
+		// Specifying --key implies --ssh; saves the user a flag.
+		useSSH = true
+	}
 
 	token, _ := cmd.Flags().GetString("token")
 	registry, _ := cmd.Flags().GetString("registry")
@@ -138,6 +151,10 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 
 	if registry == "" {
 		registry = store.DefaultRegistry()
+	}
+
+	if useSSH {
+		return runAuthLoginSSH(cmd, store, registry, keyPath, local, isConsole)
 	}
 
 	if token == "" {
@@ -187,6 +204,76 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 
 	printLoginSuccess(registry, cred.Orgs, local, isConsole)
 	return nil
+}
+
+// runAuthLoginSSH performs the SSH challenge-response handshake against the
+// registry and persists the resulting short-lived JWT alongside the path of
+// the key that produced it, so future commands can refresh transparently.
+func runAuthLoginSSH(cmd *cobra.Command, store *bootauth.Store, registry, keyPath string, local, isConsole bool) error {
+	if keyPath == "" {
+		keyPath = bootauth.SSHKeyFromEnv()
+	}
+	if keyPath == "" {
+		keyPath = bootauth.FindDefaultSSHKey()
+	}
+	if keyPath == "" {
+		return fmt.Errorf("no ssh key found; pass --key or set %s", bootauth.EnvSSHKey)
+	}
+
+	signer, err := bootauth.LoadSSHSigner(keyPath, sshPassphrasePrompter)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	result, err := bootauth.ExchangeSSHForToken(ctx, registry, signer)
+	if err != nil {
+		return err
+	}
+
+	cred := &auth.Credential{
+		Token:     result.Token,
+		Registry:  registry,
+		Scope:     auth.ScopeRead,
+		ExpiresAt: result.ExpiresAt,
+	}
+	if err := store.SetWithSSHKey(cred, signer.KeyPath(), !local); err != nil {
+		return bootauth.NewStoreError(registry, err)
+	}
+
+	printSSHLoginSuccess(registry, signer.Fingerprint(), result.ExpiresAt, local, isConsole)
+	return nil
+}
+
+func sshPassphrasePrompter(keyPath string) ([]byte, error) {
+	fmt.Printf("Passphrase for %s: ", keyPath)
+	bytesPass, err := term.ReadPassword(stdinFd())
+	fmt.Println()
+	if err != nil {
+		return nil, err
+	}
+	return bytesPass, nil
+}
+
+func printSSHLoginSuccess(registry, fingerprint string, expiresAt time.Time, local, isConsole bool) {
+	authPrintf(isConsole, "Logged in via SSH key", authSuccessStyle)
+	if isConsole {
+		fmt.Printf("  Registry:    %s\n", authInfoStyle.Render(registry))
+		fmt.Printf("  Fingerprint: %s\n", authDimStyle.Render(fingerprint))
+		if !expiresAt.IsZero() {
+			fmt.Printf("  Token TTL:   %s (auto-refreshed using the same key)\n", authDimStyle.Render(time.Until(expiresAt).Round(time.Minute).String()))
+		}
+		storage := "global config"
+		if local {
+			storage = "project config"
+		}
+		fmt.Printf("  Stored in:   %s\n", authInfoStyle.Render(storage))
+		return
+	}
+	fmt.Printf("Registry: %s\n", registry)
+	fmt.Printf("Fingerprint: %s\n", fingerprint)
 }
 
 func runAuthLogout(cmd *cobra.Command, _ []string) error {

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -191,11 +191,15 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			Version: module.Version,
 		})
 		if err != nil {
-			return NewDownloadModuleError(moduleRef, err)
+			return NewDownloadModuleError(moduleRef, hub.DecorateAuthError(err, token != ""))
 		}
 
 		if downloadInfo.URL == "" {
 			return NewNoContentDownloadedError(moduleRef)
+		}
+
+		if downloadInfo.Protected {
+			logger.Info("module is private", zap.String("module", module.Name))
 		}
 
 		// Download .wapp file

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -187,7 +187,7 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 		{Org: org, Name: module, Constraint: constraint},
 	}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve dependencies from %s: %w", registryURL, err)
+		return nil, fmt.Errorf("failed to resolve dependencies from %s: %w", registryURL, hub.DecorateAuthError(err, token != ""))
 	}
 
 	if len(resolved.Errors) > 0 {
@@ -212,10 +212,14 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 		moduleName := fmt.Sprintf("%s/%s", m.Org, m.Name)
 		packPath := filepath.Join(cacheDir, m.Org, fmt.Sprintf("%s-%s.wapp", m.Name, m.Version))
 
+		tag := ""
+		if m.Protected {
+			tag = " (private)"
+		}
 		if _, err := os.Stat(packPath); err == nil {
-			fmt.Printf("%s %s@%s (cached)\n", dimStyle.Render(""), moduleName, m.Version)
+			fmt.Printf("%s %s@%s%s (cached)\n", dimStyle.Render(""), moduleName, m.Version, tag)
 		} else {
-			fmt.Printf("%s Downloading %s@%s...\n", dimStyle.Render(""), moduleName, m.Version)
+			fmt.Printf("%s Downloading %s@%s%s...\n", dimStyle.Render(""), moduleName, m.Version, tag)
 			if m.URL == "" {
 				return nil, fmt.Errorf("no download URL for %s@%s from %s", moduleName, m.Version, registryURL)
 			}


### PR DESCRIPTION
Two related improvements for working with private modules from the CLI.

**1.** Decorate hub errors so an anonymous request that hits a private module surfaces "run wippy auth login" instead of the opaque NotFound the hub returns to hide existence. Adds a (private) badge to add/install/run output so users see what they're pulling. Bonus: wippy auth whoami alias and wippy auth token for CI/Docker secrets.

**2.** wippy auth login --ssh signs a challenge with a registered key, exchanges it at /api/v1/ssh/auth for a short-lived JWT, and persists the key path so the token refreshes transparently on expiry. WIPPY_SSH_KEY env var does the same for ephemeral CI runners.

Note: the hub issues HS256 JWTs but the Bearer middleware only accepts wpy_* and Keycloak-RSA today. Landing the HS256 validator hub-side is the follow-up that closes the loop end-to-end.