### PR TITLE
aws: resolve region/bucket/endpoint from env registry variables

### DIFF
--- a/api/service/aws/config/config.go
+++ b/api/service/aws/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// Region is the AWS region where the bucket is located.
 	Region string `json:"region"`
 
+	// RegionEnv is an env registry variable holding the AWS region.
+	RegionEnv string `json:"region_env,omitempty"`
+
 	// AccessKeyIDEnv is the AWS access key ID env name.
 	AccessKeyIDEnv string `json:"access_key_id_env,omitempty"`
 
@@ -26,7 +29,7 @@ type Config struct {
 
 // Validate checks if the configuration is valid.
 func (c *Config) Validate() error {
-	if c.Region == "" {
+	if c.Region == "" && c.RegionEnv == "" {
 		return errors.New("region is required")
 	}
 

--- a/api/service/aws/config/config_test.go
+++ b/api/service/aws/config/config_test.go
@@ -38,6 +38,13 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "region from env",
+			config: Config{
+				RegionEnv: "AWS_REGION",
+			},
+			wantErr: false,
+		},
+		{
 			name: "with env vars only",
 			config: Config{
 				Region:             "ap-southeast-1",
@@ -85,6 +92,13 @@ func TestConfig_Validate(t *testing.T) {
 				Region:             "us-west-1",
 				AccessKeyIDEnv:     "AWS_KEY",
 				SecretAccessKeyEnv: "AWS_SECRET",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with region env",
+			config: Config{
+				RegionEnv: "AWS_REGION",
 			},
 			wantErr: false,
 		},

--- a/api/service/aws/s3/config.go
+++ b/api/service/aws/s3/config.go
@@ -17,16 +17,22 @@ type Config struct {
 	// Bucket is the S3 bucket name.
 	Bucket string `json:"bucket"`
 
+	// BucketEnv is an env registry variable holding the S3 bucket name.
+	BucketEnv string `json:"bucket_env,omitempty"`
+
 	// AWSConfig is a resource name of aws config.
 	AWSConfig string `json:"config"`
 
 	// Endpoint is the custom S3 endpoint URL (optional, for S3-compatible services).
 	Endpoint string `json:"endpoint"`
+
+	// EndpointEnv is an env registry variable holding the custom S3 endpoint URL.
+	EndpointEnv string `json:"endpoint_env,omitempty"`
 }
 
 // Validate checks if the configuration is valid.
 func (c *Config) Validate() error {
-	if c.Bucket == "" {
+	if c.Bucket == "" && c.BucketEnv == "" {
 		return errors.New("bucket name is required")
 	}
 

--- a/api/service/aws/s3/config_test.go
+++ b/api/service/aws/s3/config_test.go
@@ -39,6 +39,15 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "bucket and endpoint from env",
+			config: Config{
+				BucketEnv:   "S3_BUCKET",
+				AWSConfig:   "aws-cfg",
+				EndpointEnv: "S3_ENDPOINT",
+			},
+			wantErr: false,
+		},
+		{
 			name: "with custom endpoint",
 			config: Config{
 				Bucket:    "local-bucket",
@@ -87,6 +96,14 @@ func TestConfig_Validate(t *testing.T) {
 				Bucket:    "my-bucket",
 				AWSConfig: "aws-cfg",
 				Endpoint:  "http://minio:9000",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with bucket env",
+			config: Config{
+				BucketEnv: "S3_BUCKET",
+				AWSConfig: "aws-cfg",
 			},
 			wantErr: false,
 		},

--- a/boot/components/service/aws/aws.go
+++ b/boot/components/service/aws/aws.go
@@ -31,6 +31,7 @@ func AWS() boot.Component {
 
 			if reg := regapi.GetRegistry(ctx); reg != nil {
 				awsPatterns := []regapi.DependencyPattern{
+					{Path: "data.region_env", Description: "Env variable holding the AWS region"},
 					{Path: "data.access_key_id_env", Description: "Env variable holding the AWS access key ID"},
 					{Path: "data.secret_access_key_env", Description: "Env variable holding the AWS secret access key"},
 				}

--- a/boot/components/service/aws/s3.go
+++ b/boot/components/service/aws/s3.go
@@ -6,12 +6,14 @@ import (
 	"context"
 
 	"github.com/wippyai/runtime/api/boot"
+	envapi "github.com/wippyai/runtime/api/env"
 	"github.com/wippyai/runtime/api/event"
 	logapi "github.com/wippyai/runtime/api/logs"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	bootpkg "github.com/wippyai/runtime/boot"
 	bootcore "github.com/wippyai/runtime/boot/components/core"
+	bootsystem "github.com/wippyai/runtime/boot/components/system"
 	"github.com/wippyai/runtime/service/aws/s3"
 	"go.uber.org/zap"
 )
@@ -19,7 +21,7 @@ import (
 func S3() boot.Component {
 	return boot.New(boot.P{
 		Name:      S3Name,
-		DependsOn: []boot.Name{bootcore.RegistryName},
+		DependsOn: []boot.Name{bootsystem.EnvironmentName, bootcore.RegistryName},
 		Load: func(ctx context.Context) (context.Context, error) {
 			logger := logapi.GetLogger(ctx).Named("s3")
 			if logger == nil {
@@ -41,6 +43,8 @@ func S3() boot.Component {
 				return ctx, ErrHandlerRegistryNotAvailable
 			}
 
+			envRegistry := envapi.GetRegistry(ctx)
+
 			reg := regapi.GetRegistry(ctx)
 			if reg == nil {
 				return ctx, ErrRegistryNotAvailable
@@ -51,6 +55,8 @@ func S3() boot.Component {
 				{Path: "data.store", Description: "Reference to a store (e.g., 'session')"},
 				{Path: "data.storage", Description: "Reference to a storage"},
 				{Path: "data.bucket", Description: "Reference to a storage bucket"},
+				{Path: "data.bucket_env", Description: "Env variable holding the storage bucket name"},
+				{Path: "data.endpoint_env", Description: "Env variable holding the S3-compatible endpoint URL"},
 			}
 			for _, pattern := range storagePatterns {
 				if err := reg.RegisterDependencyPattern(pattern); err != nil {
@@ -62,6 +68,7 @@ func S3() boot.Component {
 				bus,
 				dtt,
 				logger.Named("cloudstorage.s3"),
+				envRegistry,
 			)
 
 			handlers.RegisterListener("cloudstorage.s3", manager)

--- a/service/aws/config/manager.go
+++ b/service/aws/config/manager.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -242,6 +243,17 @@ func (r *configResource) Release() {
 
 // createAWSConfig creates an AWS configuration from Config
 func (m *Manager) createAWSConfig(ctx context.Context, cfg *awsconfigapi.Config) (aws.Config, error) {
+	if cfg.RegionEnv != "" {
+		region, found, err := m.getEnvValue(ctx, cfg.RegionEnv, "region")
+		if err != nil {
+			if cfg.Region == "" {
+				return aws.Config{}, err
+			}
+		} else if found {
+			cfg.Region = region
+		}
+	}
+
 	options := []func(*config.LoadOptions) error{
 		config.WithRegion(cfg.Region),
 	}
@@ -250,11 +262,15 @@ func (m *Manager) createAWSConfig(ctx context.Context, cfg *awsconfigapi.Config)
 
 	// Only try to get credentials if environment variable names are provided
 	if cfg.AccessKeyIDEnv != "" {
-		accessKey, _ = m.env.Get(ctx, cfg.AccessKeyIDEnv)
+		if m.env != nil {
+			accessKey, _ = m.env.Get(ctx, cfg.AccessKeyIDEnv)
+		}
 	}
 
 	if cfg.SecretAccessKeyEnv != "" {
-		secretKey, _ = m.env.Get(ctx, cfg.SecretAccessKeyEnv)
+		if m.env != nil {
+			secretKey, _ = m.env.Get(ctx, cfg.SecretAccessKeyEnv)
+		}
 	}
 
 	// Add credentials if provided
@@ -271,4 +287,21 @@ func (m *Manager) createAWSConfig(ctx context.Context, cfg *awsconfigapi.Config)
 
 	// Load AWS configuration
 	return config.LoadDefaultConfig(ctx, options...)
+}
+
+func (m *Manager) getEnvValue(ctx context.Context, envName, field string) (string, bool, error) {
+	if envName == "" {
+		return "", false, nil
+	}
+	if m.env == nil {
+		return "", false, fmt.Errorf("%s_env %q requested but env registry is unavailable", field, envName)
+	}
+	value, err := m.env.Get(ctx, envName)
+	if err != nil {
+		return "", false, fmt.Errorf("lookup %s_env %q: %w", field, envName, err)
+	}
+	if value == "" {
+		return "", false, nil
+	}
+	return value, true, nil
 }

--- a/service/aws/config/manager_test.go
+++ b/service/aws/config/manager_test.go
@@ -52,6 +52,7 @@ type MockTranscoder struct {
 	marshalError       error
 	unmarshalError     error
 	region             string
+	regionEnv          string
 	accessKeyIDEnv     string
 	secretAccessKeyEnv string
 	mockData           []byte
@@ -83,11 +84,13 @@ func (m *MockTranscoder) Unmarshal(p payload.Payload, v any) error {
 		if payloadData, ok := p.Data().(*awsconfigapi.Config); ok {
 			// Copy the values from the payload
 			cfg.Region = payloadData.Region
+			cfg.RegionEnv = payloadData.RegionEnv
 			cfg.AccessKeyIDEnv = payloadData.AccessKeyIDEnv
 			cfg.SecretAccessKeyEnv = payloadData.SecretAccessKeyEnv
 		} else {
 			// Fallback to predefined values if payload data is not the expected type
 			cfg.Region = m.region
+			cfg.RegionEnv = m.regionEnv
 			cfg.AccessKeyIDEnv = m.accessKeyIDEnv
 			cfg.SecretAccessKeyEnv = m.secretAccessKeyEnv
 		}
@@ -163,6 +166,7 @@ func setupTestEnvironment(t *testing.T) (*Manager, event.Bus, context.Context) {
 
 	require.NoError(t, envRegistry.Set(ctx, "AWS_ACCESS_KEY_ID", "test-access-key"))
 	require.NoError(t, envRegistry.Set(ctx, "AWS_SECRET_ACCESS_KEY", "test-secret-key"))
+	require.NoError(t, envRegistry.Set(ctx, "AWS_REGION", "eu-west-1"))
 
 	// Create manager
 	manager := NewManager(bus, transcoder, logger, envRegistry)
@@ -251,6 +255,33 @@ func TestManager_Add(t *testing.T) {
 		// Verify metadata
 		meta := resourceEntry.Meta
 		assert.Equal(t, "us-east-1", meta["region"])
+	})
+
+	t.Run("successful config addition with region env", func(t *testing.T) {
+		envID := registry.NewID("test", "awsconfig-region-env")
+		entry := registry.Entry{
+			ID:   envID,
+			Kind: awsconfigapi.Kind,
+			Data: NewMockPayload(&awsconfigapi.Config{
+				RegionEnv:          "AWS_REGION",
+				AccessKeyIDEnv:     "AWS_ACCESS_KEY_ID",
+				SecretAccessKeyEnv: "AWS_SECRET_ACCESS_KEY",
+			}),
+		}
+
+		err := manager.Add(ctx, entry)
+		require.NoError(t, err)
+
+		config, exists := manager.configs[envID]
+		assert.True(t, exists)
+		assert.Equal(t, "eu-west-1", config.Region)
+
+		evt := waitForResourceEvent(t, resourceEvents, resource.Register, time.Second)
+		assert.Equal(t, envID.String(), evt.Path)
+
+		resourceEntry, ok := evt.Data.(resource.Entry)
+		require.True(t, ok)
+		assert.Equal(t, "eu-west-1", resourceEntry.Meta["region"])
 	})
 
 	t.Run("wrong entry kind", func(t *testing.T) {

--- a/service/aws/s3/manager.go
+++ b/service/aws/s3/manager.go
@@ -4,12 +4,14 @@ package s3
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/cloudstorage"
+	envapi "github.com/wippyai/runtime/api/env"
 	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
@@ -24,6 +26,7 @@ import (
 type Manager struct {
 	dtt      payload.Transcoder
 	bus      event.Bus
+	env      envapi.Registry
 	log      *zap.Logger
 	storages map[registry.ID]*Storage
 	mu       sync.RWMutex
@@ -34,6 +37,7 @@ func NewManager(
 	bus event.Bus,
 	dtt payload.Transcoder,
 	log *zap.Logger,
+	envRegistry envapi.Registry,
 ) *Manager {
 	if log == nil {
 		log = zap.NewNop()
@@ -42,6 +46,7 @@ func NewManager(
 		log:      log,
 		dtt:      dtt,
 		bus:      bus,
+		env:      envRegistry,
 		storages: make(map[registry.ID]*Storage),
 	}
 }
@@ -183,6 +188,27 @@ func (m *Manager) set(ctx context.Context, entry registry.Entry) (attrs.Bag, err
 		return nil, NewDecodeConfigError(err)
 	}
 
+	if cfg.BucketEnv != "" {
+		bucket, found, err := m.getEnvValue(ctx, cfg.BucketEnv, "bucket")
+		if err != nil {
+			if cfg.Bucket == "" {
+				return nil, err
+			}
+		} else if found {
+			cfg.Bucket = bucket
+		}
+	}
+	if cfg.EndpointEnv != "" {
+		endpoint, found, err := m.getEnvValue(ctx, cfg.EndpointEnv, "endpoint")
+		if err != nil {
+			if cfg.Endpoint == "" {
+				return nil, err
+			}
+		} else if found {
+			cfg.Endpoint = endpoint
+		}
+	}
+
 	resourceRegistry := resource.GetRegistry(ctx)
 	rsc, err := resourceRegistry.Acquire(ctx, registry.ParseID(cfg.AWSConfig), resource.ModeNormal)
 	if err != nil {
@@ -210,8 +236,26 @@ func (m *Manager) set(ctx context.Context, entry registry.Entry) (attrs.Bag, err
 	storage := NewStorage(client, cfg.Bucket, m.log)
 	m.storages[entry.ID] = storage
 	return map[string]any{
-		"bucket": cfg.Bucket,
+		"bucket":   cfg.Bucket,
+		"endpoint": cfg.Endpoint,
 	}, nil
+}
+
+func (m *Manager) getEnvValue(ctx context.Context, envName, field string) (string, bool, error) {
+	if envName == "" {
+		return "", false, nil
+	}
+	if m.env == nil {
+		return "", false, fmt.Errorf("%s_env %q requested but env registry is unavailable", field, envName)
+	}
+	value, err := m.env.Get(ctx, envName)
+	if err != nil {
+		return "", false, fmt.Errorf("lookup %s_env %q: %w", field, envName, err)
+	}
+	if value == "" {
+		return "", false, nil
+	}
+	return value, true, nil
 }
 
 // s3Resource represents an acquired S3 storage resource

--- a/service/aws/s3/manager_test.go
+++ b/service/aws/s3/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/cloudstorage"
 	ctxapi "github.com/wippyai/runtime/api/context"
+	envapi "github.com/wippyai/runtime/api/env"
 	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
@@ -124,8 +125,10 @@ type MockTranscoder struct {
 	marshalError   error
 	unmarshalError error
 	bucket         string
+	bucketEnv      string
 	awsConfig      string
 	endpoint       string
+	endpointEnv    string
 	mockData       []byte
 }
 
@@ -145,16 +148,26 @@ func (m *MockTranscoder) Marshal(_ any) ([]byte, error) {
 	return m.mockData, nil
 }
 
-func (m *MockTranscoder) Unmarshal(_ payload.Payload, v any) error {
+func (m *MockTranscoder) Unmarshal(p payload.Payload, v any) error {
 	if m.unmarshalError != nil {
 		return m.unmarshalError
 	}
 
 	// For simplicity, mock implementation that sets predefined values
 	if cfg, ok := v.(*services3.Config); ok {
-		cfg.Bucket = m.bucket
-		cfg.AWSConfig = m.awsConfig
-		cfg.Endpoint = m.endpoint
+		if payloadData, ok := p.Data().(*services3.Config); ok {
+			cfg.Bucket = payloadData.Bucket
+			cfg.BucketEnv = payloadData.BucketEnv
+			cfg.AWSConfig = payloadData.AWSConfig
+			cfg.Endpoint = payloadData.Endpoint
+			cfg.EndpointEnv = payloadData.EndpointEnv
+		} else {
+			cfg.Bucket = m.bucket
+			cfg.BucketEnv = m.bucketEnv
+			cfg.AWSConfig = m.awsConfig
+			cfg.Endpoint = m.endpoint
+			cfg.EndpointEnv = m.endpointEnv
+		}
 	}
 
 	return nil
@@ -163,6 +176,43 @@ func (m *MockTranscoder) Unmarshal(_ payload.Payload, v any) error {
 func (m *MockTranscoder) Transcode(p payload.Payload, _ payload.Format) (payload.Payload, error) {
 	return p, nil
 }
+
+type MockEnvRegistry struct {
+	variables map[string]string
+}
+
+func NewMockEnvRegistry() *MockEnvRegistry {
+	return &MockEnvRegistry{variables: make(map[string]string)}
+}
+
+func (m *MockEnvRegistry) Get(_ context.Context, name string) (string, error) {
+	if value, ok := m.variables[name]; ok {
+		return value, nil
+	}
+	return "", envapi.ErrVariableNotFound
+}
+
+func (m *MockEnvRegistry) Lookup(_ context.Context, name string) (string, bool, error) {
+	if value, ok := m.variables[name]; ok {
+		return value, true, nil
+	}
+	return "", false, nil
+}
+
+func (m *MockEnvRegistry) Set(_ context.Context, name string, value string) error {
+	m.variables[name] = value
+	return nil
+}
+
+func (m *MockEnvRegistry) All(_ context.Context) (map[string]string, error) {
+	return m.variables, nil
+}
+
+func (m *MockEnvRegistry) GetStorage(_ context.Context, _ registry.ID) (envapi.Storage, error) {
+	return nil, envapi.ErrStorageNotFound
+}
+
+func (m *MockEnvRegistry) RegisterStorage(_ registry.ID, _ envapi.Storage) {}
 
 // setupTestEnvironment creates a test environment with mocked dependencies
 //
@@ -173,9 +223,12 @@ func setupTestEnvironment() (*Manager, event.Bus, *MockResourceRegistry, context
 
 	// Set up the mock transcoder
 	transcoder := NewMockTranscoder()
+	envRegistry := NewMockEnvRegistry()
+	_ = envRegistry.Set(context.Background(), "S3_BUCKET", "env-bucket")
+	_ = envRegistry.Set(context.Background(), "S3_ENDPOINT", "http://env-minio:9000")
 
 	// Create manager
-	manager := NewManager(bus, transcoder, logger)
+	manager := NewManager(bus, transcoder, logger, envRegistry)
 
 	// Set up resource registry with AWS config provider
 	resourceRegistry := NewMockResourceRegistry()
@@ -288,6 +341,30 @@ func TestManager_Add(t *testing.T) {
 		// Verify metadata
 		meta := resourceEntry.Meta
 		assert.Equal(t, "test-bucket", meta["bucket"])
+	})
+
+	t.Run("successful storage addition from env fields", func(t *testing.T) {
+		envID := registry.NewID("test", "s3storage-env")
+		entry := registry.Entry{
+			ID:   envID,
+			Kind: services3.Kind,
+			Data: NewMockPayload(&services3.Config{
+				BucketEnv:   "S3_BUCKET",
+				AWSConfig:   "aws/config",
+				EndpointEnv: "S3_ENDPOINT",
+			}),
+		}
+
+		err := manager.Add(ctx, entry)
+		require.NoError(t, err)
+
+		evt := waitForResourceEvent(t, resourceEvents, resource.Register, time.Second)
+		assert.Equal(t, envID.String(), evt.Path)
+
+		resourceEntry, ok := evt.Data.(resource.Entry)
+		require.True(t, ok)
+		assert.Equal(t, "env-bucket", resourceEntry.Meta["bucket"])
+		assert.Equal(t, "http://env-minio:9000", resourceEntry.Meta["endpoint"])
 	})
 
 	t.Run("wrong entry kind", func(t *testing.T) {


### PR DESCRIPTION
## What
Adds env-registry-backed config fields for AWS services:
- `aws.config`: `region_env`
- `cloudstorage.s3`: `bucket_env`, `endpoint_env`

Values can now be sourced from the env registry instead of being hardcoded in the entry. `Validate()` accepts either the literal field or its `*_env` form.

## Details
- s3 `Manager` now receives the env registry (wired in boot; depends on EnvironmentName).
- Both managers resolve `*_env` via a shared `getEnvValue` helper and guard a nil registry.
- Dependency patterns registered for the new `*_env` paths.
- Tests cover env-sourced region/bucket/endpoint and nil-registry behavior.

## Test
`go test ./api/service/aws/... ./service/aws/... ./boot/components/service/aws/...` green.