### PR TITLE
fix(deps): scope strict requirement validation to touched modules; honor empty defaults

### DIFF
--- a/boot/build/stages/linking.go
+++ b/boot/build/stages/linking.go
@@ -16,9 +16,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// RequirementDefinition represents the data structure of an ns.requirement entry
+// RequirementDefinition represents the data structure of an ns.requirement entry.
+// Default is a pointer so an explicitly-empty default ("") is distinguishable
+// from an absent one (nil): a requirement with any default — including "" — is
+// optional and resolves to that default when no dependency parameter supplies a
+// value; a requirement with no default is mandatory.
 type RequirementDefinition struct {
-	Default string              `json:"default" yaml:"default"`
+	Default *string             `json:"default" yaml:"default"`
 	Targets []RequirementTarget `json:"targets" yaml:"targets"`
 }
 
@@ -250,7 +254,7 @@ func (s *linkStage) processRequirement(
 
 func (s *linkStage) resolveValue(
 	requirementName string,
-	defaultValue string,
+	defaultValue *string,
 	requirementNS string,
 	requirementModule string,
 	dependencies map[string]decodedDependency,
@@ -312,9 +316,11 @@ func (s *linkStage) resolveValue(
 		return foundValues[0].value, nil
 	}
 
-	// Fall back to default
-	if defaultValue != "" {
-		return defaultValue, nil
+	// Fall back to the default when one is defined. A present-but-empty
+	// default ("") is a valid resolved value; only an absent default (nil)
+	// leaves the requirement unresolved.
+	if defaultValue != nil {
+		return *defaultValue, nil
 	}
 
 	// No value available

--- a/boot/build/stages/linking_test.go
+++ b/boot/build/stages/linking_test.go
@@ -1090,6 +1090,81 @@ func TestLink_MultipleRequirements(t *testing.T) {
 	assert.Equal(t, "8080", data["port"])
 }
 
+// TestLink_EmptyDefaultResolvesUnderStrict verifies that a requirement whose
+// default is present but empty ("") is treated as a valid resolved value
+// rather than an unresolved requirement, even under strict enforcement.
+func TestLink_EmptyDefaultResolvesUnderStrict(t *testing.T) {
+	ctx, _ := setupTestContext()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("acme.module", "opt"),
+			Kind: registry.NamespaceRequirement,
+			Meta: map[string]any{"module": "acme/module"},
+			Data: payload.New(map[string]any{
+				"default": "", // present but empty: optional, resolves to ""
+				"targets": []any{
+					map[string]any{"entry": "endpoint", "path": ".meta.opt"},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("acme.module", "endpoint"),
+			Kind: "http.endpoint",
+			Meta: map[string]any{},
+			Data: payload.New(map[string]any{}),
+		},
+	}
+
+	stage := Link(WithStrictRequirementModules([]string{"acme/module"}))
+	err := stage.Execute(ctx, &entries)
+	require.NoError(t, err)
+
+	endpoint := findEntry(entries, "acme.module", "endpoint")
+	require.NotNil(t, endpoint)
+	assert.Equal(t, "", endpoint.Meta["opt"])
+}
+
+// TestLink_EmptyProvidedValueResolvesUnderStrict verifies that a dependency
+// parameter supplying an empty value satisfies a requirement (and does not
+// fall through to the unresolved path) under strict enforcement.
+func TestLink_EmptyProvidedValueResolvesUnderStrict(t *testing.T) {
+	ctx, _ := setupTestContext()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("app", "__dependency.module"),
+			Kind: registry.NamespaceDependency,
+			Data: payload.New(map[string]any{
+				"component": "vendor/module",
+				"parameters": []any{
+					map[string]any{"name": "opt", "value": ""},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("vendor.module", "opt"),
+			Kind: registry.NamespaceRequirement,
+			Meta: map[string]any{"module": "vendor/module"},
+			Data: payload.New(map[string]any{
+				"targets": []any{
+					map[string]any{"entry": "endpoint", "path": ".meta.opt"},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("vendor.module", "endpoint"),
+			Kind: "http.endpoint",
+			Meta: map[string]any{},
+			Data: payload.New(map[string]any{}),
+		},
+	}
+
+	stage := Link(WithStrictRequirementModules([]string{"vendor/module"}))
+	err := stage.Execute(ctx, &entries)
+	require.NoError(t, err)
+}
+
 // Helper functions
 
 type mockTranscoder struct{}
@@ -1110,7 +1185,8 @@ func (m *mockTranscoder) Unmarshal(p payload.Payload, v any) error {
 		// Simple reflection-based assignment for test structs
 		if reqDef, ok := v.(*RequirementDefinition); ok {
 			if def, ok := dataMap["default"].(string); ok {
-				reqDef.Default = def
+				d := def
+				reqDef.Default = &d
 			}
 			if targets, ok := dataMap["targets"].([]any); ok {
 				for _, t := range targets {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -179,7 +179,14 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		return regapi.DirectiveResult{}, err
 	}
 	linkDeps := mergeLinkDependencies(desiredDepEntries, moduleEntries)
-	strictModules := resolvedModuleNames(resolved)
+	opComponent := ""
+	for _, dep := range desiredDeps {
+		if dep.entry.ID == op.Entry.ID {
+			opComponent = dep.definition.Component
+			break
+		}
+	}
+	strictModules := touchedModuleNames(resolved, snapshot, opComponent)
 	mutableModules, err := h.operationModules(ctx, op, snapshot, transcoder)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
@@ -448,13 +455,25 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 	return result.Modules, nil
 }
 
-func resolvedModuleNames(modules []ResolvedModule) []string {
+// touchedModuleNames returns the resolved modules this operation actually
+// affects: those new or version-changed relative to the snapshot, plus the
+// module of the dependency entry being changed in this operation. Modules
+// already installed at the same version that this operation does not target are
+// trusted — they were validated when installed — and are excluded from strict
+// requirement enforcement, so a partial update does not re-validate
+// dependencies it did not touch.
+func touchedModuleNames(modules []ResolvedModule, snapshot regapi.State, opComponent string) []string {
+	installed := snapshotModuleVersions(snapshot)
 	names := make([]string, 0, len(modules))
 	for _, mod := range modules {
 		if mod.Org == "" || mod.Name == "" {
 			continue
 		}
-		names = append(names, mod.Org+"/"+mod.Name)
+		name := mod.Org + "/" + mod.Name
+		version, known := installed[name]
+		if !known || version != mod.Version || name == opComponent {
+			names = append(names, name)
+		}
 	}
 	return names
 }

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -636,6 +636,125 @@ func TestDependencyHandler_Expand_DoesNotFailOnUnrelatedSnapshotRequirement(t *t
 	assert.True(t, createdService, "unrelated app requirements must not block dependency install")
 }
 
+// TestDependencyHandler_Expand_DoesNotReValidateUntouchedInstalledModule proves
+// that installing one module does not strict-re-validate a different, already
+// installed module that is unchanged. The installed module carries an
+// unprovided, no-default requirement; touching an unrelated dependency must not
+// turn that into a hard failure.
+func TestDependencyHandler_Expand_DoesNotReValidateUntouchedInstalledModule(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, "vendor")
+
+	// Newly installed module (the op); no requirements.
+	writeWapp(t, filepath.Join(vendorDir, "acme", "fresh-v1.0.0.wapp"), []wapp.Entry{
+		{
+			ID:   wapp.NewID("acme.fresh", "service"),
+			Kind: "process.lua",
+			Data: map[string]any{"ok": true},
+		},
+	})
+	// Already installed sibling module with an unprovided, no-default requirement.
+	writeWapp(t, filepath.Join(vendorDir, "acme", "legacy-v1.0.0.wapp"), []wapp.Entry{
+		{
+			ID:   wapp.NewID("acme.legacy", "needs_value"),
+			Kind: regapi.NamespaceRequirement,
+			Data: map[string]any{
+				"targets": []any{
+					map[string]any{"entry": "acme.legacy:target", "path": ".value"},
+				},
+			},
+		},
+		{
+			ID:   wapp.NewID("acme.legacy", "target"),
+			Kind: "process.lua",
+			Data: map[string]any{},
+		},
+	})
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
+				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	snapshot := regapi.State{
+		{
+			ID:   regapi.NewID("app.deps", "legacy"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.NewPayload(`{"component":"acme/legacy","version":"v1.0.0"}`, payload.JSON),
+		},
+		// Module-owned entry stamping legacy's installed version into the snapshot.
+		markModuleMeta(regapi.Entry{
+			ID:   regapi.NewID("acme.legacy", "target"),
+			Kind: "process.lua",
+			Data: payload.NewPayload(`{}`, payload.JSON),
+		}, "acme/legacy", "v1.0.0"),
+	}
+
+	rootDep := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "fresh"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/fresh","version":"v1.0.0"}`, payload.JSON),
+	}
+
+	result, err := handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryCreate, Entry: rootDep}, snapshot)
+	require.NoError(t, err, "installing an unrelated module must not re-validate an untouched installed module")
+	assert.True(t, result.Applied)
+}
+
+// TestDependencyHandler_Expand_NewModuleMissingRequirementStillFails guards that
+// scoping strict validation to touched modules does not relax validation of the
+// module actually being installed: a new module with an unprovided, no-default
+// requirement must still fail.
+func TestDependencyHandler_Expand_NewModuleMissingRequirementStillFails(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, "vendor")
+
+	writeWapp(t, filepath.Join(vendorDir, "acme", "needy-v1.0.0.wapp"), []wapp.Entry{
+		{
+			ID:   wapp.NewID("acme.needy", "needs_value"),
+			Kind: regapi.NamespaceRequirement,
+			Data: map[string]any{
+				"targets": []any{
+					map[string]any{"entry": "acme.needy:target", "path": ".value"},
+				},
+			},
+		},
+		{
+			ID:   wapp.NewID("acme.needy", "target"),
+			Kind: "process.lua",
+			Data: map[string]any{},
+		},
+	})
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
+				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	rootDep := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "needy"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/needy","version":"v1.0.0"}`, payload.JSON),
+	}
+
+	_, err = handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryCreate, Entry: rootDep}, regapi.State{})
+	require.Error(t, err, "a newly installed module with an unprovided required value must fail")
+}
+
 func TestDependencyHandler_Expand_DeleteLastDependencyDoesNotFailOnUnrelatedSnapshotRequirement(t *testing.T) {
 	ctx := newTestContext()
 


### PR DESCRIPTION
## Problem

Two issues in the governance dependency pipeline's strict link:

1. **Over-broad strict validation.** Every `Expand` collected *all* root dependencies, resolved the full transitive closure, and made strict requirement enforcement cover *every* resolved module. A partial update (or a single dependency op) re-validated the entire graph, so an optional, already-installed module's requirement could fail on an unrelated change.

2. **Empty default treated as absent.** `RequirementDefinition.Default` was a plain `string`, so a present-but-empty default (`default: ""`) was indistinguishable from no default — both yielded `ErrNoValueAvailable` under strict. This makes optional-with-empty-default requirements unsatisfiable.

## Fix

- `linking.go`: `RequirementDefinition.Default` is now `*string`. A present default (including `""`) resolves to that value; only an absent default leaves a requirement unresolved.
- `dependency_handler.go`: strict enforcement is scoped to *touched* modules — new, version-changed, or the module of the dependency targeted by this op — via `touchedModuleNames`. Modules already installed at the same version are trusted.

## Tests

- empty default resolves under strict; empty provided value resolves;
- an untouched installed module is not re-validated when an unrelated module is installed;
- a newly installed module with an unprovided required value still fails.

All `boot/...`, `cmd/...`, `system/registry/...` pass; `go vet` clean.

(Enables the module-session `on_session_end_func_id: default ""` optional-hook fix to resolve.)