### PR TITLE
test(http): narrow nullable response body via tostring before json.decode

### DIFF
--- a/tests/app/src/test/http/request_stream.lua
+++ b/tests/app/src/test/http/request_stream.lua
@@ -16,7 +16,7 @@ local function main()
 	assert.eq(resp.status_code, 200, "status code 200")
 	assert.not_nil(resp.body, "body present")
 
-	local data = json.decode(resp.body)
+	local data = json.decode(tostring(resp.body))
 	assert.eq(data.has_body, true, "has_body should be true")
 	assert.eq(data.total_size, #body, "total_size matches body length")
 	assert.eq(data.content, body, "content matches original body")
@@ -32,7 +32,7 @@ local function main()
 	assert.is_nil(err2, "large POST should not error")
 	assert.not_nil(resp2.body, "body present")
 
-	local data2 = json.decode(resp2.body)
+	local data2 = json.decode(tostring(resp2.body))
 	assert.eq(data2.total_size, 2048, "large body size correct")
 	assert.ok(data2.chunk_count >= 1, "read in chunks")
 	assert.eq(data2.content, large_body, "large content matches")
@@ -44,7 +44,7 @@ local function main()
 	assert.is_nil(err3, "empty POST should not error")
 	assert.not_nil(resp3.body, "body present")
 
-	local data3 = json.decode(resp3.body)
+	local data3 = json.decode(tostring(resp3.body))
 	-- Empty body still has has_body=false typically
 	assert.eq(data3.total_size or 0, 0, "empty body size is 0")
 

--- a/tests/app/src/test/http_auth/test_bearer.lua
+++ b/tests/app/src/test/http_auth/test_bearer.lua
@@ -19,7 +19,7 @@ local function main()
 	end
 
 	assert.not_nil(login_res.body, "login response body present")
-	local login_body = json.decode(login_res.body)
+	local login_body = json.decode(tostring(login_res.body))
 	assert.not_nil(login_body, "login response should be valid JSON")
 	assert.not_nil(login_body.token, "login response should contain token")
 
@@ -37,7 +37,7 @@ local function main()
 	end
 
 	assert.not_nil(protected_res.body, "protected response body present")
-	local protected_body = json.decode(protected_res.body)
+	local protected_body = json.decode(tostring(protected_res.body))
 	if not protected_body then
 		return false, "invalid JSON response, status=" .. protected_res.status_code .. ", body=[" .. (protected_res.body or "nil") .. "]"
 	end

--- a/tests/app/src/test/http_auth/test_query.lua
+++ b/tests/app/src/test/http_auth/test_query.lua
@@ -19,7 +19,7 @@ local function main()
 	end
 
 	assert.not_nil(login_res.body, "login response body present")
-	local login_body = json.decode(login_res.body)
+	local login_body = json.decode(tostring(login_res.body))
 	assert.not_nil(login_body, "login response should be valid JSON")
 	assert.not_nil(login_body.token, "login response should contain token")
 
@@ -34,7 +34,7 @@ local function main()
 	assert.eq(protected_res.status_code, 200, "should return 200 OK with query token")
 	assert.not_nil(protected_res.body, "protected response body present")
 
-	local protected_body = json.decode(protected_res.body)
+	local protected_body = json.decode(tostring(protected_res.body))
 	assert.not_nil(protected_body, "protected response should be valid JSON")
 	assert.eq(protected_body.message, "access granted", "should grant access")
 	assert.eq(protected_body.actor_id, "queryuser", "actor_id should match username")

--- a/tests/app/src/test/http_auth/test_unauthorized.lua
+++ b/tests/app/src/test/http_auth/test_unauthorized.lua
@@ -14,7 +14,7 @@ local function main()
 	assert.eq(res.status_code, 401, "should return 401 Unauthorized")
 	assert.not_nil(res.body, "response body present")
 
-	local body = json.decode(res.body)
+	local body = json.decode(tostring(res.body))
 	assert.not_nil(body, "response should be valid JSON")
 	assert.not_nil(body.error, "response should contain error")
 

--- a/tests/app/src/test/httpclient/get.lua
+++ b/tests/app/src/test/httpclient/get.lua
@@ -16,7 +16,7 @@ local function main()
 	assert.not_nil(resp.body, "body present")
 
 	-- Parse JSON response
-	local data = json.decode(resp.body)
+	local data = json.decode(tostring(resp.body))
 	assert.not_nil(data, "JSON parsed")
 	assert.eq(data.message, "hello world", "message field matches")
 

--- a/tests/app/src/test/httpclient/headers.lua
+++ b/tests/app/src/test/httpclient/headers.lua
@@ -15,7 +15,7 @@ local function main()
 	assert.eq(resp.status_code, 200, "status code 200")
 	assert.not_nil(resp.body, "response body present")
 
-	local data = json.decode(resp.body)
+	local data = json.decode(tostring(resp.body))
 	assert.eq(data.header_value, "custom-value", "custom header received")
 
 	-- Test response headers (custom_headers endpoint sets X-Custom-Header)

--- a/tests/app/src/test/httpclient/post.lua
+++ b/tests/app/src/test/httpclient/post.lua
@@ -16,7 +16,7 @@ local function main()
 	assert.eq(resp.status_code, 200, "POST status 200")
 	assert.not_nil(resp.body, "response body present")
 
-	local result = json.decode(resp.body)
+	local result = json.decode(tostring(resp.body))
 	assert.is_nil(result.parse_error, "no parse error")
 	assert.not_nil(result.body_json, "JSON body parsed by server")
 	assert.eq(result.body_json.name, "test", "name field correct")

--- a/tests/app/src/test/httpclient/query.lua
+++ b/tests/app/src/test/httpclient/query.lua
@@ -15,7 +15,7 @@ local function main()
 	assert.eq(resp.status_code, 200, "status code 200")
 	assert.not_nil(resp.body, "response body present")
 
-	local data = json.decode(resp.body)
+	local data = json.decode(tostring(resp.body))
 	assert.eq(data.specific, "test_value", "query param value")
 	assert.eq(data.all_params.foo, "bar", "query param foo")
 	assert.eq(data.all_params.num, "123", "query param num")

--- a/tests/app/src/test/network/empty_clearnet.lua
+++ b/tests/app/src/test/network/empty_clearnet.lua
@@ -18,7 +18,7 @@ local function main()
 	assert.eq(resp.status_code, 200, "clearnet status is 200")
 	assert.not_nil(resp.body, "response body present")
 
-	local data = json.decode(resp.body)
+	local data = json.decode(tostring(resp.body))
 	assert.not_nil(data, "decoded JSON body")
 	assert.eq(data.message, "hello world", "hello endpoint answered directly")
 

--- a/tests/app/src/uploads/test.lua
+++ b/tests/app/src/uploads/test.lua
@@ -24,7 +24,7 @@ local function main()
 	assert.ok(resp.body, "response body should not be nil: status=" .. tostring(resp.status_code))
 	assert.eq(resp.status_code, 200, "status code should be 200, body: " .. tostring(resp.body))
 
-	local data = json.decode(resp.body)
+	local data = json.decode(tostring(resp.body))
 	assert.ok(data, "json decode should succeed, body: " .. tostring(resp.body))
 	assert.is_nil(data.error, "no error in response: " .. tostring(data.error))
 	assert.eq(data.filename, filename, "filename matches")


### PR DESCRIPTION
## Summary

After the Lua cache invalidation fix (#257), the type checker re-runs on previously-cached test nodes and flags `json.decode(resp.body)` where `resp.body` is `string?` (legitimately optional — stream mode and empty bodies don't set it).

Statement-form `assert.not_nil(resp.body)` does not narrow `string?` to `string`. This wraps the argument in `tostring()`, which the checker trusts for narrowing — matching the existing pattern in `tests/app/src/test/registry/dependency_requirements.lua`.

## Files
10 test files across httpclient, http, http_auth, network, uploads.

## Test
`tests/app/test.sh` — 399 tests pass.