### PR TITLE
test(ctx): cover process to async function future delivery

### DIFF
--- a/tests/app/src/test/ctx/_index.yaml
+++ b/tests/app/src/test/ctx/_index.yaml
@@ -133,3 +133,69 @@ entries:
       - time
     imports:
       assert2: app.lib:assert
+
+  # Worker: calls funcs.new():async() to test process->async func future delivery.
+  - name: process_calls_func_async_worker
+    kind: process.lua
+    meta:
+      comment: Worker that starts an async function from a process
+    source: file://process_calls_func_async_worker.lua
+    method: main
+    modules:
+      - funcs
+
+  - name: process_to_func_async
+    kind: function.lua
+    meta:
+      type: test
+      suite: ctx
+      description: Future payload delivery from process to async function call
+    source: file://process_to_func_async.lua
+    method: main
+    modules:
+      - time
+    imports:
+      assert2: app.lib:assert
+
+  # Worker: process.exec target that starts funcs.new():async().
+  - name: process_exec_async_worker
+    kind: process.lua
+    meta:
+      comment: Worker executed by process.exec that awaits an async function future
+    source: file://process_exec_async_worker.lua
+    method: main
+    modules:
+      - funcs
+
+  - name: process_exec_to_func_async
+    kind: function.lua
+    meta:
+      type: test
+      suite: ctx
+      description: process.exec target receives funcs.async future payload
+    source: file://process_exec_to_func_async.lua
+    method: main
+    imports:
+      assert2: app.lib:assert
+
+  # Worker: process.exec target that selects over two funcs.new():async() futures.
+  - name: process_exec_async_select_worker
+    kind: process.lua
+    meta:
+      comment: Worker executed by process.exec that awaits two async future channels
+    source: file://process_exec_async_select_worker.lua
+    method: main
+    modules:
+      - funcs
+      - time
+
+  - name: process_exec_async_select
+    kind: function.lua
+    meta:
+      type: test
+      suite: ctx
+      description: process.exec target receives multiple funcs.async future payloads through channel.select
+    source: file://process_exec_async_select.lua
+    method: main
+    imports:
+      assert2: app.lib:assert

--- a/tests/app/src/test/ctx/process_calls_func_async_worker.lua
+++ b/tests/app/src/test/ctx/process_calls_func_async_worker.lua
@@ -1,0 +1,41 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Worker that calls a function with funcs.async() from inside a process.
+-- This guards the process -> async function -> future response path.
+local funcs = require("funcs")
+
+local function main()
+	local exec = funcs.new():with_context({
+		process_to_func_async_id = "ptfa-654",
+		process_async_called = true,
+	})
+
+	local future, async_err = exec:async("app.test.ctx:ctx_reader", { "process_to_func_async_id", "process_async_called" })
+	if async_err then
+		error("funcs async failed to start: " .. tostring(async_err))
+	end
+
+	local payload, ok = future:response():receive()
+	if not ok then
+		local ferr, has_error = future:error()
+		if has_error then
+			error("future closed with error: " .. tostring(ferr))
+		end
+		error("future response channel closed without payload")
+	end
+	if not payload then
+		error("future response payload is nil")
+	end
+
+	local result = payload:data()
+	if result.process_to_func_async_id ~= "ptfa-654" then
+		error("process_to_func_async_id not inherited: got " .. tostring(result.process_to_func_async_id))
+	end
+	if result.process_async_called ~= true then
+		error("process_async_called marker not inherited: got " .. tostring(result.process_async_called))
+	end
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/ctx/process_exec_async_select.lua
+++ b/tests/app/src/test/ctx/process_exec_async_select.lua
@@ -1,0 +1,18 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: process.exec target can collect multiple concurrent funcs.async
+-- results with channel.select without losing the process target.
+local assert = require("assert2")
+
+local function main()
+	local result, err = process.exec("app.test.ctx:process_exec_async_select_worker", "app:processes")
+	assert.is_nil(err, "process.exec no error")
+	assert.not_nil(result, "process.exec returned result")
+	assert.eq(result.ok, true, "both async future payloads arrived inside process.exec worker")
+	assert.eq(result.stage, "done", "worker completed")
+	assert.eq(result.got_id, true, "context id propagated")
+	assert.eq(result.got_marker, true, "context marker propagated")
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/ctx/process_exec_async_select_worker.lua
+++ b/tests/app/src/test/ctx/process_exec_async_select_worker.lua
@@ -1,0 +1,65 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Worker executed with process.exec. It starts two async function calls, then
+-- receives both payloads through future channels with channel.select.
+local funcs = require("funcs")
+local time = require("time")
+
+local function main()
+	local exec = funcs.new():with_context({
+		process_exec_async_select_id = "peas-246",
+		process_exec_async_select_called = true,
+	})
+
+	local first, first_err = exec:async("app.test.ctx:ctx_reader", { "process_exec_async_select_id" })
+	if first_err then
+		return { ok = false, stage = "first_start", error = tostring(first_err) }
+	end
+
+	local second, second_err = exec:async("app.test.ctx:ctx_reader", { "process_exec_async_select_called" })
+	if second_err then
+		return { ok = false, stage = "second_start", error = tostring(second_err) }
+	end
+
+	local first_ch = first:channel()
+	local second_ch = second:channel()
+	local timeout = time.after("3s")
+	local got_id = false
+	local got_marker = false
+
+	while not (got_id and got_marker) do
+		local cases = table.create(3, 0)
+		if not got_id then cases[#cases + 1] = first_ch:case_receive() end
+		if not got_marker then cases[#cases + 1] = second_ch:case_receive() end
+		cases[#cases + 1] = timeout:case_receive()
+		local selected = channel.select(cases)
+		if selected.channel == timeout then
+			return { ok = false, stage = "timeout" }
+		end
+		if selected.ok == false then
+			local stage = selected.channel == first_ch and "first_closed" or "second_closed"
+			local future = selected.channel == first_ch and first or second
+			local ferr, has_error = future:error()
+			return { ok = false, stage = stage, has_error = has_error, error = tostring(ferr) }
+		end
+		if not selected.value then
+			return { ok = false, stage = "nil_payload" }
+		end
+
+		local data = selected.value:data()
+		if selected.channel == first_ch then
+			got_id = data.process_exec_async_select_id == "peas-246"
+		elseif selected.channel == second_ch then
+			got_marker = data.process_exec_async_select_called == true
+		end
+	end
+
+	return {
+		ok = true,
+		stage = "done",
+		got_id = got_id,
+		got_marker = got_marker,
+	}
+end
+
+return { main = main }

--- a/tests/app/src/test/ctx/process_exec_async_worker.lua
+++ b/tests/app/src/test/ctx/process_exec_async_worker.lua
@@ -1,0 +1,40 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Worker executed with process.exec that starts an async function and awaits the future.
+local funcs = require("funcs")
+
+local function main()
+	local exec = funcs.new():with_context({
+		process_exec_async_id = "pefa-987",
+		process_exec_async_called = true,
+	})
+
+	local future, async_err = exec:async("app.test.ctx:ctx_reader", { "process_exec_async_id", "process_exec_async_called" })
+	if async_err then
+		return { ok = false, stage = "async_start", error = tostring(async_err) }
+	end
+
+	local payload, ok = future:response():receive()
+	if not ok then
+		local ferr, has_error = future:error()
+		return {
+			ok = false,
+			stage = "future_receive",
+			has_error = has_error,
+			error = tostring(ferr),
+		}
+	end
+	if not payload then
+		return { ok = false, stage = "future_payload", error = "nil payload" }
+	end
+
+	local result = payload:data()
+	return {
+		ok = result.process_exec_async_id == "pefa-987" and result.process_exec_async_called == true,
+		stage = "done",
+		process_exec_async_id = result.process_exec_async_id,
+		process_exec_async_called = result.process_exec_async_called,
+	}
+end
+
+return { main = main }

--- a/tests/app/src/test/ctx/process_exec_to_func_async.lua
+++ b/tests/app/src/test/ctx/process_exec_to_func_async.lua
@@ -1,0 +1,17 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: process.exec process can await funcs.async future payloads.
+local assert = require("assert2")
+
+local function main()
+	local result, err = process.exec("app.test.ctx:process_exec_async_worker", "app:processes")
+	assert.is_nil(err, "process.exec no error")
+	assert.not_nil(result, "process.exec returned result")
+	assert.eq(result.ok, true, "async future payload arrived inside process.exec worker")
+	assert.eq(result.stage, "done", "worker completed")
+	assert.eq(result.process_exec_async_id, "pefa-987", "context id propagated")
+	assert.eq(result.process_exec_async_called, true, "context marker propagated")
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/ctx/process_to_func_async.lua
+++ b/tests/app/src/test/ctx/process_to_func_async.lua
@@ -1,0 +1,32 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: funcs.async from inside a process returns a real future payload.
+local assert = require("assert2")
+local time = require("time")
+
+local function main()
+	local events_ch = process.events()
+
+	local child_pid, err = process.spawn_monitored("app.test.ctx:process_calls_func_async_worker", "app:processes")
+	assert.is_nil(err, "spawn no error")
+	assert.not_nil(child_pid, "spawn returns pid")
+
+	local timeout = time.after("3s")
+	local result = channel.select {
+		events_ch:case_receive(),
+		timeout:case_receive(),
+	}
+
+	if result.channel ~= events_ch then
+		return false, "timeout waiting for async worker"
+	end
+
+	local event = result.value
+	assert.eq(event.kind, process.event.EXIT, "got EXIT event")
+	assert.is_nil(event.error, "worker exited without error")
+	assert.eq(event.result.value, true, "worker returned true")
+
+	return true
+end
+
+return { main = main }


### PR DESCRIPTION
## What
Adds ctx-suite coverage for `funcs.new():async()` future payload delivery in process contexts:
- `process_to_func_async` - async function started from inside a spawned process
- `process_exec_to_func_async` - `process.exec` target awaiting an async future
- `process_exec_async_select` - `process.exec` target selecting over two async futures via `channel.select`

Plus the process.lua worker fixtures they drive.

## Test
Full app suite green: 379 tests / 46 suites PASSED; ctx suite 9/9 including the three new cases.