### PR TITLE
http: make static mount updates idempotent

### DIFF
--- a/service/http/manager_test.go
+++ b/service/http/manager_test.go
@@ -534,8 +534,48 @@ func TestManager_StaticOperations(t *testing.T) {
 	// Verify pending server rebuild
 	assert.True(t, manager.pending[serverID])
 
+	// Updating the same static entry must replace the entry-owned mount in place.
+	err = manager.Update(ctx, staticEntry)
+	require.NoError(t, err)
+
+	// Updating the same static entry can move the mount path.
+	movedStaticCfg := *staticCfg
+	movedStaticCfg.Path = "/assets"
+	staticEntry.Data = payload.New(&movedStaticCfg)
+	err = manager.Update(ctx, staticEntry)
+	require.NoError(t, err)
+
+	server := manager.servers[serverID].(*ServerService)
+	assert.Equal(t, "/assets", server.mountPaths[staticID])
+
+	// A different static entry cannot claim the same mount path.
+	otherStaticEntry := apiregistry.Entry{
+		ID:   apiregistry.NewID("test", "static2"),
+		Kind: config.Static,
+		Data: payload.New(&movedStaticCfg),
+	}
+	err = manager.Add(ctx, otherStaticEntry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mount path already exists")
+
+	// Failed path move leaves the previous static mount intact.
+	otherStaticCfg := *staticCfg
+	otherStaticCfg.Path = "/occupied"
+	otherStaticEntry.Data = payload.New(&otherStaticCfg)
+	err = manager.Add(ctx, otherStaticEntry)
+	require.NoError(t, err)
+	conflictingStaticCfg := movedStaticCfg
+	conflictingStaticCfg.Path = "/occupied"
+	staticEntry.Data = payload.New(&conflictingStaticCfg)
+	err = manager.Update(ctx, staticEntry)
+	require.Error(t, err)
+	assert.Equal(t, "/assets", server.mountPaths[staticID])
+	assert.Equal(t, "/occupied", server.mountPaths[otherStaticEntry.ID])
+
 	// Delete static handler
 	err = manager.Delete(ctx, staticEntry)
+	require.NoError(t, err)
+	err = manager.Delete(ctx, otherStaticEntry)
 	require.NoError(t, err)
 }
 

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -225,6 +225,25 @@ func (rm *RouteManager) Mount(path string, handler http.Handler) error {
 	return nil
 }
 
+// ReplaceMount replaces an existing root mount in place.
+func (rm *RouteManager) ReplaceMount(path string, handler http.Handler) error {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	if path == "" {
+		return ErrMountPathCannotBeEmpty
+	}
+	if !strings.HasPrefix(path, "/") {
+		return NewInvalidMountPathError(path)
+	}
+	if _, exists := rm.mounts[path]; !exists {
+		return NewMountPathNotFoundError(path)
+	}
+
+	rm.mounts[path] = handler
+	return nil
+}
+
 // Unmount removes a handler from the specified root path
 func (rm *RouteManager) Unmount(path string) error {
 	rm.mu.Lock()

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -73,6 +73,24 @@ func TestRouteManager_BasicOperations(t *testing.T) {
 		err = rm.Mount("/static", http.FileServer(http.Dir(".")))
 		assert.Error(t, err)
 
+		// Replace existing mount in place
+		replacement := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("replacement"))
+		})
+		err = rm.ReplaceMount("/static", replacement)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		rm.mounts["/static"].ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/static/app.js", nil))
+		assert.Equal(t, "replacement", rec.Body.String())
+
+		// Replace validates paths and only updates existing mounts
+		err = rm.ReplaceMount("", replacement)
+		assert.Error(t, err)
+		err = rm.ReplaceMount("static", replacement)
+		assert.Error(t, err)
+		err = rm.ReplaceMount("/missing", replacement)
+		assert.Error(t, err)
+
 		// Unmount
 		err = rm.Unmount("/static")
 		require.NoError(t, err)

--- a/service/http/server.go
+++ b/service/http/server.go
@@ -49,6 +49,7 @@ type ServerService struct {
 	statusChan    chan any
 	server        *http.Server
 	mountPaths    map[registry.ID]string
+	mountHandlers map[registry.ID]http.Handler
 	routeMgr      *RouteManager
 	config        *config.ServerConfig
 	id            registry.ID
@@ -70,6 +71,7 @@ func NewServerService(id registry.ID, cfg *config.ServerConfig, middleware Middl
 		routeMgr:      routeManager,
 		statusChan:    make(chan any, StatusBuffer),
 		mountPaths:    make(map[registry.ID]string),
+		mountHandlers: make(map[registry.ID]http.Handler),
 		middlewareFac: middleware,
 	}, nil
 }
@@ -150,12 +152,38 @@ func (s *ServerService) Mount(id registry.ID, path string, handler http.Handler)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if oldPath, exists := s.mountPaths[id]; exists {
+		if oldPath == path {
+			if err := s.routeMgr.ReplaceMount(path, handler); err != nil {
+				return err
+			}
+			s.mountHandlers[id] = handler
+			return nil
+		}
+
+		oldHandler := s.mountHandlers[id]
+		if err := s.routeMgr.Unmount(oldPath); err != nil {
+			return err
+		}
+		if err := s.routeMgr.Mount(path, handler); err != nil {
+			if oldHandler != nil {
+				_ = s.routeMgr.Mount(oldPath, oldHandler)
+			}
+			return err
+		}
+
+		s.mountPaths[id] = path
+		s.mountHandlers[id] = handler
+		return nil
+	}
+
 	if err := s.routeMgr.Mount(path, handler); err != nil {
 		return err
 	}
 
 	// Store path mapping for later unmount
 	s.mountPaths[id] = path
+	s.mountHandlers[id] = handler
 	return nil
 }
 
@@ -175,6 +203,7 @@ func (s *ServerService) Remove(id registry.ID) error {
 
 	// Clean up the mapping
 	delete(s.mountPaths, id)
+	delete(s.mountHandlers, id)
 	return nil
 }
 

--- a/service/http/server_test.go
+++ b/service/http/server_test.go
@@ -237,13 +237,41 @@ func TestServerService_RouterOperations(t *testing.T) {
 
 		// Verify the mount path is stored
 		assert.Equal(t, "/static", server.mountPaths[mountID])
+		assert.NotNil(t, server.mountHandlers[mountID])
+
+		// Re-mounting the same entry at the same path is an update, not a conflict.
+		err = server.Mount(mountID, "/static", http.FileServer(http.Dir(tempDir)))
+		require.NoError(t, err)
+
+		// Moving the same entry to a new path releases the old mount.
+		err = server.Mount(mountID, "/assets", http.FileServer(http.Dir(tempDir)))
+		require.NoError(t, err)
+		assert.Equal(t, "/assets", server.mountPaths[mountID])
+
+		// Different entries still cannot claim the same path.
+		otherID := registry.NewID("test", "static2")
+		err = server.Mount(otherID, "/assets", http.FileServer(http.Dir(tempDir)))
+		require.Error(t, err)
+		assert.Equal(t, "/assets", server.mountPaths[mountID])
+
+		// Failed move to an occupied path rolls back the original entry mount.
+		err = server.Mount(otherID, "/occupied", http.FileServer(http.Dir(tempDir)))
+		require.NoError(t, err)
+		err = server.Mount(mountID, "/occupied", http.FileServer(http.Dir(tempDir)))
+		require.Error(t, err)
+		assert.Equal(t, "/assets", server.mountPaths[mountID])
+		assert.Equal(t, "/occupied", server.mountPaths[otherID])
 
 		// Now unmount
 		err = server.Remove(mountID)
 		require.NoError(t, err)
+		err = server.Remove(otherID)
+		require.NoError(t, err)
 
 		// Verify the mapping is removed
 		_, exists := server.mountPaths[mountID]
+		assert.False(t, exists)
+		_, exists = server.mountHandlers[mountID]
 		assert.False(t, exists)
 
 		// Try unmounting non-existent handler


### PR DESCRIPTION
## Summary
- make root static mounts entry-owned upserts so registry updates for the same http.static entry do not collide with their existing path
- preserve conflicts when a different static entry claims an occupied mount path
- add route-manager, server-service, and manager-level regressions including same-path update, path move, conflict, and rollback

## Validation
- go test ./service/http
- go test ./api/service/http ./service/http
- go test ./...
