### PR TITLE
loader: honor wippy.yaml exclude rules for replacements

### DIFF
--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -363,10 +363,16 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 }
 
 func shouldApplyModuleConfigFilters(mp lock.ModuleLoadPath) bool {
-	// Replacement paths are commonly used by module-local test workspaces to load
-	// unpublished test entries from the module under development. Versioned module
-	// paths represent installed dependencies and should behave like published packs.
-	return mp.Module != "" && mp.Version != "" && filepath.Ext(mp.Path) != ".wapp"
+	// Apply the module's wippy.yaml exclude/exclude_meta rules whenever we're
+	// loading a module from a directory tree — both versioned vendored sources
+	// and replacement paths (wippy.lock `replacements:`). Without this, a host
+	// app that points `replacements:` at a module's source picks up that
+	// module's own test fixtures (e.g. test/_index.yaml under namespace `app`),
+	// which then collide with the host's real entries via "use last definition"
+	// dedup. .wapp files are skipped: they were filtered at publish time, and
+	// re-running the filter would require parsing a manifest the archive does
+	// not expose.
+	return mp.Module != "" && filepath.Ext(mp.Path) != ".wapp"
 }
 
 func applyModuleConfigFilters(

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -917,7 +917,7 @@ entries:
 	}
 }
 
-func TestLoadEntriesFromModuleLoadPaths_DoesNotApplySourceModuleExcludesToReplacements(t *testing.T) {
+func TestLoadEntriesFromModuleLoadPaths_AppliesSourceModuleExcludesToReplacements(t *testing.T) {
 	ctx := setupTestContext(t)
 	logger := zap.NewNop()
 	tmpDir := t.TempDir()
@@ -944,6 +944,10 @@ entries:
       type: test
     source: |
       return {}
+  - name: real_handler
+    kind: function.lua
+    source: |
+      return {}
 `
 	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
 		t.Fatalf("write module _index.yaml: %v", err)
@@ -956,16 +960,103 @@ entries:
 		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
 	}
 
+	found := map[string]regapi.Entry{}
 	for _, entry := range entries {
-		if entry.ID.String() != "userspace.dataflow:local_test" {
+		found[entry.ID.String()] = entry
+	}
+	if _, ok := found["userspace.dataflow:local_test"]; ok {
+		t.Fatalf("replacement leaked excluded meta.type=test entry")
+	}
+	real, ok := found["userspace.dataflow:real_handler"]
+	if !ok {
+		t.Fatalf("non-excluded module entry missing")
+	}
+	if got := real.Meta.GetString("module", ""); got != "wippy/dataflow" {
+		t.Fatalf("module meta = %q, want wippy/dataflow", got)
+	}
+}
+
+// Mirrors the reported bug: a replacement points at a module's source tree
+// that ships a test/_index.yaml defining entries under a namespace the host
+// also uses. Without manifest filtering, the test fixture and the host's real
+// entry collide; with filtering, only the host entry survives.
+func TestLoadEntriesFromModuleLoadPaths_ReplacementHostCollisionFiltered(t *testing.T) {
+	ctx := setupTestContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	moduleDir := filepath.Join(tmpDir, "facade-src")
+	if err := os.MkdirAll(filepath.Join(moduleDir, "test"), 0o755); err != nil {
+		t.Fatalf("mkdir module + test dir: %v", err)
+	}
+	moduleConfig := `organization: wippy
+module: facade
+exclude:
+  - "app:**"
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "wippy.yaml"), []byte(moduleConfig), 0o644); err != nil {
+		t.Fatalf("write module config: %v", err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: wippy.facade
+entries:
+  - name: real_handler
+    kind: function.lua
+    source: |
+      return {}
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+	testFixtureYAML := `version: "1.0"
+namespace: app
+entries:
+  - name: gateway
+    kind: http.service
+    addr: :19085
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "test", "_index.yaml"), []byte(testFixtureYAML), 0o644); err != nil {
+		t.Fatalf("write module test fixture: %v", err)
+	}
+
+	appDir := filepath.Join(tmpDir, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatalf("mkdir app dir: %v", err)
+	}
+	hostYAML := `version: "1.0"
+namespace: app
+entries:
+  - name: gateway
+    kind: http.service
+    addr: :8086
+`
+	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(hostYAML), 0o644); err != nil {
+		t.Fatalf("write host app _index.yaml: %v", err)
+	}
+
+	entries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: appDir},
+		{Path: moduleDir, Module: "wippy/facade"},
+	}, logger)
+	if err != nil {
+		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
+	}
+
+	gatewayCount := 0
+	var gateway regapi.Entry
+	for _, entry := range entries {
+		if entry.ID.String() != "app:gateway" {
 			continue
 		}
-		if got := entry.Meta.GetString("module", ""); got != "wippy/dataflow" {
-			t.Fatalf("module meta = %q, want wippy/dataflow", got)
-		}
-		return
+		gatewayCount++
+		gateway = entry
 	}
-	t.Fatalf("replacement test entry was filtered")
+	if gatewayCount != 1 {
+		t.Fatalf("app:gateway count = %d, want 1 (collision not filtered)", gatewayCount)
+	}
+	if got := gateway.Meta.GetString("module", ""); got != "" {
+		t.Fatalf("app:gateway tagged with module=%q, want host (untagged) entry to win", got)
+	}
 }
 
 func TestNormalizeEntries_PreLinkOverrideAffectsRequirementDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary
- Drop the `Version != ""` gate in `shouldApplyModuleConfigFilters` so replacement paths honor the module's `wippy.yaml` exclude/exclude_meta the same way vendored `.wapp` loads do.
- Without this, a replacement module's test fixtures (e.g. `test/_index.yaml` under namespace `app`) leak into the host registry and collide with real host entries via "use last definition" dedup. Reported externally as a host returning HTTP 500 because the colliding test stub wins.

## Test plan
- [x] `go test ./... -count=1` (full sweep, no regressions)
- [x] New unit tests: `TestLoadEntriesFromModuleLoadPaths_AppliesSourceModuleExcludesToReplacements`, `TestLoadEntriesFromModuleLoadPaths_ReplacementHostCollisionFiltered`
- [x] `golangci-lint run ./cmd/internal/entries/...` clean
- [x] Side-by-side binary smoke against bug-shaped fixture: unpatched `main` returns 2 `app:gateway`; this branch returns 1 (host-owned)

## Behavior change
Devs who relied on `replacements:` to surface a module's own test entries during local development should drop those entries from the module's `wippy.yaml` exclude rules. Replacements now mirror the published `.wapp` shape.