### PR TITLE
Fix memory queue nack redelivery

### DIFF
--- a/api/queue/message.go
+++ b/api/queue/message.go
@@ -100,3 +100,20 @@ func NewMessageWithID(id string, body payload.Payload) *Message {
 	msg.ID = id
 	return msg
 }
+
+// CloneMessage returns a non-pooled copy of msg that is safe to keep after
+// the original message is released back to the pool.
+func CloneMessage(msg *Message) *Message {
+	if msg == nil {
+		return nil
+	}
+	headers := attrs.NewBag()
+	for k, v := range msg.Headers {
+		headers.Set(k, v)
+	}
+	return &Message{
+		ID:      msg.ID,
+		Body:    msg.Body,
+		Headers: headers,
+	}
+}

--- a/api/queue/message_test.go
+++ b/api/queue/message_test.go
@@ -189,6 +189,64 @@ func TestMessageWithCustomHeaders(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestCloneMessage(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		assert.Nil(t, queue.CloneMessage(nil))
+	})
+
+	t.Run("CopiesIDBodyAndHeaders", func(t *testing.T) {
+		body := payload.New("clone-body")
+		msg := queue.NewMessageWithID("msg-1", body)
+		msg.Headers.Set("job_id", "job-1")
+		msg.Headers.Set("attempt", 2)
+
+		clone := queue.CloneMessage(msg)
+
+		assert.NotSame(t, msg, clone)
+		assert.Equal(t, "msg-1", clone.ID)
+		assert.Equal(t, body, clone.Body)
+		assert.Equal(t, "job-1", clone.Headers.GetString("job_id", ""))
+		assert.Equal(t, 2, clone.Headers.GetInt("attempt", 0))
+	})
+
+	t.Run("HeaderBagIsIndependent", func(t *testing.T) {
+		msg := queue.NewMessageWithID("msg-1", payload.New("clone-body"))
+		msg.Headers.Set("job_id", "job-1")
+
+		clone := queue.CloneMessage(msg)
+		msg.Headers.Set("job_id", "mutated")
+		msg.Headers.Set("new_header", "new")
+		clone.Headers.Set("clone_only", "yes")
+
+		assert.Equal(t, "job-1", clone.Headers.GetString("job_id", ""))
+		assert.Equal(t, "", clone.Headers.GetString("new_header", ""))
+		assert.Equal(t, "", msg.Headers.GetString("clone_only", ""))
+	})
+
+	t.Run("SurvivesOriginalRelease", func(t *testing.T) {
+		msg := queue.AcquireMessageWithID("pooled-1", payload.New("pooled-body"))
+		msg.Headers.Set("job_id", "job-1")
+
+		clone := queue.CloneMessage(msg)
+		queue.ReleaseMessage(msg)
+
+		assert.Equal(t, "pooled-1", clone.ID)
+		assert.NotNil(t, clone.Body)
+		assert.Equal(t, "pooled-body", clone.Body.Data())
+		assert.Equal(t, "job-1", clone.Headers.GetString("job_id", ""))
+	})
+
+	t.Run("NilHeadersBecomeEmptyBag", func(t *testing.T) {
+		msg := &queue.Message{ID: "manual", Body: payload.New("body")}
+
+		clone := queue.CloneMessage(msg)
+
+		assert.NotNil(t, clone.Headers)
+		assert.Equal(t, "manual", clone.ID)
+		assert.Equal(t, "body", clone.Body.Data())
+	})
+}
+
 func BenchmarkNewMessage(b *testing.B) {
 	body := payload.New("benchmark message")
 	b.ResetTimer()

--- a/service/queue/memory/driver.go
+++ b/service/queue/memory/driver.go
@@ -134,7 +134,7 @@ func (d *Driver) Attach(ctx context.Context, queueID registry.ID, _ *queueapi.Co
 						return nil
 					},
 					Nack: func(ctx context.Context) error {
-						return q.requeue(ctx, msg)
+						return q.requeue(ctx, queueapi.CloneMessage(msg))
 					},
 				}
 

--- a/service/queue/memory/driver_test.go
+++ b/service/queue/memory/driver_test.go
@@ -5,6 +5,7 @@ package memory
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,48 @@ import (
 	"github.com/wippyai/runtime/service/queue/drivertest"
 	"go.uber.org/zap/zaptest"
 )
+
+func requireDelivery(t *testing.T, deliveries <-chan *queueapi.Delivery) *queueapi.Delivery {
+	t.Helper()
+	select {
+	case delivery := <-deliveries:
+		require.NotNil(t, delivery)
+		require.NotNil(t, delivery.Message)
+		return delivery
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delivery")
+		return nil
+	}
+}
+
+func requireNoDelivery(t *testing.T, deliveries <-chan *queueapi.Delivery) {
+	t.Helper()
+	select {
+	case delivery := <-deliveries:
+		t.Fatalf("unexpected delivery: %#v", delivery)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func newStartedMemoryDriver(t *testing.T) (context.Context, *Driver, registry.ID, chan *queueapi.Delivery) {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	driver := NewDriver(registry.ParseID("test:driver"), logger)
+	ctx := context.Background()
+	queueID := registry.ParseID("test:queue1")
+
+	require.NoError(t, driver.DeclareQueue(ctx, queueID, &queueapi.Config{}))
+	_, err := driver.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, driver.Stop(ctx)) })
+
+	deliveries := make(chan *queueapi.Delivery, 8)
+	cancel, err := driver.Attach(ctx, queueID, &queueapi.ConsumerOptions{}, deliveries)
+	require.NoError(t, err)
+	t.Cleanup(cancel)
+
+	return ctx, driver, queueID, deliveries
+}
 
 // TestMemoryDriver_Conformance runs the shared driver conformance suite.
 func TestMemoryDriver_Conformance(t *testing.T) {
@@ -109,6 +152,149 @@ func TestMemoryDriver_PublishAfterStop(t *testing.T) {
 
 	err = driver.Publish(ctx, queueID, msg)
 	assert.ErrorIs(t, err, queueapi.ErrQueueNotFound, "publish should fail after stop")
+}
+
+func TestMemoryDriver_NackRedeliverySurvivesMessageRelease(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	msg := queueapi.AcquireMessageWithID("msg1", payload.New("payload-1"))
+	msg.Headers.Set("job_id", "job-1")
+	require.NoError(t, driver.Publish(ctx, queueID, msg))
+
+	first := requireDelivery(t, deliveries)
+	require.Equal(t, "msg1", first.Message.ID)
+	require.NoError(t, first.Nack(ctx))
+
+	queueapi.ReleaseMessage(first.Message)
+
+	redelivered := requireDelivery(t, deliveries)
+	require.Equal(t, "msg1", redelivered.Message.ID)
+	require.NotNil(t, redelivered.Message.Body)
+	require.Equal(t, "payload-1", redelivered.Message.Body.Data())
+	require.Equal(t, "job-1", redelivered.Message.Headers.GetString("job_id", ""))
+}
+
+func TestMemoryDriver_NackRedeliveryPreservesMultipleHeaders(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	msg := queueapi.AcquireMessageWithID("msg-headers", payload.New("payload"))
+	msg.Headers.Set("job_id", "job-headers")
+	msg.Headers.Set(queueapi.HeaderCorrelationID, "corr-1")
+	msg.Headers.Set("priority", 7)
+	msg.Headers.Set("retryable", true)
+	require.NoError(t, driver.Publish(ctx, queueID, msg))
+
+	first := requireDelivery(t, deliveries)
+	require.NoError(t, first.Nack(ctx))
+	queueapi.ReleaseMessage(first.Message)
+
+	redelivered := requireDelivery(t, deliveries)
+	require.Equal(t, "job-headers", redelivered.Message.Headers.GetString("job_id", ""))
+	require.Equal(t, "corr-1", redelivered.Message.Headers.GetString(queueapi.HeaderCorrelationID, ""))
+	require.Equal(t, 7, redelivered.Message.Headers.GetInt("priority", 0))
+	assert.Equal(t, true, redelivered.Message.Headers["retryable"])
+}
+
+func TestMemoryDriver_NackRedeliveryCloneIsIndependentFromReleasedOriginal(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	msg := queueapi.AcquireMessageWithID("msg-isolated", payload.New("body-a"))
+	msg.Headers.Set("job_id", "job-original")
+	require.NoError(t, driver.Publish(ctx, queueID, msg))
+
+	first := requireDelivery(t, deliveries)
+	require.NoError(t, first.Nack(ctx))
+	first.Message.ID = "mutated-after-nack"
+	first.Message.Headers.Set("job_id", "mutated-after-nack")
+	first.Message.Headers.Set("extra", "should-not-leak")
+	queueapi.ReleaseMessage(first.Message)
+
+	redelivered := requireDelivery(t, deliveries)
+	require.Equal(t, "msg-isolated", redelivered.Message.ID)
+	require.Equal(t, "job-original", redelivered.Message.Headers.GetString("job_id", ""))
+	require.Equal(t, "", redelivered.Message.Headers.GetString("extra", ""))
+}
+
+func TestMemoryDriver_NackRedeliveryCanBeNackedRepeatedly(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	msg := queueapi.AcquireMessageWithID("msg-repeat", payload.New("repeat-body"))
+	msg.Headers.Set("job_id", "job-repeat")
+	require.NoError(t, driver.Publish(ctx, queueID, msg))
+
+	for i := 0; i < 3; i++ {
+		delivery := requireDelivery(t, deliveries)
+		require.Equal(t, "msg-repeat", delivery.Message.ID)
+		require.NotNil(t, delivery.Message.Body)
+		require.Equal(t, "repeat-body", delivery.Message.Body.Data())
+		require.Equal(t, "job-repeat", delivery.Message.Headers.GetString("job_id", ""))
+		require.NoError(t, delivery.Nack(ctx))
+		queueapi.ReleaseMessage(delivery.Message)
+	}
+
+	final := requireDelivery(t, deliveries)
+	require.Equal(t, "msg-repeat", final.Message.ID)
+	require.Equal(t, "repeat-body", final.Message.Body.Data())
+	require.Equal(t, "job-repeat", final.Message.Headers.GetString("job_id", ""))
+}
+
+func TestMemoryDriver_AckDoesNotRedeliverAfterRelease(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	msg := queueapi.AcquireMessageWithID("msg-ack", payload.New("ack-body"))
+	require.NoError(t, driver.Publish(ctx, queueID, msg))
+
+	first := requireDelivery(t, deliveries)
+	require.NoError(t, first.Ack(ctx))
+	queueapi.ReleaseMessage(first.Message)
+
+	requireNoDelivery(t, deliveries)
+}
+
+func TestMemoryDriver_NackRedeliveryWithNilHeaderBag(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	msg := &queueapi.Message{ID: "manual", Body: payload.New("manual-body")}
+	require.NoError(t, driver.Publish(ctx, queueID, msg))
+
+	first := requireDelivery(t, deliveries)
+	require.NoError(t, first.Nack(ctx))
+	queueapi.ReleaseMessage(first.Message)
+
+	redelivered := requireDelivery(t, deliveries)
+	require.Equal(t, "manual", redelivered.Message.ID)
+	require.NotNil(t, redelivered.Message.Headers)
+	require.Equal(t, "manual-body", redelivered.Message.Body.Data())
+}
+
+func TestMemoryDriver_NackRedeliveryAfterPublishingSeveralMessages(t *testing.T) {
+	ctx, driver, queueID, deliveries := newStartedMemoryDriver(t)
+
+	for i := 1; i <= 3; i++ {
+		msg := queueapi.AcquireMessageWithID("msg-batch-"+string(rune('0'+i)), payload.New("body-"+string(rune('0'+i))))
+		msg.Headers.Set("job_id", "job-"+string(rune('0'+i)))
+		require.NoError(t, driver.Publish(ctx, queueID, msg))
+	}
+
+	first := requireDelivery(t, deliveries)
+	require.Equal(t, "msg-batch-1", first.Message.ID)
+	require.NoError(t, first.Nack(ctx))
+	queueapi.ReleaseMessage(first.Message)
+
+	second := requireDelivery(t, deliveries)
+	require.Equal(t, "msg-batch-2", second.Message.ID)
+	require.NoError(t, second.Ack(ctx))
+	queueapi.ReleaseMessage(second.Message)
+
+	third := requireDelivery(t, deliveries)
+	require.Equal(t, "msg-batch-3", third.Message.ID)
+	require.NoError(t, third.Ack(ctx))
+	queueapi.ReleaseMessage(third.Message)
+
+	redelivered := requireDelivery(t, deliveries)
+	require.Equal(t, "msg-batch-1", redelivered.Message.ID)
+	require.Equal(t, "body-1", redelivered.Message.Body.Data())
+	require.Equal(t, "job-1", redelivered.Message.Headers.GetString("job_id", ""))
 }
 
 func TestMemoryDriver_StopWithoutStart(t *testing.T) {


### PR DESCRIPTION
## Summary
- clone memory queue messages before requeueing on nack so redelivery survives pooled message release
- add queue message clone coverage
- add memory driver regressions for nack redelivery, headers, nil headers, repeated nacks, ack behavior, and multiple messages

## Tests
- go test ./api/queue ./service/queue/... ./runtime/lua/modules/queue
- curriculum harness seed curriculum_sample:queue_consumers passed as run c353c529-6f02-447e-b566-762b2d36e117