### PR TITLE
feat(cli): --set for YAML config overrides; README accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <div align="center">
 
 [![Documentation](https://img.shields.io/badge/docs-wippy.ai-0F6640.svg?style=for-the-badge)][documentation]
-[![Go Version](https://img.shields.io/badge/go-1.25+-00ADD8.svg?style=for-the-badge&logo=go)](#installation)
+[![Go Version](https://img.shields.io/badge/go-1.26+-00ADD8.svg?style=for-the-badge&logo=go)](#installation)
 [![License](https://img.shields.io/badge/license-MPL%202.0-brightgreen.svg?style=for-the-badge)](LICENSE)
 
 </div>
@@ -75,10 +75,12 @@ The architecture enables declarative composition of complex applications that ca
 - HTTP request tracing
 
 **Clustering**
-- Gossip-based membership discovery
-- Cross-node process messaging via relay
-- Distributed topology tracking
-- Secret-based cluster authentication
+- Bounded Raft consensus core (voters, standbys, gossip-only clients)
+- SWIM gossip membership with gossip-driven bootstrap (`bootstrap_expect`)
+- Cluster-wide process names with consistency scopes: local, eventual, consistent, strong
+- Distributed locks, auto-released when the holder exits
+- Process groups: join named groups and broadcast across nodes
+- Location-transparent process messaging via relay; encrypted gossip
 
 **Extensibility**
 - Pluggable command dispatchers
@@ -102,14 +104,31 @@ wippy init        # Initialize project with lock file
 wippy install     # Install dependencies from lock file
 wippy update      # Update dependencies to latest versions
 wippy run         # Run application
-wippy replace     # Manage local module overrides
 ```
 
 ## Cluster Mode
 
+Configure clustering in `.wippy.yaml` — point each node at a seed and set the expected initial quorum size:
+
+```yaml
+cluster:
+  enabled: true
+  name: node-1
+  membership:
+    join_addrs: "node-2:7946,node-3:7946"
+  raft:
+    bootstrap_expect: 3
 ```
-wippy run --cluster --cluster-name=node1 --cluster-join=seed:7946
+
+Any config value can also be set on the command line with repeatable `--set section.path=value`, which take precedence over the file:
+
 ```
+wippy run --set cluster.enabled=true \
+          --set cluster.membership.join_addrs=node-2:7946,node-3:7946 \
+          --set cluster.raft.bootstrap_expect=3
+```
+
+See the [documentation][documentation] for the cluster model — naming scopes, routing, distributed locks, and process groups.
 
 ## Configuration
 
@@ -234,7 +253,7 @@ shutdown:
 
 ## Requirements
 
-- Go 1.25+
+- Go 1.26+
 
 ## License
 

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -78,6 +78,7 @@ func init() {
 	runCmd.Flags().StringP("exec", "x", "", "Execute process and exit (format: namespace:entry)")
 	runCmd.Flags().String("host", "", "Terminal host ID for exec (auto-detected if only one terminal.host exists)")
 	runCmd.Flags().String("registry", "", "Registry URL for hub modules (default: from credentials)")
+	runCmd.Flags().StringArray("set", nil, "Override a .wippy.yaml config value (format: section.path=value, repeatable)")
 }
 
 // commandMeta represents the command metadata from entry.Meta
@@ -292,6 +293,14 @@ func loadRuntimeConfigWithDefaults(cmd *cobra.Command, logger *zap.Logger, runti
 
 	if cmd == nil {
 		return cfg, nil
+	}
+
+	if sets, _ := cmd.Flags().GetStringArray("set"); len(sets) > 0 {
+		merged, err := applySetOverrides(cfg, sets)
+		if err != nil {
+			return nil, err
+		}
+		cfg = merged
 	}
 
 	overrides, _ := cmd.Flags().GetStringSlice("override")
@@ -522,6 +531,56 @@ func applyCLIOverrides(cfg boot.Config) boot.Config {
 	opts = append(opts, boot.WithSection("logmanager", logmanagerCfg))
 
 	return bootconfig.Merge(cfg, boot.NewConfig(opts...))
+}
+
+// applySetOverrides merges --set section.path=value pairs into the boot config,
+// taking precedence over the config file. The first path segment is the section;
+// the remainder is the dotted leaf key, matching how the YAML is flattened — so
+// `--set cluster.enabled=true` overrides only that leaf and preserves the rest of
+// the cluster section. Values are coerced via coerceSetValue.
+func applySetOverrides(cfg boot.Config, sets []string) (boot.Config, error) {
+	sections := make(map[string]map[string]any)
+	for _, s := range sets {
+		key, val, ok := strings.Cut(s, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --set %q: expected section.path=value", s)
+		}
+		key = strings.TrimSpace(key)
+		dot := strings.IndexByte(key, '.')
+		if dot <= 0 || dot == len(key)-1 {
+			return nil, fmt.Errorf("invalid --set %q: key must be section.path (e.g. cluster.enabled)", s)
+		}
+		section, sub := key[:dot], key[dot+1:]
+		if sections[section] == nil {
+			sections[section] = make(map[string]any)
+		}
+		sections[section][sub] = coerceSetValue(val)
+	}
+
+	opts := make([]boot.ConfigOption, 0, len(sections))
+	for name, vals := range sections {
+		opts = append(opts, boot.WithSection(name, vals))
+	}
+	return bootconfig.Merge(cfg, boot.NewConfig(opts...)), nil
+}
+
+// coerceSetValue converts a --set string to the type config consumers expect:
+// `true`/`false` to bool, integers to int, decimals to float64; everything else
+// (durations like "5s", addresses, names) stays a string.
+func coerceSetValue(s string) any {
+	switch s {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+	if i, err := strconv.Atoi(s); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return s
 }
 
 // applyOverrideFlags parses repeated `-o namespace:entry:field=value` flags and

--- a/cmd/wippy/cmd/set_override_test.go
+++ b/cmd/wippy/cmd/set_override_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+)
+
+func TestCoerceSetValue(t *testing.T) {
+	assert.Equal(t, true, coerceSetValue("true"))
+	assert.Equal(t, false, coerceSetValue("false"))
+	assert.Equal(t, 3, coerceSetValue("3"))
+	assert.Equal(t, 7946, coerceSetValue("7946"))
+	assert.Equal(t, 0.5, coerceSetValue("0.5"))
+	assert.Equal(t, "5s", coerceSetValue("5s")) // duration stays string (GetDuration parses)
+	assert.Equal(t, "node-2:7946", coerceSetValue("node-2:7946"))
+	assert.Equal(t, "", coerceSetValue(""))
+}
+
+func setTestClusterConfig() boot.Config {
+	return boot.NewConfig(boot.WithSection("cluster", map[string]any{
+		"enabled":               false,
+		"membership.bind_port":  7946,
+		"membership.join_addrs": "seed:7946",
+	}))
+}
+
+func TestApplySetOverrides_OverridesLeafPreservesRest(t *testing.T) {
+	cfg, err := applySetOverrides(setTestClusterConfig(), []string{"cluster.enabled=true"})
+	require.NoError(t, err)
+	assert.True(t, cfg.GetBool("cluster.enabled", false))
+	// sibling leaves in the same section are preserved, not wiped
+	assert.Equal(t, 7946, cfg.GetInt("cluster.membership.bind_port", 0))
+	assert.Equal(t, "seed:7946", cfg.GetString("cluster.membership.join_addrs", ""))
+}
+
+func TestApplySetOverrides_NestedPath(t *testing.T) {
+	cfg, err := applySetOverrides(boot.NewConfig(), []string{"cluster.raft.bootstrap_expect=3"})
+	require.NoError(t, err)
+	assert.Equal(t, 3, cfg.Sub("cluster").GetInt("raft.bootstrap_expect", 1))
+}
+
+func TestApplySetOverrides_OverrideWinsOverFile(t *testing.T) {
+	cfg, err := applySetOverrides(setTestClusterConfig(), []string{
+		"cluster.enabled=true",
+		"cluster.membership.bind_port=9999",
+	})
+	require.NoError(t, err)
+	assert.True(t, cfg.GetBool("cluster.enabled", false))
+	assert.Equal(t, 9999, cfg.GetInt("cluster.membership.bind_port", 0))
+}
+
+func TestApplySetOverrides_DurationValue(t *testing.T) {
+	cfg, err := applySetOverrides(boot.NewConfig(), []string{"cluster.raft.reconcile_debounce=10s"})
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, cfg.Sub("cluster").GetDuration("raft.reconcile_debounce", 0))
+}
+
+func TestApplySetOverrides_Malformed(t *testing.T) {
+	for _, bad := range []string{"clusterenabled", "=true", "nodotkey=1", "cluster.=1"} {
+		_, err := applySetOverrides(boot.NewConfig(), []string{bad})
+		assert.Error(t, err, "expected error for %q", bad)
+	}
+}

--- a/cmd/wippy/cmd/set_override_test.go
+++ b/cmd/wippy/cmd/set_override_test.go
@@ -3,12 +3,16 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/boot"
+	"go.uber.org/zap"
 )
 
 func TestCoerceSetValue(t *testing.T) {
@@ -66,4 +70,44 @@ func TestApplySetOverrides_Malformed(t *testing.T) {
 		_, err := applySetOverrides(boot.NewConfig(), []string{bad})
 		assert.Error(t, err, "expected error for %q", bad)
 	}
+}
+
+// TestLoadRuntimeConfig_SetFlag exercises --set end to end: through the cobra
+// flag, into loadRuntimeConfig, merged over an on-disk .wippy.yaml.
+func TestLoadRuntimeConfig_SetFlag(t *testing.T) {
+	tempDir := t.TempDir()
+	cfgPath := filepath.Join(tempDir, "wippy.yaml")
+	cfgBody := []byte("version: \"1.0\"\n" +
+		"cluster:\n" +
+		"  enabled: false\n" +
+		"  membership:\n" +
+		"    bind_port: 7946\n" +
+		"    join_addrs: \"seed:7946\"\n")
+	require.NoError(t, os.WriteFile(cfgPath, cfgBody, 0o644))
+
+	prevConfigFile, prevProfiler := configFile, profiler
+	prevVerbose, prevVeryVerbose, prevConsole, prevEventStreams := verbose, veryVerbose, console, eventStreams
+	configFile = cfgPath
+	profiler, verbose, veryVerbose, console, eventStreams = false, false, false, false, false
+	t.Cleanup(func() {
+		configFile, profiler = prevConfigFile, prevProfiler
+		verbose, veryVerbose, console, eventStreams = prevVerbose, prevVeryVerbose, prevConsole, prevEventStreams
+	})
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringArray("set", nil, "")
+	require.NoError(t, cmd.Flags().Set("set", "cluster.enabled=true"))
+	require.NoError(t, cmd.Flags().Set("set", "cluster.raft.bootstrap_expect=3"))
+
+	cfg, err := loadRuntimeConfig(cmd, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// --set overrides the file value...
+	assert.True(t, cfg.GetBool("cluster.enabled", false))
+	// ...adds a new nested leaf...
+	assert.Equal(t, 3, cfg.Sub("cluster").GetInt("raft.bootstrap_expect", 1))
+	// ...and leaves the file's other cluster leaves intact.
+	assert.Equal(t, 7946, cfg.GetInt("cluster.membership.bind_port", 0))
+	assert.Equal(t, "seed:7946", cfg.GetString("cluster.membership.join_addrs", ""))
 }


### PR DESCRIPTION
## --set config overrides

`wippy run --set section.path=value` (repeatable) overrides any `.wippy.yaml` value from the command line — flexible (any key), clear (path mirrors the YAML tree), and tested.

```
wippy run --set cluster.enabled=true \
          --set cluster.membership.join_addrs=node-2:7946 \
          --set cluster.raft.bootstrap_expect=3
```

- **Precedence**: defaults < `.wippy.yaml` < `--set`.
- **Per-leaf merge**: `--set cluster.enabled=true` overrides only that leaf and preserves the rest of the `cluster` section (built on the existing `bootconfig.Merge`).
- **Type coercion** to what consumers expect (`GetBool` needs bool, `GetInt` needs int): `true`/`false`→bool, integers→int, decimals→float64; durations (`5s`) and strings stay strings (`GetDuration` parses).
- **Validation**: `section.path=value` required; malformed input errors clearly.
- Wired through the existing `applyCLIOverrides` path in `run.go`; `-o` (entry overrides) unchanged.
- Unit tests: coercion, nesting, precedence, leaf-preservation, malformed input.

## README accuracy fixes

- Remove fake `--cluster*` CLI flags and the nonexistent `wippy replace` command.
- Refresh the Clustering feature list (bounded Raft, naming scopes, locks, process groups).
- Document cluster config via YAML **and** `--set`.
- Bump `Go 1.25+` → `1.26+` to match `go.mod` (`go 1.26.1`).

## Verification
- `go build ./cmd/wippy` clean; `go test ./cmd/wippy/cmd/ -run 'Set|Coerce'` passes.