### PR TITLE
test(queue/consumer): fix StressHighThroughput race on ack counter

### DIFF
--- a/service/queue/consumer/consumer_test.go
+++ b/service/queue/consumer/consumer_test.go
@@ -928,10 +928,10 @@ func TestConsumer_StressHighThroughput(t *testing.T) {
 	}
 
 	assert.Eventually(t, func() bool {
-		return processedCount.Load() == messageCount
-	}, 30*time.Second, 10*time.Millisecond, "all messages should be processed")
+		return ackCount.Load() == messageCount
+	}, 30*time.Second, 10*time.Millisecond, "all messages should be acked")
 
-	assert.Equal(t, int64(messageCount), ackCount.Load(), "all messages should be acked")
+	assert.Equal(t, int64(messageCount), processedCount.Load(), "all messages should be processed")
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Problem

`TestConsumer_StressHighThroughput` is flaky under `-race`: ~5% on `main`, ~60% on busier branches (caught while validating PR #269 with the full `-race` suite).

```
--- FAIL: TestConsumer_StressHighThroughput (0.06s)
    consumer_test.go:934:
        Error: Not equal: expected: 10000 actual: 9996
        Messages: all messages should be acked
```

## Root cause

Race in the harness, not the SUT. Each worker calls `funcReg.Call` (the mock increments `processedCount`) and then calls `delivery.Ack` (increments `ackCount`) — sequential within `processDelivery`. The test was:

```go
assert.Eventually(func() bool { return processedCount.Load() == messageCount }, ...)
assert.Equal(int64(messageCount), ackCount.Load(), ...)
```

`Eventually` returned as soon as all 10000 `Call`s landed, but each worker still had its `Ack` step in flight. The immediate `assert.Equal` on `ackCount` raced the tail end of those acks.

## Fix

Poll on `ackCount` (the terminal state) and then assert `processedCount`. Ack happens strictly after Call in the same goroutine, so this both removes the race and keeps the original ordering invariant verified.

## Does this resolve or just mask the bug?

It resolves. The original assertion was logically wrong, not just unlucky.

Inside `processDelivery` (`consumer.go:166-235`) a single worker runs, sequentially in the same goroutine:

1. `funcReg.Call(...)` → synchronous `onCall` → `processedCount.Add(1)`
2. err / `MarkSettled` check
3. `delivery.Ack(ctx)` → synchronous `Ack` → `ackCount.Add(1)`

With 10 workers, the instant the 10000th `processedCount.Add` lands, up to 10 acks are still in flight on those workers' next statement. The implication `processedCount == messageCount ⟹ ackCount == messageCount` *right now* is false by construction of the code — there is always a non-zero gap between steps 1 and 3.

The new version still catches a real SUT regression: if the consumer ever loses an ack, `Eventually` times out at 30s and the test fails. Empirically:

- 200 consecutive `-race` runs of the fixed test: 200/200 pass, each returning in ~1s.
- A genuine ack loss would surface as a 30s `Eventually` timeout, never as a 1s pass.
- The mock `Ack` callback is trivial and synchronous — no async buffering where acks could disappear.

The fix expresses the intent of the test ("at the end, all 10000 acks landed and the processed count agrees"), rather than asserting a false instantaneous invariant.

## Test plan

- [x] `go test -count=200 -race -run TestConsumer_StressHighThroughput ./service/queue/consumer/...` — 200/200 pass.
- [x] `go test -count=1 -race ./...` — 274 packages clean, exit 0.
- [x] `golangci-lint run ./service/queue/consumer/...` — 0 issues.
- [x] `go vet ./...` + `go build ./...` — clean.