### PR TITLE
ci: run repository lint target

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,13 +25,10 @@ jobs:
           cache: true
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v9.2.0
         env:
           CGO_ENABLED: 1
-        with:
-          version: latest
-          only-new-issues: false
-          args: --timeout=10m --build-tags=race ./...
+          GOFLAGS: -buildvcs=false
+        run: make lint
 
   test:
     name: Test (${{ matrix.os }})


### PR DESCRIPTION
Run the same lint target in GitHub Actions that developers run locally: make lint with GOFLAGS=-buildvcs=false. This avoids floating golangci-lint action binaries and keeps CI aligned with the repository-pinned linter version.

Local validation before merge:
- GOFLAGS=-buildvcs=false make lint
- GOFLAGS=-buildvcs=false make test
- Combined validation with PR #259 plus x/net #253 passed locally in /tmp/wippy-local-combined.