### PR TITLE
CLI: wippy publish --create + local-stack support

### DIFF
--- a/boot/deps/auth/client.go
+++ b/boot/deps/auth/client.go
@@ -35,8 +35,12 @@ func NewClient(baseURL string) (*Client, error) {
 		return nil, fmt.Errorf("invalid registry URL: %w", err)
 	}
 
-	// Require HTTPS for non-localhost
-	isLocal := u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1"
+	// Require HTTPS for non-local hosts. host.docker.internal /
+	// host.containers.internal only ever resolve to the host machine, so
+	// plaintext across them is no riskier than localhost.
+	host := u.Hostname()
+	isLocal := host == "localhost" || host == "127.0.0.1" ||
+		host == "host.docker.internal" || host == "host.containers.internal"
 	if u.Scheme != "https" && !isLocal {
 		return nil, fmt.Errorf("registry must use HTTPS")
 	}

--- a/boot/deps/hub/client.go
+++ b/boot/deps/hub/client.go
@@ -50,7 +50,13 @@ func NewClient(opts Options) (*Client, error) {
 		return nil, fmt.Errorf("invalid registry URL: %w", err)
 	}
 
-	isLocal := u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1"
+	host := u.Hostname()
+	isLocal := host == "localhost" || host == "127.0.0.1" ||
+		// Container-side aliases for local Docker stacks: host.docker.internal
+		// (Docker Desktop / OrbStack) and host.containers.internal (Podman).
+		// They never resolve to anything but the host machine, so plaintext
+		// HTTP across them is no riskier than localhost.
+		host == "host.docker.internal" || host == "host.containers.internal"
 	if u.Scheme != "https" && !isLocal {
 		return nil, fmt.Errorf("registry must use HTTPS")
 	}

--- a/boot/deps/hub/client.go
+++ b/boot/deps/hub/client.go
@@ -30,6 +30,8 @@ type Client struct {
 	Manifest manifestv1connect.ManifestServiceClient
 
 	httpClient *http.Client
+	baseURL    string
+	token      string
 }
 
 type Options struct {
@@ -84,6 +86,8 @@ func NewClient(opts Options) (*Client, error) {
 		Download:   downloadv1connect.NewDownloadServiceClient(httpClient, baseURL, connectOpts...),
 		Manifest:   manifestv1connect.NewManifestServiceClient(httpClient, baseURL, connectOpts...),
 		httpClient: httpClient,
+		baseURL:    baseURL,
+		token:      opts.Token,
 	}, nil
 }
 

--- a/boot/deps/hub/register_module.go
+++ b/boot/deps/hub/register_module.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// RegisterModuleParams covers the fields the hub's
+// POST /api/v1/account/modules endpoint accepts. Only Org/Name/ModuleType
+// are required; everything else is optional. Visibility defaults to
+// "private" on the server when empty — this matches the wippy CLI default
+// of treating new modules as private until the user opts them public.
+type RegisterModuleParams struct {
+	Org           string   `json:"org_name"`
+	Name          string   `json:"name"`
+	DisplayName   string   `json:"display_name,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	ModuleType    string   `json:"module_type"`
+	Visibility    string   `json:"visibility,omitempty"`
+	License       string   `json:"license,omitempty"`
+	RepositoryURL string   `json:"repository_url,omitempty"`
+	HomepageURL   string   `json:"homepage_url,omitempty"`
+	Keywords      []string `json:"keywords,omitempty"`
+}
+
+// RegisteredModule is the subset of the hub's REST response we surface to
+// the CLI; the full payload includes timestamps, owner ID, etc.
+type RegisteredModule struct {
+	ID          string `json:"id"`
+	OrgName     string `json:"org_name"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	ModuleType  string `json:"module_type"`
+	Visibility  string `json:"visibility"`
+}
+
+// ErrModuleAlreadyExists is returned when the hub responds 409 to a
+// register request — the module is already in the registry.
+var ErrModuleAlreadyExists = errors.New("module already exists")
+
+// RegisterModule POSTs to the hub's account-module REST endpoint to create
+// the module record before any version is published. The publish flow
+// requires the module row to exist in advance; this is the
+// one-step-before-publish CLI helper.
+//
+// Returns ErrModuleAlreadyExists when the hub answers with 409 so callers
+// can treat re-runs as idempotent.
+func (c *Client) RegisterModule(ctx context.Context, p *RegisterModuleParams) (*RegisteredModule, error) {
+	if c.baseURL == "" {
+		return nil, errors.New("hub client missing base URL")
+	}
+	body, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal register-module request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/v1/account/modules", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build register-module request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post register-module: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusOK:
+		var out RegisteredModule
+		if err := json.Unmarshal(respBody, &out); err != nil {
+			return nil, fmt.Errorf("decode register-module response: %w", err)
+		}
+		return &out, nil
+	case http.StatusConflict:
+		return nil, ErrModuleAlreadyExists
+	default:
+		return nil, fmt.Errorf("hub register-module %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+}

--- a/boot/deps/hub/register_module.go
+++ b/boot/deps/hub/register_module.go
@@ -28,7 +28,7 @@ type RegisterModuleParams struct {
 	License       string   `json:"license,omitempty"`
 	RepositoryURL string   `json:"repository_url,omitempty"`
 	HomepageURL   string   `json:"homepage_url,omitempty"`
-	Keywords      []string `json:"keywords,omitempty"`
+	Keywords      []string `json:"keywords"`
 }
 
 // RegisteredModule is the subset of the hub's REST response we surface to

--- a/boot/deps/hub/register_module_test.go
+++ b/boot/deps/hub/register_module_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRegisterModule_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/account/modules" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer wpy_test" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var got RegisterModuleParams
+		if err := json.Unmarshal(body, &got); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if got.Org != "tmp" || got.Name != "hello-world" || got.Visibility != "private" {
+			http.Error(w, "unexpected fields", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"abc","org_name":"tmp","name":"hello-world","display_name":"Hello","module_type":"application","visibility":"private"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "wpy_test"})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	c.httpClient = srv.Client()
+
+	got, err := c.RegisterModule(context.Background(), &RegisterModuleParams{
+		Org: "tmp", Name: "hello-world", DisplayName: "Hello",
+		ModuleType: "application", Visibility: "private",
+	})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if got.ID != "abc" || got.Visibility != "private" {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+func TestRegisterModule_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"conflict","message":"module exists"}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(Options{BaseURL: srv.URL, Token: "wpy_test"})
+	c.httpClient = srv.Client()
+
+	_, err := c.RegisterModule(context.Background(), &RegisterModuleParams{
+		Org: "tmp", Name: "hello-world", ModuleType: "application",
+	})
+	if !errors.Is(err, ErrModuleAlreadyExists) {
+		t.Fatalf("expected ErrModuleAlreadyExists, got %v", err)
+	}
+}
+
+func TestRegisterModule_BadStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"forbidden","message":"insufficient permissions"}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(Options{BaseURL: srv.URL, Token: "wpy_test"})
+	c.httpClient = srv.Client()
+
+	_, err := c.RegisterModule(context.Background(), &RegisterModuleParams{
+		Org: "tmp", Name: "hello-world", ModuleType: "application",
+	})
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected 403 error, got %v", err)
+	}
+}

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -60,6 +60,10 @@ func init() {
 	publishCmd.Flags().String("config", ".", "path to directory containing wippy.yaml")
 	publishCmd.Flags().String("registry", "", "registry URL (default: from credentials)")
 	publishCmd.Flags().StringSlice("embed", nil, "embed fs.directory entries by id or name (default: none)")
+	publishCmd.Flags().Bool("create", false, "create the module on the registry if it does not yet exist")
+	publishCmd.Flags().String("module-visibility", "private", "visibility for newly created modules (--create only): public or private")
+	publishCmd.Flags().String("module-type", "application", "module type for newly created modules (--create only): library, application, agent or plugin")
+	publishCmd.Flags().String("module-display-name", "", "display name for newly created modules (--create only)")
 }
 
 func runPublish(cmd *cobra.Command, _ []string) error {
@@ -74,6 +78,10 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 	registryURL, _ := cmd.Flags().GetString("registry")
 	embedFlag, _ := cmd.Flags().GetStringSlice("embed")
 	embedChanged := cmd.Flags().Changed("embed")
+	createIfMissing, _ := cmd.Flags().GetBool("create")
+	moduleVisibility, _ := cmd.Flags().GetString("module-visibility")
+	moduleType, _ := cmd.Flags().GetString("module-type")
+	moduleDisplayName, _ := cmd.Flags().GetString("module-display-name")
 
 	cfg, err := config.Load(configDir)
 	if err != nil {
@@ -168,6 +176,36 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 	})
 	if err != nil {
 		return NewPublishClientError(registryURL, err)
+	}
+
+	if createIfMissing {
+		displayName := moduleDisplayName
+		if displayName == "" {
+			displayName = cfg.ModuleName
+		}
+		registerCtx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		regResult, regErr := client.RegisterModule(registerCtx, &hub.RegisterModuleParams{
+			Org:           cfg.Organization,
+			Name:          cfg.ModuleName,
+			DisplayName:   displayName,
+			Description:   cfg.Description,
+			ModuleType:    moduleType,
+			Visibility:    moduleVisibility,
+			License:       cfg.License,
+			Keywords:      cfg.Keywords,
+			RepositoryURL: cfg.Repository,
+			HomepageURL:   cfg.Homepage,
+		})
+		cancel()
+		switch {
+		case regErr == nil:
+			printStatus(fmt.Sprintf("Registered module %s/%s (visibility=%s, type=%s)",
+				regResult.OrgName, regResult.Name, regResult.Visibility, regResult.ModuleType))
+		case errors.Is(regErr, hub.ErrModuleAlreadyExists):
+			printStatus(fmt.Sprintf("Module %s/%s already exists, skipping create", cfg.Organization, cfg.ModuleName))
+		default:
+			return fmt.Errorf("register module on %s: %w", registryURL, regErr)
+		}
 	}
 
 	params := &hub.PublishParams{

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -183,6 +183,10 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		if displayName == "" {
 			displayName = cfg.ModuleName
 		}
+		keywords := cfg.Keywords
+		if keywords == nil {
+			keywords = []string{}
+		}
 		registerCtx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		regResult, regErr := client.RegisterModule(registerCtx, &hub.RegisterModuleParams{
 			Org:           cfg.Organization,
@@ -192,7 +196,7 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 			ModuleType:    moduleType,
 			Visibility:    moduleVisibility,
 			License:       cfg.License,
-			Keywords:      cfg.Keywords,
+			Keywords:      keywords,
 			RepositoryURL: cfg.Repository,
 			HomepageURL:   cfg.Homepage,
 		})


### PR DESCRIPTION
## Summary
- New `wippy publish --create` flag registers the module on the registry before initiating publish (one-shot publish for new modules)
- New `--module-visibility` (public/private, default private), `--module-type`, `--module-display-name` flags
- Auth + hub clients: allow `host.docker.internal` / `host.containers.internal` plaintext (for local Docker stacks where the CLI runs in a container)

## Test plan
- [x] `wippy auth login --token wpy_... --registry http://host.docker.internal:8082 --local` succeeds from inside Debian arm64 container
- [x] `wippy publish --create --module-visibility public` registers + publishes in one shot
- [x] Same flow with --module-visibility private