### PR TITLE
client: route publish/install through hub-mediated endpoints with retry

### DIFF
--- a/boot/deps/hub/errors.go
+++ b/boot/deps/hub/errors.go
@@ -17,7 +17,33 @@ var (
 	ErrDigestMismatch    = errors.New("digest mismatch")
 	ErrUploadExpired     = errors.New("upload URL expired")
 	ErrPublishInProgress = errors.New("publish already in progress")
+	ErrQuotaExceeded     = errors.New("quota exceeded")
 )
+
+type QuotaExceededError struct {
+	Reason string
+}
+
+func (e *QuotaExceededError) Error() string {
+	if e.Reason == "" {
+		return ErrQuotaExceeded.Error()
+	}
+
+	return ErrQuotaExceeded.Error() + ": " + e.Reason
+}
+
+func (e *QuotaExceededError) Is(target error) bool {
+	return target == ErrQuotaExceeded
+}
+
+func QuotaReason(err error) string {
+	var qe *QuotaExceededError
+	if errors.As(err, &qe) {
+		return qe.Reason
+	}
+
+	return ""
+}
 
 func MapConnectError(err error) error {
 	if err == nil {
@@ -38,6 +64,8 @@ func MapConnectError(err error) error {
 		return ErrModuleNotFound
 	case connect.CodeAlreadyExists:
 		return ErrVersionExists
+	case connect.CodeResourceExhausted:
+		return &QuotaExceededError{Reason: connectErr.Message()}
 	case connect.CodeInvalidArgument:
 		if containsMessage(connectErr, "version") {
 			return ErrInvalidVersion

--- a/boot/deps/hub/errors_test.go
+++ b/boot/deps/hub/errors_test.go
@@ -4,6 +4,7 @@ package hub
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -80,6 +81,44 @@ func TestMapConnectError_UnknownCode(t *testing.T) {
 	// returns original connect error
 	var connectErr *connect.Error
 	assert.True(t, errors.As(result, &connectErr))
+}
+
+func TestMapConnectError_ResourceExhausted(t *testing.T) {
+	reason := "Private-module quota exhausted (2 of 0). Ask an admin to enable more private modules for this org."
+	err := connect.NewError(connect.CodeResourceExhausted, errors.New(reason))
+	got := MapConnectError(err)
+	assert.ErrorIs(t, got, ErrQuotaExceeded)
+	var qe *QuotaExceededError
+	assert.True(t, errors.As(got, &qe))
+	assert.Equal(t, reason, qe.Reason)
+	assert.Equal(t, "quota exceeded: "+reason, got.Error())
+}
+
+func TestQuotaReason_DirectAndWrapped(t *testing.T) {
+	reason := "you have 2 private modules out of 0 allowed"
+	mapped := MapConnectError(connect.NewError(connect.CodeResourceExhausted, errors.New(reason)))
+
+	assert.Equal(t, reason, QuotaReason(mapped))
+
+	wrappedOnce := fmt.Errorf("publish step failed: %w", mapped)
+	assert.Equal(t, reason, QuotaReason(wrappedOnce))
+	assert.ErrorIs(t, wrappedOnce, ErrQuotaExceeded)
+
+	wrappedTwice := fmt.Errorf("outer: %w", wrappedOnce)
+	assert.Equal(t, reason, QuotaReason(wrappedTwice))
+	assert.ErrorIs(t, wrappedTwice, ErrQuotaExceeded)
+}
+
+func TestQuotaReason_NotQuotaError(t *testing.T) {
+	assert.Empty(t, QuotaReason(nil))
+	assert.Empty(t, QuotaReason(errors.New("not a quota error")))
+}
+
+func TestQuotaExceededError_EmptyReason(t *testing.T) {
+	qe := &QuotaExceededError{}
+	assert.Equal(t, "quota exceeded", qe.Error())
+	assert.ErrorIs(t, qe, ErrQuotaExceeded)
+	assert.Empty(t, QuotaReason(qe))
 }
 
 func TestContainsMessage(t *testing.T) {

--- a/boot/deps/hub/hub_io.go
+++ b/boot/deps/hub/hub_io.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// UploadInput is the input to PublishViaHub: the wapp on disk plus all
+// the metadata the hub needs to set up the publish workflow. This is the
+// one-call replacement for InitiatePublish + Upload-to-S3 + ConfirmPublish.
+type UploadInput struct {
+	Org          string
+	Module       string
+	Version      string
+	Label        string
+	ReleaseNotes string
+	FilePath     string
+	Protected    bool
+}
+
+// UploadOutput is the publish workflow id the caller polls on.
+type UploadOutput struct {
+	PublishID string `json:"publish_id"`
+}
+
+// PublishViaHub uploads a .wapp file to the hub-mediated upload endpoint and
+// returns the publish workflow id. The retry policy is consistent with the
+// hub side: jittered exponential backoff on transient network/HTTP errors.
+//
+// This is the preferred client path because the only hop the CLI makes is
+// to the hub itself (server-stable HTTPS). The hub does the second hop to
+// S3 with its own retry. Direct-to-S3 PUTs from clients on flaky networks
+// — notably Windows winsock against AWS endpoints — get retried *here*,
+// not silently fail.
+func (c *Client) PublishViaHub(ctx context.Context, in UploadInput) (*UploadOutput, error) {
+	if c.token == "" {
+		return nil, errors.New("publish requires an authentication token")
+	}
+
+	// Load the body once; the hub-mediated handler caps at 100 MB so we
+	// can afford to keep it in memory, and a fresh bytes.Reader per
+	// retry attempt keeps the op closure idempotent.
+	body, err := os.ReadFile(in.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", filepath.Base(in.FilePath), err)
+	}
+	sum := sha256.Sum256(body)
+	digest := hex.EncodeToString(sum[:])
+	size := int64(len(body))
+
+	uploadURL := c.baseURL + "/api/v1/publish/upload"
+
+	var out UploadOutput
+	err = retryDo(ctx, DefaultRetryConfig(), func(_ int) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("build upload request: %w", err)
+		}
+		req.ContentLength = size
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("X-Wippy-Org", in.Org)
+		req.Header.Set("X-Wippy-Module", in.Module)
+		if in.Version != "" {
+			req.Header.Set("X-Wippy-Version", in.Version)
+		}
+		if in.Label != "" {
+			req.Header.Set("X-Wippy-Label", in.Label)
+		}
+		req.Header.Set("X-Wippy-Digest", digest)
+		req.Header.Set("X-Wippy-Size", strconv.FormatInt(size, 10))
+		if in.Protected {
+			req.Header.Set("X-Wippy-Protected", "true")
+		}
+		if in.ReleaseNotes != "" {
+			req.Header.Set("X-Wippy-Release-Notes", in.ReleaseNotes)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			b, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+			return &hubStatusError{statusCode: resp.StatusCode, body: string(b)}
+		}
+
+		var fresh UploadOutput
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&fresh); err != nil {
+			return fmt.Errorf("decode upload response: %w", err)
+		}
+		if fresh.PublishID == "" {
+			return errors.New("hub returned empty publish_id")
+		}
+		out = fresh
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DownloadViaHub streams a .wapp from the hub-mediated download endpoint to
+// destPath. The retry covers the open (request + status check); once the
+// body starts streaming, a failure mid-stream returns an error to the
+// caller — HTTP doesn't support un-writing bytes, so partial files are
+// cleaned up and the install fails.
+func (c *Client) DownloadViaHub(ctx context.Context, digest, destPath string) error {
+	if len(digest) != 64 {
+		return fmt.Errorf("invalid digest: expected 64-char hex, got %d", len(digest))
+	}
+
+	downloadURL := c.baseURL + "/api/v1/wapp/" + digest
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	return retryDo(ctx, DefaultRetryConfig(), func(_ int) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+		if err != nil {
+			return fmt.Errorf("build download request: %w", err)
+		}
+		if c.token != "" {
+			req.Header.Set("Authorization", "Bearer "+c.token)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+			return &hubStatusError{statusCode: resp.StatusCode, body: string(b)}
+		}
+
+		// Write to a temp file first so the destination is only renamed
+		// into place once we've successfully copied + synced everything.
+		tmp, err := os.CreateTemp(filepath.Dir(destPath), filepath.Base(destPath)+".part-*")
+		if err != nil {
+			return fmt.Errorf("create temp file: %w", err)
+		}
+		tmpPath := tmp.Name()
+		// Best-effort cleanup; ignored if the rename below succeeds first.
+		defer func() {
+			_ = os.Remove(tmpPath)
+		}()
+
+		if _, err := io.Copy(tmp, resp.Body); err != nil {
+			tmp.Close()
+			// Mid-stream failure: surface as a network error so the
+			// retry classifier can decide based on its shape.
+			return err
+		}
+		if err := tmp.Sync(); err != nil {
+			tmp.Close()
+			return fmt.Errorf("sync temp file: %w", err)
+		}
+		if err := tmp.Close(); err != nil {
+			return fmt.Errorf("close temp file: %w", err)
+		}
+		return os.Rename(tmpPath, destPath)
+	})
+}

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -75,7 +75,11 @@ type ManifestDep struct {
 	Protected bool
 }
 
-// GetManifest retrieves the manifest for a single module version.
+// GetManifest retrieves the manifest for a single module version. The
+// resolution walk visits each transitive dependency once, so a transient
+// network/5xx on any one of them aborts the whole install. Wrap the RPC
+// in the shared retry helper so a hub flake doesn't make the user retype
+// "wippy install" against a corp-flaky network.
 func (c *Client) GetManifest(ctx context.Context, org, module, constraint string) (*ModuleManifest, error) {
 	req := &manifestv1.GetManifestRequest{
 		Module: &modulev1.ModuleRef{
@@ -92,9 +96,17 @@ func (c *Client) GetManifest(ctx context.Context, org, module, constraint string
 		req.Version = buildVersionRef(constraint)
 	}
 
-	resp, err := c.Manifest.GetManifest(ctx, connect.NewRequest(req))
+	var resp *connect.Response[manifestv1.GetManifestResponse]
+	err := retryDo(ctx, DefaultRetryConfig(), func(_ int) error {
+		r, err := c.Manifest.GetManifest(ctx, connect.NewRequest(req))
+		if err != nil {
+			return MapConnectError(err)
+		}
+		resp = r
+		return nil
+	})
 	if err != nil {
-		return nil, MapConnectError(err)
+		return nil, err
 	}
 
 	m := resp.Msg.Manifest

--- a/boot/deps/hub/publish.go
+++ b/boot/deps/hub/publish.go
@@ -44,6 +44,7 @@ type PublishResult struct {
 type StatusResult struct {
 	VersionID    string
 	ErrorMessage string
+	ErrorCode    string
 	Status       PublishStatus
 }
 
@@ -144,6 +145,7 @@ func (c *Client) GetPublishStatus(ctx context.Context, publishID string) (*Statu
 
 	if resp.Msg.Details != nil {
 		result.ErrorMessage = resp.Msg.Details.ErrorMessage
+		result.ErrorCode = resp.Msg.Details.ErrorCode
 		if resp.Msg.Details.Version != nil {
 			result.VersionID = resp.Msg.Details.Version.Id
 		}

--- a/boot/deps/hub/retry.go
+++ b/boot/deps/hub/retry.go
@@ -4,6 +4,7 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"math/rand/v2"
@@ -139,14 +140,50 @@ func httpStatusText(code int) string {
 	return "hub responded with HTTP status"
 }
 
-// IsHubEndpointMissing reports whether err is a 404 from a hub-mediated
-// endpoint. Used by the CLI to decide whether to fall back to the legacy
-// presigned-URL flow when targeting an older hub deployment.
+// IsHubEndpointMissing reports whether err means the hub-mediated route
+// itself is absent (an older hub), so the CLI may fall back to the legacy
+// presigned-URL flow. A 404 that carries the hub's structured error
+// envelope ({"error":{"code":...}}) is a real resource error (e.g. the
+// module does not exist) — NOT a missing route — and must not trigger the
+// misleading legacy fallback. Only a bare/non-JSON 404 (the net/http
+// "404 page not found" an older hub returns for an unknown path) counts.
 func IsHubEndpointMissing(err error) bool {
 	var statusErr *hubStatusError
-	if errors.As(err, &statusErr) {
-		return statusErr.statusCode == http.StatusNotFound ||
-			statusErr.statusCode == http.StatusMethodNotAllowed
+	if !errors.As(err, &statusErr) {
+		return false
 	}
-	return false
+	switch statusErr.statusCode {
+	case http.StatusMethodNotAllowed:
+		return true
+	case http.StatusNotFound:
+		return hubErrorCode(statusErr.body) == ""
+	default:
+		return false
+	}
+}
+
+// IsModuleNotFound reports whether err is the hub's 404 for a target that
+// does not exist (module/org). The CLI uses this to tell the user to
+// create the module (wippy publish --create) instead of surfacing an
+// opaque "resource not found".
+func IsModuleNotFound(err error) bool {
+	var statusErr *hubStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.statusCode == http.StatusNotFound && hubErrorCode(statusErr.body) == "not_found"
+}
+
+// hubErrorCode returns the hub error-envelope code ({"error":{"code"}}),
+// or "" when the body is not a structured hub error.
+func hubErrorCode(body string) string {
+	var e struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal([]byte(body), &e) != nil {
+		return ""
+	}
+	return e.Error.Code
 }

--- a/boot/deps/hub/retry.go
+++ b/boot/deps/hub/retry.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RetryConfig is the client-side retry policy used by the hub-mediated
+// upload/download/manifest paths. It mirrors the hub's storage.RetryConfig
+// so users see consistent timing on both sides; the CLI bumps MaxAttempts
+// since a human is waiting and would rather wait through a flaky network
+// than retype the command.
+type RetryConfig struct {
+	MaxAttempts    int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	BackoffFactor  float64
+	Jitter         time.Duration
+}
+
+// DefaultRetryConfig: 8 attempts × backoff up to 30s covers the longest
+// realistic blip from any client network (corp proxy / AV interception /
+// flaky WiFi) without dragging the user through a hanging command forever.
+// Total worst-case wait ≈ 0.5+1+2+4+8+16+30+30 ≈ 91s.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:    8,
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     30 * time.Second,
+		BackoffFactor:  2.0,
+		Jitter:         250 * time.Millisecond,
+	}
+}
+
+// Do runs op with jittered exponential backoff. It returns nil on the first
+// successful attempt, a wrapped final error after MaxAttempts, or the
+// context error on cancellation. Non-retryable errors short-circuit
+// immediately so we don't spin on a permanent fault.
+func retryDo(ctx context.Context, cfg RetryConfig, op func(attempt int) error) error {
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 1
+	}
+	backoff := cfg.InitialBackoff
+	var lastErr error
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := op(attempt)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			return err
+		}
+		if attempt == cfg.MaxAttempts {
+			break
+		}
+		sleep := backoff
+		if cfg.Jitter > 0 {
+			sleep += time.Duration(rand.Int64N(int64(cfg.Jitter) + 1)) //nolint:gosec // jitter only; not security-sensitive
+		}
+		timer := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		backoff = time.Duration(float64(backoff) * cfg.BackoffFactor)
+		if backoff > cfg.MaxBackoff {
+			backoff = cfg.MaxBackoff
+		}
+	}
+	return lastErr
+}
+
+// isRetryable mirrors the hub-side classification — but for client-side
+// errors (HTTP status code lives in our typed errors, not in a minio
+// ErrorResponse). Network resets, EOF mid-stream, timeouts, HTTP 429, and
+// HTTP 5xx are retried; 4xx (other than 429) and context-cancel are not.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "broken pipe") ||
+		// Windows winsock variants — same wire-level cause, OS-specific text.
+		strings.Contains(msg, "wsarecv: ") ||
+		strings.Contains(msg, "wsasend: ") {
+		return true
+	}
+	var statusErr *hubStatusError
+	if errors.As(err, &statusErr) {
+		code := statusErr.statusCode
+		return code == http.StatusRequestTimeout ||
+			code == http.StatusTooManyRequests ||
+			(code >= http.StatusInternalServerError && code < 600)
+	}
+	return false
+}
+
+// hubStatusError captures a non-2xx response from a hub-mediated endpoint
+// so the retry classifier can inspect the status code without parsing
+// strings. The body is bounded (maxResponseSize) on the read site.
+type hubStatusError struct {
+	body       string
+	statusCode int
+}
+
+func (e *hubStatusError) Error() string {
+	return httpStatusText(e.statusCode) + ": " + e.body
+}
+
+func httpStatusText(code int) string {
+	if t := http.StatusText(code); t != "" {
+		return "hub responded " + t
+	}
+	return "hub responded with HTTP status"
+}
+
+// IsHubEndpointMissing reports whether err is a 404 from a hub-mediated
+// endpoint. Used by the CLI to decide whether to fall back to the legacy
+// presigned-URL flow when targeting an older hub deployment.
+func IsHubEndpointMissing(err error) bool {
+	var statusErr *hubStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.statusCode == http.StatusNotFound ||
+			statusErr.statusCode == http.StatusMethodNotAllowed
+	}
+	return false
+}

--- a/boot/deps/hub/retry_test.go
+++ b/boot/deps/hub/retry_test.go
@@ -1,0 +1,41 @@
+package hub
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsHubEndpointMissing_StructuredVsBare guards the prod incident
+// where a 404 "module not found" (structured hub error envelope) was
+// misclassified as "the hub-mediated endpoint is missing", triggering a
+// misleading legacy-flow fallback that also failed. Only a bare/non-JSON
+// 404 (an older hub with no such route) is endpoint-missing.
+func TestIsHubEndpointMissing_StructuredVsBare(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		missing bool
+		modNF   bool
+	}{
+		{"bare 404 (old hub, no route)", &hubStatusError{statusCode: 404, body: "404 page not found\n"}, true, false},
+		{"empty 404", &hubStatusError{statusCode: 404, body: ""}, true, false},
+		{"structured module not_found", &hubStatusError{statusCode: 404, body: `{"error":{"code":"not_found","message":"resource not found"}}`}, false, true},
+		{"structured other not_found code", &hubStatusError{statusCode: 404, body: `{"error":{"code":"version_not_found"}}`}, false, false},
+		{"405 method not allowed", &hubStatusError{statusCode: http.StatusMethodNotAllowed, body: ""}, true, false},
+		{"409 version exists", &hubStatusError{statusCode: 409, body: `{"error":{"code":"version_exists"}}`}, false, false},
+		{"403 forbidden", &hubStatusError{statusCode: 403, body: `{"error":{"code":"forbidden"}}`}, false, false},
+		{"non-hub error", assertErr("boom"), false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.missing, IsHubEndpointMissing(c.err), "IsHubEndpointMissing")
+			assert.Equal(t, c.modNF, IsModuleNotFound(c.err), "IsModuleNotFound")
+		})
+	}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,23 @@ import (
 	"github.com/wippyai/runtime/cmd/internal/entries"
 	"go.uber.org/zap"
 )
+
+// downloadWappViaHubOrLegacy attempts the hub-mediated download first
+// (single HTTPS hop to the hub, hub retries into S3); if the hub doesn't
+// advertise the endpoint yet (404 / 405) and a presigned S3 URL is
+// available, falls back to the legacy direct-to-S3 flow.
+func downloadWappViaHubOrLegacy(ctx context.Context, hubClient *hub.Client, info *hub.DownloadInfo, wappPath string) error {
+	if info.Digest != "" {
+		err := hubClient.DownloadViaHub(ctx, info.Digest, wappPath)
+		if err == nil {
+			return nil
+		}
+		if !hub.IsHubEndpointMissing(err) || info.URL == "" {
+			return err
+		}
+	}
+	return hubClient.DownloadToFile(ctx, info.URL, wappPath)
+}
 
 var installCmd = &cobra.Command{
 	Use:   "install [module...]",
@@ -190,13 +208,18 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			return NewDownloadModuleError(moduleRef, err)
 		}
 
-		if downloadInfo.URL == "" {
+		if downloadInfo.URL == "" && downloadInfo.Digest == "" {
 			return NewNoContentDownloadedError(moduleRef)
 		}
 
-		// Download .wapp file
+		// Download .wapp file. Prefer the hub-mediated download path
+		// (one HTTPS hop to the hub, hub-side retry into S3) — same
+		// motivation as publish: a direct-to-S3 GET from a client on a
+		// flaky network fails without retry. Fall back to the legacy
+		// presigned-URL flow only if the new endpoint is missing on
+		// this hub deployment.
 		wappPath := filepath.Join(vendorDir, lock.WappPath(modName, module.Version))
-		if err := hubClient.DownloadToFile(app.Ctx, downloadInfo.URL, wappPath); err != nil {
+		if err := downloadWappViaHubOrLegacy(app.Ctx, hubClient, downloadInfo, wappPath); err != nil {
 			return NewDownloadModuleError(moduleRef, err)
 		}
 

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -178,38 +178,12 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		return NewPublishClientError(registryURL, err)
 	}
 
+	registeredThisRun := false
 	if createIfMissing {
-		displayName := moduleDisplayName
-		if displayName == "" {
-			displayName = cfg.ModuleName
+		if err := ensureModuleRegistered(cmd.Context(), client, registryURL, cfg, moduleDisplayName, moduleType, moduleVisibility); err != nil {
+			return err
 		}
-		keywords := cfg.Keywords
-		if keywords == nil {
-			keywords = []string{}
-		}
-		registerCtx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
-		regResult, regErr := client.RegisterModule(registerCtx, &hub.RegisterModuleParams{
-			Org:           cfg.Organization,
-			Name:          cfg.ModuleName,
-			DisplayName:   displayName,
-			Description:   cfg.Description,
-			ModuleType:    moduleType,
-			Visibility:    moduleVisibility,
-			License:       cfg.License,
-			Keywords:      keywords,
-			RepositoryURL: cfg.Repository,
-			HomepageURL:   cfg.Homepage,
-		})
-		cancel()
-		switch {
-		case regErr == nil:
-			printStatus(fmt.Sprintf("Registered module %s/%s (visibility=%s, type=%s)",
-				regResult.OrgName, regResult.Name, regResult.Visibility, regResult.ModuleType))
-		case errors.Is(regErr, hub.ErrModuleAlreadyExists):
-			printStatus(fmt.Sprintf("Module %s/%s already exists, skipping create", cfg.Organization, cfg.ModuleName))
-		default:
-			return fmt.Errorf("register module on %s: %w", registryURL, regErr)
-		}
+		registeredThisRun = true
 	}
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Minute)
@@ -221,6 +195,17 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 	// InitiatePublish/PUT/ConfirmPublish triplet only if the new endpoint
 	// is missing — i.e., publishing against an older hub.
 	publishID, err := publishViaHubOrLegacy(ctx, client, registryURL, cfg, outputFile, label, releaseNotes, protected)
+	if err != nil && !registeredThisRun && hub.IsModuleNotFound(err) {
+		// First publish of a module that was never registered: create it
+		// (private by default) and retry, so `wippy publish` just works.
+		// A user without create permission gets the real 403 here — that
+		// is the honest failure, not something to paper over.
+		printStatus(fmt.Sprintf("Module %s/%s not registered yet — creating it", cfg.Organization, cfg.ModuleName))
+		if regErr := ensureModuleRegistered(cmd.Context(), client, registryURL, cfg, moduleDisplayName, moduleType, moduleVisibility); regErr != nil {
+			return regErr
+		}
+		publishID, err = publishViaHubOrLegacy(ctx, client, registryURL, cfg, outputFile, label, releaseNotes, protected)
+	}
 	if err != nil {
 		return err
 	}
@@ -231,6 +216,7 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		printStatus(fmt.Sprintf("Status: %s", s.StatusString()))
 	})
 	if err != nil {
+		printPublishFailure(publishID, status)
 		return NewPublishProcessingError(registryURL, err)
 	}
 
@@ -283,7 +269,8 @@ func publishViaHubOrLegacy(
 		return out.PublishID, nil
 	}
 	// Only fall back when the *server* tells us the hub-mediated endpoint
-	// doesn't exist. Any other failure (auth, validation, network) is the
+	// doesn't exist. Any other failure (auth, validation, network, or a
+	// module-not-found that runPublish auto-registers + retries) is the
 	// real failure and shouldn't be papered over by the legacy path.
 	if !hub.IsHubEndpointMissing(err) {
 		return "", NewPublishUploadError(registryURL, err)
@@ -608,6 +595,47 @@ func printSuccess(msg string) {
 	fmt.Printf("  %s\n", successStyle.Render(msg))
 }
 
+// printPublishFailure surfaces the correlation id, server error code and
+// an actionable hint so a failed publish is self-explanatory instead of
+// an opaque message. The command still returns a non-zero error — this
+// only enriches the output, it never masks the failure.
+func printPublishFailure(publishID string, status *hub.StatusResult) {
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+
+	fmt.Println()
+	if publishID != "" {
+		fmt.Printf("  %s %s\n", dimStyle.Render("publish id:"), publishID)
+	}
+	if status == nil {
+		return
+	}
+	code := status.ErrorCode
+	if code != "" {
+		fmt.Printf("  %s %s — %s\n", errStyle.Render("error:"), code, status.ErrorMessage)
+	} else if status.ErrorMessage != "" {
+		fmt.Printf("  %s %s\n", errStyle.Render("error:"), status.ErrorMessage)
+	}
+	if h := hintFor(code); h != "" {
+		fmt.Printf("  %s %s\n", dimStyle.Render("hint:"), h)
+	}
+}
+
+func hintFor(code string) string {
+	switch code {
+	case "version_exists":
+		return "bump the version (wippy publish --version <next>) — published versions are immutable"
+	case "version_missing":
+		return "transient infrastructure issue — retry; if it persists report the publish id to ops"
+	case "scan_unavailable":
+		return "antivirus temporarily unavailable — retry shortly, your upload is preserved"
+	case "malware_detected":
+		return "the package was flagged by antivirus and held for security review"
+	default:
+		return ""
+	}
+}
+
 func formatFileSize(size int64) string {
 	const unit = 1024
 	if size < unit {
@@ -635,6 +663,45 @@ func NewPublishClientError(registryURL string, cause error) error {
 
 func NewPublishInitiateError(registryURL string, cause error) error {
 	return fmt.Errorf("failed to initiate publish on %s: %w", registryURL, cause)
+}
+
+// ensureModuleRegistered registers org/module on the hub (private by
+// default). Idempotent: an existing module is a no-op. A real failure
+// (notably 403 — no create permission in the org) is returned verbatim
+// so the user sees the honest cause, never a masked one.
+func ensureModuleRegistered(ctx context.Context, client *hub.Client, registryURL string, cfg *config.ModuleConfig, displayName, moduleType, moduleVisibility string) error {
+	if displayName == "" {
+		displayName = cfg.ModuleName
+	}
+	keywords := cfg.Keywords
+	if keywords == nil {
+		keywords = []string{}
+	}
+	regCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	regResult, regErr := client.RegisterModule(regCtx, &hub.RegisterModuleParams{
+		Org:           cfg.Organization,
+		Name:          cfg.ModuleName,
+		DisplayName:   displayName,
+		Description:   cfg.Description,
+		ModuleType:    moduleType,
+		Visibility:    moduleVisibility,
+		License:       cfg.License,
+		Keywords:      keywords,
+		RepositoryURL: cfg.Repository,
+		HomepageURL:   cfg.Homepage,
+	})
+	switch {
+	case regErr == nil:
+		printStatus(fmt.Sprintf("Registered module %s/%s (visibility=%s, type=%s)",
+			regResult.OrgName, regResult.Name, regResult.Visibility, regResult.ModuleType))
+		return nil
+	case errors.Is(regErr, hub.ErrModuleAlreadyExists):
+		printStatus(fmt.Sprintf("Module %s/%s already exists", cfg.Organization, cfg.ModuleName))
+		return nil
+	default:
+		return fmt.Errorf("register module on %s: %w", registryURL, regErr)
+	}
 }
 
 func NewPublishUploadError(registryURL string, cause error) error {

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -207,6 +207,10 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		publishID, err = publishViaHubOrLegacy(ctx, client, registryURL, cfg, outputFile, label, releaseNotes, protected)
 	}
 	if err != nil {
+		if errors.Is(err, hub.ErrQuotaExceeded) {
+			return NewPublishQuotaExceededError(hub.QuotaReason(err))
+		}
+
 		return err
 	}
 
@@ -706,6 +710,14 @@ func ensureModuleRegistered(ctx context.Context, client *hub.Client, registryURL
 
 func NewPublishUploadError(registryURL string, cause error) error {
 	return fmt.Errorf("failed to upload package to %s: %w", registryURL, cause)
+}
+
+func NewPublishQuotaExceededError(reason string) error {
+	if reason == "" {
+		reason = "the organization is over its plan quota; upgrade the plan or reduce usage and try again"
+	}
+
+	return fmt.Errorf("cannot publish: %s", reason)
 }
 
 func NewPublishConfirmError(registryURL string, cause error) error {

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -212,46 +212,22 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	params := &hub.PublishParams{
-		Org:          cfg.Organization,
-		Module:       cfg.ModuleName,
-		Digest:       packResult.Digest,
-		Size:         packResult.Size,
-		ReleaseNotes: releaseNotes,
-		Protected:    protected,
-	}
-
-	if label != "" {
-		params.Label = label
-	} else {
-		params.Version = cfg.Version
-	}
-
-	printStatus("Initiating publish...")
-
-	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Minute)
 	defer cancel()
 
-	result, err := client.InitiatePublish(ctx, params)
+	// Prefer the hub-mediated upload path (one robust HTTP hop, hub-side
+	// retry into S3, never the brittle client→S3 path that's bitten
+	// Windows users with winsock resets). Fall back to the legacy
+	// InitiatePublish/PUT/ConfirmPublish triplet only if the new endpoint
+	// is missing — i.e., publishing against an older hub.
+	publishID, err := publishViaHubOrLegacy(ctx, client, registryURL, cfg, outputFile, label, releaseNotes, protected)
 	if err != nil {
-		return NewPublishInitiateError(registryURL, err)
-	}
-
-	printStatus("Uploading package...")
-
-	if err := client.Upload(ctx, result.UploadURL, outputFile); err != nil {
-		return NewPublishUploadError(registryURL, err)
-	}
-
-	printStatus("Confirming upload...")
-
-	if err := client.ConfirmPublish(ctx, result.PublishID); err != nil {
-		return NewPublishConfirmError(registryURL, err)
+		return err
 	}
 
 	printStatus("Processing...")
 
-	status, err := client.WaitForCompletion(ctx, result.PublishID, func(s *hub.StatusResult) {
+	status, err := client.WaitForCompletion(ctx, publishID, func(s *hub.StatusResult) {
 		printStatus(fmt.Sprintf("Status: %s", s.StatusString()))
 	})
 	if err != nil {
@@ -271,6 +247,94 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 	fmt.Println()
 
 	return nil
+}
+
+// publishViaHubOrLegacy runs the publish flow once. It prefers the new
+// hub-mediated upload endpoint (single HTTPS hop to the hub, hub retries
+// into S3) and falls back to the legacy presigned-URL triplet only if the
+// hub responds 404 to the new path. Returns the publish workflow id to
+// poll on.
+func publishViaHubOrLegacy(
+	ctx context.Context,
+	client *hub.Client,
+	registryURL string,
+	cfg *config.ModuleConfig,
+	outputFile, label, releaseNotes string,
+	protected bool,
+) (string, error) {
+	printStatus("Uploading via hub...")
+
+	in := hub.UploadInput{
+		Org:          cfg.Organization,
+		Module:       cfg.ModuleName,
+		Version:      cfg.Version,
+		Label:        label,
+		ReleaseNotes: releaseNotes,
+		FilePath:     outputFile,
+		Protected:    protected,
+	}
+	if label != "" {
+		// When publishing a label, the version is resolved server-side.
+		in.Version = ""
+	}
+
+	out, err := client.PublishViaHub(ctx, in)
+	if err == nil {
+		return out.PublishID, nil
+	}
+	// Only fall back when the *server* tells us the hub-mediated endpoint
+	// doesn't exist. Any other failure (auth, validation, network) is the
+	// real failure and shouldn't be papered over by the legacy path.
+	if !hub.IsHubEndpointMissing(err) {
+		return "", NewPublishUploadError(registryURL, err)
+	}
+
+	printStatus("Hub-mediated upload not available, using legacy flow...")
+
+	// Legacy fallback: InitiatePublish → PUT to presigned URL → ConfirmPublish.
+	params := &hub.PublishParams{
+		Org:          cfg.Organization,
+		Module:       cfg.ModuleName,
+		Digest:       "", // hub fills in from the upload body it sees
+		ReleaseNotes: releaseNotes,
+		Protected:    protected,
+	}
+	if label != "" {
+		params.Label = label
+	} else {
+		params.Version = cfg.Version
+	}
+	// The legacy InitiatePublish needs Digest + Size so the hub can size
+	// the presigned URL; the caller computed them while packing.
+	params.Digest, params.Size, err = digestAndSizeFromFile(outputFile)
+	if err != nil {
+		return "", NewPublishUploadError(registryURL, err)
+	}
+	result, err := client.InitiatePublish(ctx, params)
+	if err != nil {
+		return "", NewPublishInitiateError(registryURL, err)
+	}
+	if err := client.Upload(ctx, result.UploadURL, outputFile); err != nil {
+		return "", NewPublishUploadError(registryURL, err)
+	}
+	if err := client.ConfirmPublish(ctx, result.PublishID); err != nil {
+		return "", NewPublishConfirmError(registryURL, err)
+	}
+	return result.PublishID, nil
+}
+
+func digestAndSizeFromFile(path string) (string, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("open %s: %w", filepath.Base(path), err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, fmt.Errorf("hash %s: %w", filepath.Base(path), err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
 }
 
 // promptVersion fetches the latest published version from the hub and presents


### PR DESCRIPTION
## Problem

Windows users on flaky networks have been unable to publish for 10+ days. The legacy presigned-URL flow does `client → S3` directly for the wapp upload; a winsock reset (`wsarecv: Connection reset by peer`) aborts the upload with no retry. Same shape failure exists on the install/download side.

## Fix

Prefer the new hub-mediated endpoints:

- `POST /api/v1/publish/upload` — body is the wapp bytes; hub validates digest/size/auth, uploads to S3 with hub-side retry, starts the existing PublishWorkflow.
- `GET /api/v1/wapp/{digest}` — hub streams from S3 with retry, writes to client.

One HTTPS hop to the hub instead of two (RPC + presigned PUT). Falls back to the legacy `InitiatePublish → presigned PUT → ConfirmPublish` triplet if the hub doesn't advertise the new endpoints (404).

Retry policy mirrors the hub side — 8 attempts × jittered exponential backoff up to 30s, classifies retryable: winsock variants (`wsarecv:`, `wsasend:`), `connection reset`, `broken pipe`, EOF, timeouts, HTTP 429/5xx. `GetManifest` also wrapped.

## Test plan

- [x] `go test ./...` clean
- [x] `golangci-lint run ./boot/deps/hub/... ./cmd/...` clean
- [x] Cross-compiled `wippy.exe` (PE32+ x86_64, mingw + CGO sqlite_vec) under wine64/Rosetta in OrbStack: publish + install against local hub both hit the new endpoints (200 OK in hub access logs).