### PR TITLE
fix(process): restore backward-compatible register arg order (name, pid, scope)

### DIFF
--- a/runtime/lua/modules/process/module.go
+++ b/runtime/lua/modules/process/module.go
@@ -653,24 +653,16 @@ func registryRegister(l *lua.LState) int {
 	name := l.CheckString(1)
 	secAttrs := map[string]any{"pid": self.String()}
 
-	// Signature: register(name, scope?, pid?) → bool, err
-	//   scope: process.registry.LOCAL | EVENTUAL | CONSISTENT | STRONG (default LOCAL)
+	// Signature: register(name, pid?, scope?) → bool, err
 	//   pid:   target PID string (default self)
+	//   scope: process.registry.LOCAL | EVENTUAL | CONSISTENT | STRONG (default LOCAL)
 	// Foreign PID (pid != self) requires process.registry.foreign on the
 	// target PID in addition to the per-scope register capability on the name.
 	mode := topology.Local
 	p := self
 
 	if l.GetTop() >= 2 && l.Get(2) != lua.LNil {
-		num, ok := l.Get(2).(lua.LNumber)
-		if !ok {
-			return pushProcessError(l, lua.LNil, newProcessError(l, lua.Invalid, "scope must be a number (process.registry.LOCAL|EVENTUAL|CONSISTENT|STRONG)"))
-		}
-		mode = topology.RegistrationMode(int(num))
-	}
-
-	if l.GetTop() >= 3 && l.Get(3) != lua.LNil {
-		raw, ok := l.Get(3).(lua.LString)
+		raw, ok := l.Get(2).(lua.LString)
 		if !ok {
 			return pushProcessError(l, lua.LNil, newProcessError(l, lua.Invalid, "pid must be a string"))
 		}
@@ -679,6 +671,14 @@ func registryRegister(l *lua.LState) int {
 			return pushProcessError(l, lua.LNil, wrapProcessError(l, err, "invalid pid", lua.Invalid))
 		}
 		p = parsed
+	}
+
+	if l.GetTop() >= 3 && l.Get(3) != lua.LNil {
+		num, ok := l.Get(3).(lua.LNumber)
+		if !ok {
+			return pushProcessError(l, lua.LNil, newProcessError(l, lua.Invalid, "scope must be a number (process.registry.LOCAL|EVENTUAL|CONSISTENT|STRONG)"))
+		}
+		mode = topology.RegistrationMode(int(num))
 	}
 
 	// Mounting a name on a foreign PID is gated by an explicit second-axis

--- a/runtime/lua/modules/process/process_edge_test.go
+++ b/runtime/lua/modules/process/process_edge_test.go
@@ -1038,7 +1038,7 @@ func TestRegistryRegister_Strong_Self(t *testing.T) {
 	l := newLuaWithScopedRegistry(t, self, reg, false)
 
 	err := l.DoString(`
-		local ok, err = process.registry.register("svc-strong", process.registry.STRONG)
+		local ok, err = process.registry.register("svc-strong", nil, process.registry.STRONG)
 		if not ok then error("expected true, got " .. tostring(ok) .. " err=" .. tostring(err)) end
 	`)
 	require.NoError(t, err)
@@ -1048,7 +1048,7 @@ func TestRegistryRegister_Strong_Self(t *testing.T) {
 	require.Equal(t, self, res.PID)
 }
 
-// TestRegistryRegister_ForeignPID_Permitted exercises (name, scope, pid)
+// TestRegistryRegister_ForeignPID_Permitted exercises (name, pid, scope)
 // when the caller has the process.registry.foreign capability (lax security).
 func TestRegistryRegister_ForeignPID_Permitted(t *testing.T) {
 	reg := newFakeScopedRegistry()
@@ -1057,7 +1057,7 @@ func TestRegistryRegister_ForeignPID_Permitted(t *testing.T) {
 	l := newLuaWithScopedRegistry(t, self, reg, false)
 
 	err := l.DoString(fmt.Sprintf(`
-		local ok, err = process.registry.register("svc-foreign", process.registry.STRONG, %q)
+		local ok, err = process.registry.register("svc-foreign", %q, process.registry.STRONG)
 		if not ok then error("expected true, got " .. tostring(ok) .. " err=" .. tostring(err)) end
 	`, other.String()))
 	require.NoError(t, err)
@@ -1077,7 +1077,7 @@ func TestRegistryRegister_ForeignPID_Denied(t *testing.T) {
 	l := newLuaWithScopedRegistry(t, self, reg, true)
 
 	err := l.DoString(fmt.Sprintf(`
-		local ok, err = process.registry.register("svc-foreign", process.registry.STRONG, %q)
+		local ok, err = process.registry.register("svc-foreign", %q, process.registry.STRONG)
 		if ok then error("expected false under strict security, got true") end
 		if err == nil then error("expected permission error") end
 		if err:kind() ~= "PermissionDenied" then
@@ -1098,7 +1098,7 @@ func TestRegistryRegister_InvalidScopeType(t *testing.T) {
 	l := newLuaWithScopedRegistry(t, self, reg, false)
 
 	err := l.DoString(`
-		local ok, err = process.registry.register("svc", "not-a-scope")
+		local ok, err = process.registry.register("svc", nil, "not-a-scope")
 		if ok then error("expected false, got true") end
 		if err == nil then error("expected error") end
 		if err:kind() ~= "Invalid" then
@@ -1115,7 +1115,7 @@ func TestRegistryRegister_InvalidPIDType(t *testing.T) {
 	l := newLuaWithScopedRegistry(t, self, reg, false)
 
 	err := l.DoString(`
-		local ok, err = process.registry.register("svc", process.registry.STRONG, 12345)
+		local ok, err = process.registry.register("svc", 12345)
 		if ok then error("expected false, got true") end
 		if err == nil then error("expected error") end
 		if err:kind() ~= "Invalid" then

--- a/runtime/lua/modules/process/spec.md
+++ b/runtime/lua/modules/process/spec.md
@@ -371,25 +371,26 @@ Subtable for process name registration.
 | `process.registry.LOCAL`       | 0    | per-node PID registry      | Visible only on the registering node. Default.                                                              |
 | `process.registry.EVENTUAL`    | 2    | gossip / CRDT (eventualreg) | Cluster-wide, eventually consistent. No fence; converges after partition heal. Sized for ~1M presence names. |
 | `process.registry.CONSISTENT`  | 1    | Raft (globalreg)            | Cluster-wide linearizable owner with fence token. Late ok. Scales to ~1M user-facing names.                 |
-| `process.registry.ROOT`        | 3    | Raft + all-live-node ack    | Cluster-wide linearizable owner; activation requires every live node in the membership snapshot to ack the committed epoch within a deadline. No late compensation: a missing ack expires the registration. Reserved for the small set of root/control-plane names (<10k).        |
+| `process.registry.STRONG`      | 3    | Raft + all-live-node ack    | Cluster-wide linearizable owner; activation requires every live node in the membership snapshot to ack the committed epoch within a deadline. No late compensation: a missing ack expires the registration. Reserved for the small set of root/control-plane names (<10k).        |
 
-### process.registry.register(name: string, scope?: number, pid?: string) -> boolean, error
+### process.registry.register(name: string, pid?: string, scope?: number) -> boolean, error
 
-Registers a name at the requested scope, optionally pointing at a foreign PID.
+Registers a name, optionally pointing at a foreign PID and/or at a wider scope.
 
 | Param | Type   | Required | Default | Notes                                                                                                |
 |-------|--------|----------|---------|------------------------------------------------------------------------------------------------------|
 | name  | string | yes      | —       | Name to register.                                                                                    |
+| pid   | string | no       | self    | Target PID. When omitted (or `nil`), defaults to the caller's PID.                                   |
 | scope | number | no       | LOCAL   | One of `process.registry.LOCAL` / `EVENTUAL` / `CONSISTENT` / `STRONG`.                              |
-| pid   | string | no       | self    | Target PID. When omitted, defaults to the caller's PID.                                              |
 
 **Returns:** `true` on success, or `nil, error` on failure.
 
 **Examples:**
 ```lua
-process.registry.register("svc")                                        -- LOCAL, self
-process.registry.register("svc", process.registry.STRONG)               -- STRONG, self
-process.registry.register("svc", process.registry.STRONG, foreign_pid)  -- STRONG, foreign PID
+process.registry.register("svc")                                       -- LOCAL, self
+process.registry.register("svc", foreign_pid)                          -- LOCAL, foreign PID
+process.registry.register("svc", nil, process.registry.STRONG)         -- STRONG, self
+process.registry.register("svc", foreign_pid, process.registry.STRONG) -- STRONG, foreign PID
 ```
 
 **Authorization (two axes):**

--- a/runtime/lua/modules/process/types.go
+++ b/runtime/lua/modules/process/types.go
@@ -85,8 +85,8 @@ var registryFieldsType = typ.NewRecord().
 var registryMethodsType = typ.NewInterface("process.registry", []typ.Method{
 	{Name: "register", Type: typ.Func().
 		Param("name", typ.String).
-		OptParam("scope", typ.Number).
 		OptParam("pid", typ.String).
+		OptParam("scope", typ.Number).
 		Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).
 		Build()},
 	{Name: "lookup", Type: typ.Func().


### PR DESCRIPTION
## Problem

The cluster-primitives work (#241) changed `process.registry.register` to `(name, scope, pid)` — the numeric `scope` now occupies slot 2. This silently broke every caller using the historical `(name, pid)` form:

- A string PID lands in the `scope` slot, so the runtime rejects it (`scope must be a number`) and the type checker reports `argument 2: expected number, got string`.
- Callers that register self/foreign PIDs and ignore the return value (supervisors, hot-upgrade flows, MCP brokers) **stopped registering entirely** — no error surfaced, the name just never bound.

## Fix

Reorder to `(name, pid?, scope?)` so the old two-arg form keeps working, with `scope` as an optional trailing argument:

```lua
register(name)                  -- LOCAL, self
register(name, pid)             -- LOCAL, foreign pid (old form works again)
register(name, nil, scope)      -- scope, self
register(name, pid, scope)      -- scope, foreign pid
```

Applied across the three layers that must agree:
- **`types.go`** — type manifest (what the linter reads): `pid` before `scope`.
- **`module.go`** — runtime arg parsing: slot 2 = pid (string), slot 3 = scope (number).
- **`spec.md`** — signature, param table, examples. Also fixed a stray `ROOT` → `STRONG` constant name in the scope table (code and examples use `STRONG`).

## Tests

`process_edge_test.go` moved to the new order. Two cases (`InvalidScopeType`, `InvalidPIDType`) were asserting against the wrong slot under the new signature; they now exercise pid-type / scope-type rejection where those args actually live.

- `go build` / `go vet` / `gofmt` clean
- 17/17 registry tests pass
- Verified downstream: rebuilt the binary and re-linted a real consumer (keeper) — `register(name, pid)` calls type-check again, 0 lint errors, full app test suite green.

Note: `unregister(name, scope?)` is unchanged — it has no PID argument, so its slot-2 scope doesn't conflict with backward compatibility.