### PR TITLE
fs/directory: resolve module-owned relative paths against module source root

### DIFF
--- a/cmd/internal/entries/extract.go
+++ b/cmd/internal/entries/extract.go
@@ -17,9 +17,7 @@ import (
 
 // ExtractWappToDir extracts a .wapp file into a source directory with _index.yaml files
 // and source files. After extraction, the .wapp file is removed.
-// projectRoot is the directory containing wippy.lock, used to compute relative paths
-// for fs.directory entries reconstructed from embedded resources.
-func ExtractWappToDir(wappPath, targetDir, projectRoot string) error {
+func ExtractWappToDir(wappPath, targetDir string) error {
 	// Open and keep file open throughout extraction so resource FS handles remain valid
 	file, err := os.Open(wappPath)
 	if err != nil {
@@ -55,7 +53,11 @@ func ExtractWappToDir(wappPath, targetDir, projectRoot string) error {
 	}
 
 	// Reconstruct fs.embed entries as fs.directory with extracted resource files
-	entries, resources, err = restoreEmbeddedResources(entries, resources, targetDir, projectRoot)
+	entries, resources, err = restoreEmbeddedResources(restoreInput{
+		Entries:   entries,
+		Resources: resources,
+		TargetDir: targetDir,
+	})
 	if err != nil {
 		return err
 	}
@@ -107,24 +109,29 @@ type extractedResource struct {
 	id   string
 }
 
+type restoreInput struct {
+	TargetDir string
+	Entries   []wapp.Entry
+	Resources []extractedResource
+}
+
 // restoreEmbeddedResources converts fs.embed entries back to fs.directory by extracting
 // their matching resource filesystems to named subdirectories. Returns the modified entries
 // and any unclaimed resources.
-func restoreEmbeddedResources(entries []wapp.Entry, resources []extractedResource, targetDir, _ string) ([]wapp.Entry, []extractedResource, error) {
-	if len(resources) == 0 {
-		return entries, resources, nil
+func restoreEmbeddedResources(in restoreInput) ([]wapp.Entry, []extractedResource, error) {
+	if len(in.Resources) == 0 {
+		return in.Entries, in.Resources, nil
 	}
 
-	// Build resource lookup by namespace:name
-	resMap := make(map[string]int, len(resources))
-	for i, res := range resources {
+	resMap := make(map[string]int, len(in.Resources))
+	for i, res := range in.Resources {
 		resMap[res.id] = i
 	}
 
 	claimed := make(map[int]bool)
-	result := make([]wapp.Entry, len(entries))
+	result := make([]wapp.Entry, len(in.Entries))
 
-	for i, entry := range entries {
+	for i, entry := range in.Entries {
 		if entry.Kind != "fs.embed" {
 			result[i] = entry
 			continue
@@ -137,16 +144,14 @@ func restoreEmbeddedResources(entries []wapp.Entry, resources []extractedResourc
 			continue
 		}
 
-		// Extract resource files to a subdirectory named after the entry
-		resDir := filepath.Join(targetDir, entry.ID.Name)
+		resDir := filepath.Join(in.TargetDir, entry.ID.Name)
 		if err := os.MkdirAll(resDir, 0755); err != nil {
 			return nil, nil, fmt.Errorf("create resource directory %s: %w", entry.ID.Name, err)
 		}
-		if err := extractResourceFS(resDir, resources[resIdx].fs); err != nil {
+		if err := extractResourceFS(resDir, in.Resources[resIdx].fs); err != nil {
 			return nil, nil, fmt.Errorf("extract embedded resource %s: %w", entryKey, err)
 		}
 
-		// Convert fs.embed back to fs.directory.
 		// Path is module-relative; the runtime joins it with the module SourceRoot.
 		result[i] = wapp.Entry{
 			ID:   entry.ID,
@@ -161,9 +166,8 @@ func restoreEmbeddedResources(entries []wapp.Entry, resources []extractedResourc
 		claimed[resIdx] = true
 	}
 
-	// Collect unclaimed resources
 	var remaining []extractedResource
-	for i, res := range resources {
+	for i, res := range in.Resources {
 		if !claimed[i] {
 			remaining = append(remaining, res)
 		}

--- a/cmd/internal/entries/extract.go
+++ b/cmd/internal/entries/extract.go
@@ -110,7 +110,7 @@ type extractedResource struct {
 // restoreEmbeddedResources converts fs.embed entries back to fs.directory by extracting
 // their matching resource filesystems to named subdirectories. Returns the modified entries
 // and any unclaimed resources.
-func restoreEmbeddedResources(entries []wapp.Entry, resources []extractedResource, targetDir, projectRoot string) ([]wapp.Entry, []extractedResource, error) {
+func restoreEmbeddedResources(entries []wapp.Entry, resources []extractedResource, targetDir, _ string) ([]wapp.Entry, []extractedResource, error) {
 	if len(resources) == 0 {
 		return entries, resources, nil
 	}
@@ -146,18 +146,16 @@ func restoreEmbeddedResources(entries []wapp.Entry, resources []extractedResourc
 			return nil, nil, fmt.Errorf("extract embedded resource %s: %w", entryKey, err)
 		}
 
-		// Compute directory path relative to project root
-		relDir, err := filepath.Rel(projectRoot, resDir)
-		if err != nil {
-			relDir = resDir
-		}
-
-		// Convert fs.embed back to fs.directory
+		// Convert fs.embed back to fs.directory.
+		// Path is module-relative; the runtime joins it with the module SourceRoot.
 		result[i] = wapp.Entry{
 			ID:   entry.ID,
 			Kind: "fs.directory",
 			Meta: entry.Meta,
-			Data: map[string]any{"directory": relDir},
+			Data: map[string]any{
+				"directory": entry.ID.Name,
+				"base":      "module",
+			},
 		}
 
 		claimed[resIdx] = true

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -134,7 +134,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 				// Migrate legacy .wapp to extracted directory when unpack is enabled
 				dirPath := filepath.Join(vendorPath, lock.ModulePath(name))
 				logger.Info("unpacking .wapp to directory", zap.String("module", mod.Name))
-				if err := ExtractWappToDir(resolved.Path, dirPath, lockDir); err != nil {
+				if err := ExtractWappToDir(resolved.Path, dirPath); err != nil {
 					return NewExtractModuleError(mod.Name, err)
 				}
 			}
@@ -206,7 +206,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
-			if err := ExtractWappToDir(fullWappPath, dirPath, lockDir); err != nil {
+			if err := ExtractWappToDir(fullWappPath, dirPath); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
 		}

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -304,6 +304,7 @@ func TestExtractWappToDirRestoresEmbeddedFilesystem(t *testing.T) {
 			Name      string `yaml:"name"`
 			Kind      string `yaml:"kind"`
 			Directory string `yaml:"directory"`
+			Base      string `yaml:"base"`
 		} `yaml:"entries"`
 	}
 	indexData, err := os.ReadFile(filepath.Join(targetDir, "_index.yaml"))
@@ -314,7 +315,6 @@ func TestExtractWappToDirRestoresEmbeddedFilesystem(t *testing.T) {
 		t.Fatalf("parse extracted index: %v", err)
 	}
 
-	wantDir := filepath.Join(".wippy", "vendor", "acme", "ui", "static_fs")
 	for _, entry := range index.Entries {
 		if entry.Name != "static_fs" {
 			continue
@@ -322,8 +322,11 @@ func TestExtractWappToDirRestoresEmbeddedFilesystem(t *testing.T) {
 		if entry.Kind != "fs.directory" {
 			t.Fatalf("extracted kind = %q, want fs.directory", entry.Kind)
 		}
-		if entry.Directory != wantDir {
-			t.Fatalf("extracted directory = %q, want %q", entry.Directory, wantDir)
+		if entry.Directory != "static_fs" {
+			t.Fatalf("extracted directory = %q, want %q", entry.Directory, "static_fs")
+		}
+		if entry.Base != "module" {
+			t.Fatalf("extracted base = %q, want %q", entry.Base, "module")
 		}
 		return
 	}

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -280,7 +280,7 @@ func TestExtractWappToDirRestoresEmbeddedFilesystem(t *testing.T) {
 	}})
 
 	targetDir := filepath.Join(vendorDir, "ui")
-	if err := ExtractWappToDir(wappPath, targetDir, projectRoot); err != nil {
+	if err := ExtractWappToDir(wappPath, targetDir); err != nil {
 		t.Fatalf("ExtractWappToDir failed: %v", err)
 	}
 

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -159,7 +159,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				if shouldUnpack {
 					// Unpack .wapp to directory when unpack is enabled
 					logger.Info("unpacking .wapp to directory", zap.String("module", module.Name))
-					if err := entries.ExtractWappToDir(resolved.Path, dirPath, lockDir); err != nil {
+					if err := entries.ExtractWappToDir(resolved.Path, dirPath); err != nil {
 						return NewExtractModuleError(module.Name, err)
 					}
 				}
@@ -205,7 +205,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewStoreModuleError(moduleRef, err)
 			}
-			if err := entries.ExtractWappToDir(wappPath, dirPath, lockDir); err != nil {
+			if err := entries.ExtractWappToDir(wappPath, dirPath); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
 		}

--- a/service/fs/directory/manager.go
+++ b/service/fs/directory/manager.go
@@ -180,7 +180,10 @@ func resolveDirectoryPath(ctx context.Context, entry registry.Entry, cfg *dirapi
 	if cfg == nil {
 		return ""
 	}
-	if cfg.Directory == "" || cfg.Base != dirapi.BaseModule || isAbsoluteConfiguredPath(cfg.Directory) {
+	if cfg.Directory == "" || isAbsoluteConfiguredPath(cfg.Directory) {
+		return cfg.Directory
+	}
+	if cfg.Base == dirapi.BaseProject {
 		return cfg.Directory
 	}
 

--- a/service/fs/directory/manager_test.go
+++ b/service/fs/directory/manager_test.go
@@ -513,9 +513,9 @@ func TestResolveDirectoryPath(t *testing.T) {
 		want string
 	}{
 		{
-			name: "project default remains working-directory relative",
+			name: "module-owned entry with no base resolves against module source root",
 			cfg:  &dirapi.Config{Directory: "./frontend"},
-			want: "./frontend",
+			want: filepath.Join(moduleRoot, "frontend"),
 		},
 		{
 			name: "project base remains working-directory relative",
@@ -537,15 +537,37 @@ func TestResolveDirectoryPath(t *testing.T) {
 			cfg:  &dirapi.Config{Directory: "./static/app", Base: dirapi.BaseModule},
 			want: "./static/app",
 		},
+		{
+			name: "app-owned entry (no module meta) with no base stays working-directory relative",
+			cfg:  &dirapi.Config{Directory: "./frontend"},
+			want: "./frontend",
+		},
+		{
+			name: "module-owned entry with explicit project base stays working-directory relative",
+			cfg:  &dirapi.Config{Directory: "./frontend", Base: dirapi.BaseProject},
+			want: "./frontend",
+		},
+		{
+			name: "module-owned entry with no base falls back to raw path when source root missing",
+			cfg:  &dirapi.Config{Directory: "./frontend"},
+			want: "./frontend",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testEntry := entry
-			if tt.name == "module base without module metadata falls back to raw path" {
+			testCtx := ctx
+
+			switch tt.name {
+			case "module base without module metadata falls back to raw path",
+				"app-owned entry (no module meta) with no base stays working-directory relative":
 				testEntry.Meta = nil
+			case "module-owned entry with no base falls back to raw path when source root missing":
+				testCtx = ctxapi.NewRootContext()
 			}
-			assert.Equal(t, tt.want, resolveDirectoryPath(ctx, testEntry, tt.cfg))
+
+			assert.Equal(t, tt.want, resolveDirectoryPath(testCtx, testEntry, tt.cfg))
 		})
 	}
 }
@@ -577,6 +599,38 @@ func TestManager_AddUsesModuleBaseForDirectoryPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, factory.Configs, 1)
 	assert.Equal(t, filepath.Join(moduleRoot, "static/app"), factory.Configs[0].DirPath)
+}
+
+// Regression: when a module is loaded via wippy.lock `replacements:` the entry's
+// fs.directory has a relative path (./public) and no explicit `base: module`.
+// The runtime must still join with the module source root, matching the path
+// that vendor-unpacked modules see.
+func TestManager_AddResolvesModuleRelativePathWhenBaseOmitted(t *testing.T) {
+	moduleRoot := t.TempDir()
+	ctx := ctxapi.NewRootContext()
+	ctx = moduleapi.WithSourceRoots(ctx, moduleapi.SourceRoots{
+		"wippy/facade": moduleRoot,
+	})
+
+	factory := NewMockFactory(&MockFS{}, nil)
+	manager := NewDirectoryManager(eventbus.NewBus(), &MockTranscoder{}, factory, zap.NewNop())
+
+	entry := registry.Entry{
+		ID:   registry.NewID("wippy.facade", "public_files"),
+		Kind: dirapi.Kind,
+		Meta: attrs.NewBagFrom(map[string]any{
+			"module": "wippy/facade",
+		}),
+		Data: NewMockPayload(&dirapi.Config{
+			Directory: "./public",
+			Mode:      "0755",
+		}),
+	}
+
+	err := manager.Add(ctx, entry)
+	require.NoError(t, err)
+	require.Len(t, factory.Configs, 1)
+	assert.Equal(t, filepath.Join(moduleRoot, "public"), factory.Configs[0].DirPath)
 }
 
 // Add test for factory error handling

--- a/tests/app/modules/fsdir-fixture/assets/hello.txt
+++ b/tests/app/modules/fsdir-fixture/assets/hello.txt
@@ -1,0 +1,1 @@
+module-relative-resolution-ok

--- a/tests/app/modules/fsdir-fixture/src/_index.yaml
+++ b/tests/app/modules/fsdir-fixture/src/_index.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MPL-2.0
+
+version: "1.0"
+namespace: wippy.fsdir
+
+entries:
+  # Module-owned fs.directory with a relative path and no explicit base.
+  # The runtime must resolve it against this module's source root, so the
+  # asset lives at <module-root>/assets, a sibling of this src directory.
+  - name: assets
+    kind: fs.directory
+    meta:
+      comment: Module-owned assets, relative path resolved against module source root
+    directory: ./assets
+    auto_init: true

--- a/tests/app/src/test/fs/_index.yaml
+++ b/tests/app/src/test/fs/_index.yaml
@@ -81,3 +81,16 @@ entries:
       - fs
     imports:
       assert2: app.lib:assert
+
+  - name: module_directory
+    kind: function.lua
+    meta:
+      type: test
+      suite: fs
+      description: Module-owned fs.directory resolves relative path against module source root
+    source: file://module_directory.lua
+    method: main
+    modules:
+      - fs
+    imports:
+      assert2: app.lib:assert

--- a/tests/app/src/test/fs/module_directory.lua
+++ b/tests/app/src/test/fs/module_directory.lua
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: a module-owned fs.directory with a relative path and no explicit base
+-- resolves against the owning module's source root, not the process working
+-- directory. The asset exists only under the module root, so a successful read
+-- proves module-relative resolution (regression for project-root anchoring).
+local assert = require("assert2")
+
+local function main()
+	local fs = require("fs")
+
+	local vol, err = fs.get("wippy.fsdir:assets")
+	assert.not_nil(vol, "module fs.directory available")
+	assert.is_nil(err, "fs.get no error")
+
+	local content, read_err = vol:readfile("/hello.txt")
+	assert.is_nil(read_err, "readfile no error")
+	assert.eq(content, "module-relative-resolution-ok", "reads asset from module source root")
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/wippy.lock
+++ b/tests/app/wippy.lock
@@ -3,3 +3,6 @@
 directories:
     modules: .wippy
     src: ./src
+replacements:
+    - from: wippy/fsdir-fixture
+      to: ./modules/fsdir-fixture


### PR DESCRIPTION
Module-owned `fs.directory` entries with a relative `directory` path (e.g. `./public`) were resolving against the wippy process CWD instead of the module's source root, so modules loaded via `wippy.lock` `replacements:` failed to find their files.

Fix: when an entry carries a `module` meta attribute and `base` is not explicitly set to `project`, the resolver now joins the path with the module's registered `SourceRoot`. Vendor unpack writes the path in the same module-relative form (`directory: <name>`, `base: module`) so both code paths agree.