### PR TITLE
wippy CLI: surface hub quota refusal up front on publish

### DIFF
--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/Masterminds/semver/v3"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
@@ -570,6 +571,13 @@ func NewPublishClientError(registryURL string, cause error) error {
 }
 
 func NewPublishInitiateError(registryURL string, cause error) error {
+	// Surface a hub quota refusal up-front instead of burying it behind
+	// "failed to initiate publish ... resource_exhausted ...". The hub
+	// already returns the actionable reason ("Private-module quota
+	// exhausted (5 of 5). Ask an admin ..."); just relabel the prefix.
+	if connect.CodeOf(cause) == connect.CodeResourceExhausted {
+		return fmt.Errorf("quota exceeded on %s: %w", registryURL, cause)
+	}
 	return fmt.Errorf("failed to initiate publish on %s: %w", registryURL, cause)
 }
 


### PR DESCRIPTION
## Why

When a `wippy publish` is refused by the hub for being over the org's
plan cap, the hub returns `connect.CodeResourceExhausted` with a clear,
actionable reason — but `NewPublishInitiateError` wraps every initiate
error the same way:

```
failed to initiate publish on https://hub.example: resource_exhausted: Private-module quota exhausted (5 of 5). Ask an admin to enable more private modules for this org.
```

The "failed to initiate publish ..." prefix buries the actual reason
the user needs to act on.

## What

Detect `connect.CodeResourceExhausted` in `NewPublishInitiateError` and
relabel the prefix to `quota exceeded on <registry>:` so the user sees:

```
quota exceeded on https://hub.example: resource_exhausted: Private-module quota exhausted (5 of 5). Ask an admin to enable more private modules for this org.
```

Same `%w` wrap — the underlying error chain is preserved.

## Validation

- `go build ./cmd/wippy/...` — clean.
- `go test ./cmd/wippy/...` — passes.
- `golangci-lint run ./cmd/wippy/...` — 0 issues.