### PR TITLE
test(app): native AWS SigV4 signer + vector test

### DIFF
--- a/tests/app/src/lib/_index.yaml
+++ b/tests/app/src/lib/_index.yaml
@@ -15,3 +15,11 @@ entries:
     meta:
       comment: Test SDK library for eval imports testing
     source: file://test_sdk.lua
+
+  - name: sigv4
+    kind: library.lua
+    meta:
+      comment: AWS Signature Version 4 signer (pure Lua, backed by hash module)
+    source: file://sigv4.lua
+    modules:
+      - hash

--- a/tests/app/src/lib/sigv4.lua
+++ b/tests/app/src/lib/sigv4.lua
@@ -1,0 +1,140 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- AWS Signature Version 4 signer, pure Lua on top of the hash module.
+--
+-- The signing-key chain requires each HMAC's raw output to become the next
+-- key, so it relies on hash.hmac_sha256(data, key, true) returning raw bytes.
+-- hash.sha256 / hash.hmac_sha256 default to lowercase hex, which is what the
+-- canonical-request and final-signature steps need.
+local hash = require("hash")
+
+local ALGORITHM = "AWS4-HMAC-SHA256"
+
+-- SignRequest describes a request to sign. headers must include host and
+-- x-amz-date; every header present is part of the signature.
+type SignRequest = {
+	method: string,
+	uri?: string,
+	query?: string,
+	headers: {[string]: string},
+	body?: string,
+	content_sha256?: string,
+	access_key: string,
+	secret_key: string,
+	region: string,
+	service: string,
+	amz_date: string
+}
+
+type SignResult = {
+	canonical_request: string,
+	string_to_sign: string,
+	signature: string,
+	authorization: string,
+	signed_headers: string,
+	payload_hash: string
+}
+
+-- hash.* return (value, error?); narrow to a definite string so the raw
+-- signing-key output can be chained as the next HMAC key under strict types.
+local function hmac_raw(data: string, key: string): string
+	local out, err = hash.hmac_sha256(data, key, true)
+	if err then
+		error(err)
+	end
+	return out or ""
+end
+
+local function hmac_hex(data: string, key: string): string
+	local out, err = hash.hmac_sha256(data, key)
+	if err then
+		error(err)
+	end
+	return out or ""
+end
+
+local function sha256_hex(data: string): string
+	local out, err = hash.sha256(data)
+	if err then
+		error(err)
+	end
+	return out or ""
+end
+
+local function trim(s: string): string
+	return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- derive_signing_key returns the raw SigV4 signing key for the credential scope.
+local function derive_signing_key(secret: string, date_stamp: string, region: string, service: string): string
+	local k_date: string = hmac_raw(date_stamp, "AWS4" .. secret)
+	local k_region: string = hmac_raw(region, k_date)
+	local k_service: string = hmac_raw(service, k_region)
+	return hmac_raw("aws4_request", k_service)
+end
+
+-- sign computes the canonical request, string to sign, signature, and the
+-- Authorization header value for req.
+local function sign(req: SignRequest): SignResult
+	local headers = req.headers
+	local uri: string = req.uri or "/"
+	local query: string = req.query or ""
+	local body: string = req.body or ""
+	local amz_date: string = req.amz_date
+	local date_stamp: string = amz_date:sub(1, 8)
+
+	local names: {string} = {}
+	local values: {[string]: string} = {}
+	for name, value in pairs(headers) do
+		local lname: string = name:lower()
+		values[lname] = trim(value)
+		names[#names + 1] = lname
+	end
+	table.sort(names)
+
+	local canonical_headers: string = ""
+	for _, lname in ipairs(names) do
+		local value: string = values[lname] or ""
+		canonical_headers = canonical_headers .. lname .. ":" .. value .. "\n"
+	end
+	local signed_headers: string = table.concat(names, ";")
+
+	local payload_hash: string = req.content_sha256 or sha256_hex(body)
+
+	local canonical_request: string = req.method .. "\n"
+		.. uri .. "\n"
+		.. query .. "\n"
+		.. canonical_headers .. "\n"
+		.. signed_headers .. "\n"
+		.. payload_hash
+
+	local scope: string = date_stamp .. "/" .. req.region .. "/" .. req.service .. "/aws4_request"
+	local string_to_sign: string = ALGORITHM .. "\n"
+		.. amz_date .. "\n"
+		.. scope .. "\n"
+		.. sha256_hex(canonical_request)
+
+	local signing_key: string = derive_signing_key(req.secret_key, date_stamp, req.region, req.service)
+	local signature: string = hmac_hex(string_to_sign, signing_key)
+
+	local authorization: string = ALGORITHM
+		.. " Credential=" .. req.access_key .. "/" .. scope
+		.. ", SignedHeaders=" .. signed_headers
+		.. ", Signature=" .. signature
+
+	return ({
+		canonical_request = canonical_request,
+		string_to_sign = string_to_sign,
+		signature = signature,
+		authorization = authorization,
+		signed_headers = signed_headers,
+		payload_hash = payload_hash
+	} as SignResult)
+end
+
+return {
+	sign = sign,
+	derive_signing_key = derive_signing_key,
+	SignRequest = SignRequest,
+	SignResult = SignResult
+}

--- a/tests/app/src/test/sigv4/_index.yaml
+++ b/tests/app/src/test/sigv4/_index.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+
+version: "1.0"
+namespace: app.test.sigv4
+
+entries:
+  - name: signer
+    kind: function.lua
+    meta:
+      type: test
+      suite: sigv4
+      description: Native SigV4 signer matches AWS published test vectors
+    source: file://signer.lua
+    method: main
+    modules:
+      - hash
+    imports:
+      assert2: app.lib:assert
+      sigv4: app.lib:sigv4

--- a/tests/app/src/test/sigv4/signer.lua
+++ b/tests/app/src/test/sigv4/signer.lua
@@ -1,0 +1,47 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: the native SigV4 signer matches AWS's published "get-vanilla" test
+-- vector, proving HMAC-SHA256 raw chaining (hash module) is sufficient to
+-- sign AWS requests natively.
+local assert = require("assert2")
+local sigv4 = require("sigv4")
+local hash = require("hash")
+
+local function main()
+	-- AWS sig-v4-test-suite "get-vanilla".
+	local result = sigv4.sign({
+		method = "GET",
+		uri = "/",
+		query = "",
+		headers = {
+			host = "example.amazonaws.com",
+			["x-amz-date"] = "20150830T123600Z",
+		},
+		body = "",
+		access_key = "AKIDEXAMPLE",
+		secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		region = "us-east-1",
+		service = "service",
+		amz_date = "20150830T123600Z",
+	})
+
+	assert.eq(result.signed_headers, "host;x-amz-date", "signed headers")
+	assert.eq(result.payload_hash,
+		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		"empty payload hash")
+	assert.eq(hash.sha256(result.canonical_request),
+		"bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63",
+		"canonical request hash matches AWS vector")
+	assert.eq(result.signature,
+		"5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31",
+		"get-vanilla signature matches AWS vector")
+	assert.eq(result.authorization,
+		"AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request"
+		.. ", SignedHeaders=host;x-amz-date"
+		.. ", Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31",
+		"authorization header matches")
+
+	return true
+end
+
+return { main = main }


### PR DESCRIPTION
Adds a pure-Lua SigV4 signer (`app.lib:sigv4`) backed only by the `hash` module, plus an app-suite test validating it against AWS's published "get-vanilla" vector (canonical-request hash, signature, Authorization header).

Demonstrates the `hash` module exposes everything SigV4 needs: `hash.hmac_sha256(data, key, true)` returns raw bytes so the signing-key chain (kDate->kRegion->kService->kSigning) can be built, and typed helpers narrow the `(string?, error?)` returns to satisfy strict types.

Test verified locally: app suite 379/379 PASSED (new `sigv4` suite).