### PR TITLE
Use released wapp v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/wippyai/module-registry-proto-go v0.0.1
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4
-	github.com/wippyai/wapp v0.1.1-0.20260430143824-c4720b3b2f20
+	github.com/wippyai/wapp v0.1.1
 	github.com/wippyai/wasm-runtime v0.0.0-20260209224309-586ea6933075
 	github.com/xuri/excelize/v2 v2.10.1
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -556,10 +556,8 @@ github.com/wippyai/tree-sitter-markdown v0.0.3 h1:u6e53+hzPSS848Xhm+I48SwtvWQHrC
 github.com/wippyai/tree-sitter-markdown v0.0.3/go.mod h1:LDcC3ar1PlugUgz7YetXmrEoSDMeQuh+CoW53+QpZtc=
 github.com/wippyai/tree-sitter-sql v0.0.4 h1:0hJyjkV6/lhoGA5FJAaf96od2xyo+OJINSEMx/IYqLQ=
 github.com/wippyai/tree-sitter-sql v0.0.4/go.mod h1:QN9CfIO55fwQNVNk1p/7pjxrLk7iKxrQs42Zh6lrr84=
-github.com/wippyai/wapp v0.1.0 h1:uKQe+Q2ea5VWhi5UhzBl0ihvVBmonTfb28coh5Mf/GY=
-github.com/wippyai/wapp v0.1.0/go.mod h1:ndCkYR80+osLGbd7AFWlP+3DxwooR+R6cxQYPZhksg4=
-github.com/wippyai/wapp v0.1.1-0.20260430143824-c4720b3b2f20 h1:17ENmvKdko/8CIXmI0xK+Hu4X/pqDg9XUlSnQArq0vA=
-github.com/wippyai/wapp v0.1.1-0.20260430143824-c4720b3b2f20/go.mod h1:ndCkYR80+osLGbd7AFWlP+3DxwooR+R6cxQYPZhksg4=
+github.com/wippyai/wapp v0.1.1 h1:34MQrXp3B27oZxz7FMEvqgBuDBggxnnj/gG6Y2wqP6Q=
+github.com/wippyai/wapp v0.1.1/go.mod h1:ndCkYR80+osLGbd7AFWlP+3DxwooR+R6cxQYPZhksg4=
 github.com/wippyai/wasm-runtime v0.0.0-20260209224309-586ea6933075 h1:TZZCgi+CTZKcHRhpziSl9t1T33Dq+VWBNZQ9w6e9b+M=
 github.com/wippyai/wasm-runtime v0.0.0-20260209224309-586ea6933075/go.mod h1:1AVYdZibORqlBez081Seakxv2u9IR+KIMrvlBKsk2bQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
## Summary
- switch runtime from the wapp pseudo-version to released github.com/wippyai/wapp v0.1.1
- keep the pack/publish resource integrity guard active so bad embedded resources are rejected before publish

## Verification
- go test ./cmd/wippy/cmd ./cmd/internal/entries ./boot/build/stages ./boot/deps/hub
- go build -o /tmp/wippy-packcheck ./cmd/wippy
- make publish-keeper-dry-run WIPPY=/tmp/wippy-packcheck
- local unpack smoke: packed Keeper UI with /tmp/wippy-packcheck and installed it from a temp lock with options.unpack_modules=true; tsMode-BI5rsYdF.js extracted at 22062 bytes