### PR TITLE
compress: add zstd dictionary support

### DIFF
--- a/runtime/lua/modules/compress/module.go
+++ b/runtime/lua/modules/compress/module.go
@@ -11,6 +11,7 @@ import (
 	"io"
 
 	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/dict"
 	"github.com/klauspost/compress/zstd"
 	lua "github.com/wippyai/go-lua"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
@@ -26,6 +27,12 @@ const (
 	zstdDefaultLevel = 3
 	defaultMaxSize   = 128 * 1024 * 1024  // 128MB default decompression limit
 	absoluteMaxSize  = 1024 * 1024 * 1024 // 1GB absolute maximum
+
+	// Zstd dictionary training bounds.
+	zstdDictMinSize     = 256
+	zstdDictDefaultSize = 112 * 1024 // matches dict.BuildZstdDict default
+	zstdDictMaxSize     = 1 << 20    // 1MB
+	zstdDictHashBytes   = 6          // recommended default match length
 )
 
 // Module is the compress module definition.
@@ -60,9 +67,11 @@ var Module = &luaapi.ModuleDef{
 		brotliTable.Immutable = true
 		mod.RawSetString("brotli", brotliTable)
 
-		zstdTable := lua.CreateTable(0, 2)
+		zstdTable := lua.CreateTable(0, 4)
 		zstdTable.RawSetString("encode", lua.LGoFunc(zstdEncode))
 		zstdTable.RawSetString("decode", lua.LGoFunc(zstdDecode))
+		zstdTable.RawSetString("train_dict", lua.LGoFunc(zstdTrainDict))
+		zstdTable.RawSetString("inspect_dict", lua.LGoFunc(zstdInspectDict))
 		zstdTable.Immutable = true
 		mod.RawSetString("zstd", zstdTable)
 
@@ -118,6 +127,27 @@ func getMaxSize(l *lua.LState) int64 {
 		}
 	}
 	return maxSize
+}
+
+// getDict reads opts.dict. Returns (nil, false) when absent, (bytes, false) when
+// present and valid, or (nil, true) when present but not a non-empty string.
+func getDict(l *lua.LState) ([]byte, bool) {
+	if l.GetTop() < 2 || l.Get(2).Type() != lua.LTTable {
+		return nil, false
+	}
+	opts := l.ToTable(2)
+	v := opts.RawGetString("dict")
+	if v.Type() == lua.LTNil {
+		return nil, false
+	}
+	if v.Type() != lua.LTString {
+		return nil, true
+	}
+	s := lua.LVAsString(v)
+	if s == "" {
+		return nil, true
+	}
+	return []byte(s), false
 }
 
 func limitedReadAll(r io.Reader, maxSize int64) ([]byte, error) {
@@ -400,8 +430,18 @@ func zstdEncode(l *lua.LState) int {
 		encoderLevel = zstd.SpeedBestCompression
 	}
 
+	dict, invalidDict := getDict(l)
+	if invalidDict {
+		return invalidInputError(l, "dict must be a non-empty string")
+	}
+
+	encoderOpts := []zstd.EOption{zstd.WithEncoderLevel(encoderLevel)}
+	if dict != nil {
+		encoderOpts = append(encoderOpts, zstd.WithEncoderDict(dict))
+	}
+
 	var buf bytes.Buffer
-	writer, err := zstd.NewWriter(&buf, zstd.WithEncoderLevel(encoderLevel))
+	writer, err := zstd.NewWriter(&buf, encoderOpts...)
 	if err != nil {
 		return internalError(l, err, "zstd encode failed")
 	}
@@ -432,7 +472,17 @@ func zstdDecode(l *lua.LState) int {
 
 	maxSize := getMaxSize(l)
 
-	reader, err := zstd.NewReader(bytes.NewReader([]byte(data)))
+	dict, invalidDict := getDict(l)
+	if invalidDict {
+		return invalidInputError(l, "dict must be a non-empty string")
+	}
+
+	var readerOpts []zstd.DOption
+	if dict != nil {
+		readerOpts = append(readerOpts, zstd.WithDecoderDicts(dict))
+	}
+
+	reader, err := zstd.NewReader(bytes.NewReader([]byte(data)), readerOpts...)
 	if err != nil {
 		return invalidInputError(l, "invalid zstd data")
 	}
@@ -444,6 +494,112 @@ func zstdDecode(l *lua.LState) int {
 	}
 
 	l.Push(lua.LString(decompressed))
+	l.Push(lua.LNil)
+	return 2
+}
+
+func zstdTrainDict(l *lua.LState) int {
+	if l.Get(1).Type() != lua.LTTable {
+		return invalidInputError(l, "samples must be a table of strings")
+	}
+	samples := l.ToTable(1)
+	maxN := samples.MaxN()
+	if maxN == 0 {
+		return invalidInputError(l, "samples table cannot be empty")
+	}
+
+	input := make([][]byte, 0, maxN)
+	hasLongEnough := false
+	for i := 1; i <= maxN; i++ {
+		v := samples.RawGetInt(i)
+		if v.Type() != lua.LTString {
+			return invalidInputError(l, "samples entries must be strings")
+		}
+		s := lua.LVAsString(v)
+		if s == "" {
+			return invalidInputError(l, "samples entries cannot be empty")
+		}
+		b := []byte(s)
+		if len(b) >= 8 {
+			hasLongEnough = true
+		}
+		input = append(input, b)
+	}
+	if !hasLongEnough {
+		return invalidInputError(l, "at least one sample must be 8 bytes or longer")
+	}
+
+	opts := dict.Options{
+		MaxDictSize:    zstdDictDefaultSize,
+		HashBytes:      zstdDictHashBytes,
+		ZstdDictCompat: true,
+	}
+
+	if l.GetTop() >= 2 && l.Get(2).Type() == lua.LTTable {
+		t := l.ToTable(2)
+
+		if v := t.RawGetString("size"); v.Type() == lua.LTNumber || v.Type() == lua.LTInteger {
+			n := int(lua.LVAsNumber(v))
+			if n < zstdDictMinSize || n > zstdDictMaxSize {
+				return invalidInputError(l, "dict size must be between 256 and 1048576")
+			}
+			opts.MaxDictSize = n
+		}
+
+		if v := t.RawGetString("id"); v.Type() == lua.LTNumber || v.Type() == lua.LTInteger {
+			n := int64(lua.LVAsNumber(v))
+			if n < 0 || n > 0xFFFFFFFF {
+				return invalidInputError(l, "dict id must fit in uint32")
+			}
+			opts.ZstdDictID = uint32(n)
+		}
+
+		if v := t.RawGetString("level"); v.Type() == lua.LTNumber || v.Type() == lua.LTInteger {
+			n := int(lua.LVAsNumber(v))
+			if n < minLevel || n > zstdMaxLevel {
+				return invalidInputError(l, "level must be between 1 and 22")
+			}
+			switch {
+			case n <= 3:
+				opts.ZstdLevel = zstd.SpeedFastest
+			case n <= 6:
+				opts.ZstdLevel = zstd.SpeedDefault
+			case n <= 9:
+				opts.ZstdLevel = zstd.SpeedBetterCompression
+			default:
+				opts.ZstdLevel = zstd.SpeedBestCompression
+			}
+		}
+	}
+
+	out, err := dict.BuildZstdDict(input, opts)
+	if err != nil {
+		return internalError(l, err, "zstd dict training failed")
+	}
+
+	l.Push(lua.LString(out))
+	l.Push(lua.LNil)
+	return 2
+}
+
+func zstdInspectDict(l *lua.LState) int {
+	if l.Get(1).Type() != lua.LTString {
+		return invalidInputError(l, "dictionary must be a string")
+	}
+	data := l.ToString(1)
+	if data == "" {
+		return invalidInputError(l, "dictionary cannot be empty")
+	}
+
+	info, err := zstd.InspectDictionary([]byte(data))
+	if err != nil {
+		return invalidInputError(l, "invalid zstd dictionary")
+	}
+
+	result := lua.CreateTable(0, 2)
+	result.RawSetString("id", lua.LNumber(info.ID()))
+	result.RawSetString("content_size", lua.LNumber(info.ContentSize()))
+	l.Push(result)
 	l.Push(lua.LNil)
 	return 2
 }

--- a/runtime/lua/modules/compress/module_test.go
+++ b/runtime/lua/modules/compress/module_test.go
@@ -3,8 +3,10 @@
 package compress
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	lua "github.com/wippyai/go-lua"
 )
 
@@ -727,6 +729,410 @@ func TestGzipLevelOne(t *testing.T) {
 	if err != nil {
 		t.Errorf("gzip level 1 test failed: %v", err)
 	}
+}
+
+func TestZstdTrainDict(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local samples = {}
+		for i = 1, 50 do
+			table.insert(samples, string.format(
+				'{"event":"click","user_id":%d,"session":"abc-%d","ts":17000000%02d}',
+				i, i, i))
+		end
+		local dict, err = compress.zstd.train_dict(samples)
+		if err then error(err) end
+		if not dict then error("dict not returned") end
+		if #dict < 64 then error("dict suspiciously small: " .. #dict) end
+		local info, ierr = compress.zstd.inspect_dict(dict)
+		if ierr then error(ierr) end
+		if not info or info.content_size <= 0 then error("inspect_dict bad result") end
+	`)
+	if err != nil {
+		t.Errorf("zstd train_dict test failed: %v", err)
+	}
+}
+
+func TestZstdRoundTripWithDict(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local samples = {}
+		for i = 1, 50 do
+			table.insert(samples, string.format(
+				'{"event":"click","user_id":%d,"session":"abc-%d","ts":17000000%02d}',
+				i, i, i))
+		end
+		local dict, err = compress.zstd.train_dict(samples)
+		if err then error(err) end
+
+		local payload = '{"event":"click","user_id":4242,"session":"abc-4242","ts":1700000999}'
+		local enc, eerr = compress.zstd.encode(payload, { dict = dict, level = 5 })
+		if eerr then error(eerr) end
+		local dec, derr = compress.zstd.decode(enc, { dict = dict })
+		if derr then error(derr) end
+		if dec ~= payload then error("round-trip with dict failed") end
+	`)
+	if err != nil {
+		t.Errorf("zstd round-trip with dict test failed: %v", err)
+	}
+}
+
+func TestZstdDictBetterThanNoDict(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local samples = {}
+		for i = 1, 80 do
+			table.insert(samples, string.format(
+				'{"event":"click","user_id":%d,"session":"abc-%d","ts":17000000%02d}',
+				i, i, i))
+		end
+		local dict, err = compress.zstd.train_dict(samples)
+		if err then error(err) end
+
+		local payload = '{"event":"click","user_id":9999,"session":"abc-9999","ts":1700000500}'
+		local with_dict, e1 = compress.zstd.encode(payload, { dict = dict })
+		if e1 then error(e1) end
+		local without_dict, e2 = compress.zstd.encode(payload)
+		if e2 then error(e2) end
+		if #with_dict >= #without_dict then
+			error(string.format("dict did not improve compression: %d >= %d",
+				#with_dict, #without_dict))
+		end
+	`)
+	if err != nil {
+		t.Errorf("zstd dict-better-than-no-dict test failed: %v", err)
+	}
+}
+
+func TestZstdDecodeWithWrongDict(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local function make_samples(prefix)
+			local s = {}
+			for i = 1, 40 do
+				table.insert(s, prefix .. string.format('-event-%04d-payload-blob', i))
+			end
+			return s
+		end
+		local dict_a, e1 = compress.zstd.train_dict(make_samples("alpha"), { id = 1 })
+		if e1 then error(e1) end
+		local dict_b, e2 = compress.zstd.train_dict(make_samples("bravo"), { id = 2 })
+		if e2 then error(e2) end
+
+		local payload = "alpha-event-9999-payload-blob"
+		local enc, eerr = compress.zstd.encode(payload, { dict = dict_a })
+		if eerr then error(eerr) end
+
+		local dec, derr = compress.zstd.decode(enc, { dict = dict_b })
+		if derr == nil or dec ~= nil then
+			error("expected decode failure with wrong dict")
+		end
+	`)
+	if err != nil {
+		t.Errorf("zstd decode-with-wrong-dict test failed: %v", err)
+	}
+}
+
+func TestZstdDecodeWithoutDictFails(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local samples = {}
+		for i = 1, 30 do
+			table.insert(samples, string.format('event-%04d-large-payload-bytes', i))
+		end
+		local dict, terr = compress.zstd.train_dict(samples, { id = 42 })
+		if terr then error(terr) end
+
+		local payload = "event-1234-large-payload-bytes"
+		local enc, eerr = compress.zstd.encode(payload, { dict = dict })
+		if eerr then error(eerr) end
+
+		local dec, derr = compress.zstd.decode(enc)
+		if derr == nil or dec ~= nil then
+			error("expected decode failure without dict")
+		end
+	`)
+	if err != nil {
+		t.Errorf("zstd decode-without-dict test failed: %v", err)
+	}
+}
+
+func TestZstdTrainDictRejectsBadInput(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		-- samples not a table
+		local _, err = compress.zstd.train_dict("not a table")
+		if err == nil then error("expected error for non-table samples") end
+
+		-- empty samples
+		_, err = compress.zstd.train_dict({})
+		if err == nil then error("expected error for empty samples") end
+
+		-- non-string sample entry
+		_, err = compress.zstd.train_dict({ 123 })
+		if err == nil then error("expected error for non-string sample") end
+
+		-- empty string sample
+		_, err = compress.zstd.train_dict({ "" })
+		if err == nil then error("expected error for empty sample") end
+
+		-- samples too short overall (<8 bytes total)
+		_, err = compress.zstd.train_dict({ "ab", "cd" })
+		if err == nil then error("expected error for too-short total samples") end
+
+		-- size out of range
+		local big = string.rep("x", 32)
+		_, err = compress.zstd.train_dict({ big, big, big }, { size = 100 })
+		if err == nil then error("expected error for size below minimum") end
+		_, err = compress.zstd.train_dict({ big, big, big }, { size = 2 * 1024 * 1024 })
+		if err == nil then error("expected error for size above maximum") end
+
+		-- id out of range
+		_, err = compress.zstd.train_dict({ big, big, big }, { id = -1 })
+		if err == nil then error("expected error for negative id") end
+
+		-- level out of range
+		_, err = compress.zstd.train_dict({ big, big, big }, { level = 99 })
+		if err == nil then error("expected error for bad level") end
+	`)
+	if err != nil {
+		t.Errorf("zstd train_dict bad-input test failed: %v", err)
+	}
+}
+
+func TestZstdInspectDict(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local samples = {}
+		for i = 1, 30 do
+			table.insert(samples, string.format('record-%04d-with-shared-tail', i))
+		end
+		local dict, terr = compress.zstd.train_dict(samples, { id = 0xCAFE })
+		if terr then error(terr) end
+
+		local info, ierr = compress.zstd.inspect_dict(dict)
+		if ierr then error(ierr) end
+		if info.id ~= 0xCAFE then
+			error("inspect_dict id mismatch: " .. tostring(info.id))
+		end
+		if info.content_size <= 0 then
+			error("inspect_dict content_size <= 0")
+		end
+
+		-- inspect_dict rejects bogus bytes
+		local _, e = compress.zstd.inspect_dict("not a dictionary at all")
+		if e == nil then error("expected error for invalid dict bytes") end
+
+		-- inspect_dict rejects empty / non-string
+		local _, e2 = compress.zstd.inspect_dict("")
+		if e2 == nil then error("expected error for empty dict") end
+		local _, e3 = compress.zstd.inspect_dict(123)
+		if e3 == nil then error("expected error for non-string dict") end
+	`)
+	if err != nil {
+		t.Errorf("zstd inspect_dict test failed: %v", err)
+	}
+}
+
+func TestZstdEncodeInvalidDictOption(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local _, err = compress.zstd.encode("hello world", { dict = 123 })
+		if err == nil then error("expected error for non-string dict") end
+
+		local _, derr = compress.zstd.decode("\x28\xb5\x2f\xfd", { dict = "" })
+		if derr == nil then error("expected error for empty dict") end
+	`)
+	if err != nil {
+		t.Errorf("zstd invalid dict option test failed: %v", err)
+	}
+}
+
+// TestZstdDictProofOfWork is the end-to-end demonstration:
+//   1. Train a dict in Lua state #1 from 200 structurally-similar JSON-ish events.
+//   2. Encode the same payload with the dict (Lua state #1) and without it (Lua
+//      state #1) and report concrete byte counts to t.Log.
+//   3. Move the trained dict bytes verbatim into a fresh Lua state #2 and decode
+//      there — proves the dict bytes are portable across process/state boundaries.
+//   4. Decode the dict-encoded frame directly with the underlying klauspost
+//      decoder using the same dict bytes — proves the output is a real, portable
+//      zstd dictionary, not something only our wrapper can read.
+func TestZstdDictProofOfWork(t *testing.T) {
+	const sampleCount = 200
+
+	// --- Lua state #1: train, encode-with-dict, encode-without-dict ---
+	l1 := lua.NewState()
+	defer l1.Close()
+	tbl, _ := Module.Build()
+	l1.SetGlobal(Module.Name, tbl)
+
+	if err := l1.DoString(`
+		samples = {}
+		for i = 1, ` + itoa(sampleCount) + ` do
+			table.insert(samples, string.format(
+				'{"event":"click","user_id":%d,"session":"sess-%04d","page":"/dashboard","ts":17000000%02d}',
+				i, i, i % 100))
+		end
+		dict, terr = compress.zstd.train_dict(samples)
+		if terr then error(terr) end
+		payload = '{"event":"click","user_id":424242,"session":"sess-4242","page":"/dashboard","ts":1700000099}'
+		enc_with,    e1 = compress.zstd.encode(payload, { dict = dict, level = 5 })
+		enc_without, e2 = compress.zstd.encode(payload, { level = 5 })
+		if e1 then error(e1) end
+		if e2 then error(e2) end
+	`); err != nil {
+		t.Fatalf("training/encoding in state #1 failed: %v", err)
+	}
+
+	dictVal := l1.GetGlobal("dict")
+	encWithVal := l1.GetGlobal("enc_with")
+	encWithoutVal := l1.GetGlobal("enc_without")
+	payloadVal := l1.GetGlobal("payload")
+	if dictVal.Type() != lua.LTString || encWithVal.Type() != lua.LTString ||
+		encWithoutVal.Type() != lua.LTString || payloadVal.Type() != lua.LTString {
+		t.Fatal("expected string globals from state #1")
+	}
+	dictBytes := lua.LVAsString(dictVal)
+	encWith := lua.LVAsString(encWithVal)
+	encWithout := lua.LVAsString(encWithoutVal)
+	payload := lua.LVAsString(payloadVal)
+
+	t.Logf("sample_count=%d", sampleCount)
+	t.Logf("dict_bytes=%d", len(dictBytes))
+	t.Logf("payload_bytes=%d", len(payload))
+	t.Logf("frame_with_dict_bytes=%d", len(encWith))
+	t.Logf("frame_without_dict_bytes=%d", len(encWithout))
+	t.Logf("ratio_with_dict=%.3f", float64(len(encWith))/float64(len(payload)))
+	t.Logf("ratio_without_dict=%.3f", float64(len(encWithout))/float64(len(payload)))
+
+	if len(encWith) >= len(encWithout) {
+		t.Fatalf("dict did not improve compression: with=%d >= without=%d",
+			len(encWith), len(encWithout))
+	}
+	if len(encWith) == 0 || len(encWithout) == 0 || len(dictBytes) == 0 {
+		t.Fatal("unexpected empty output")
+	}
+
+	// --- Lua state #2: load dict bytes from outside, decode ---
+	l2 := lua.NewState()
+	defer l2.Close()
+	l2.SetGlobal(Module.Name, tbl)
+	l2.SetGlobal("dict", lua.LString(dictBytes))
+	l2.SetGlobal("enc_with", lua.LString(encWith))
+	l2.SetGlobal("payload", lua.LString(payload))
+
+	if err := l2.DoString(`
+		local dec, derr = compress.zstd.decode(enc_with, { dict = dict })
+		if derr then error(derr) end
+		if dec ~= payload then error("cross-state decode mismatch") end
+
+		-- Decoding the dict-compressed frame without the dict must fail.
+		local bad, berr = compress.zstd.decode(enc_with)
+		if berr == nil or bad ~= nil then
+			error("expected failure decoding without dict")
+		end
+	`); err != nil {
+		t.Fatalf("cross-state decode in state #2 failed: %v", err)
+	}
+	t.Log("cross_state_decode=ok")
+
+	// --- External proof: decode the same frame using klauspost directly ---
+	dec, err := zstd.NewReader(bytes.NewReader([]byte(encWith)),
+		zstd.WithDecoderDicts([]byte(dictBytes)))
+	if err != nil {
+		t.Fatalf("klauspost decoder rejected our dict: %v", err)
+	}
+	defer dec.Close()
+	got, err := decodeAll(dec)
+	if err != nil {
+		t.Fatalf("klauspost decode failed: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("klauspost decode mismatch:\n got: %q\nwant: %q", got, payload)
+	}
+	t.Log("external_klauspost_decode=ok")
+
+	// --- External proof in reverse: encode with klauspost using our dict,
+	//     decode in Lua state #2 with the same dict. ---
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderDict([]byte(dictBytes)))
+	if err != nil {
+		t.Fatalf("klauspost encoder rejected our dict: %v", err)
+	}
+	externalFrame := enc.EncodeAll([]byte(payload), nil)
+	_ = enc.Close()
+
+	l2.SetGlobal("ext_frame", lua.LString(externalFrame))
+	if err := l2.DoString(`
+		local out, e = compress.zstd.decode(ext_frame, { dict = dict })
+		if e then error(e) end
+		if out ~= payload then error("external-encoded decode mismatch") end
+	`); err != nil {
+		t.Fatalf("decoding klauspost-produced frame in Lua failed: %v", err)
+	}
+	t.Logf("external_klauspost_encode_bytes=%d", len(externalFrame))
+	t.Log("external_klauspost_encode_then_lua_decode=ok")
+}
+
+func decodeAll(r *zstd.Decoder) ([]byte, error) {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }
 
 func TestLoadReuse(t *testing.T) {

--- a/runtime/lua/modules/compress/module_test.go
+++ b/runtime/lua/modules/compress/module_test.go
@@ -981,14 +981,14 @@ func TestZstdEncodeInvalidDictOption(t *testing.T) {
 }
 
 // TestZstdDictProofOfWork is the end-to-end demonstration:
-//   1. Train a dict in Lua state #1 from 200 structurally-similar JSON-ish events.
-//   2. Encode the same payload with the dict (Lua state #1) and without it (Lua
-//      state #1) and report concrete byte counts to t.Log.
-//   3. Move the trained dict bytes verbatim into a fresh Lua state #2 and decode
-//      there — proves the dict bytes are portable across process/state boundaries.
-//   4. Decode the dict-encoded frame directly with the underlying klauspost
-//      decoder using the same dict bytes — proves the output is a real, portable
-//      zstd dictionary, not something only our wrapper can read.
+//  1. Train a dict in Lua state #1 from 200 structurally-similar JSON-ish events.
+//  2. Encode the same payload with the dict (Lua state #1) and without it (Lua
+//     state #1) and report concrete byte counts to t.Log.
+//  3. Move the trained dict bytes verbatim into a fresh Lua state #2 and decode
+//     there — proves the dict bytes are portable across process/state boundaries.
+//  4. Decode the dict-encoded frame directly with the underlying klauspost
+//     decoder using the same dict bytes — proves the output is a real, portable
+//     zstd dictionary, not something only our wrapper can read.
 func TestZstdDictProofOfWork(t *testing.T) {
 	const sampleCount = 200
 

--- a/runtime/lua/modules/compress/spec.md
+++ b/runtime/lua/modules/compress/spec.md
@@ -242,6 +242,7 @@ Compresses data using Zstandard.
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | level | integer | 3 | Compression level (1-22) |
+| dict | string | nil | Dictionary bytes from `zstd.train_dict` |
 
 **Returns:** `string` - Compressed data, or `nil, error` on failure
 
@@ -252,6 +253,7 @@ Compresses data using Zstandard.
 | Input not a string | errors.INVALID | no |
 | Input is empty | errors.INVALID | no |
 | Level out of range (1-22) | errors.INVALID | no |
+| `dict` present but not a non-empty string | errors.INVALID | no |
 | Compression failed | errors.INTERNAL | no |
 
 **Notes:**
@@ -259,6 +261,7 @@ Compresses data using Zstandard.
 - Level 4-6: default compression
 - Level 7-9: better compression
 - Level 10-22: best compression
+- When `dict` is supplied, the decoder must use the same dictionary
 
 ### zstd.decode(data: string, options?: table) → string, error
 
@@ -274,6 +277,7 @@ Decompresses Zstandard data.
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | max_size | integer | 134217728 | Maximum decompressed size in bytes (128MB), max 1GB |
+| dict | string | nil | Dictionary bytes (must match the dict used to encode) |
 
 **Returns:** `string` - Decompressed data, or `nil, error` on failure
 
@@ -284,7 +288,78 @@ Decompresses Zstandard data.
 | Input not a string | errors.INVALID | no |
 | Input is empty | errors.INVALID | no |
 | Invalid Zstandard data | errors.INVALID | no |
+| `dict` present but not a non-empty string | errors.INVALID | no |
 | Decompressed size exceeds limit | errors.INTERNAL | no |
+| Wrong / missing dict for a dict-compressed frame | errors.INTERNAL | no |
+
+### zstd.train_dict(samples: table, options?: table) → string, error
+
+Trains a Zstandard dictionary from a set of representative samples. Use
+`encode`/`decode` with `{ dict = result }` to get much smaller frames for small,
+structurally-similar payloads (log lines, RPC frames, JSON events).
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| samples | table | yes | - | Array of non-empty strings; at least one must be >= 8 bytes |
+| options | table | no | nil | Training options |
+
+**options fields:**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| size | integer | 114688 | Target dictionary size in bytes (256 to 1048576) |
+| id | integer | 0 | Dictionary id (uint32). `0` picks a random non-zero id |
+| level | integer | (best) | Compression level (1-22) used while building the dictionary |
+
+**Returns:** `string` - Serialized dictionary bytes, or `nil, error` on failure
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| samples not a table | errors.INVALID | no |
+| samples table is empty | errors.INVALID | no |
+| sample entry not a string | errors.INVALID | no |
+| sample entry is empty | errors.INVALID | no |
+| no sample is at least 8 bytes long | errors.INVALID | no |
+| `size` out of range (256..1048576) | errors.INVALID | no |
+| `id` does not fit in uint32 | errors.INVALID | no |
+| `level` out of range (1..22) | errors.INVALID | no |
+| Training failed | errors.INTERNAL | no |
+
+**Notes:**
+- Dictionaries are most useful for small payloads (under a few KB) that share
+  recurring structure. They do not help for already-random or already-compressed
+  data.
+- The returned bytes are an opaque zstd dictionary; pass them verbatim as
+  `dict = ...` to `zstd.encode`/`zstd.decode`. They are also accepted by other
+  zstd implementations.
+- This wraps `dict.BuildZstdDict` from `github.com/klauspost/compress` with
+  `HashBytes = 6` and `ZstdDictCompat = true`.
+
+### zstd.inspect_dict(dict: string) → table, error
+
+Inspects a serialized Zstandard dictionary and returns its metadata. Useful for
+diagnostics and for asserting that two parties share the same dictionary.
+
+| Param | Type | Required | Notes |
+|-------|------|----------|-------|
+| dict | string | yes | Dictionary bytes (e.g. produced by `zstd.train_dict`) |
+
+**Returns:** `table` with the fields below, or `nil, error` on failure:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | integer | Dictionary id (uint32, always non-zero for valid dicts) |
+| content_size | integer | Size of the dictionary content section, in bytes |
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| Input not a string | errors.INVALID | no |
+| Input is empty | errors.INVALID | no |
+| Invalid dictionary bytes | errors.INVALID | no |
 
 ## Errors
 

--- a/runtime/lua/modules/compress/types.go
+++ b/runtime/lua/modules/compress/types.go
@@ -11,12 +11,34 @@ import (
 var compressOptionsType = typ.NewRecord().
 	OptField("level", typ.Number).
 	OptField("max_size", typ.Number).
+	OptField("dict", typ.String).
 	Build()
 
-// Codec type for each compression algorithm
+// Codec type for each compression algorithm (no dictionary support).
 var codecType = typ.NewInterface("compress.Codec", []typ.Method{
 	{Name: "encode", Type: typ.Func().Param("data", typ.String).OptParam("opts", compressOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "decode", Type: typ.Func().Param("data", typ.String).OptParam("opts", compressOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+})
+
+// Zstd train_dict options.
+var zstdTrainDictOptionsType = typ.NewRecord().
+	OptField("size", typ.Number).
+	OptField("id", typ.Number).
+	OptField("level", typ.Number).
+	Build()
+
+// Zstd inspect_dict result.
+var zstdDictInfoType = typ.NewRecord().
+	Field("id", typ.Number).
+	Field("content_size", typ.Number).
+	Build()
+
+// Zstd codec extends Codec with dict training and inspection.
+var zstdCodecType = typ.NewInterface("compress.ZstdCodec", []typ.Method{
+	{Name: "encode", Type: typ.Func().Param("data", typ.String).OptParam("opts", compressOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "decode", Type: typ.Func().Param("data", typ.String).OptParam("opts", compressOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "train_dict", Type: typ.Func().Param("samples", typ.NewArray(typ.String)).OptParam("opts", zstdTrainDictOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "inspect_dict", Type: typ.Func().Param("dict", typ.String).Returns(zstdDictInfoType, typ.NewOptional(typ.LuaError)).Build()},
 })
 
 // ModuleTypes returns the type manifest for the compress module.
@@ -25,6 +47,9 @@ func ModuleTypes() *io.Manifest {
 
 	m.DefineType("Options", compressOptionsType)
 	m.DefineType("Codec", codecType)
+	m.DefineType("ZstdCodec", zstdCodecType)
+	m.DefineType("ZstdTrainDictOptions", zstdTrainDictOptionsType)
+	m.DefineType("ZstdDictInfo", zstdDictInfoType)
 
 	// Module exports codecs as fields (accessed as compress.gzip, compress.zlib, etc.)
 	moduleType := typ.NewRecord().
@@ -32,7 +57,7 @@ func ModuleTypes() *io.Manifest {
 		Field("deflate", codecType).
 		Field("zlib", codecType).
 		Field("brotli", codecType).
-		Field("zstd", codecType).
+		Field("zstd", zstdCodecType).
 		Build()
 
 	m.SetExport(moduleType)

--- a/tests/app/src/test/compress/_index.yaml
+++ b/tests/app/src/test/compress/_index.yaml
@@ -94,3 +94,16 @@ entries:
       - compress
     imports:
       assert2: app.lib:assert
+
+  - name: zstd_dict
+    kind: function.lua
+    meta:
+      type: test
+      suite: compress
+      description: zstd dictionary training and dict-based encode/decode
+    source: file://zstd_dict.lua
+    method: main
+    modules:
+      - compress
+    imports:
+      assert2: app.lib:assert

--- a/tests/app/src/test/compress/zstd_dict.lua
+++ b/tests/app/src/test/compress/zstd_dict.lua
@@ -1,0 +1,79 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: zstd dictionary training and dict-based encode/decode
+local assert = require("assert2")
+
+local function make_samples(prefix)
+	local s = {}
+	for i = 1, 80 do
+		table.insert(s, string.format(
+			'{"event":"%s","user_id":%d,"session":"sess-%04d","ts":17000000%02d}',
+			prefix, i, i, i % 100))
+	end
+	return s
+end
+
+local function main()
+	local compress = require("compress")
+
+	-- 1. Train a dictionary from structurally-similar JSON-ish samples
+	local samples = make_samples("click")
+	local dict, terr = compress.zstd.train_dict(samples)
+	assert.is_nil(terr, "train_dict should succeed")
+	assert.not_nil(dict, "dict bytes returned")
+	assert.ok(#dict > 64, "dict has reasonable size")
+
+	-- 2. inspect_dict returns a populated table
+	local info, ierr = compress.zstd.inspect_dict(dict)
+	assert.is_nil(ierr, "inspect_dict should succeed")
+	assert.not_nil(info, "info table returned")
+	assert.ok(info.id > 0, "dict id is non-zero")
+	assert.ok(info.content_size > 0, "dict content_size > 0")
+
+	-- 3. Round-trip: encode with dict, decode with dict
+	local payload = '{"event":"click","user_id":4242,"session":"sess-4242","ts":1700000099}'
+	local enc, e1 = compress.zstd.encode(payload, { dict = dict, level = 5 })
+	assert.is_nil(e1, "encode with dict")
+	local dec, e2 = compress.zstd.decode(enc, { dict = dict })
+	assert.is_nil(e2, "decode with dict")
+	assert.eq(dec, payload, "dict round-trip preserves data")
+
+	-- 4. Compression win: dict-encoded must be strictly smaller than dictionary-less
+	local without, ew = compress.zstd.encode(payload)
+	assert.is_nil(ew, "encode without dict")
+	assert.ok(#enc < #without,
+		string.format("dict should improve compression: %d >= %d", #enc, #without))
+
+	-- 5. Decode without dict fails on dict-compressed frame
+	local _, e3 = compress.zstd.decode(enc)
+	assert.not_nil(e3, "decode without dict should fail")
+
+	-- 6. Decode with the wrong dict fails
+	local other_dict, e4 = compress.zstd.train_dict(make_samples("purchase"))
+	assert.is_nil(e4, "train_dict for wrong-dict test")
+	local _, e5 = compress.zstd.decode(enc, { dict = other_dict })
+	assert.not_nil(e5, "decode with wrong dict should fail")
+
+	-- 7. train_dict rejects bad input (type errors are caught by the linter)
+	local _, e6 = compress.zstd.train_dict({})
+	assert.not_nil(e6, "empty samples table is rejected")
+	assert.eq(e6:kind(), errors.INVALID, "empty samples kind")
+
+	local _, e8 = compress.zstd.train_dict({ "ab", "cd" })
+	assert.not_nil(e8, "all-too-short samples rejected")
+	assert.eq(e8:kind(), errors.INVALID, "too-short samples kind")
+
+	-- 8. inspect_dict rejects bogus bytes
+	local _, e9 = compress.zstd.inspect_dict("not a dictionary")
+	assert.not_nil(e9, "bogus dict bytes rejected")
+	assert.eq(e9:kind(), errors.INVALID, "bogus dict kind")
+
+	-- 9. encode/decode reject invalid dict option
+	local _, e10 = compress.zstd.encode(payload, { dict = "" })
+	assert.not_nil(e10, "empty dict rejected on encode")
+	assert.eq(e10:kind(), errors.INVALID, "empty dict kind")
+
+	return true
+end
+
+return { main = main }


### PR DESCRIPTION
Adds `train_dict` / `inspect_dict` and a `dict` option on `encode`/`decode` to the Lua `compress.zstd` module. Backed by `dict.BuildZstdDict` from `klauspost/compress`.

## Why it matters — compression ratio on small payloads

On a 92-byte JSON event with a dict trained from 200 similar samples:

| frame | bytes | ratio |
|---|---|---|
| raw payload | 92 | 1.000 |
| zstd, no dict | 105 | **1.141** (zstd overhead exceeds payload) |
| zstd, with dict | 51 | **0.554** |
| dict itself (reusable) | 595 | — |

Dictionaries turn a net-negative compression into ~2x. This is the canonical zstd win for small, structurally-similar payloads (log lines, RPC frames, JSON events). Numbers are reproducible from `TestZstdDictProofOfWork`.

## API

```lua
local dict = compress.zstd.train_dict(samples, { size = 64*1024, id = 0xCAFE, level = 19 })
local enc  = compress.zstd.encode(payload, { dict = dict, level = 5 })
local dec  = compress.zstd.decode(enc,    { dict = dict })
local info = compress.zstd.inspect_dict(dict)  -- { id, content_size }
```

## Tests

- Go: 9 new tests including the proof-of-work test that round-trips dict bytes across distinct Lua VM instances and through the underlying klauspost encoder/decoder (proves the bytes are a real, portable zstd dictionary).
- Lua: new `tests/app/src/test/compress/zstd_dict.lua` registered under `app.test.compress`.
- Full local sweep: `make test` (270 packages, 0 failures), `golangci-lint` clean, `wippy lint --ns 'app.test.compress'` clean.

Docs change for `wippyai/docs` lives on a matching `feat/zstd-dictionary-support` branch; English-only, other languages are a follow-up.