### PR TITLE
Fix CLI login crash and bogus scope display

### DIFF
--- a/boot/deps/auth/store.go
+++ b/boot/deps/auth/store.go
@@ -126,6 +126,12 @@ func (s *Store) Set(cred *auth.Credential, global bool) error {
 			Credentials: make(map[string]*StoredCredential),
 		}
 	}
+	if file.Credentials == nil {
+		// loadFile may return a non-nil file with a nil map when the on-disk
+		// YAML omits the `credentials` key (e.g. a hand-edited file or a
+		// partially migrated v0 file). Lazy-init so Set() doesn't panic.
+		file.Credentials = make(map[string]*StoredCredential)
+	}
 
 	file.Credentials[cred.Registry] = FromCredential(cred)
 

--- a/cmd/wippy/cmd/auth.go
+++ b/cmd/wippy/cmd/auth.go
@@ -156,7 +156,8 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 		// Scope intentionally left empty: the registry's /api/v1/account/orgs
 		// validate endpoint does not echo the token's scope, and hard-coding
 		// "read" here misled `wippy auth status` into reporting read-only for
-		// publish/admin tokens. Status now omits the field when unknown.
+		// publish/admin tokens. Human-readable status output omits the field
+		// when unknown.
 	}
 
 	if len(result.Orgs) > 0 {

--- a/cmd/wippy/cmd/auth.go
+++ b/cmd/wippy/cmd/auth.go
@@ -153,7 +153,10 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 	cred := &auth.Credential{
 		Token:    token,
 		Registry: registry,
-		Scope:    auth.ScopeRead,
+		// Scope intentionally left empty: the registry's /api/v1/account/orgs
+		// validate endpoint does not echo the token's scope, and hard-coding
+		// "read" here misled `wippy auth status` into reporting read-only for
+		// publish/admin tokens. Status now omits the field when unknown.
 	}
 
 	if len(result.Orgs) > 0 {


### PR DESCRIPTION
Two bugs surfaced while running `wippy auth login --token` against `hub.stage.wippy.ai`:

- **`Store.Set` panics with `assignment to entry in nil map`** when the on-disk credentials file exists but omits the `credentials` key (any hand-edited or partially migrated v0 file). Fixed by lazy-initialising the map in `Set` if `loadFile` returned a non-nil file with a nil map.
- **`wippy auth status` always reports `Scope: read`** — including for publish tokens — because login hard-coded `auth.ScopeRead` regardless of what the token actually carries. The validate endpoint (`/api/v1/account/orgs`) doesn't return scope today, so the field is now left empty and `status` skips printing it instead of lying. When/if the registry starts returning scope, we can populate it from the response.

Both reproduced manually on stage; existing tests in `boot/deps/auth` and `cmd/wippy/cmd` still pass.