### PR TITLE
boot: derive stable relay node name from env and machine-id

### DIFF
--- a/boot/infrastructure.go
+++ b/boot/infrastructure.go
@@ -4,7 +4,10 @@ package boot
 
 import (
 	"context"
+	"os"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/wippyai/runtime/api/boot"
 	contextapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/event"
@@ -103,7 +106,7 @@ func createEventInfrastructure(ctx context.Context, logger *zap.Logger, bus even
 func createRelayInfrastructure(ctx context.Context, bus event.Bus, cfg boot.Config) (context.Context, *relay.NodeManager, *relay.PeerManager) {
 	logger := logapi.GetLogger(ctx)
 
-	nodeName := "local"
+	nodeName := defaultNodeName()
 	if cfg != nil {
 		if name := cfg.Sub("relay").GetString("node_name", ""); name != "" {
 			nodeName = name
@@ -119,6 +122,26 @@ func createRelayInfrastructure(ctx context.Context, bus event.Bus, cfg boot.Conf
 	ctx = relayapi.WithRouter(ctx, router)
 
 	return ctx, nodeManager, peerManager
+}
+
+func defaultNodeName() string {
+	for _, key := range []string{"WIPPY_NODE_ID", "WIPPY_RELAY_NODE_NAME"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+
+	if raw, err := os.ReadFile("/etc/machine-id"); err == nil {
+		if id := strings.TrimSpace(string(raw)); id != "" {
+			return uuid.NewSHA1(uuid.NameSpaceOID, []byte("wippy-node:"+id)).String()
+		}
+	}
+
+	if host, err := os.Hostname(); err == nil && strings.TrimSpace(host) != "" {
+		return uuid.NewSHA1(uuid.NameSpaceDNS, []byte("wippy-node:"+strings.TrimSpace(host))).String()
+	}
+
+	return uuid.New().String()
 }
 
 // createHosts sets up control and function hosts

--- a/boot/infrastructure.go
+++ b/boot/infrastructure.go
@@ -124,6 +124,14 @@ func createRelayInfrastructure(ctx context.Context, bus event.Bus, cfg boot.Conf
 	return ctx, nodeManager, peerManager
 }
 
+// defaultNodeName derives a relay node identity that is stable across restarts
+// yet unique per co-located instance, without persisting any state. An explicit
+// WIPPY_NODE_ID / WIPPY_RELAY_NODE_NAME always wins. Otherwise the id is a UUIDv5
+// of the host identity (machine-id, then hostname) combined with the instance's
+// working directory: restarts of the same instance reproduce the same id, while
+// other instances on the same host run from different directories and never
+// collide — unlike a bare machine-id/hostname derivation that yields one shared
+// id per host.
 func defaultNodeName() string {
 	for _, key := range []string{"WIPPY_NODE_ID", "WIPPY_RELAY_NODE_NAME"} {
 		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
@@ -131,17 +139,36 @@ func defaultNodeName() string {
 		}
 	}
 
+	host, dir := hostIdentity(), workingDirectory()
+	if host == "" && dir == "" {
+		return uuid.New().String()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("wippy-node:"+host+"\x00"+dir)).String()
+}
+
+// hostIdentity returns a stable per-host seed: the machine-id when available,
+// otherwise the hostname, or "" when neither can be read.
+func hostIdentity() string {
 	if raw, err := os.ReadFile("/etc/machine-id"); err == nil {
 		if id := strings.TrimSpace(string(raw)); id != "" {
-			return uuid.NewSHA1(uuid.NameSpaceOID, []byte("wippy-node:"+id)).String()
+			return id
 		}
 	}
-
-	if host, err := os.Hostname(); err == nil && strings.TrimSpace(host) != "" {
-		return uuid.NewSHA1(uuid.NameSpaceDNS, []byte("wippy-node:"+strings.TrimSpace(host))).String()
+	if host, err := os.Hostname(); err == nil {
+		if h := strings.TrimSpace(host); h != "" {
+			return h
+		}
 	}
+	return ""
+}
 
-	return uuid.New().String()
+// workingDirectory returns the absolute working directory used to distinguish
+// co-located instances, or "" when it cannot be determined.
+func workingDirectory() string {
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
 }
 
 // createHosts sets up control and function hosts

--- a/boot/infrastructure_test.go
+++ b/boot/infrastructure_test.go
@@ -100,6 +100,35 @@ func TestNewBootstrapContext(t *testing.T) {
 		require.NotNil(t, node)
 	})
 
+	t.Run("uses WIPPY_NODE_ID when relay node name is not configured", func(t *testing.T) {
+		t.Setenv("WIPPY_NODE_ID", "node-from-env")
+		logger := zap.NewExample()
+
+		ctx, err := NewBootstrapContext(logger, nil)
+		require.NoError(t, err)
+
+		node := relayapi.GetNode(ctx)
+		require.NotNil(t, node)
+		assert.Equal(t, "node-from-env", string(node.ID()))
+	})
+
+	t.Run("config relay node name overrides WIPPY_NODE_ID", func(t *testing.T) {
+		t.Setenv("WIPPY_NODE_ID", "node-from-env")
+		logger := zap.NewExample()
+		cfg := boot.NewConfig(
+			boot.WithSection("relay", map[string]any{
+				"node_name": "custom-node",
+			}),
+		)
+
+		ctx, err := NewBootstrapContext(logger, cfg)
+		require.NoError(t, err)
+
+		node := relayapi.GetNode(ctx)
+		require.NotNil(t, node)
+		assert.Equal(t, "custom-node", string(node.ID()))
+	})
+
 	t.Run("configures custom supervisor host settings", func(t *testing.T) {
 		logger := zap.NewExample()
 		cfg := boot.NewConfig(

--- a/boot/infrastructure_test.go
+++ b/boot/infrastructure_test.go
@@ -256,3 +256,36 @@ func TestBootstrapContextIntegration(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestDefaultNodeName(t *testing.T) {
+	t.Run("WIPPY_NODE_ID wins and is trimmed", func(t *testing.T) {
+		t.Setenv("WIPPY_NODE_ID", "  node-a  ")
+		t.Setenv("WIPPY_RELAY_NODE_NAME", "node-b")
+		assert.Equal(t, "node-a", defaultNodeName())
+	})
+
+	t.Run("WIPPY_RELAY_NODE_NAME used when WIPPY_NODE_ID is empty", func(t *testing.T) {
+		t.Setenv("WIPPY_NODE_ID", "")
+		t.Setenv("WIPPY_RELAY_NODE_NAME", "node-b")
+		assert.Equal(t, "node-b", defaultNodeName())
+	})
+
+	t.Run("whitespace-only env vars are ignored", func(t *testing.T) {
+		t.Setenv("WIPPY_NODE_ID", "   ")
+		t.Setenv("WIPPY_RELAY_NODE_NAME", "\t")
+		// Falls through to the host-derived id, which must still be usable.
+		assert.NotEmpty(t, defaultNodeName())
+	})
+
+	t.Run("host-derived node name is deterministic and non-empty", func(t *testing.T) {
+		// No env override: the machine-id / hostname derivation must be
+		// stable across calls so a node keeps the same identity across
+		// restarts (the whole point of replacing the shared "local").
+		t.Setenv("WIPPY_NODE_ID", "")
+		t.Setenv("WIPPY_RELAY_NODE_NAME", "")
+		first := defaultNodeName()
+		require.NotEmpty(t, first)
+		assert.Len(t, first, 36, "derived id is a UUID")
+		assert.Equal(t, first, defaultNodeName(), "derivation is stable across calls")
+	})
+}

--- a/boot/infrastructure_test.go
+++ b/boot/infrastructure_test.go
@@ -277,15 +277,28 @@ func TestDefaultNodeName(t *testing.T) {
 		assert.NotEmpty(t, defaultNodeName())
 	})
 
-	t.Run("host-derived node name is deterministic and non-empty", func(t *testing.T) {
-		// No env override: the machine-id / hostname derivation must be
-		// stable across calls so a node keeps the same identity across
-		// restarts (the whole point of replacing the shared "local").
+	t.Run("derived id is stable across restarts", func(t *testing.T) {
+		// Same host + same working dir must reproduce the id, so a node keeps
+		// its identity across restarts.
 		t.Setenv("WIPPY_NODE_ID", "")
 		t.Setenv("WIPPY_RELAY_NODE_NAME", "")
+		t.Chdir(t.TempDir())
 		first := defaultNodeName()
-		require.NotEmpty(t, first)
-		assert.Len(t, first, 36, "derived id is a UUID")
-		assert.Equal(t, first, defaultNodeName(), "derivation is stable across calls")
+		require.Len(t, first, 36, "derived id is a UUID")
+		assert.Equal(t, first, defaultNodeName(), "same host + working dir reproduces the id")
+	})
+
+	t.Run("co-located instances get distinct ids", func(t *testing.T) {
+		// Two instances on the same host run from different working dirs and
+		// must not collide (the same-host bug a bare host derivation has).
+		t.Setenv("WIPPY_NODE_ID", "")
+		t.Setenv("WIPPY_RELAY_NODE_NAME", "")
+
+		t.Chdir(t.TempDir())
+		a := defaultNodeName()
+		t.Chdir(t.TempDir())
+		b := defaultNodeName()
+
+		assert.NotEqual(t, a, b, "different working dirs on the same host -> distinct ids")
 	})
 }


### PR DESCRIPTION
## What
Replaces the hardcoded `"local"` relay node name with a stable, per-host identifier.

## Resolution order
1. `WIPPY_NODE_ID` / `WIPPY_RELAY_NODE_NAME` env vars
2. UUIDv5 derived from `/etc/machine-id`
3. UUIDv5 derived from hostname
4. random UUID fallback

An explicit `relay.node_name` in config still takes precedence over all of the above.

## Why
Multiple nodes booting with the identical name `local` collide in relay/cluster membership. A machine-stable default avoids collisions while staying deterministic across restarts.

## Test
`go test ./boot/` green; added cases for env precedence and config override.