### PR TITLE
Add object metadata and conditional ops to cloudstorage

### DIFF
--- a/api/cloudstorage/command.go
+++ b/api/cloudstorage/command.go
@@ -14,6 +14,7 @@ func init() {
 	dispatcher.MustRegisterCommands("cloudstorage",
 		ListObjects, DownloadObject, UploadObject,
 		DeleteObjects, PresignedGetURL, PresignedPutURL,
+		HeadObject,
 	)
 }
 
@@ -25,6 +26,7 @@ const (
 	DeleteObjects   dispatcher.CommandID = 163
 	PresignedGetURL dispatcher.CommandID = 164
 	PresignedPutURL dispatcher.CommandID = 165
+	HeadObject      dispatcher.CommandID = 166
 )
 
 // ListObjectsCmd lists objects in cloud storage.
@@ -82,6 +84,7 @@ type DownloadObjectResponse struct {
 type UploadObjectCmd struct {
 	Storage Storage
 	Reader  io.Reader
+	Options *UploadOptions
 	Key     string
 }
 
@@ -94,6 +97,7 @@ func (c *UploadObjectCmd) Release() {
 	c.Storage = nil
 	c.Key = ""
 	c.Reader = nil
+	c.Options = nil
 	uploadObjectCmdPool.Put(c)
 }
 
@@ -182,4 +186,27 @@ func (c *PresignedPutURLCmd) Release() {
 type PresignedPutURLResponse struct {
 	Error error
 	URL   string
+}
+
+// HeadObjectCmd fetches full metadata for a single object.
+type HeadObjectCmd struct {
+	Storage Storage
+	Key     string
+}
+
+var headObjectCmdPool = sync.Pool{New: func() any { return &HeadObjectCmd{} }}
+
+// AcquireHeadObjectCmd returns a pooled HeadObjectCmd.
+func AcquireHeadObjectCmd() *HeadObjectCmd           { return headObjectCmdPool.Get().(*HeadObjectCmd) }
+func (c *HeadObjectCmd) CmdID() dispatcher.CommandID { return HeadObject }
+func (c *HeadObjectCmd) Release() {
+	c.Storage = nil
+	c.Key = ""
+	headObjectCmdPool.Put(c)
+}
+
+// HeadObjectResponse contains head_object results.
+type HeadObjectResponse struct {
+	Result *HeadObjectResult
+	Error  error
 }

--- a/api/cloudstorage/storage.go
+++ b/api/cloudstorage/storage.go
@@ -41,8 +41,14 @@ type (
 	// HeadObjectResult contains the full metadata for a single object,
 	// including provider-specific user metadata.
 	HeadObjectResult struct {
-		LastModified       time.Time
-		UserMetadata       map[string]string
+		LastModified time.Time
+		UserMetadata map[string]string
+		// Headers carries the raw response headers from the provider, with
+		// lowercased keys. Multi-valued headers are joined with ", " per
+		// RFC 7230 §3.2.2. Useful for accessing provider-specific fields
+		// not modeled as typed fields above (e.g. x-amz-tagging-count,
+		// x-amz-replication-status, x-amz-server-side-encryption).
+		Headers            map[string]string
 		ContentType        string
 		ETag               string
 		CacheControl       string
@@ -98,7 +104,13 @@ type (
 
 	// UploadOptions contains options for uploading objects.
 	UploadOptions struct {
-		Metadata           map[string]string
+		Metadata map[string]string
+		// Headers passes through arbitrary HTTP request headers to the
+		// provider. Useful for provider-specific options that are not
+		// modeled as typed fields above (e.g. x-amz-tagging,
+		// x-amz-server-side-encryption, x-amz-website-redirect-location).
+		// Headers are sent verbatim and participate in request signing.
+		Headers            map[string]string
 		ContentType        string
 		CacheControl       string
 		ContentDisposition string

--- a/api/cloudstorage/storage.go
+++ b/api/cloudstorage/storage.go
@@ -14,6 +14,10 @@ import (
 // is not satisfied (HTTP 412 from the underlying provider).
 var ErrPreconditionFailed = errors.New("cloudstorage: precondition failed")
 
+// ErrNotFound is returned when the requested object does not exist
+// (HTTP 404 / SDK NoSuchKey / NotFound from the underlying provider).
+var ErrNotFound = errors.New("cloudstorage: not found")
+
 type (
 	// Owner identifies the owner of an object (when surfaced by the provider).
 	Owner struct {

--- a/api/cloudstorage/storage.go
+++ b/api/cloudstorage/storage.go
@@ -5,17 +5,48 @@ package cloudstorage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 )
 
+// ErrPreconditionFailed is returned when an If-Match or If-None-Match precondition
+// is not satisfied (HTTP 412 from the underlying provider).
+var ErrPreconditionFailed = errors.New("cloudstorage: precondition failed")
+
 type (
+	// Owner identifies the owner of an object (when surfaced by the provider).
+	Owner struct {
+		ID          string
+		DisplayName string
+	}
+
 	// ObjectMetadata represents metadata for an object stored in cloud storage.
 	ObjectMetadata struct {
-		Key         string
-		ContentType string
-		ETag        string
-		Size        int64
+		LastModified time.Time
+		Owner        *Owner
+		UserMetadata map[string]string
+		Key          string
+		ContentType  string
+		ETag         string
+		StorageClass string
+		VersionID    string
+		Size         int64
+	}
+
+	// HeadObjectResult contains the full metadata for a single object,
+	// including provider-specific user metadata.
+	HeadObjectResult struct {
+		LastModified       time.Time
+		UserMetadata       map[string]string
+		ContentType        string
+		ETag               string
+		CacheControl       string
+		ContentDisposition string
+		ContentEncoding    string
+		StorageClass       string
+		VersionID          string
+		Size               int64
 	}
 
 	// ListObjectsOptions defines options for listing objects.
@@ -23,6 +54,12 @@ type (
 		Prefix            string
 		ContinuationToken string
 		MaxKeys           int
+		// IncludeOwner asks the provider to populate Owner on each result.
+		// On S3 this maps to FetchOwner=true.
+		IncludeOwner bool
+		// IncludeVersions switches to a versioned listing (S3: ListObjectVersions)
+		// so that VersionID is filled per item.
+		IncludeVersions bool
 	}
 
 	// ListObjectsResult contains the results of a list operation.
@@ -49,6 +86,23 @@ type (
 	DownloadOptions struct {
 		// Range specifies a byte range to retrieve (e.g., "bytes=0-1023" for first 1KB).
 		Range string
+		// IfMatch returns the object only if its current ETag matches.
+		IfMatch string
+		// IfNoneMatch returns the object only if its current ETag does NOT match.
+		IfNoneMatch string
+	}
+
+	// UploadOptions contains options for uploading objects.
+	UploadOptions struct {
+		Metadata           map[string]string
+		ContentType        string
+		CacheControl       string
+		ContentDisposition string
+		ContentEncoding    string
+		// IfMatch uploads only if the existing object's ETag matches.
+		IfMatch string
+		// IfNoneMatch uploads only if no object exists ("*") or its ETag does not match.
+		IfNoneMatch string
 	}
 
 	// Storage defines the interface for cloud storage providers.
@@ -56,11 +110,14 @@ type (
 		// ListObjects lists objects with the given options.
 		ListObjects(ctx context.Context, opts *ListObjectsOptions) (*ListObjectsResult, error)
 
+		// HeadObject returns full metadata for a single object, including user metadata.
+		HeadObject(ctx context.Context, key string) (*HeadObjectResult, error)
+
 		// DownloadObject retrieves an object and writes it to w.
 		DownloadObject(ctx context.Context, key string, w io.Writer, opts *DownloadOptions) error
 
 		// UploadObject uploads an object.
-		UploadObject(ctx context.Context, key string, content io.Reader) error
+		UploadObject(ctx context.Context, key string, content io.Reader, opts *UploadOptions) error
 
 		// DeleteObjects removes multiple objects.
 		DeleteObjects(ctx context.Context, keys []string) error

--- a/runtime/lua/modules/cloudstorage/module.go
+++ b/runtime/lua/modules/cloudstorage/module.go
@@ -347,6 +347,11 @@ func storageUploadObject(l *lua.LState) int {
 		if v := optsTable.RawGetString("if_none_match"); v != lua.LNil {
 			uo.IfNoneMatch = v.String()
 		}
+		// only_if_absent is a Lua-friendly alias for if_none_match = "*".
+		// When true it wins over an explicit if_none_match string.
+		if v := optsTable.RawGetString("only_if_absent"); v != lua.LNil && lua.LVAsBool(v) {
+			uo.IfNoneMatch = "*"
+		}
 		if v := optsTable.RawGetString("metadata"); v != lua.LNil {
 			if mt, ok := v.(*lua.LTable); ok {
 				uo.Metadata = make(map[string]string, mt.Len())

--- a/runtime/lua/modules/cloudstorage/module.go
+++ b/runtime/lua/modules/cloudstorage/module.go
@@ -362,6 +362,16 @@ func storageUploadObject(l *lua.LState) int {
 				})
 			}
 		}
+		if v := optsTable.RawGetString("headers"); v != lua.LNil {
+			if ht, ok := v.(*lua.LTable); ok {
+				uo.Headers = make(map[string]string, ht.Len())
+				ht.ForEach(func(k, hv lua.LValue) {
+					if ks, kok := k.(lua.LString); kok {
+						uo.Headers[string(ks)] = hv.String()
+					}
+				})
+			}
+		}
 		yield.Options = uo
 	}
 

--- a/runtime/lua/modules/cloudstorage/module.go
+++ b/runtime/lua/modules/cloudstorage/module.go
@@ -36,6 +36,7 @@ var Module = &luaapi.ModuleDef{
 			{Sample: &DeleteObjectsYield{}, CmdID: csapi.DeleteObjects},
 			{Sample: &PresignedGetURLYield{}, CmdID: csapi.PresignedGetURL},
 			{Sample: &PresignedPutURLYield{}, CmdID: csapi.PresignedPutURL},
+			{Sample: &HeadObjectYield{}, CmdID: csapi.HeadObject},
 		}
 	},
 	Types: ModuleTypes,
@@ -51,6 +52,7 @@ type storageWrapper struct {
 
 var storageMethods = map[string]lua.LGoFunc{
 	"list_objects":      storageListObjects,
+	"head_object":       storageHeadObject,
 	"download_object":   storageDownloadObject,
 	"upload_object":     storageUploadObject,
 	"delete_objects":    storageDeleteObjects,
@@ -200,7 +202,40 @@ func storageListObjects(l *lua.LState) int {
 		if token := optsTable.RawGetString("continuation_token"); token != lua.LNil {
 			yield.Options.ContinuationToken = token.String()
 		}
+		if v := optsTable.RawGetString("include_owner"); v != lua.LNil {
+			yield.Options.IncludeOwner = lua.LVAsBool(v)
+		}
+		if v := optsTable.RawGetString("include_versions"); v != lua.LNil {
+			yield.Options.IncludeVersions = lua.LVAsBool(v)
+		}
 	}
+
+	l.Push(yield)
+	return -1
+}
+
+func storageHeadObject(l *lua.LState) int {
+	wrapper := checkStorage(l, 1)
+	if wrapper == nil {
+		return 0
+	}
+
+	if wrapper.released {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "storage has been released").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	key := l.CheckString(2)
+	if key == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "key is required").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	yield := AcquireHeadObjectYield()
+	yield.Storage = wrapper.storage
+	yield.Key = key
 
 	l.Push(yield)
 	return -1
@@ -247,6 +282,12 @@ func storageDownloadObject(l *lua.LState) int {
 		if rang := optsTable.RawGetString("range"); rang != lua.LNil {
 			yield.Options.Range = rang.String()
 		}
+		if v := optsTable.RawGetString("if_match"); v != lua.LNil {
+			yield.Options.IfMatch = v.String()
+		}
+		if v := optsTable.RawGetString("if_none_match"); v != lua.LNil {
+			yield.Options.IfNoneMatch = v.String()
+		}
 	}
 
 	l.Push(yield)
@@ -283,6 +324,41 @@ func storageUploadObject(l *lua.LState) int {
 	yield.Storage = wrapper.storage
 	yield.Key = key
 	yield.Content = content
+
+	if l.Get(4) != lua.LNil {
+		optsTable := l.CheckTable(4)
+		uo := &csapi.UploadOptions{}
+
+		if v := optsTable.RawGetString("content_type"); v != lua.LNil {
+			uo.ContentType = v.String()
+		}
+		if v := optsTable.RawGetString("cache_control"); v != lua.LNil {
+			uo.CacheControl = v.String()
+		}
+		if v := optsTable.RawGetString("content_disposition"); v != lua.LNil {
+			uo.ContentDisposition = v.String()
+		}
+		if v := optsTable.RawGetString("content_encoding"); v != lua.LNil {
+			uo.ContentEncoding = v.String()
+		}
+		if v := optsTable.RawGetString("if_match"); v != lua.LNil {
+			uo.IfMatch = v.String()
+		}
+		if v := optsTable.RawGetString("if_none_match"); v != lua.LNil {
+			uo.IfNoneMatch = v.String()
+		}
+		if v := optsTable.RawGetString("metadata"); v != lua.LNil {
+			if mt, ok := v.(*lua.LTable); ok {
+				uo.Metadata = make(map[string]string, mt.Len())
+				mt.ForEach(func(k, mv lua.LValue) {
+					if ks, kok := k.(lua.LString); kok {
+						uo.Metadata[string(ks)] = mv.String()
+					}
+				})
+			}
+		}
+		yield.Options = uo
+	}
 
 	l.Push(yield)
 	return -1

--- a/runtime/lua/modules/cloudstorage/module_test.go
+++ b/runtime/lua/modules/cloudstorage/module_test.go
@@ -662,6 +662,7 @@ func TestHeadObjectYieldHandleResult_Success(t *testing.T) {
 			VersionID:          "v1",
 			LastModified:       now,
 			UserMetadata:       map[string]string{"env": "staging"},
+			Headers:            map[string]string{"x-amz-tagging-count": "1"},
 		},
 	}
 
@@ -695,6 +696,13 @@ func TestHeadObjectYieldHandleResult_Success(t *testing.T) {
 	}
 	if got := meta.RawGetString("env").String(); got != "staging" {
 		t.Errorf("metadata.env mismatch: got %q", got)
+	}
+	headers, ok := tbl.RawGetString("headers").(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected headers table")
+	}
+	if got := headers.RawGetString("x-amz-tagging-count").String(); got != "1" {
+		t.Errorf("headers[x-amz-tagging-count] mismatch: got %q", got)
 	}
 }
 

--- a/runtime/lua/modules/cloudstorage/module_test.go
+++ b/runtime/lua/modules/cloudstorage/module_test.go
@@ -737,6 +737,48 @@ func TestPreconditionFailedMapping(t *testing.T) {
 	}
 }
 
+func TestNotFoundMapping(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	t.Run("head_object", func(t *testing.T) {
+		y := AcquireHeadObjectYield()
+		defer ReleaseHeadObjectYield(y)
+
+		result := y.HandleResult(l, csapi.HeadObjectResponse{Error: csapi.ErrNotFound}, nil)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 return values")
+		}
+		luaErr, ok := result[1].(*lua.Error)
+		if !ok {
+			t.Fatalf("expected *lua.Error, got %T", result[1])
+		}
+		if luaErr.Kind() != lua.NotFound {
+			t.Errorf("expected NotFound kind, got %s", luaErr.Kind())
+		}
+		if !strings.Contains(luaErr.Message, "not_found") {
+			t.Errorf("expected message to contain 'not_found', got %q", luaErr.Message)
+		}
+	})
+
+	t.Run("download_object", func(t *testing.T) {
+		y := AcquireDownloadObjectYield()
+		defer ReleaseDownloadObjectYield(y)
+
+		result := y.HandleResult(l, csapi.DownloadObjectResponse{Error: csapi.ErrNotFound}, nil)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 return values")
+		}
+		luaErr, ok := result[1].(*lua.Error)
+		if !ok {
+			t.Fatalf("expected *lua.Error, got %T", result[1])
+		}
+		if luaErr.Kind() != lua.NotFound {
+			t.Errorf("expected NotFound kind, got %s", luaErr.Kind())
+		}
+	})
+}
+
 func TestListObjectsYieldHandleResult_Fields(t *testing.T) {
 	l := lua.NewState()
 	defer l.Close()

--- a/runtime/lua/modules/cloudstorage/module_test.go
+++ b/runtime/lua/modules/cloudstorage/module_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	lua "github.com/wippyai/go-lua"
 	csapi "github.com/wippyai/runtime/api/cloudstorage"
@@ -18,8 +19,8 @@ func TestModuleLoads(t *testing.T) {
 		t.Fatal("expected module table to be non-nil")
 	}
 
-	if len(yields) != 6 {
-		t.Errorf("expected 6 yield types, got %d", len(yields))
+	if len(yields) != 7 {
+		t.Errorf("expected 7 yield types, got %d", len(yields))
 	}
 }
 
@@ -50,6 +51,7 @@ func TestYieldTypes(t *testing.T) {
 		int(csapi.DeleteObjects):   false,
 		int(csapi.PresignedGetURL): false,
 		int(csapi.PresignedPutURL): false,
+		int(csapi.HeadObject):      false,
 	}
 
 	for _, y := range yields {
@@ -215,6 +217,7 @@ func TestYieldTypes_LuaType(t *testing.T) {
 }
 
 func TestListObjectsYieldHandleResult(t *testing.T) {
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		data    any
 		err     error
@@ -226,7 +229,16 @@ func TestListObjectsYieldHandleResult(t *testing.T) {
 			data: csapi.ListObjectsResponse{
 				Result: &csapi.ListObjectsResult{
 					Objects: []csapi.ObjectMetadata{
-						{Key: "test.txt", Size: 100, ContentType: "text/plain", ETag: "etag1"},
+						{
+							Key:          "test.txt",
+							Size:         100,
+							ContentType:  "text/plain",
+							ETag:         "etag1",
+							StorageClass: "STANDARD",
+							LastModified: now,
+							Owner:        &csapi.Owner{ID: "owner-id", DisplayName: "Owner Name"},
+							VersionID:    "v1",
+						},
 					},
 					IsTruncated:           false,
 					NextContinuationToken: "",
@@ -613,5 +625,161 @@ func TestModuleInfo(t *testing.T) {
 	}
 	if len(Module.Class) == 0 {
 		t.Error("module should have at least one class")
+	}
+}
+
+func TestHeadObjectYieldPool(t *testing.T) {
+	y1 := AcquireHeadObjectYield()
+	if y1 == nil || y1.HeadObjectCmd == nil {
+		t.Fatal("expected non-nil yield with command")
+	}
+	ReleaseHeadObjectYield(y1)
+
+	y2 := AcquireHeadObjectYield()
+	if y2 == nil {
+		t.Fatal("expected non-nil yield after release")
+	}
+	ReleaseHeadObjectYield(y2)
+}
+
+func TestHeadObjectYieldHandleResult_Success(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireHeadObjectYield()
+	defer ReleaseHeadObjectYield(y)
+
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	data := csapi.HeadObjectResponse{
+		Result: &csapi.HeadObjectResult{
+			Size:               42,
+			ETag:               "head-etag",
+			ContentType:        "text/plain",
+			CacheControl:       "max-age=60",
+			ContentDisposition: "inline",
+			ContentEncoding:    "identity",
+			StorageClass:       "STANDARD",
+			VersionID:          "v1",
+			LastModified:       now,
+			UserMetadata:       map[string]string{"env": "staging"},
+		},
+	}
+
+	result := y.HandleResult(l, data, nil)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 return values, got %d", len(result))
+	}
+	if result[1] != lua.LNil {
+		t.Fatalf("expected nil error, got %v", result[1])
+	}
+	tbl, ok := result[0].(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected table result, got %T", result[0])
+	}
+
+	if got := tbl.RawGetString("etag").String(); got != "head-etag" {
+		t.Errorf("etag mismatch: got %q", got)
+	}
+	if got := lua.LVAsNumber(tbl.RawGetString("size")); got != 42 {
+		t.Errorf("size mismatch: got %v", got)
+	}
+	if got := tbl.RawGetString("storage_class").String(); got != "STANDARD" {
+		t.Errorf("storage_class mismatch: got %q", got)
+	}
+	if got := lua.LVAsNumber(tbl.RawGetString("last_modified")); int64(got) != now.Unix() {
+		t.Errorf("last_modified mismatch: got %v", got)
+	}
+	meta, ok := tbl.RawGetString("metadata").(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected metadata table")
+	}
+	if got := meta.RawGetString("env").String(); got != "staging" {
+		t.Errorf("metadata.env mismatch: got %q", got)
+	}
+}
+
+func TestHeadObjectYieldHandleResult_Error(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireHeadObjectYield()
+	defer ReleaseHeadObjectYield(y)
+
+	result := y.HandleResult(l, csapi.HeadObjectResponse{Error: errors.New("boom")}, nil)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 return values, got %d", len(result))
+	}
+	if result[1] == lua.LNil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestPreconditionFailedMapping(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireUploadObjectYield()
+	defer ReleaseUploadObjectYield(y)
+
+	result := y.HandleResult(l, csapi.UploadObjectResponse{Error: csapi.ErrPreconditionFailed}, nil)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 return values")
+	}
+	luaErr, ok := result[1].(*lua.Error)
+	if !ok {
+		t.Fatalf("expected *lua.Error, got %T", result[1])
+	}
+	if luaErr.Kind() != lua.Conflict {
+		t.Errorf("expected Conflict kind, got %s", luaErr.Kind())
+	}
+	if !strings.Contains(luaErr.Message, "precondition_failed") {
+		t.Errorf("expected message to contain 'precondition_failed', got %q", luaErr.Message)
+	}
+}
+
+func TestListObjectsYieldHandleResult_Fields(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireListObjectsYield()
+	defer ReleaseListObjectsYield(y)
+
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	data := csapi.ListObjectsResponse{
+		Result: &csapi.ListObjectsResult{
+			Objects: []csapi.ObjectMetadata{
+				{
+					Key:          "f.txt",
+					Size:         11,
+					ETag:         "e",
+					StorageClass: "STANDARD",
+					LastModified: now,
+					VersionID:    "v1",
+					Owner:        &csapi.Owner{ID: "oid", DisplayName: "ON"},
+				},
+			},
+		},
+	}
+
+	res := y.HandleResult(l, data, nil)
+	tbl := res[0].(*lua.LTable)
+	objs := tbl.RawGetString("objects").(*lua.LTable)
+	first := objs.RawGetInt(1).(*lua.LTable)
+
+	if first.RawGetString("storage_class").String() != "STANDARD" {
+		t.Error("storage_class missing")
+	}
+	if int64(lua.LVAsNumber(first.RawGetString("last_modified"))) != now.Unix() {
+		t.Error("last_modified missing")
+	}
+	if first.RawGetString("version_id").String() != "v1" {
+		t.Error("version_id missing")
+	}
+	owner, ok := first.RawGetString("owner").(*lua.LTable)
+	if !ok {
+		t.Fatal("owner missing")
+	}
+	if owner.RawGetString("id").String() != "oid" {
+		t.Error("owner.id missing")
 	}
 }

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -72,7 +72,7 @@ Lists objects in storage with optional filtering.
 | max_keys | integer | 0 | Maximum objects to return (0 = unlimited) |
 | continuation_token | string | "" | Token for pagination |
 | include_owner | boolean | false | When true, populate `owner` on each result (S3: FetchOwner=true) |
-| include_versions | boolean | false | When true, list every version (S3: ListObjectVersions); pagination uses key markers |
+| include_versions | boolean | false | When true, list every version (S3: ListObjectVersions). `next_continuation_token` then carries S3's `NextKeyMarker` instead of an opaque V2 token, so do not switch `include_versions` mid-pagination. Versioning must be enabled on the bucket; otherwise the response only contains the current "null" version per key. |
 
 **Returns:**
 - Success: `table` - result table with fields below
@@ -144,7 +144,7 @@ provider has set it on upload).
 | Field | Type | Notes |
 |-------|------|-------|
 | size | integer | Object size in bytes |
-| etag | string | Entity tag, returned without surrounding quotes — pass it back as-is to `if_match` / `if_none_match` |
+| etag | string | Entity tag (RFC 7232 form, including the surrounding `"` quotes) — pass it back as-is to `if_match` / `if_none_match` |
 | content_type | string | MIME type |
 | cache_control | string | Cache-Control header |
 | content_disposition | string | Content-Disposition header |

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -274,8 +274,10 @@ storage:upload_object("data/photo.jpg", bytes, {
     metadata = { uploaded_by = "tests", env = "staging" },
 })
 
--- Optimistic concurrency: only upload if no object exists yet
+-- Optimistic concurrency: only upload if no object exists yet.
+-- The two forms are equivalent; only_if_absent is the Lua-friendly alias.
 local _, err = storage:upload_object("data/once.txt", "first", { if_none_match = "*" })
+local _, err = storage:upload_object("data/once.txt", "first", { only_if_absent = true })
 if err and err:kind() == errors.CONFLICT then
     -- another writer beat us to it
 end

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -153,6 +153,7 @@ provider has set it on upload).
 | version_id | string | Version ID (omitted when empty) |
 | last_modified | integer | Last-modified timestamp in Unix seconds (sub-second precision is dropped; omitted if zero) |
 | metadata | table<string,string> | User-defined metadata. AWS lowercases keys. Always present — empty table when there is no user metadata. |
+| headers | table<string,string> | Raw HTTP response headers (lowercased keys; multi-valued joined with `, `). Escape hatch for provider-specific fields not modeled above (e.g. `x-amz-tagging-count`, `x-amz-replication-status`, `x-amz-server-side-encryption`). Always present — empty when the provider sends no headers. |
 
 **Errors (structured):**
 
@@ -241,6 +242,7 @@ preconditions.
 | if_match | string | "" | Only upload if the existing object's ETag matches |
 | if_none_match | string | "" | Only upload if no object exists ("*") or its ETag does not match |
 | only_if_absent | boolean | false | Friendly alias for `if_none_match = "*"`. When `true`, overrides any explicit `if_none_match`. |
+| headers | table<string,string> | nil | Raw HTTP request headers passed verbatim to the provider. Escape hatch for provider-specific options (e.g. `x-amz-tagging`, `x-amz-server-side-encryption`, `x-amz-website-redirect-location`). Headers participate in request signing. |
 
 **Returns:**
 - Success: `true`
@@ -482,10 +484,48 @@ storage:delete_objects({"backups/data.txt"})
 storage:release()
 ```
 
+## Portability notes
+
+The S3 protocol is implemented by many backends (AWS, MinIO, Cloudflare R2,
+Backblaze B2, DigitalOcean Spaces, Wasabi, Scaleway, OVH, IBM, Oracle,
+Alibaba OSS, Tencent COS, Ceph RGW, etc.) with subtle behavior differences.
+The most important caveats:
+
+- **`etag` is not a content checksum.** AWS multipart uploads return
+  `<md5>-<partCount>`. SSE-KMS / SSE-C objects return opaque values.
+  Backblaze B2 returns SHA-1 shaped like an MD5 string. Use `etag` only for
+  round-tripping into `if_match` / `if_none_match` against the same backend.
+- **Conditional ops are not universally honored.** AWS, MinIO and R2 respect
+  `if_match` / `if_none_match` correctly; some older or self-hosted
+  S3-compatible implementations silently ignore them, so `only_if_absent`
+  may degrade into "always overwrite." Validate against your backend if
+  optimistic concurrency is critical.
+- **`version_id`.** Cloudflare R2 (as of writing) and several other
+  S3-compatible backends do not implement versioning at all;
+  `include_versions = true` returns an empty result or an error there.
+  The literal string `"null"` is a valid version_id for objects created
+  before versioning was enabled. Don't parse version_id values.
+- **`storage_class` values are provider-specific.** Most single-tier
+  backends (R2, B2, DO Spaces, Wasabi, MinIO) report `STANDARD` always.
+  AWS, Scaleway, IBM, Alibaba and Tencent expose richer tiers with
+  different vocabularies. Ceph operators can configure arbitrary
+  placement-target names. Code that branches on `storage_class` is
+  implicitly coupled to a specific deployment.
+- **`metadata`.** Limits vary (AWS ~2 KB total, R2 8 KB, MinIO ~32 KB).
+  Stick to ASCII values and stay under 2 KB to be portable. Keys come back
+  lowercased on every reasonable provider.
+- **`headers` escape-hatch.** Use this when you need a provider-specific
+  feature (tagging, SSE, replication) that is not modeled as a typed
+  field. The trade-off is that you are now coupled to that backend's
+  header conventions.
+
 ## Changelog
 
 - Object metadata, ETag, and conditional ops — [#264](https://github.com/wippyai/runtime/pull/264):
   `head_object`, richer `list_objects` fields (`last_modified`, `storage_class`,
   `owner`, `version_id`), `upload_object` options (content headers, user metadata,
   `if_match`/`if_none_match`), `download_object` `if_match`/`if_none_match`,
-  and 404 from `head_object` / `download_object` mapped to `errors.NOT_FOUND`.
+  404 from `head_object` / `download_object` mapped to `errors.NOT_FOUND`,
+  and a `headers` escape-hatch on both `upload_object` (request) and
+  `head_object` (response) for provider-specific HTTP headers not modeled
+  as typed fields.

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -484,4 +484,5 @@ storage:release()
 - Object metadata, ETag, and conditional ops — [#264](https://github.com/wippyai/runtime/pull/264):
   `head_object`, richer `list_objects` fields (`last_modified`, `storage_class`,
   `owner`, `version_id`), `upload_object` options (content headers, user metadata,
-  `if_match`/`if_none_match`), and `download_object` `if_match`/`if_none_match`.
+  `if_match`/`if_none_match`), `download_object` `if_match`/`if_none_match`,
+  and 404 from `head_object` / `download_object` mapped to `errors.NOT_FOUND`.

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -240,6 +240,7 @@ preconditions.
 | metadata | table<string,string> | nil | User metadata; AWS lowercases keys |
 | if_match | string | "" | Only upload if the existing object's ETag matches |
 | if_none_match | string | "" | Only upload if no object exists ("*") or its ETag does not match |
+| only_if_absent | boolean | false | Friendly alias for `if_none_match = "*"`. When `true`, overrides any explicit `if_none_match`. |
 
 **Returns:**
 - Success: `true`

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -144,15 +144,15 @@ provider has set it on upload).
 | Field | Type | Notes |
 |-------|------|-------|
 | size | integer | Object size in bytes |
-| etag | string | Entity tag |
+| etag | string | Entity tag, returned without surrounding quotes — pass it back as-is to `if_match` / `if_none_match` |
 | content_type | string | MIME type |
 | cache_control | string | Cache-Control header |
 | content_disposition | string | Content-Disposition header |
 | content_encoding | string | Content-Encoding header |
 | storage_class | string | Storage class |
 | version_id | string | Version ID (omitted when empty) |
-| last_modified | integer | Last-modified timestamp in Unix seconds (omitted if zero) |
-| metadata | table<string,string> | User-defined metadata. AWS lowercases keys. |
+| last_modified | integer | Last-modified timestamp in Unix seconds (sub-second precision is dropped; omitted if zero) |
+| metadata | table<string,string> | User-defined metadata. AWS lowercases keys. Always present — empty table when there is no user metadata. |
 
 **Errors (structured):**
 

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -521,11 +521,38 @@ The most important caveats:
 
 ## Changelog
 
-- Object metadata, ETag, and conditional ops — [#264](https://github.com/wippyai/runtime/pull/264):
-  `head_object`, richer `list_objects` fields (`last_modified`, `storage_class`,
-  `owner`, `version_id`), `upload_object` options (content headers, user metadata,
-  `if_match`/`if_none_match`), `download_object` `if_match`/`if_none_match`,
-  404 from `head_object` / `download_object` mapped to `errors.NOT_FOUND`,
-  and a `headers` escape-hatch on both `upload_object` (request) and
-  `head_object` (response) for provider-specific HTTP headers not modeled
-  as typed fields.
+### [#264](https://github.com/wippyai/runtime/pull/264) — object metadata, ETag, conditional ops, headers escape-hatch
+
+All additions are purely additive; pre-existing call signatures keep working unchanged.
+
+**New method**
+- `storage:head_object(key)` → `result, error` — full per-object metadata, the only way to read user metadata (`x-amz-meta-*`).
+
+**`storage:list_objects(options)` new options**
+- `include_owner: boolean` — populates `owner` on each result (S3: `FetchOwner=true`).
+- `include_versions: boolean` — switches to `ListObjectVersions`, fills `version_id`.
+
+**`storage:list_objects` result — new fields per object**
+- `last_modified` (Unix seconds)
+- `storage_class` (string, provider-specific)
+- `version_id` (only with `include_versions`)
+- `owner` (table `{ id, display_name }`, only with `include_owner`)
+
+**`storage:upload_object(key, content, options)` — new optional 4th arg**
+- `content_type`, `cache_control`, `content_disposition`, `content_encoding`
+- `metadata: table<string,string>` — user metadata (`x-amz-meta-*`)
+- `if_match: string`, `if_none_match: string` — conditional upload
+- `only_if_absent: boolean` — Lua-friendly alias for `if_none_match = "*"`
+- `headers: table<string,string>` — raw HTTP request headers escape-hatch
+
+**`storage:download_object(key, writer, options)` — new option fields**
+- `if_match: string`, `if_none_match: string`
+
+**`storage:head_object` result fields**
+- `size`, `etag`, `content_type`, `cache_control`, `content_disposition`, `content_encoding`, `storage_class`, `version_id`, `last_modified`
+- `metadata: table<string,string>` (always present)
+- `headers: table<string,string>` (always present; lowercased keys)
+
+**New error kinds surfaced**
+- `errors.NOT_FOUND` — `head_object` / `download_object` on a missing key.
+- `errors.CONFLICT` (message `"precondition_failed"`) — when `if_match` / `if_none_match` / `only_if_absent` fails.

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -478,3 +478,10 @@ print("Share this URL:", url)
 storage:delete_objects({"backups/data.txt"})
 storage:release()
 ```
+
+## Changelog
+
+- Object metadata, ETag, and conditional ops — [#264](https://github.com/wippyai/runtime/pull/264):
+  `head_object`, richer `list_objects` fields (`last_modified`, `storage_class`,
+  `owner`, `version_id`), `upload_object` options (content headers, user metadata,
+  `if_match`/`if_none_match`), and `download_object` `if_match`/`if_none_match`.

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -48,8 +48,9 @@ Returned by `cloudstorage.get()`. Provides methods for cloud storage operations.
 | Method | Signature | Returns | Notes |
 |--------|-----------|---------|-------|
 | list_objects | (options?: table) | table, error | Lists objects with optional filtering |
+| head_object | (key: string) | table, error | Fetches full metadata for a single object |
 | download_object | (key: string, writer: io.Writer, options?: table) | boolean, error | Downloads object to writer |
-| upload_object | (key: string, content: string \| io.Reader) | boolean, error | Uploads object from string or reader |
+| upload_object | (key: string, content: string \| io.Reader, options?: table) | boolean, error | Uploads object from string or reader |
 | delete_objects | (keys: string[]) | boolean, error | Deletes multiple objects |
 | presigned_get_url | (key: string, options?: table) | string, error | Generates presigned download URL |
 | presigned_put_url | (key: string, options?: table) | string, error | Generates presigned upload URL |
@@ -70,6 +71,8 @@ Lists objects in storage with optional filtering.
 | prefix | string | "" | Filter objects starting with prefix |
 | max_keys | integer | 0 | Maximum objects to return (0 = unlimited) |
 | continuation_token | string | "" | Token for pagination |
+| include_owner | boolean | false | When true, populate `owner` on each result (S3: FetchOwner=true) |
+| include_versions | boolean | false | When true, list every version (S3: ListObjectVersions); pagination uses key markers |
 
 **Returns:**
 - Success: `table` - result table with fields below
@@ -89,8 +92,12 @@ Lists objects in storage with optional filtering.
 |-------|------|-------|
 | key | string | Object key/path |
 | size | integer | Object size in bytes |
-| content_type | string | MIME type |
+| content_type | string | MIME type (empty for ListObjectsV2 — use `head_object` to retrieve) |
 | etag | string | Entity tag |
+| storage_class | string | Storage class (e.g. STANDARD, STANDARD_IA, GLACIER) |
+| last_modified | integer | Last-modified timestamp in Unix seconds (omitted if zero) |
+| version_id | string | Object version ID (only present when `include_versions = true`) |
+| owner | table | `{ id = string, display_name = string }` — only present when `include_owner = true` |
 
 **Errors (structured):**
 
@@ -117,6 +124,51 @@ if result.is_truncated then
 end
 ```
 
+#### storage:head_object(key: string) → table, error
+
+Fetches full metadata for a single object, including user-defined metadata (`x-amz-meta-*`).
+Useful when you need richer information than `list_objects` provides — list responses do not
+include user metadata, and `content_type` is only populated by `head_object` (or after the
+provider has set it on upload).
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| key | string | yes | - | Object key |
+
+**Returns:**
+- Success: `table` — see fields below
+- Error: `nil, error` — structured error
+
+**Result table:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| size | integer | Object size in bytes |
+| etag | string | Entity tag |
+| content_type | string | MIME type |
+| cache_control | string | Cache-Control header |
+| content_disposition | string | Content-Disposition header |
+| content_encoding | string | Content-Encoding header |
+| storage_class | string | Storage class |
+| version_id | string | Version ID (omitted when empty) |
+| last_modified | integer | Last-modified timestamp in Unix seconds (omitted if zero) |
+| metadata | table<string,string> | User-defined metadata. AWS lowercases keys. |
+
+**Errors (structured):**
+
+| Condition | Kind |
+|-----------|------|
+| key empty | errors.INVALID |
+| storage released | errors.INVALID |
+| object not found | errors.NOT_FOUND |
+| operation failed | errors.INTERNAL |
+
+```lua
+local head, err = storage:head_object("uploads/photo.jpg")
+if err then error(err) end
+print(head.content_type, head.size, head.metadata.uploaded_by)
+```
+
 #### storage:download_object(key: string, writer: io.Writer, options?: table) → boolean, error
 
 Downloads an object to an io.Writer (typically fs.File).
@@ -132,6 +184,8 @@ Downloads an object to an io.Writer (typically fs.File).
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | range | string | "" | Byte range (e.g., "bytes=0-1023" for first 1KB) |
+| if_match | string | "" | Only download if the object's current ETag matches |
+| if_none_match | string | "" | Only download if the object's current ETag does NOT match |
 
 **Returns:**
 - Success: `true`
@@ -145,6 +199,7 @@ Downloads an object to an io.Writer (typically fs.File).
 | storage released | errors.INVALID |
 | writer not io.Writer | errors.INVALID |
 | object not found | errors.NOT_FOUND |
+| if_match / if_none_match precondition fails | errors.CONFLICT (message `precondition_failed`) |
 | operation failed | errors.INTERNAL |
 
 **Yields:** until download completes
@@ -162,14 +217,29 @@ file:close()
 if err then error(err) end
 ```
 
-#### storage:upload_object(key: string, content: string | io.Reader) → boolean, error
+#### storage:upload_object(key: string, content: string | io.Reader, options?: table) → boolean, error
 
-Uploads an object from string or io.Reader.
+Uploads an object from string or io.Reader. The optional fourth argument carries
+metadata and HTTP headers that are sent to the provider, plus optional ETag-based
+preconditions.
 
 | Param | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
 | key | string | yes | - | Object key/path |
 | content | string \| io.Reader | yes | - | Content as string or reader (e.g., fs.File) |
+| options | table | no | nil | Metadata, headers, and preconditions |
+
+**options fields:**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| content_type | string | "" | Content-Type header |
+| cache_control | string | "" | Cache-Control header |
+| content_disposition | string | "" | Content-Disposition header |
+| content_encoding | string | "" | Content-Encoding header |
+| metadata | table<string,string> | nil | User metadata; AWS lowercases keys |
+| if_match | string | "" | Only upload if the existing object's ETag matches |
+| if_none_match | string | "" | Only upload if no object exists ("*") or its ETag does not match |
 
 **Returns:**
 - Success: `true`
@@ -182,6 +252,7 @@ Uploads an object from string or io.Reader.
 | key empty | errors.INVALID |
 | content nil | errors.INVALID |
 | storage released | errors.INVALID |
+| if_match / if_none_match precondition fails | errors.CONFLICT (message `precondition_failed`) |
 | operation failed | errors.INTERNAL |
 
 **Yields:** until upload completes
@@ -195,12 +266,18 @@ Uploads an object from string or io.Reader.
 -- Upload string
 storage:upload_object("data/hello.txt", "Hello, World!")
 
--- Upload from file
-local fs = require("fs")
-local vol, _ = fs.get("app:temp")
-local file, _ = vol:open("/local.txt", "r")
-storage:upload_object("data/uploaded.txt", file)
-file:close()
+-- Upload with metadata and Content-Type
+storage:upload_object("data/photo.jpg", bytes, {
+    content_type = "image/jpeg",
+    cache_control = "max-age=86400",
+    metadata = { uploaded_by = "tests", env = "staging" },
+})
+
+-- Optimistic concurrency: only upload if no object exists yet
+local _, err = storage:upload_object("data/once.txt", "first", { if_none_match = "*" })
+if err and err:kind() == errors.CONFLICT then
+    -- another writer beat us to it
+end
 ```
 
 #### storage:delete_objects(keys: string[]) → boolean, error
@@ -361,7 +438,7 @@ if err then
 end
 ```
 
-**Possible kinds:** `errors.INVALID`, `errors.NOT_FOUND`, `errors.INTERNAL`
+**Possible kinds:** `errors.INVALID`, `errors.NOT_FOUND`, `errors.CONFLICT`, `errors.INTERNAL`
 
 ## Example
 

--- a/runtime/lua/modules/cloudstorage/types.go
+++ b/runtime/lua/modules/cloudstorage/types.go
@@ -41,6 +41,7 @@ var headObjectResultType = typ.NewRecord().
 	OptField("version_id", typ.String).
 	OptField("last_modified", typ.Number).
 	Field("metadata", typ.Any).
+	Field("headers", typ.Any).
 	Build()
 
 // DownloadOptions type
@@ -57,6 +58,7 @@ var uploadOptionsType = typ.NewRecord().
 	OptField("content_disposition", typ.String).
 	OptField("content_encoding", typ.String).
 	OptField("metadata", typ.Any).
+	OptField("headers", typ.Any).
 	OptField("if_match", typ.String).
 	OptField("if_none_match", typ.String).
 	OptField("only_if_absent", typ.Boolean).

--- a/runtime/lua/modules/cloudstorage/types.go
+++ b/runtime/lua/modules/cloudstorage/types.go
@@ -59,6 +59,7 @@ var uploadOptionsType = typ.NewRecord().
 	OptField("metadata", typ.Any).
 	OptField("if_match", typ.String).
 	OptField("if_none_match", typ.String).
+	OptField("only_if_absent", typ.Boolean).
 	Build()
 
 // PresignedURLOptions type

--- a/runtime/lua/modules/cloudstorage/types.go
+++ b/runtime/lua/modules/cloudstorage/types.go
@@ -12,18 +12,53 @@ var listObjectsOptionsType = typ.NewRecord().
 	OptField("prefix", typ.String).
 	OptField("max_keys", typ.Number).
 	OptField("continuation_token", typ.String).
+	OptField("include_owner", typ.Boolean).
+	OptField("include_versions", typ.Boolean).
+	Build()
+
+// Owner type
+var ownerType = typ.NewRecord().
+	Field("id", typ.String).
+	Field("display_name", typ.String).
 	Build()
 
 // ListObjectsResult type
 var listObjectsResultType = typ.NewRecord().
 	Field("objects", typ.NewArray(typ.Any)).
-	OptField("continuation_token", typ.String).
+	OptField("next_continuation_token", typ.String).
 	Field("is_truncated", typ.Boolean).
+	Build()
+
+// HeadObjectResult type
+var headObjectResultType = typ.NewRecord().
+	Field("size", typ.Number).
+	Field("etag", typ.String).
+	Field("content_type", typ.String).
+	Field("cache_control", typ.String).
+	Field("content_disposition", typ.String).
+	Field("content_encoding", typ.String).
+	Field("storage_class", typ.String).
+	OptField("version_id", typ.String).
+	OptField("last_modified", typ.Number).
+	Field("metadata", typ.Any).
 	Build()
 
 // DownloadOptions type
 var downloadOptionsType = typ.NewRecord().
 	OptField("range", typ.String).
+	OptField("if_match", typ.String).
+	OptField("if_none_match", typ.String).
+	Build()
+
+// UploadOptions type
+var uploadOptionsType = typ.NewRecord().
+	OptField("content_type", typ.String).
+	OptField("cache_control", typ.String).
+	OptField("content_disposition", typ.String).
+	OptField("content_encoding", typ.String).
+	OptField("metadata", typ.Any).
+	OptField("if_match", typ.String).
+	OptField("if_none_match", typ.String).
 	Build()
 
 // PresignedURLOptions type
@@ -36,8 +71,9 @@ var presignedURLOptionsType = typ.NewRecord().
 // Storage type
 var storageType = typ.NewInterface("cloudstorage.Storage", []typ.Method{
 	{Name: "list_objects", Type: typ.Func().Param("self", typ.Self).OptParam("options", listObjectsOptionsType).Returns(listObjectsResultType, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "head_object", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Returns(headObjectResultType, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "download_object", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Param("dest", typ.Any).OptParam("options", downloadOptionsType).Returns(typ.Number, typ.NewOptional(typ.LuaError)).Build()},
-	{Name: "upload_object", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Param("source", typ.Any).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "upload_object", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Param("source", typ.Any).OptParam("options", uploadOptionsType).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "delete_objects", Type: typ.Func().Param("self", typ.Self).Param("keys", typ.NewArray(typ.String)).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "presigned_get_url", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).OptParam("options", presignedURLOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "presigned_put_url", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).OptParam("options", presignedURLOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
@@ -51,7 +87,10 @@ func ModuleTypes() *io.Manifest {
 	m.DefineType("Storage", storageType)
 	m.DefineType("ListObjectsOptions", listObjectsOptionsType)
 	m.DefineType("ListObjectsResult", listObjectsResultType)
+	m.DefineType("Owner", ownerType)
+	m.DefineType("HeadObjectResult", headObjectResultType)
 	m.DefineType("DownloadOptions", downloadOptionsType)
+	m.DefineType("UploadOptions", uploadOptionsType)
 	m.DefineType("PresignedURLOptions", presignedURLOptionsType)
 
 	moduleType := typ.NewInterface("cloudstorage", []typ.Method{

--- a/runtime/lua/modules/cloudstorage/yields.go
+++ b/runtime/lua/modules/cloudstorage/yields.go
@@ -22,6 +22,11 @@ func wrapStorageError(l *lua.LState, err error, op string) lua.LValue {
 			WithKind(lua.Conflict).
 			WithRetryable(false)
 	}
+	if errors.Is(err, csapi.ErrNotFound) {
+		return lua.NewLuaError(l, "not_found").
+			WithKind(lua.NotFound).
+			WithRetryable(false)
+	}
 	return lua.WrapErrorWithLua(l, err, op)
 }
 

--- a/runtime/lua/modules/cloudstorage/yields.go
+++ b/runtime/lua/modules/cloudstorage/yields.go
@@ -410,5 +410,10 @@ func headObjectResultToLua(l *lua.LState, result *csapi.HeadObjectResult) lua.LV
 		metaTbl.RawSetString(k, lua.LString(v))
 	}
 	t.RawSetString("metadata", metaTbl)
+	headersTbl := l.CreateTable(0, len(result.Headers))
+	for k, v := range result.Headers {
+		headersTbl.RawSetString(k, lua.LString(v))
+	}
+	t.RawSetString("headers", headersTbl)
 	return t
 }

--- a/runtime/lua/modules/cloudstorage/yields.go
+++ b/runtime/lua/modules/cloudstorage/yields.go
@@ -4,6 +4,7 @@ package cloudstorage
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"sync"
 	"time"
@@ -12,6 +13,17 @@ import (
 	csapi "github.com/wippyai/runtime/api/cloudstorage"
 	"github.com/wippyai/runtime/api/dispatcher"
 )
+
+// wrapStorageError translates known cloudstorage errors into structured Lua errors.
+// Unknown errors fall back to lua.WrapErrorWithLua.
+func wrapStorageError(l *lua.LState, err error, op string) lua.LValue {
+	if errors.Is(err, csapi.ErrPreconditionFailed) {
+		return lua.NewLuaError(l, "precondition_failed").
+			WithKind(lua.Conflict).
+			WithRetryable(false)
+	}
+	return lua.WrapErrorWithLua(l, err, op)
+}
 
 // ListObjectsYield wraps ListObjectsCmd for Lua.
 type ListObjectsYield struct {
@@ -42,14 +54,14 @@ func (y *ListObjectsYield) Release()                      { ReleaseListObjectsYi
 
 func (y *ListObjectsYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
 	if err != nil {
-		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "list_objects")}
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "list_objects")}
 	}
 	resp, ok := data.(csapi.ListObjectsResponse)
 	if !ok {
 		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
 	}
 	if resp.Error != nil {
-		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, resp.Error, "list_objects")}
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "list_objects")}
 	}
 	return []lua.LValue{listObjectsResultToLua(l, resp.Result), lua.LNil}
 }
@@ -59,11 +71,24 @@ func listObjectsResultToLua(l *lua.LState, result *csapi.ListObjectsResult) lua.
 
 	objects := l.CreateTable(len(result.Objects), 0)
 	for i, obj := range result.Objects {
-		objTbl := l.CreateTable(0, 4)
+		objTbl := l.CreateTable(0, 8)
 		objTbl.RawSetString("key", lua.LString(obj.Key))
 		objTbl.RawSetString("size", lua.LNumber(obj.Size))
 		objTbl.RawSetString("content_type", lua.LString(obj.ContentType))
 		objTbl.RawSetString("etag", lua.LString(obj.ETag))
+		objTbl.RawSetString("storage_class", lua.LString(obj.StorageClass))
+		if !obj.LastModified.IsZero() {
+			objTbl.RawSetString("last_modified", lua.LNumber(obj.LastModified.Unix()))
+		}
+		if obj.VersionID != "" {
+			objTbl.RawSetString("version_id", lua.LString(obj.VersionID))
+		}
+		if obj.Owner != nil {
+			ownerTbl := l.CreateTable(0, 2)
+			ownerTbl.RawSetString("id", lua.LString(obj.Owner.ID))
+			ownerTbl.RawSetString("display_name", lua.LString(obj.Owner.DisplayName))
+			objTbl.RawSetString("owner", ownerTbl)
+		}
 		objects.RawSetInt(i+1, objTbl)
 	}
 	t.RawSetString("objects", objects)
@@ -107,14 +132,14 @@ func (y *DownloadObjectYield) Release() { ReleaseDownloadObjectYield(y) }
 
 func (y *DownloadObjectYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
 	if err != nil {
-		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "download_object")}
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "download_object")}
 	}
 	resp, ok := data.(csapi.DownloadObjectResponse)
 	if !ok {
 		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
 	}
 	if resp.Error != nil {
-		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, resp.Error, "download_object")}
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "download_object")}
 	}
 	return []lua.LValue{lua.LTrue}
 }
@@ -160,14 +185,14 @@ func (y *UploadObjectYield) Release() { ReleaseUploadObjectYield(y) }
 
 func (y *UploadObjectYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
 	if err != nil {
-		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "upload_object")}
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "upload_object")}
 	}
 	resp, ok := data.(csapi.UploadObjectResponse)
 	if !ok {
 		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
 	}
 	if resp.Error != nil {
-		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, resp.Error, "upload_object")}
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "upload_object")}
 	}
 	return []lua.LValue{lua.LTrue, lua.LNil}
 }
@@ -317,4 +342,68 @@ func (y *PresignedPutURLYield) HandleResult(l *lua.LState, data any, err error) 
 		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, resp.Error, "presigned_put_url")}
 	}
 	return []lua.LValue{lua.LString(resp.URL), lua.LNil}
+}
+
+// HeadObjectYield wraps HeadObjectCmd for Lua.
+type HeadObjectYield struct {
+	*csapi.HeadObjectCmd
+}
+
+var headObjectYieldPool = sync.Pool{New: func() any { return &HeadObjectYield{} }}
+
+func AcquireHeadObjectYield() *HeadObjectYield {
+	y := headObjectYieldPool.Get().(*HeadObjectYield)
+	y.HeadObjectCmd = csapi.AcquireHeadObjectCmd()
+	return y
+}
+
+func ReleaseHeadObjectYield(y *HeadObjectYield) {
+	if y.HeadObjectCmd != nil {
+		y.HeadObjectCmd.Release()
+		y.HeadObjectCmd = nil
+	}
+	headObjectYieldPool.Put(y)
+}
+
+func (y *HeadObjectYield) String() string                { return "<cloudstorage_head_object_yield>" }
+func (y *HeadObjectYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *HeadObjectYield) CmdID() dispatcher.CommandID   { return csapi.HeadObject }
+func (y *HeadObjectYield) ToCommand() dispatcher.Command { return y.HeadObjectCmd }
+func (y *HeadObjectYield) Release()                      { ReleaseHeadObjectYield(y) }
+
+func (y *HeadObjectYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "head_object")}
+	}
+	resp, ok := data.(csapi.HeadObjectResponse)
+	if !ok {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
+	}
+	if resp.Error != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "head_object")}
+	}
+	return []lua.LValue{headObjectResultToLua(l, resp.Result), lua.LNil}
+}
+
+func headObjectResultToLua(l *lua.LState, result *csapi.HeadObjectResult) lua.LValue {
+	t := l.CreateTable(0, 10)
+	t.RawSetString("size", lua.LNumber(result.Size))
+	t.RawSetString("etag", lua.LString(result.ETag))
+	t.RawSetString("content_type", lua.LString(result.ContentType))
+	t.RawSetString("cache_control", lua.LString(result.CacheControl))
+	t.RawSetString("content_disposition", lua.LString(result.ContentDisposition))
+	t.RawSetString("content_encoding", lua.LString(result.ContentEncoding))
+	t.RawSetString("storage_class", lua.LString(result.StorageClass))
+	if result.VersionID != "" {
+		t.RawSetString("version_id", lua.LString(result.VersionID))
+	}
+	if !result.LastModified.IsZero() {
+		t.RawSetString("last_modified", lua.LNumber(result.LastModified.Unix()))
+	}
+	metaTbl := l.CreateTable(0, len(result.UserMetadata))
+	for k, v := range result.UserMetadata {
+		metaTbl.RawSetString(k, lua.LString(v))
+	}
+	t.RawSetString("metadata", metaTbl)
+	return t
 }

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -164,6 +164,9 @@ func (s *Storage) HeadObject(ctx context.Context, key string) (*cloudstorage.Hea
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrNotFound) {
+			return nil, mapped
+		}
 		s.log.Error("head object failed",
 			zap.String("key", key),
 			zap.Error(err))
@@ -214,7 +217,8 @@ func (s *Storage) DownloadObject(ctx context.Context, key string, w io.Writer, o
 
 	output, err := s.client.GetObject(ctx, input)
 	if err != nil {
-		if mapped := mapPreconditionError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
+		mapped := mapKnownError(err)
+		if errors.Is(mapped, cloudstorage.ErrPreconditionFailed) || errors.Is(mapped, cloudstorage.ErrNotFound) {
 			return mapped
 		}
 		s.log.Error("download object failed",
@@ -271,7 +275,7 @@ func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reade
 
 	_, err := s.client.PutObject(ctx, input)
 	if err != nil {
-		if mapped := mapPreconditionError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
+		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
 			return mapped
 		}
 		s.log.Error("upload object failed",
@@ -377,14 +381,28 @@ func (s *Storage) PresignedPutURL(ctx context.Context, key string, opts *cloudst
 	return result.URL, nil
 }
 
-// mapPreconditionError converts S3 412 / 304 responses to cloudstorage.ErrPreconditionFailed.
-func mapPreconditionError(err error) error {
+// mapKnownError translates S3 SDK errors into the typed sentinels exposed by
+// the cloudstorage package: 404 / NoSuchKey / NotFound → ErrNotFound,
+// 412 / 304 → ErrPreconditionFailed. Other errors pass through unchanged.
+func mapKnownError(err error) error {
 	if err == nil {
 		return nil
 	}
+
+	var noSuchKey *types.NoSuchKey
+	if errors.As(err, &noSuchKey) {
+		return cloudstorage.ErrNotFound
+	}
+	var notFound *types.NotFound
+	if errors.As(err, &notFound) {
+		return cloudstorage.ErrNotFound
+	}
+
 	var respErr *awshttp.ResponseError
 	if errors.As(err, &respErr) {
 		switch respErr.HTTPStatusCode() {
+		case http.StatusNotFound:
+			return cloudstorage.ErrNotFound
 		case http.StatusPreconditionFailed, http.StatusNotModified:
 			return cloudstorage.ErrPreconditionFailed
 		}

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -7,12 +7,15 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/wippyai/runtime/api/cloudstorage"
 	"go.uber.org/zap"
 )
@@ -159,9 +162,15 @@ func (s *Storage) listObjectVersions(ctx context.Context, opts *cloudstorage.Lis
 
 // HeadObject fetches full metadata for a single object.
 func (s *Storage) HeadObject(ctx context.Context, key string) (*cloudstorage.HeadObjectResult, error) {
+	var rawHeaders http.Header
+	captureMW := &captureResponseHeadersMiddleware{out: &rawHeaders}
 	output, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
+	}, func(o *s3.Options) {
+		o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+			return stack.Deserialize.Add(captureMW, middleware.After)
+		})
 	})
 	if err != nil {
 		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrNotFound) {
@@ -182,6 +191,7 @@ func (s *Storage) HeadObject(ctx context.Context, key string) (*cloudstorage.Hea
 		ContentEncoding:    aws.ToString(output.ContentEncoding),
 		StorageClass:       string(output.StorageClass),
 		VersionID:          aws.ToString(output.VersionId),
+		Headers:            flattenHeaders(rawHeaders),
 	}
 	if output.LastModified != nil {
 		res.LastModified = *output.LastModified
@@ -273,7 +283,17 @@ func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reade
 		}
 	}
 
-	_, err := s.client.PutObject(ctx, input)
+	var apiOptions []func(*s3.Options)
+	if opts != nil && len(opts.Headers) > 0 {
+		mw := &addRequestHeadersMiddleware{headers: opts.Headers}
+		apiOptions = append(apiOptions, func(o *s3.Options) {
+			o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+				return stack.Build.Add(mw, middleware.After)
+			})
+		})
+	}
+
+	_, err := s.client.PutObject(ctx, input, apiOptions...)
 	if err != nil {
 		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
 			return mapped
@@ -379,6 +399,62 @@ func (s *Storage) PresignedPutURL(ctx context.Context, key string, opts *cloudst
 	}
 
 	return result.URL, nil
+}
+
+// addRequestHeadersMiddleware injects the given HTTP headers into the outgoing
+// request before signing, so they participate in the SigV4 canonical request.
+// Used by UploadObject to pass through caller-supplied headers (e.g.
+// x-amz-tagging, x-amz-server-side-encryption).
+type addRequestHeadersMiddleware struct {
+	headers map[string]string
+}
+
+func (m *addRequestHeadersMiddleware) ID() string { return "wippyAddRequestHeaders" }
+
+func (m *addRequestHeadersMiddleware) HandleBuild(
+	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
+) (middleware.BuildOutput, middleware.Metadata, error) {
+	if req, ok := in.Request.(*smithyhttp.Request); ok {
+		for k, v := range m.headers {
+			req.Header.Set(k, v)
+		}
+	}
+	return next.HandleBuild(ctx, in)
+}
+
+// captureResponseHeadersMiddleware snapshots the raw HTTP response headers
+// from a successful operation. Used by HeadObject to expose headers that are
+// not modeled as typed fields.
+type captureResponseHeadersMiddleware struct {
+	out *http.Header
+}
+
+func (m *captureResponseHeadersMiddleware) ID() string { return "wippyCaptureResponseHeaders" }
+
+func (m *captureResponseHeadersMiddleware) HandleDeserialize(
+	ctx context.Context, in middleware.DeserializeInput, next middleware.DeserializeHandler,
+) (middleware.DeserializeOutput, middleware.Metadata, error) {
+	out, metadata, err := next.HandleDeserialize(ctx, in)
+	if err != nil {
+		return out, metadata, err
+	}
+	if resp, ok := out.RawResponse.(*smithyhttp.Response); ok && resp != nil {
+		*m.out = resp.Header.Clone()
+	}
+	return out, metadata, err
+}
+
+// flattenHeaders converts http.Header to map[string]string with lowercased
+// keys. Multi-valued headers are joined with ", " per RFC 7230 §3.2.2.
+func flattenHeaders(h http.Header) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, vs := range h {
+		out[strings.ToLower(k)] = strings.Join(vs, ", ")
+	}
+	return out
 }
 
 // mapKnownError translates S3 SDK errors into the typed sentinels exposed by

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -4,10 +4,13 @@ package s3
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/wippyai/runtime/api/cloudstorage"
@@ -39,14 +42,19 @@ func NewStorage(client *s3.Client, bucket string, log *zap.Logger) *Storage {
 	}
 }
 
-// ListObjects lists objects in the S3 bucket with the given options
+// ListObjects lists objects in the S3 bucket with the given options.
 func (s *Storage) ListObjects(ctx context.Context, opts *cloudstorage.ListObjectsOptions) (*cloudstorage.ListObjectsResult, error) {
-	// Initialize the S3 input parameters
+	if opts != nil && opts.IncludeVersions {
+		return s.listObjectVersions(ctx, opts)
+	}
+	return s.listObjectsV2(ctx, opts)
+}
+
+func (s *Storage) listObjectsV2(ctx context.Context, opts *cloudstorage.ListObjectsOptions) (*cloudstorage.ListObjectsResult, error) {
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
 	}
 
-	// Apply options if provided
 	if opts != nil {
 		if opts.Prefix != "" {
 			input.Prefix = aws.String(opts.Prefix)
@@ -57,51 +65,158 @@ func (s *Storage) ListObjects(ctx context.Context, opts *cloudstorage.ListObject
 		if opts.ContinuationToken != "" {
 			input.ContinuationToken = aws.String(opts.ContinuationToken)
 		}
+		if opts.IncludeOwner {
+			input.FetchOwner = aws.Bool(true)
+		}
 	}
 
-	// Call the AWS S3 API
 	output, err := s.client.ListObjectsV2(ctx, input)
 	if err != nil {
 		s.log.Error("list objects failed", zap.Error(err))
 		return nil, err
 	}
 
-	// Prepare the result
 	result := &cloudstorage.ListObjectsResult{
 		IsTruncated:           aws.ToBool(output.IsTruncated),
 		NextContinuationToken: aws.ToString(output.NextContinuationToken),
 		Objects:               make([]cloudstorage.ObjectMetadata, 0, len(output.Contents)),
 	}
 
-	// Convert AWS objects to our ObjectMetadata format
 	for _, item := range output.Contents {
-		result.Objects = append(result.Objects, cloudstorage.ObjectMetadata{
-			Key:  aws.ToString(item.Key),
-			Size: aws.ToInt64(item.Size),
-			ETag: aws.ToString(item.ETag),
-			// ContentType is not available in ListObjectsV2 response
-		})
+		obj := cloudstorage.ObjectMetadata{
+			Key:          aws.ToString(item.Key),
+			Size:         aws.ToInt64(item.Size),
+			ETag:         aws.ToString(item.ETag),
+			StorageClass: string(item.StorageClass),
+			// ContentType is not available in ListObjectsV2 response.
+		}
+		if item.LastModified != nil {
+			obj.LastModified = *item.LastModified
+		}
+		if item.Owner != nil {
+			obj.Owner = &cloudstorage.Owner{
+				ID:          aws.ToString(item.Owner.ID),
+				DisplayName: aws.ToString(item.Owner.DisplayName),
+			}
+		}
+		result.Objects = append(result.Objects, obj)
 	}
 
 	return result, nil
 }
 
-// DownloadObject retrieves an object from the S3 bucket and writes it to w
+func (s *Storage) listObjectVersions(ctx context.Context, opts *cloudstorage.ListObjectsOptions) (*cloudstorage.ListObjectsResult, error) {
+	input := &s3.ListObjectVersionsInput{
+		Bucket: aws.String(s.bucket),
+	}
+
+	if opts != nil {
+		if opts.Prefix != "" {
+			input.Prefix = aws.String(opts.Prefix)
+		}
+		if opts.MaxKeys > 0 {
+			input.MaxKeys = aws.Int32(int32(opts.MaxKeys))
+		}
+		if opts.ContinuationToken != "" {
+			input.KeyMarker = aws.String(opts.ContinuationToken)
+		}
+	}
+
+	output, err := s.client.ListObjectVersions(ctx, input)
+	if err != nil {
+		s.log.Error("list object versions failed", zap.Error(err))
+		return nil, err
+	}
+
+	result := &cloudstorage.ListObjectsResult{
+		IsTruncated:           aws.ToBool(output.IsTruncated),
+		NextContinuationToken: aws.ToString(output.NextKeyMarker),
+		Objects:               make([]cloudstorage.ObjectMetadata, 0, len(output.Versions)),
+	}
+
+	for _, v := range output.Versions {
+		obj := cloudstorage.ObjectMetadata{
+			Key:          aws.ToString(v.Key),
+			Size:         aws.ToInt64(v.Size),
+			ETag:         aws.ToString(v.ETag),
+			StorageClass: string(v.StorageClass),
+			VersionID:    aws.ToString(v.VersionId),
+		}
+		if v.LastModified != nil {
+			obj.LastModified = *v.LastModified
+		}
+		if v.Owner != nil {
+			obj.Owner = &cloudstorage.Owner{
+				ID:          aws.ToString(v.Owner.ID),
+				DisplayName: aws.ToString(v.Owner.DisplayName),
+			}
+		}
+		result.Objects = append(result.Objects, obj)
+	}
+
+	return result, nil
+}
+
+// HeadObject fetches full metadata for a single object.
+func (s *Storage) HeadObject(ctx context.Context, key string) (*cloudstorage.HeadObjectResult, error) {
+	output, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		s.log.Error("head object failed",
+			zap.String("key", key),
+			zap.Error(err))
+		return nil, err
+	}
+
+	res := &cloudstorage.HeadObjectResult{
+		Size:               aws.ToInt64(output.ContentLength),
+		ETag:               aws.ToString(output.ETag),
+		ContentType:        aws.ToString(output.ContentType),
+		CacheControl:       aws.ToString(output.CacheControl),
+		ContentDisposition: aws.ToString(output.ContentDisposition),
+		ContentEncoding:    aws.ToString(output.ContentEncoding),
+		StorageClass:       string(output.StorageClass),
+		VersionID:          aws.ToString(output.VersionId),
+	}
+	if output.LastModified != nil {
+		res.LastModified = *output.LastModified
+	}
+	if len(output.Metadata) > 0 {
+		res.UserMetadata = make(map[string]string, len(output.Metadata))
+		for k, v := range output.Metadata {
+			res.UserMetadata[k] = v
+		}
+	}
+
+	return res, nil
+}
+
+// DownloadObject retrieves an object from the S3 bucket and writes it to w.
 func (s *Storage) DownloadObject(ctx context.Context, key string, w io.Writer, opts *cloudstorage.DownloadOptions) error {
-	// Create GetObject input parameters
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	}
 
-	// Apply range header if options are provided
-	if opts != nil && opts.Range != "" {
-		input.Range = aws.String(opts.Range)
+	if opts != nil {
+		if opts.Range != "" {
+			input.Range = aws.String(opts.Range)
+		}
+		if opts.IfMatch != "" {
+			input.IfMatch = aws.String(opts.IfMatch)
+		}
+		if opts.IfNoneMatch != "" {
+			input.IfNoneMatch = aws.String(opts.IfNoneMatch)
+		}
 	}
 
-	// Call the AWS S3 API
 	output, err := s.client.GetObject(ctx, input)
 	if err != nil {
+		if mapped := mapPreconditionError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
+			return mapped
+		}
 		s.log.Error("download object failed",
 			zap.String("key", key),
 			zap.Error(err))
@@ -109,7 +224,6 @@ func (s *Storage) DownloadObject(ctx context.Context, key string, w io.Writer, o
 	}
 	defer func() { _ = output.Body.Close() }()
 
-	// Copy the data to the provided writer
 	if _, err = io.Copy(w, output.Body); err != nil {
 		s.log.Error("write object data failed",
 			zap.String("key", key),
@@ -120,18 +234,46 @@ func (s *Storage) DownloadObject(ctx context.Context, key string, w io.Writer, o
 	return nil
 }
 
-// UploadObject uploads an object to the S3 bucket
-func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reader) error {
-	// Create PutObject input parameters
+// UploadObject uploads an object to the S3 bucket.
+func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reader, opts *cloudstorage.UploadOptions) error {
 	input := &s3.PutObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 		Body:   content,
 	}
 
-	// Call the AWS S3 API
+	if opts != nil {
+		if opts.ContentType != "" {
+			input.ContentType = aws.String(opts.ContentType)
+		}
+		if opts.CacheControl != "" {
+			input.CacheControl = aws.String(opts.CacheControl)
+		}
+		if opts.ContentDisposition != "" {
+			input.ContentDisposition = aws.String(opts.ContentDisposition)
+		}
+		if opts.ContentEncoding != "" {
+			input.ContentEncoding = aws.String(opts.ContentEncoding)
+		}
+		if opts.IfMatch != "" {
+			input.IfMatch = aws.String(opts.IfMatch)
+		}
+		if opts.IfNoneMatch != "" {
+			input.IfNoneMatch = aws.String(opts.IfNoneMatch)
+		}
+		if len(opts.Metadata) > 0 {
+			input.Metadata = make(map[string]string, len(opts.Metadata))
+			for k, v := range opts.Metadata {
+				input.Metadata[k] = v
+			}
+		}
+	}
+
 	_, err := s.client.PutObject(ctx, input)
 	if err != nil {
+		if mapped := mapPreconditionError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
+			return mapped
+		}
 		s.log.Error("upload object failed",
 			zap.String("key", key),
 			zap.Error(err))
@@ -141,13 +283,12 @@ func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reade
 	return nil
 }
 
-// DeleteObjects removes multiple objects from the S3 bucket
+// DeleteObjects removes multiple objects from the S3 bucket.
 func (s *Storage) DeleteObjects(ctx context.Context, keys []string) error {
 	if len(keys) == 0 {
 		return nil
 	}
 
-	// Transform keys slice to S3 ObjectIdentifier slice
 	objects := make([]types.ObjectIdentifier, len(keys))
 	for i, key := range keys {
 		objects[i] = types.ObjectIdentifier{
@@ -155,16 +296,14 @@ func (s *Storage) DeleteObjects(ctx context.Context, keys []string) error {
 		}
 	}
 
-	// Create DeleteObjects input parameters
 	input := &s3.DeleteObjectsInput{
 		Bucket: aws.String(s.bucket),
 		Delete: &types.Delete{
 			Objects: objects,
-			Quiet:   aws.Bool(true), // Don't return details about each deletion
+			Quiet:   aws.Bool(true),
 		},
 	}
 
-	// Call the AWS S3 API
 	_, err := s.client.DeleteObjects(ctx, input)
 	if err != nil {
 		s.log.Error("delete objects failed",
@@ -176,23 +315,20 @@ func (s *Storage) DeleteObjects(ctx context.Context, keys []string) error {
 	return nil
 }
 
-// PresignedGetURL generates a presigned URL for downloading an object from S3
+// PresignedGetURL generates a presigned URL for downloading an object from S3.
 func (s *Storage) PresignedGetURL(ctx context.Context, key string, opts *cloudstorage.PresignedGetOptions) (string, error) {
 	expiration := DefaultPresignExpiration
 	if opts != nil && opts.Expiration > 0 {
 		expiration = opts.Expiration
 	}
 
-	// Create the presigner
 	presigner := s3.NewPresignClient(s.client)
 
-	// Create presigned GET URL input
 	getInput := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	}
 
-	// Generate the presigned URL
 	result, err := presigner.PresignGetObject(ctx, getInput, func(options *s3.PresignOptions) {
 		options.Expires = expiration
 	})
@@ -206,33 +342,28 @@ func (s *Storage) PresignedGetURL(ctx context.Context, key string, opts *cloudst
 	return result.URL, nil
 }
 
-// PresignedPutURL generates a presigned URL for uploading an object to S3
+// PresignedPutURL generates a presigned URL for uploading an object to S3.
 func (s *Storage) PresignedPutURL(ctx context.Context, key string, opts *cloudstorage.PresignedPutOptions) (string, error) {
 	expiration := DefaultPresignExpiration
 	if opts != nil && opts.Expiration > 0 {
 		expiration = opts.Expiration
 	}
 
-	// Create the presigner
 	presigner := s3.NewPresignClient(s.client)
 
-	// Create presigned PUT URL input
 	putInput := &s3.PutObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	}
 
-	// Set content type if provided
 	if opts != nil && opts.ContentType != "" {
 		putInput.ContentType = aws.String(opts.ContentType)
 	}
 
-	// Set content length constraint if provided
 	if opts != nil && opts.ContentLength > 0 {
 		putInput.ContentLength = aws.Int64(opts.ContentLength)
 	}
 
-	// Generate the presigned URL
 	result, err := presigner.PresignPutObject(ctx, putInput, func(options *s3.PresignOptions) {
 		options.Expires = expiration
 	})
@@ -244,4 +375,19 @@ func (s *Storage) PresignedPutURL(ctx context.Context, key string, opts *cloudst
 	}
 
 	return result.URL, nil
+}
+
+// mapPreconditionError converts S3 412 / 304 responses to cloudstorage.ErrPreconditionFailed.
+func mapPreconditionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var respErr *awshttp.ResponseError
+	if errors.As(err, &respErr) {
+		switch respErr.HTTPStatusCode() {
+		case http.StatusPreconditionFailed, http.StatusNotModified:
+			return cloudstorage.ErrPreconditionFailed
+		}
+	}
+	return err
 }

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -51,13 +51,31 @@ func TestStorage_DeleteObjects_EmptyKeys(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// mockListObjectsClient is a mock S3 client for ListObjectsV2
+// mockListObjectsClient is a mock S3 client for ListObjectsV2.
+// It records the most recent input so tests can assert option pass-through.
 type mockListObjectsClient struct {
 	output *s3.ListObjectsV2Output
 	err    error
+	lastIn *s3.ListObjectsV2Input
 }
 
-func (m *mockListObjectsClient) ListObjectsV2(_ context.Context, _ *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+func (m *mockListObjectsClient) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	m.lastIn = in
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.output, nil
+}
+
+// mockListObjectVersionsClient is a mock S3 client for ListObjectVersions.
+type mockListObjectVersionsClient struct {
+	output *s3.ListObjectVersionsOutput
+	err    error
+	lastIn *s3.ListObjectVersionsInput
+}
+
+func (m *mockListObjectVersionsClient) ListObjectVersions(_ context.Context, in *s3.ListObjectVersionsInput, _ ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+	m.lastIn = in
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -150,15 +168,145 @@ func TestStorage_ListObjects(t *testing.T) {
 		assert.Equal(t, "Owner Name", obj.Owner.DisplayName)
 	})
 
-	t.Run("error", func(t *testing.T) {
-		mock := &mockListObjectsClient{
-			err: errors.New("list failed"),
-		}
+	t.Run("IncludeOwner=true sets FetchOwner on the input", func(t *testing.T) {
+		mock := &mockListObjectsClient{output: &s3.ListObjectsV2Output{}}
+		_, err := listObjectsWithMock(context.Background(), mock, "test-bucket",
+			&cloudstorage.ListObjectsOptions{IncludeOwner: true})
+		require.NoError(t, err)
+		require.NotNil(t, mock.lastIn)
+		require.NotNil(t, mock.lastIn.FetchOwner)
+		assert.True(t, *mock.lastIn.FetchOwner, "FetchOwner should be true when IncludeOwner is set")
+	})
 
+	t.Run("IncludeOwner=false does not set FetchOwner", func(t *testing.T) {
+		mock := &mockListObjectsClient{output: &s3.ListObjectsV2Output{}}
+		_, err := listObjectsWithMock(context.Background(), mock, "test-bucket",
+			&cloudstorage.ListObjectsOptions{IncludeOwner: false})
+		require.NoError(t, err)
+		require.NotNil(t, mock.lastIn)
+		assert.Nil(t, mock.lastIn.FetchOwner, "FetchOwner should not be set when IncludeOwner is false")
+	})
+
+	t.Run("error from API surfaces", func(t *testing.T) {
+		mock := &mockListObjectsClient{err: errors.New("list failed")}
 		result, err := listObjectsWithMock(context.Background(), mock, "test-bucket", nil)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
+}
+
+func TestStorage_ListObjectVersions(t *testing.T) {
+	t.Run("maps Versions to ObjectMetadata with VersionID", func(t *testing.T) {
+		now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+		mock := &mockListObjectVersionsClient{
+			output: &s3.ListObjectVersionsOutput{
+				Versions: []types.ObjectVersion{
+					{
+						Key:          aws.String("k.txt"),
+						Size:         aws.Int64(11),
+						ETag:         aws.String("etag-v1"),
+						VersionId:    aws.String("v1"),
+						LastModified: aws.Time(now),
+						StorageClass: types.ObjectVersionStorageClassStandard,
+					},
+					{
+						Key:          aws.String("k.txt"),
+						Size:         aws.Int64(22),
+						ETag:         aws.String("etag-v2"),
+						VersionId:    aws.String("v2"),
+						LastModified: aws.Time(now.Add(time.Minute)),
+						StorageClass: types.ObjectVersionStorageClassStandard,
+					},
+				},
+				IsTruncated:   aws.Bool(false),
+				NextKeyMarker: nil,
+			},
+		}
+
+		result, err := listObjectVersionsWithMock(context.Background(), mock, "test-bucket",
+			&cloudstorage.ListObjectsOptions{Prefix: "k", IncludeVersions: true})
+		require.NoError(t, err)
+		require.Len(t, result.Objects, 2)
+
+		assert.Equal(t, "v1", result.Objects[0].VersionID)
+		assert.Equal(t, "v2", result.Objects[1].VersionID)
+		assert.Equal(t, "STANDARD", result.Objects[0].StorageClass)
+		assert.Equal(t, int64(11), result.Objects[0].Size)
+		assert.Equal(t, int64(22), result.Objects[1].Size)
+		assert.Equal(t, now, result.Objects[0].LastModified)
+
+		require.NotNil(t, mock.lastIn)
+		require.NotNil(t, mock.lastIn.Prefix)
+		assert.Equal(t, "k", *mock.lastIn.Prefix)
+	})
+
+	t.Run("KeyMarker is used as continuation_token", func(t *testing.T) {
+		mock := &mockListObjectVersionsClient{
+			output: &s3.ListObjectVersionsOutput{IsTruncated: aws.Bool(false)},
+		}
+		_, err := listObjectVersionsWithMock(context.Background(), mock, "test-bucket",
+			&cloudstorage.ListObjectsOptions{ContinuationToken: "marker-from-prev-page", IncludeVersions: true})
+		require.NoError(t, err)
+		require.NotNil(t, mock.lastIn)
+		require.NotNil(t, mock.lastIn.KeyMarker)
+		assert.Equal(t, "marker-from-prev-page", *mock.lastIn.KeyMarker)
+	})
+
+	t.Run("error from API surfaces", func(t *testing.T) {
+		mock := &mockListObjectVersionsClient{err: errors.New("list versions failed")}
+		_, err := listObjectVersionsWithMock(context.Background(), mock, "test-bucket",
+			&cloudstorage.ListObjectsOptions{IncludeVersions: true})
+		assert.Error(t, err)
+	})
+}
+
+// listObjectVersionsWithMock mirrors Storage.listObjectVersions for testing.
+func listObjectVersionsWithMock(ctx context.Context, client *mockListObjectVersionsClient, bucket string, opts *cloudstorage.ListObjectsOptions) (*cloudstorage.ListObjectsResult, error) {
+	input := &s3.ListObjectVersionsInput{Bucket: aws.String(bucket)}
+	if opts != nil {
+		if opts.Prefix != "" {
+			input.Prefix = aws.String(opts.Prefix)
+		}
+		if opts.MaxKeys > 0 {
+			input.MaxKeys = aws.Int32(int32(opts.MaxKeys))
+		}
+		if opts.ContinuationToken != "" {
+			input.KeyMarker = aws.String(opts.ContinuationToken)
+		}
+	}
+
+	output, err := client.ListObjectVersions(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &cloudstorage.ListObjectsResult{
+		IsTruncated:           aws.ToBool(output.IsTruncated),
+		NextContinuationToken: aws.ToString(output.NextKeyMarker),
+		Objects:               make([]cloudstorage.ObjectMetadata, 0, len(output.Versions)),
+	}
+
+	for _, v := range output.Versions {
+		obj := cloudstorage.ObjectMetadata{
+			Key:          aws.ToString(v.Key),
+			Size:         aws.ToInt64(v.Size),
+			ETag:         aws.ToString(v.ETag),
+			StorageClass: string(v.StorageClass),
+			VersionID:    aws.ToString(v.VersionId),
+		}
+		if v.LastModified != nil {
+			obj.LastModified = *v.LastModified
+		}
+		if v.Owner != nil {
+			obj.Owner = &cloudstorage.Owner{
+				ID:          aws.ToString(v.Owner.ID),
+				DisplayName: aws.ToString(v.Owner.DisplayName),
+			}
+		}
+		result.Objects = append(result.Objects, obj)
+	}
+
+	return result, nil
 }
 
 // listObjectsWithMock is a helper that mimics ListObjects logic with a mock

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -636,9 +636,9 @@ func (m *mockEndpointResolver) ResolveEndpoint(_ context.Context, _ s3.EndpointP
 	return smithyendpoints.Endpoint{URI: *u}, nil
 }
 
-func TestMapPreconditionError(t *testing.T) {
+func TestMapKnownError(t *testing.T) {
 	t.Run("nil passes through", func(t *testing.T) {
-		assert.NoError(t, mapPreconditionError(nil))
+		assert.NoError(t, mapKnownError(nil))
 	})
 
 	t.Run("412 maps to ErrPreconditionFailed", func(t *testing.T) {
@@ -649,7 +649,7 @@ func TestMapPreconditionError(t *testing.T) {
 			},
 			RequestID: "req-1",
 		}
-		err := mapPreconditionError(respErr)
+		err := mapKnownError(respErr)
 		assert.True(t, errors.Is(err, cloudstorage.ErrPreconditionFailed))
 	})
 
@@ -661,8 +661,30 @@ func TestMapPreconditionError(t *testing.T) {
 			},
 			RequestID: "req-2",
 		}
-		err := mapPreconditionError(respErr)
+		err := mapKnownError(respErr)
 		assert.True(t, errors.Is(err, cloudstorage.ErrPreconditionFailed))
+	})
+
+	t.Run("404 maps to ErrNotFound", func(t *testing.T) {
+		respErr := &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
+				Err:      &smithy.GenericAPIError{Code: "NotFound"},
+			},
+			RequestID: "req-3",
+		}
+		err := mapKnownError(respErr)
+		assert.True(t, errors.Is(err, cloudstorage.ErrNotFound))
+	})
+
+	t.Run("typed NoSuchKey maps to ErrNotFound", func(t *testing.T) {
+		err := mapKnownError(&types.NoSuchKey{Message: aws.String("missing")})
+		assert.True(t, errors.Is(err, cloudstorage.ErrNotFound))
+	})
+
+	t.Run("typed NotFound maps to ErrNotFound", func(t *testing.T) {
+		err := mapKnownError(&types.NotFound{Message: aws.String("missing")})
+		assert.True(t, errors.Is(err, cloudstorage.ErrNotFound))
 	})
 
 	t.Run("other status passes through unchanged", func(t *testing.T) {
@@ -671,16 +693,17 @@ func TestMapPreconditionError(t *testing.T) {
 				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
 				Err:      &smithy.GenericAPIError{Code: "InternalError"},
 			},
-			RequestID: "req-3",
+			RequestID: "req-4",
 		}
-		err := mapPreconditionError(respErr)
+		err := mapKnownError(respErr)
 		assert.False(t, errors.Is(err, cloudstorage.ErrPreconditionFailed))
+		assert.False(t, errors.Is(err, cloudstorage.ErrNotFound))
 		assert.Same(t, respErr, err)
 	})
 
 	t.Run("non-aws error passes through unchanged", func(t *testing.T) {
 		base := errors.New("plain error")
-		err := mapPreconditionError(base)
+		err := mapKnownError(base)
 		assert.Same(t, base, err)
 	})
 }

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -707,3 +707,32 @@ func TestMapKnownError(t *testing.T) {
 		assert.Same(t, base, err)
 	})
 }
+
+func TestFlattenHeaders(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, flattenHeaders(nil))
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		assert.Nil(t, flattenHeaders(http.Header{}))
+	})
+
+	t.Run("lowercases keys", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Content-Type", "text/plain")
+		h.Set("X-Amz-Storage-Class", "STANDARD")
+		out := flattenHeaders(h)
+		assert.Equal(t, "text/plain", out["content-type"])
+		assert.Equal(t, "STANDARD", out["x-amz-storage-class"])
+		_, hasCanonical := out["Content-Type"]
+		assert.False(t, hasCanonical, "canonical-cased keys should not appear")
+	})
+
+	t.Run("joins multi-valued headers with comma-space", func(t *testing.T) {
+		h := http.Header{
+			"X-Repeated": {"a", "b", "c"},
+		}
+		out := flattenHeaders(h)
+		assert.Equal(t, "a, b, c", out["x-repeated"])
+	})
+}

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -7,15 +7,19 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	neturl "net/url"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/cloudstorage"
@@ -114,6 +118,38 @@ func TestStorage_ListObjects(t *testing.T) {
 		assert.Equal(t, "token123", result.NextContinuationToken)
 	})
 
+	t.Run("surfaces last_modified, storage_class, owner", func(t *testing.T) {
+		now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+		mock := &mockListObjectsClient{
+			output: &s3.ListObjectsV2Output{
+				Contents: []types.Object{
+					{
+						Key:          aws.String("file1.txt"),
+						Size:         aws.Int64(100),
+						ETag:         aws.String("etag1"),
+						LastModified: aws.Time(now),
+						StorageClass: types.ObjectStorageClassStandard,
+						Owner: &types.Owner{
+							ID:          aws.String("owner-id"),
+							DisplayName: aws.String("Owner Name"),
+						},
+					},
+				},
+			},
+		}
+		opts := &cloudstorage.ListObjectsOptions{IncludeOwner: true}
+
+		result, err := listObjectsWithMock(context.Background(), mock, "test-bucket", opts)
+		require.NoError(t, err)
+		require.Len(t, result.Objects, 1)
+		obj := result.Objects[0]
+		assert.Equal(t, now, obj.LastModified)
+		assert.Equal(t, "STANDARD", obj.StorageClass)
+		require.NotNil(t, obj.Owner)
+		assert.Equal(t, "owner-id", obj.Owner.ID)
+		assert.Equal(t, "Owner Name", obj.Owner.DisplayName)
+	})
+
 	t.Run("error", func(t *testing.T) {
 		mock := &mockListObjectsClient{
 			err: errors.New("list failed"),
@@ -141,6 +177,9 @@ func listObjectsWithMock(ctx context.Context, client *mockListObjectsClient, buc
 		if opts.ContinuationToken != "" {
 			input.ContinuationToken = aws.String(opts.ContinuationToken)
 		}
+		if opts.IncludeOwner {
+			input.FetchOwner = aws.Bool(true)
+		}
 	}
 
 	output, err := client.ListObjectsV2(ctx, input)
@@ -155,11 +194,22 @@ func listObjectsWithMock(ctx context.Context, client *mockListObjectsClient, buc
 	}
 
 	for _, item := range output.Contents {
-		result.Objects = append(result.Objects, cloudstorage.ObjectMetadata{
-			Key:  aws.ToString(item.Key),
-			Size: aws.ToInt64(item.Size),
-			ETag: aws.ToString(item.ETag),
-		})
+		obj := cloudstorage.ObjectMetadata{
+			Key:          aws.ToString(item.Key),
+			Size:         aws.ToInt64(item.Size),
+			ETag:         aws.ToString(item.ETag),
+			StorageClass: string(item.StorageClass),
+		}
+		if item.LastModified != nil {
+			obj.LastModified = *item.LastModified
+		}
+		if item.Owner != nil {
+			obj.Owner = &cloudstorage.Owner{
+				ID:          aws.ToString(item.Owner.ID),
+				DisplayName: aws.ToString(item.Owner.DisplayName),
+			}
+		}
+		result.Objects = append(result.Objects, obj)
 	}
 
 	return result, nil
@@ -519,7 +569,22 @@ func TestStorage_RealClientMethods(t *testing.T) {
 
 	t.Run("UploadObject", func(t *testing.T) {
 		content := bytes.NewReader([]byte("test"))
-		err := storage.UploadObject(context.Background(), "test-key", content)
+		err := storage.UploadObject(context.Background(), "test-key", content, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("UploadObject with options", func(t *testing.T) {
+		content := bytes.NewReader([]byte("test"))
+		opts := &cloudstorage.UploadOptions{
+			ContentType: "text/plain",
+			Metadata:    map[string]string{"foo": "bar"},
+		}
+		err := storage.UploadObject(context.Background(), "test-key", content, opts)
+		assert.Error(t, err)
+	})
+
+	t.Run("HeadObject", func(t *testing.T) {
+		_, err := storage.HeadObject(context.Background(), "test-key")
 		assert.Error(t, err)
 	})
 
@@ -569,4 +634,53 @@ type mockEndpointResolver struct{}
 func (m *mockEndpointResolver) ResolveEndpoint(_ context.Context, _ s3.EndpointParameters) (smithyendpoints.Endpoint, error) {
 	u, _ := neturl.Parse("https://s3.localhost.localstack.cloud:4566")
 	return smithyendpoints.Endpoint{URI: *u}, nil
+}
+
+func TestMapPreconditionError(t *testing.T) {
+	t.Run("nil passes through", func(t *testing.T) {
+		assert.NoError(t, mapPreconditionError(nil))
+	})
+
+	t.Run("412 maps to ErrPreconditionFailed", func(t *testing.T) {
+		respErr := &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusPreconditionFailed}},
+				Err:      &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "etag mismatch"},
+			},
+			RequestID: "req-1",
+		}
+		err := mapPreconditionError(respErr)
+		assert.True(t, errors.Is(err, cloudstorage.ErrPreconditionFailed))
+	})
+
+	t.Run("304 maps to ErrPreconditionFailed", func(t *testing.T) {
+		respErr := &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusNotModified}},
+				Err:      &smithy.GenericAPIError{Code: "NotModified"},
+			},
+			RequestID: "req-2",
+		}
+		err := mapPreconditionError(respErr)
+		assert.True(t, errors.Is(err, cloudstorage.ErrPreconditionFailed))
+	})
+
+	t.Run("other status passes through unchanged", func(t *testing.T) {
+		respErr := &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
+				Err:      &smithy.GenericAPIError{Code: "InternalError"},
+			},
+			RequestID: "req-3",
+		}
+		err := mapPreconditionError(respErr)
+		assert.False(t, errors.Is(err, cloudstorage.ErrPreconditionFailed))
+		assert.Same(t, respErr, err)
+	})
+
+	t.Run("non-aws error passes through unchanged", func(t *testing.T) {
+		base := errors.New("plain error")
+		err := mapPreconditionError(base)
+		assert.Same(t, base, err)
+	})
 }

--- a/service/cloudstorage/dispatcher.go
+++ b/service/cloudstorage/dispatcher.go
@@ -30,6 +30,7 @@ func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispat
 	register(csapi.DeleteObjects, dispatcher.HandlerFunc(d.handleDeleteObjects))
 	register(csapi.PresignedGetURL, dispatcher.HandlerFunc(d.handlePresignedGetURL))
 	register(csapi.PresignedPutURL, dispatcher.HandlerFunc(d.handlePresignedPutURL))
+	register(csapi.HeadObject, dispatcher.HandlerFunc(d.handleHeadObject))
 }
 
 func (d *Dispatcher) handleListObjects(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
@@ -57,9 +58,20 @@ func (d *Dispatcher) handleDownloadObject(ctx context.Context, cmd dispatcher.Co
 func (d *Dispatcher) handleUploadObject(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
 	c := cmd.(*csapi.UploadObjectCmd)
 	go func() {
-		err := c.Storage.UploadObject(ctx, c.Key, c.Reader)
+		err := c.Storage.UploadObject(ctx, c.Key, c.Reader, c.Options)
 		if ctx.Err() == nil {
 			receiver.CompleteYield(tag, csapi.UploadObjectResponse{Error: err}, nil)
+		}
+	}()
+	return nil
+}
+
+func (d *Dispatcher) handleHeadObject(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := cmd.(*csapi.HeadObjectCmd)
+	go func() {
+		result, err := c.Storage.HeadObject(ctx, c.Key)
+		if ctx.Err() == nil {
+			receiver.CompleteYield(tag, csapi.HeadObjectResponse{Result: result, Error: err}, nil)
 		}
 	}()
 	return nil

--- a/service/cloudstorage/dispatcher_test.go
+++ b/service/cloudstorage/dispatcher_test.go
@@ -29,12 +29,15 @@ func newTestReceiver(fn func(tag uint64, data any, err error)) dispatcher.Result
 
 type mockStorage struct {
 	listErr         error
+	headErr         error
 	downloadErr     error
 	uploadErr       error
 	deleteErr       error
 	presignGetErr   error
 	presignPutErr   error
 	listResult      *csapi.ListObjectsResult
+	headResult      *csapi.HeadObjectResult
+	uploadOpts      *csapi.UploadOptions
 	presignGetURL   string
 	presignPutURL   string
 	downloadContent []byte
@@ -42,6 +45,10 @@ type mockStorage struct {
 
 func (m *mockStorage) ListObjects(_ context.Context, _ *csapi.ListObjectsOptions) (*csapi.ListObjectsResult, error) {
 	return m.listResult, m.listErr
+}
+
+func (m *mockStorage) HeadObject(_ context.Context, _ string) (*csapi.HeadObjectResult, error) {
+	return m.headResult, m.headErr
 }
 
 func (m *mockStorage) DownloadObject(_ context.Context, _ string, w io.Writer, _ *csapi.DownloadOptions) error {
@@ -52,7 +59,8 @@ func (m *mockStorage) DownloadObject(_ context.Context, _ string, w io.Writer, _
 	return err
 }
 
-func (m *mockStorage) UploadObject(_ context.Context, _ string, _ io.Reader) error {
+func (m *mockStorage) UploadObject(_ context.Context, _ string, _ io.Reader, opts *csapi.UploadOptions) error {
+	m.uploadOpts = opts
 	return m.uploadErr
 }
 
@@ -90,13 +98,14 @@ func TestDispatcher_RegisterAll(t *testing.T) {
 
 	d.RegisterAll(register)
 
-	assert.Len(t, registered, 6)
+	assert.Len(t, registered, 7)
 	assert.Contains(t, registered, csapi.ListObjects)
 	assert.Contains(t, registered, csapi.DownloadObject)
 	assert.Contains(t, registered, csapi.UploadObject)
 	assert.Contains(t, registered, csapi.DeleteObjects)
 	assert.Contains(t, registered, csapi.PresignedGetURL)
 	assert.Contains(t, registered, csapi.PresignedPutURL)
+	assert.Contains(t, registered, csapi.HeadObject)
 }
 
 func TestDispatcher_ListObjects(t *testing.T) {
@@ -106,10 +115,21 @@ func TestDispatcher_ListObjects(t *testing.T) {
 		handlers[id] = h
 	})
 
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
 	storage := &mockStorage{
 		listResult: &csapi.ListObjectsResult{
 			Objects: []csapi.ObjectMetadata{
-				{Key: "file1.txt", Size: 100},
+				{
+					Key:          "file1.txt",
+					Size:         100,
+					ETag:         "etag1",
+					StorageClass: "STANDARD",
+					LastModified: now,
+					Owner: &csapi.Owner{
+						ID:          "owner-id",
+						DisplayName: "Owner Name",
+					},
+				},
 				{Key: "file2.txt", Size: 200},
 			},
 			IsTruncated: false,
@@ -131,7 +151,56 @@ func TestDispatcher_ListObjects(t *testing.T) {
 	case resp := <-done:
 		assert.NoError(t, resp.Error)
 		assert.Len(t, resp.Result.Objects, 2)
-		assert.Equal(t, "file1.txt", resp.Result.Objects[0].Key)
+		first := resp.Result.Objects[0]
+		assert.Equal(t, "file1.txt", first.Key)
+		assert.Equal(t, "STANDARD", first.StorageClass)
+		assert.Equal(t, now, first.LastModified)
+		require.NotNil(t, first.Owner)
+		assert.Equal(t, "owner-id", first.Owner.ID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_HeadObject(t *testing.T) {
+	d := NewDispatcher()
+	handlers := make(map[dispatcher.CommandID]dispatcher.Handler)
+	d.RegisterAll(func(id dispatcher.CommandID, h dispatcher.Handler) {
+		handlers[id] = h
+	})
+
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	storage := &mockStorage{
+		headResult: &csapi.HeadObjectResult{
+			Size:         42,
+			ETag:         "head-etag",
+			ContentType:  "text/plain",
+			CacheControl: "max-age=60",
+			StorageClass: "STANDARD",
+			LastModified: now,
+			UserMetadata: map[string]string{"env": "staging"},
+		},
+	}
+
+	cmd := &csapi.HeadObjectCmd{
+		Storage: storage,
+		Key:     "test.txt",
+	}
+
+	done := make(chan csapi.HeadObjectResponse, 1)
+	err := handlers[csapi.HeadObject].Handle(context.Background(), cmd, 1, newTestReceiver(func(_ uint64, data any, _ error) {
+		done <- data.(csapi.HeadObjectResponse)
+	}))
+	require.NoError(t, err)
+
+	select {
+	case resp := <-done:
+		assert.NoError(t, resp.Error)
+		require.NotNil(t, resp.Result)
+		assert.Equal(t, int64(42), resp.Result.Size)
+		assert.Equal(t, "head-etag", resp.Result.ETag)
+		assert.Equal(t, "staging", resp.Result.UserMetadata["env"])
+		assert.Equal(t, now, resp.Result.LastModified)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout")
 	}
@@ -183,6 +252,10 @@ func TestDispatcher_UploadObject(t *testing.T) {
 		Storage: storage,
 		Key:     "test.txt",
 		Reader:  bytes.NewReader([]byte("test content")),
+		Options: &csapi.UploadOptions{
+			ContentType: "text/plain",
+			Metadata:    map[string]string{"env": "staging"},
+		},
 	}
 
 	done := make(chan csapi.UploadObjectResponse, 1)
@@ -194,6 +267,9 @@ func TestDispatcher_UploadObject(t *testing.T) {
 	select {
 	case resp := <-done:
 		assert.NoError(t, resp.Error)
+		require.NotNil(t, storage.uploadOpts, "options should reach the storage backend")
+		assert.Equal(t, "text/plain", storage.uploadOpts.ContentType)
+		assert.Equal(t, "staging", storage.uploadOpts.Metadata["env"])
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout")
 	}

--- a/tests/app/src/test/cloudstorage/_index.yaml
+++ b/tests/app/src/test/cloudstorage/_index.yaml
@@ -166,3 +166,17 @@ entries:
       - cloudstorage
     imports:
       assert_primitives: app.lib:assert
+
+  # list_objects pagination via continuation_token
+  - name: pagination
+    kind: function.lua
+    meta:
+      type: test
+      suite: cloudstorage
+      description: cloudstorage list_objects pagination across multiple pages
+    source: file://pagination.lua
+    method: main
+    modules:
+      - cloudstorage
+    imports:
+      assert_primitives: app.lib:assert

--- a/tests/app/src/test/cloudstorage/_index.yaml
+++ b/tests/app/src/test/cloudstorage/_index.yaml
@@ -152,3 +152,17 @@ entries:
       - fs
     imports:
       assert_primitives: app.lib:assert
+
+  # list_objects with include_versions on a versioned bucket
+  - name: versions
+    kind: function.lua
+    meta:
+      type: test
+      suite: cloudstorage
+      description: cloudstorage list_objects with include_versions against a versioned bucket
+    source: file://versions.lua
+    method: main
+    modules:
+      - cloudstorage
+    imports:
+      assert_primitives: app.lib:assert

--- a/tests/app/src/test/cloudstorage/_index.yaml
+++ b/tests/app/src/test/cloudstorage/_index.yaml
@@ -137,3 +137,18 @@ entries:
       - fs
     imports:
       assert_primitives: app.lib:assert
+
+  # head_object + metadata round-trip + conditional ops
+  - name: head
+    kind: function.lua
+    meta:
+      type: test
+      suite: cloudstorage
+      description: cloudstorage head_object, metadata round-trip, and conditional ops
+    source: file://head.lua
+    method: main
+    modules:
+      - cloudstorage
+      - fs
+    imports:
+      assert_primitives: app.lib:assert

--- a/tests/app/src/test/cloudstorage/download.lua
+++ b/tests/app/src/test/cloudstorage/download.lua
@@ -51,6 +51,44 @@ local function main()
 	assert.not_nil(err3, "should have error for non-existent file")
 	assert.eq(err3:kind(), "NotFound", "missing key error should map to NotFound kind")
 
+	-- Range download: fetch only a slice of the object.
+	local big_body = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" -- 26 bytes
+	storage:upload_object("download-test/range.txt", big_body)
+
+	local rfile, rferr = vol:open("/cloudstorage_range.txt", "w")
+	assert.is_nil(rferr, "should open range temp file")
+	local rok, rerr = storage:download_object("download-test/range.txt", rfile, { range = "bytes=0-4" })
+	rfile:close()
+	assert.is_nil(rerr, "range download should not error")
+	assert.eq(rok, true, "range download should return true")
+	local got_range = vol:readfile("/cloudstorage_range.txt")
+	assert.eq(got_range, "ABCDE", "range download should return the requested slice")
+	vol:remove("/cloudstorage_range.txt")
+
+	-- Suffix range: last 5 bytes.
+	local sfile, _ = vol:open("/cloudstorage_suffix.txt", "w")
+	local _, serr = storage:download_object("download-test/range.txt", sfile, { range = "bytes=-5" })
+	sfile:close()
+	assert.is_nil(serr, "suffix range download should not error")
+	local got_suffix = vol:readfile("/cloudstorage_suffix.txt")
+	assert.eq(got_suffix, "VWXYZ", "suffix range should return the last 5 bytes")
+	vol:remove("/cloudstorage_suffix.txt")
+
+	-- Range combined with conditional: matching if_match + range = success.
+	local h = storage:head_object("download-test/range.txt")
+	local cfile, _ = vol:open("/cloudstorage_cond_range.txt", "w")
+	local _, cerr = storage:download_object("download-test/range.txt", cfile, {
+		range = "bytes=10-14",
+		if_match = h.etag,
+	})
+	cfile:close()
+	assert.is_nil(cerr, "range + matching if_match should succeed")
+	local got_cond = vol:readfile("/cloudstorage_cond_range.txt")
+	assert.eq(got_cond, "KLMNO", "conditional range should return the requested slice")
+	vol:remove("/cloudstorage_cond_range.txt")
+
+	storage:delete_objects({"download-test/range.txt"})
+
 	-- Cleanup
 	storage:delete_objects({"download-test/hello.txt"})
 	storage:release()

--- a/tests/app/src/test/cloudstorage/download.lua
+++ b/tests/app/src/test/cloudstorage/download.lua
@@ -49,6 +49,7 @@ local function main()
 	vol:remove("/cloudstorage_nonexistent.txt")
 	assert.is_nil(content2, "should not have content for non-existent file")
 	assert.not_nil(err3, "should have error for non-existent file")
+	assert.eq(err3:kind(), "NotFound", "missing key error should map to NotFound kind")
 
 	-- Cleanup
 	storage:delete_objects({"download-test/hello.txt"})

--- a/tests/app/src/test/cloudstorage/head.lua
+++ b/tests/app/src/test/cloudstorage/head.lua
@@ -41,7 +41,6 @@ local function main()
 	assert.eq(head.metadata.owner, "tests", "user metadata owner should round-trip")
 
 	-- Conditional download: if_none_match with the current etag should yield precondition_failed.
-	local sink = { write = function(self, data) self.buf = (self.buf or "") .. data end }
 	local fs = require("fs")
 	local vol, _ = fs.get("app:temp")
 	local file, _ = vol:open("/cloudstorage_head_dl.txt", "w")
@@ -68,11 +67,16 @@ local function main()
 	assert.not_nil(uerr, "upload with if_none_match=* should fail when object exists")
 	assert.eq(uerr:kind(), "Conflict", "precondition error should map to Conflict kind")
 
+	-- head_object on a missing key should error (currently surfaces a generic error;
+	-- mapping to errors.NOT_FOUND is tracked separately).
+	local missing, mherr = storage:head_object("head-test/does-not-exist.txt")
+	assert.is_nil(missing, "head_object on missing key should not return a result")
+	assert.not_nil(mherr, "head_object on missing key should return an error")
+
 	-- Cleanup
 	storage:delete_objects({ key })
 	storage:release()
 
-	_ = sink
 	return true
 end
 

--- a/tests/app/src/test/cloudstorage/head.lua
+++ b/tests/app/src/test/cloudstorage/head.lua
@@ -67,11 +67,11 @@ local function main()
 	assert.not_nil(uerr, "upload with if_none_match=* should fail when object exists")
 	assert.eq(uerr:kind(), "Conflict", "precondition error should map to Conflict kind")
 
-	-- head_object on a missing key should error (currently surfaces a generic error;
-	-- mapping to errors.NOT_FOUND is tracked separately).
+	-- head_object on a missing key should error with NotFound kind.
 	local missing, mherr = storage:head_object("head-test/does-not-exist.txt")
 	assert.is_nil(missing, "head_object on missing key should not return a result")
 	assert.not_nil(mherr, "head_object on missing key should return an error")
+	assert.eq(mherr:kind(), "NotFound", "missing key error should map to NotFound kind")
 
 	-- Cleanup
 	storage:delete_objects({ key })

--- a/tests/app/src/test/cloudstorage/head.lua
+++ b/tests/app/src/test/cloudstorage/head.lua
@@ -80,6 +80,31 @@ local function main()
 	assert.not_nil(mherr, "head_object on missing key should return an error")
 	assert.eq(mherr:kind(), "NotFound", "missing key error should map to NotFound kind")
 
+	-- Headers escape-hatch: upload sending a raw x-amz-meta-* header,
+	-- then verify it round-trips via head.metadata (the SDK channels
+	-- x-amz-meta-* into the Metadata map). Also verify head.headers
+	-- exposes the response headers we care about.
+	local hkey = "head-test/with-headers.txt"
+	local _, herr2 = storage:upload_object(hkey, "raw header upload", {
+		headers = {
+			["x-amz-meta-via-headers"] = "yes",
+		},
+	})
+	assert.is_nil(herr2, "upload with raw headers should not error")
+
+	local h2, herr3 = storage:head_object(hkey)
+	assert.is_nil(herr3, "head_object should not error")
+	assert.not_nil(h2, "head_object should return a result")
+	assert.eq(h2.metadata["via-headers"], "yes",
+		"x-amz-meta-* sent via raw headers should round-trip into metadata")
+	assert.not_nil(h2.headers, "head.headers escape-hatch should be a table")
+	assert.eq(type(h2.headers["content-length"]), "string",
+		"response headers should include content-length (lowercased keys)")
+	assert.eq(type(h2.headers["etag"]), "string",
+		"response headers should include etag (lowercased keys)")
+
+	storage:delete_objects({ hkey })
+
 	-- Cleanup
 	storage:delete_objects({ key })
 	storage:release()

--- a/tests/app/src/test/cloudstorage/head.lua
+++ b/tests/app/src/test/cloudstorage/head.lua
@@ -67,6 +67,13 @@ local function main()
 	assert.not_nil(uerr, "upload with if_none_match=* should fail when object exists")
 	assert.eq(uerr:kind(), "Conflict", "precondition error should map to Conflict kind")
 
+	-- Same precondition expressed via the only_if_absent alias.
+	local _, uerr2 = storage:upload_object(key, "should not overwrite", {
+		only_if_absent = true,
+	})
+	assert.not_nil(uerr2, "upload with only_if_absent=true should fail when object exists")
+	assert.eq(uerr2:kind(), "Conflict", "only_if_absent should also map to Conflict kind")
+
 	-- head_object on a missing key should error with NotFound kind.
 	local missing, mherr = storage:head_object("head-test/does-not-exist.txt")
 	assert.is_nil(missing, "head_object on missing key should not return a result")

--- a/tests/app/src/test/cloudstorage/head.lua
+++ b/tests/app/src/test/cloudstorage/head.lua
@@ -1,0 +1,79 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: cloudstorage head_object, upload options, and conditional ops
+local assert = require("assert_primitives")
+
+local function main()
+	local cloudstorage = require("cloudstorage")
+
+	local storage, err = cloudstorage.get("app.test.cloudstorage:minio")
+	assert.is_nil(err, "should get storage without error")
+	assert.not_nil(storage, "should have storage connection")
+
+	local key = "head-test/object.txt"
+	local body = "Hello from head_object"
+
+	-- Upload with rich options: content_type, cache_control, content_disposition, custom metadata
+	local ok, err1 = storage:upload_object(key, body, {
+		content_type = "text/plain; charset=utf-8",
+		cache_control = "max-age=3600",
+		content_disposition = "inline",
+		metadata = { env = "staging", owner = "tests" },
+	})
+	assert.is_nil(err1, "upload with options should not error")
+	assert.eq(ok, true, "upload should return true")
+
+	-- head_object returns full metadata, including user-defined metadata.
+	local head, herr = storage:head_object(key)
+	assert.is_nil(herr, "head_object should not error")
+	assert.not_nil(head, "head_object should return a result")
+	assert.eq(head.size, #body, "size should match body length")
+	assert.eq(type(head.etag), "string", "etag should be a string")
+	assert.eq(head.etag ~= "", true, "etag should not be empty")
+	assert.eq(head.content_type, "text/plain; charset=utf-8", "content_type should round-trip")
+	assert.eq(head.cache_control, "max-age=3600", "cache_control should round-trip")
+	assert.eq(head.content_disposition, "inline", "content_disposition should round-trip")
+	assert.eq(type(head.last_modified), "number", "last_modified should be a unix timestamp")
+	assert.eq(head.last_modified > 0, true, "last_modified should be > 0")
+	assert.not_nil(head.metadata, "should have metadata table")
+	-- AWS lowercases user metadata keys; values pass through as-is.
+	assert.eq(head.metadata.env, "staging", "user metadata env should round-trip")
+	assert.eq(head.metadata.owner, "tests", "user metadata owner should round-trip")
+
+	-- Conditional download: if_none_match with the current etag should yield precondition_failed.
+	local sink = { write = function(self, data) self.buf = (self.buf or "") .. data end }
+	local fs = require("fs")
+	local vol, _ = fs.get("app:temp")
+	local file, _ = vol:open("/cloudstorage_head_dl.txt", "w")
+	local _, derr = storage:download_object(key, file, { if_none_match = head.etag })
+	file:close()
+	vol:remove("/cloudstorage_head_dl.txt")
+	assert.not_nil(derr, "download with matching if_none_match should fail")
+	assert.eq(derr:kind(), "Conflict", "precondition error should map to Conflict kind")
+
+	-- Conditional download: if_match with current etag should succeed.
+	local file2, _ = vol:open("/cloudstorage_head_dl_ok.txt", "w")
+	local dok, derr2 = storage:download_object(key, file2, { if_match = head.etag })
+	file2:close()
+	assert.is_nil(derr2, "download with matching if_match should succeed")
+	assert.eq(dok, true, "download with matching if_match should return true")
+	local got = vol:readfile("/cloudstorage_head_dl_ok.txt")
+	assert.eq(got, body, "downloaded content should match original")
+	vol:remove("/cloudstorage_head_dl_ok.txt")
+
+	-- Conditional upload: if_none_match = "*" against an existing object should fail.
+	local _, uerr = storage:upload_object(key, "should not overwrite", {
+		if_none_match = "*",
+	})
+	assert.not_nil(uerr, "upload with if_none_match=* should fail when object exists")
+	assert.eq(uerr:kind(), "Conflict", "precondition error should map to Conflict kind")
+
+	-- Cleanup
+	storage:delete_objects({ key })
+	storage:release()
+
+	_ = sink
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/cloudstorage/list.lua
+++ b/tests/app/src/test/cloudstorage/list.lua
@@ -48,8 +48,55 @@ local function main()
 	assert.is_nil(err3, "list without options should not error")
 	assert.not_nil(result3, "should have result3")
 
+	-- include_owner = true populates owner on each result.
+	local owned, oerr = storage:list_objects({ prefix = "list-test/", include_owner = true })
+	assert.is_nil(oerr, "list with include_owner should not error")
+	assert.not_nil(owned, "should have owned-listing result")
+	assert.eq(#owned.objects > 0, true, "owned listing should contain items")
+	local first_owned
+	for _, obj in ipairs(owned.objects) do
+		if obj.key:match("^list%-test/") then
+			first_owned = obj
+			break
+		end
+	end
+	assert.not_nil(first_owned, "should have a list-test object in owned listing")
+	assert.not_nil(first_owned.owner, "owner table should be present when include_owner=true")
+	assert.eq(type(first_owned.owner.id), "string", "owner.id should be a string")
+	assert.eq(first_owned.owner.id ~= "", true, "owner.id should not be empty")
+
+	-- Special characters in keys: slashes, spaces, plus signs, percent-encoded chars.
+	-- All of these need to round-trip through the URL-signing path.
+	local special_keys = {
+		"list-test/with space/file.txt",
+		"list-test/with+plus/file.txt",
+		"list-test/with%20encoded/file.txt",
+		"list-test/sub/path/with/many/levels.txt",
+	}
+	for _, k in ipairs(special_keys) do
+		local _, e = storage:upload_object(k, "x")
+		assert.is_nil(e, "upload should succeed for key: " .. k)
+	end
+
+	local listed, lerr = storage:list_objects({ prefix = "list-test/" })
+	assert.is_nil(lerr, "list after special-char uploads should not error")
+	local seen_keys = {}
+	for _, obj in ipairs(listed.objects) do
+		seen_keys[obj.key] = true
+	end
+	for _, k in ipairs(special_keys) do
+		assert.eq(seen_keys[k], true, "list should observe special-character key: " .. k)
+	end
+
+	-- Empty prefix listing should return zero results.
+	local empty_result, eerr = storage:list_objects({ prefix = "this-prefix-does-not-exist/" })
+	assert.is_nil(eerr, "empty-prefix list should not error")
+	assert.not_nil(empty_result, "empty-prefix list should return a result")
+	assert.eq(#empty_result.objects, 0, "empty-prefix list should have no objects")
+
 	-- Cleanup
 	storage:delete_objects({"list-test/file1.txt", "list-test/file2.txt", "list-test/subdir/file3.txt", "other/file4.txt"})
+	storage:delete_objects(special_keys)
 	storage:release()
 
 	return true

--- a/tests/app/src/test/cloudstorage/list.lua
+++ b/tests/app/src/test/cloudstorage/list.lua
@@ -24,12 +24,18 @@ local function main()
 
 	-- Should find at least our test files
 	local found_count = 0
+	local sample
 	for _, obj in ipairs(result.objects) do
 		if obj.key:match("^list%-test/") then
 			found_count = found_count + 1
+			sample = sample or obj
 		end
 	end
 	assert.eq(found_count >= 3, true, "should find at least 3 files with prefix")
+	assert.not_nil(sample, "should have captured a sample object")
+	assert.eq(type(sample.last_modified), "number", "last_modified should be a unix timestamp")
+	assert.eq(sample.last_modified > 0, true, "last_modified should be > 0")
+	assert.eq(type(sample.storage_class), "string", "storage_class should be a string")
 
 	-- List with max_keys
 	local result2, err2 = storage:list_objects({ prefix = "list-test/", max_keys = 2 })

--- a/tests/app/src/test/cloudstorage/pagination.lua
+++ b/tests/app/src/test/cloudstorage/pagination.lua
@@ -1,0 +1,84 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: cloudstorage list_objects pagination via continuation_token.
+-- Uploads N objects, walks the listing in pages of max_keys, and asserts
+-- every key is observed exactly once across pages.
+local assert = require("assert_primitives")
+
+local function main()
+	local cloudstorage = require("cloudstorage")
+
+	local storage, err = cloudstorage.get("app.test.cloudstorage:minio")
+	assert.is_nil(err, "should get storage without error")
+	assert.not_nil(storage, "should have storage connection")
+
+	local prefix = "pagination-test/"
+	local keys = {
+		prefix .. "obj-01.txt",
+		prefix .. "obj-02.txt",
+		prefix .. "obj-03.txt",
+		prefix .. "obj-04.txt",
+		prefix .. "obj-05.txt",
+		prefix .. "obj-06.txt",
+		prefix .. "obj-07.txt",
+	}
+	local total = #keys
+	local expected = {}
+	for i, key in ipairs(keys) do
+		local _, uerr = storage:upload_object(key, "body-" .. i)
+		assert.is_nil(uerr, "upload should not error for " .. key)
+		expected[key] = true
+	end
+
+	-- Walk the listing in pages of 2.
+	-- continuation_token is initialized to the empty string and refreshed each
+	-- page; the empty string is treated as "no token" by the underlying driver.
+	local seen = {}
+	local pages = 0
+	local token = ""
+	local guard = 0
+	repeat
+		pages = pages + 1
+		guard = guard + 1
+		assert.eq(guard <= total + 5, true, "pagination loop should terminate")
+
+		local result, lerr = storage:list_objects({
+			prefix = prefix,
+			max_keys = 2,
+			continuation_token = token,
+		})
+		assert.is_nil(lerr, "page list should not error")
+		assert.not_nil(result, "page should return a result")
+		assert.eq(#result.objects <= 2, true, "page should respect max_keys")
+
+		for _, obj in ipairs(result.objects) do
+			assert.eq(seen[obj.key], nil, "each key should appear at most once across pages: " .. obj.key)
+			seen[obj.key] = true
+		end
+
+		if not result.is_truncated then
+			break
+		end
+		token = result.next_continuation_token or ""
+		assert.eq(token ~= "", true,
+			"truncated page should provide a non-empty continuation_token")
+	until false
+
+	-- Every uploaded key should have been observed exactly once.
+	local seen_count = 0
+	for k in pairs(seen) do
+		assert.eq(expected[k], true, "observed unexpected key: " .. k)
+		seen_count = seen_count + 1
+	end
+	assert.eq(seen_count, total, "all uploaded keys should be observed")
+	-- And we should have used multiple pages.
+	assert.eq(pages >= math.ceil(total / 2), true, "pagination should span multiple pages")
+
+	-- Cleanup.
+	storage:delete_objects(keys)
+	storage:release()
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/cloudstorage/upload.lua
+++ b/tests/app/src/test/cloudstorage/upload.lua
@@ -51,12 +51,39 @@ local function main()
 	local verified = vol:readfile("/cloudstorage_upload_verify.txt")
 	assert.eq(verified, file_content, "uploaded file content should match")
 
+	-- Zero-byte upload: the empty string should be a valid object.
+	local zok, zerr = storage:upload_object("test/empty.txt", "")
+	assert.is_nil(zerr, "zero-byte upload should not error")
+	assert.eq(zok, true, "zero-byte upload should return true")
+	local zhead, _ = storage:head_object("test/empty.txt")
+	assert.not_nil(zhead, "head_object on zero-byte upload should succeed")
+	assert.eq(zhead.size, 0, "zero-byte object should report size 0")
+
+	-- Overwrite: re-uploading the same key replaces the body and the etag changes.
+	local ovk = "test/overwrite.txt"
+	storage:upload_object(ovk, "first")
+	local h1 = storage:head_object(ovk)
+	storage:upload_object(ovk, "second-and-longer")
+	local h2 = storage:head_object(ovk)
+	assert.eq(h1.size, 5, "first upload size should be 5")
+	assert.eq(h2.size, 17, "second upload size should reflect the new body")
+	assert.eq(h1.etag ~= h2.etag, true, "overwrite should produce a new etag")
+
+	-- And a download after overwrite returns the latest body.
+	local ofile, _ = vol:open("/cloudstorage_overwrite.txt", "w")
+	local _, oderr = storage:download_object(ovk, ofile)
+	ofile:close()
+	assert.is_nil(oderr, "download after overwrite should not error")
+	local got = vol:readfile("/cloudstorage_overwrite.txt")
+	assert.eq(got, "second-and-longer", "download should return the latest body")
+	vol:remove("/cloudstorage_overwrite.txt")
+
 	-- Cleanup local files
 	vol:remove(tmp_path)
 	vol:remove("/cloudstorage_upload_verify.txt")
 
 	-- Cleanup remote files
-	storage:delete_objects({"test/from-file.txt"})
+	storage:delete_objects({"test/from-file.txt", "test/empty.txt", ovk})
 	storage:release()
 
 	return true

--- a/tests/app/src/test/cloudstorage/versions.lua
+++ b/tests/app/src/test/cloudstorage/versions.lua
@@ -1,0 +1,52 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: cloudstorage list_objects with include_versions against a versioned bucket.
+-- Requires the test bucket to have versioning enabled (see tests/docker-compose.yml minio-setup).
+local assert = require("assert_primitives")
+
+local function main()
+	local cloudstorage = require("cloudstorage")
+
+	local storage, err = cloudstorage.get("app.test.cloudstorage:minio")
+	assert.is_nil(err, "should get storage without error")
+	assert.not_nil(storage, "should have storage connection")
+
+	local key = "versions-test/object.txt"
+
+	-- Upload twice to create two versions on the same key.
+	local _, uerr1 = storage:upload_object(key, "v1 contents")
+	assert.is_nil(uerr1, "first upload should succeed")
+	local _, uerr2 = storage:upload_object(key, "v2 contents (overwritten)")
+	assert.is_nil(uerr2, "second upload should succeed")
+
+	-- list_objects with include_versions should return both versions of the same key.
+	local result, lerr = storage:list_objects({
+		prefix = "versions-test/",
+		include_versions = true,
+	})
+	assert.is_nil(lerr, "list_objects with include_versions should not error")
+	assert.not_nil(result, "should have a result")
+	assert.not_nil(result.objects, "should have objects array")
+
+	local seen = {}
+	local matched = 0
+	for _, obj in ipairs(result.objects) do
+		if obj.key == key then
+			matched = matched + 1
+			assert.eq(type(obj.version_id), "string", "version_id should be a string")
+			assert.eq(obj.version_id ~= "", true, "version_id should not be empty")
+			assert.is_nil(seen[obj.version_id], "version_id should be unique per object version")
+			seen[obj.version_id] = true
+		end
+	end
+	assert.eq(matched >= 2, true, "should observe at least 2 versions of the key")
+
+	-- Cleanup. With versioning enabled this only creates a delete marker; OK
+	-- because the test fully drives its own state.
+	storage:delete_objects({ key })
+	storage:release()
+
+	return true
+end
+
+return { main = main }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -252,6 +252,7 @@ services:
       mc alias set myminio http://minio:9000 minioadmin minioadmin;
       mc mb --ignore-existing myminio/test-bucket;
       mc anonymous set public myminio/test-bucket;
+      mc version enable myminio/test-bucket;
       exit 0;
       "
 


### PR DESCRIPTION
## Summary

Adds object metadata, ETag, conditional ops, NotFound mapping, a raw-HTTP-headers escape hatch, and a comprehensive Lua test suite to the cloudstorage module. Backwards compatible — all additions are purely additive.

### New Lua API surface

**New method**
- `storage:head_object(key)` → `result, error` — full per-object metadata, only way to read user metadata (`x-amz-meta-*`).

**`storage:list_objects(options)` new options**
- `include_owner: boolean` — populates `owner` on each result (S3: `FetchOwner=true`).
- `include_versions: boolean` — switches to `ListObjectVersions`, fills `version_id`.

**`storage:list_objects` result — new fields per object**
- `last_modified` (Unix seconds)
- `storage_class` (string, provider-specific)
- `version_id` (only with `include_versions`)
- `owner` (table `{ id, display_name }`, only with `include_owner`)

**`storage:upload_object(key, content, options)` — new optional 4th arg**
- `content_type`, `cache_control`, `content_disposition`, `content_encoding`
- `metadata: table<string,string>` — user metadata (`x-amz-meta-*`)
- `if_match: string`, `if_none_match: string` — conditional upload
- `only_if_absent: boolean` — Lua-friendly alias for `if_none_match = "*"`
- `headers: table<string,string>` — raw HTTP request headers escape-hatch

**`storage:download_object(key, writer, options)` — new option fields**
- `if_match: string`, `if_none_match: string`

**`storage:head_object(key)` result fields**
- `size`, `etag`, `content_type`, `cache_control`, `content_disposition`, `content_encoding`, `storage_class`, `version_id`, `last_modified`
- `metadata: table<string,string>` (always present; empty when no user metadata)
- `headers: table<string,string>` — raw HTTP response headers escape-hatch (lowercased keys)

**New error kinds**
- `errors.NOT_FOUND` — `head_object` / `download_object` on a missing key.
- `errors.CONFLICT` (message `"precondition_failed"`) — when `if_match` / `if_none_match` / `only_if_absent` fails.

### Documentation
- `runtime/lua/modules/cloudstorage/spec.md` updated for every new field + a **Portability notes** section covering `etag` (not a content checksum), conditional ops (not universally honored), `version_id` (provider quirks), `storage_class` (values are provider-specific), `metadata` size limits, and the headers escape-hatch trade-off.

## Test plan
- [x] `golangci-lint run ./...` clean on touched packages
- [x] `go test ./...` passes
- [x] Lua suite against local MinIO (versioned bucket): **`cloudstorage 10/10`** — basic, delete, download, errors, head, list, pagination, presigned, upload, versions
- [x] `mc admin trace` confirms real S3 calls: `HeadObject 200/404`, `GetObject 200/206/304/404`, `PutObject 200/412`, `ListObjectsV2 200`, `ListObjectVersions 200`
- [x] Mappings verified end-to-end: 404 → `errors.NOT_FOUND` (`Conflict`-free), 412/304 → `errors.CONFLICT`, 206 → range slice