### PR TITLE
fix: typed entry-kind override (salvaged)

### DIFF
--- a/boot/build/stages/override.go
+++ b/boot/build/stages/override.go
@@ -4,6 +4,7 @@ package stages
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/wippyai/runtime/api/boot"
@@ -72,7 +73,7 @@ func (s *overrideStage) Execute(ctx context.Context, entries *[]registry.Entry) 
 		}
 
 		for _, targetEntry := range targetEntries {
-			if err := mutator.Set(targetEntry, path, value); err != nil {
+			if err := applyOverrideValue(mutator, targetEntry, path, value); err != nil {
 				errs = append(errs, NewSetValueError(namespace, entryName, path, err))
 				continue
 			}
@@ -85,6 +86,26 @@ func (s *overrideStage) Execute(ctx context.Context, entries *[]registry.Entry) 
 	}
 
 	return nil
+}
+
+func applyOverrideValue(mutator *entry.Mutator, target *registry.Entry, path string, value any) error {
+	normalizedPath := strings.TrimPrefix(path, ".")
+	if normalizedPath == "kind" {
+		kind, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("kind override must be a string, got %T", value)
+		}
+
+		kind = strings.TrimSpace(kind)
+		if kind == "" {
+			return fmt.Errorf("kind override must not be empty")
+		}
+
+		target.Kind = registry.Kind(kind)
+		return nil
+	}
+
+	return mutator.Set(target, path, value)
 }
 
 // parseOverrideKey parses a key in format "namespace:entry:path" into components.

--- a/boot/build/stages/override_test.go
+++ b/boot/build/stages/override_test.go
@@ -97,6 +97,44 @@ func TestOverride_NestedPath(t *testing.T) {
 	}
 }
 
+func TestOverride_KindPathChangesEntryKind(t *testing.T) {
+	ctx, _ := setupTestContext()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("app", "db"),
+			Kind: "db.sql.sqlite",
+			Data: payload.New(map[string]any{
+				"kind": "data-kind-stays-data",
+				"file": ".wippy/app.db",
+			}),
+		},
+	}
+
+	cfg := boot.NewConfig(
+		boot.WithSection("override", map[string]any{
+			"app:db:kind":      "db.sql.postgres",
+			"app:db:data.kind": "explicit-data-kind",
+		}),
+	)
+
+	ctx = boot.WithConfig(ctx, cfg)
+	stage := Override()
+
+	if err := stage.Execute(ctx, &entries); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if entries[0].Kind != "db.sql.postgres" {
+		t.Fatalf("Kind = %q, want db.sql.postgres", entries[0].Kind)
+	}
+
+	data := entries[0].Data.Data().(map[string]any)
+	if data["kind"] != "explicit-data-kind" {
+		t.Fatalf("data.kind = %v, want explicit-data-kind", data["kind"])
+	}
+}
+
 func TestOverride_MetaPath(t *testing.T) {
 	ctx, _ := setupTestContext()
 

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -546,12 +547,13 @@ func applyOverrideFlags(cfg boot.Config, overrides []string, logger *zap.Logger)
 		}
 
 		key := fmt.Sprintf("%s:%s:%s", namespace, entry, field)
-		overrideMap[key] = value
+		parsedValue := parseOverrideValue(value)
+		overrideMap[key] = parsedValue
 
 		if logger != nil {
 			logger.Debug("applying override",
 				zap.String("key", key),
-				zap.String("value", value))
+				zap.Any("value", parsedValue))
 		}
 	}
 
@@ -564,6 +566,32 @@ func applyOverrideFlags(cfg boot.Config, overrides []string, logger *zap.Logger)
 	}
 
 	return boot.NewConfig(opts...), nil
+}
+
+func parseOverrideValue(raw string) any {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return raw
+	}
+
+	switch strings.ToLower(trimmed) {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+
+	if i, err := strconv.ParseInt(trimmed, 10, 0); err == nil && strconv.FormatInt(i, 10) == trimmed {
+		return int(i)
+	}
+
+	if strings.ContainsAny(trimmed, ".eE") {
+		if f, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return f
+		}
+	}
+
+	return raw
 }
 
 // parseOverride parses `namespace:entry:field=value`.

--- a/cmd/wippy/cmd/run_test.go
+++ b/cmd/wippy/cmd/run_test.go
@@ -71,6 +71,8 @@ func TestLoadRuntimeConfigAppliesOverridesAndCLISettings(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().StringSlice("override", nil, "")
 	require.NoError(t, cmd.Flags().Set("override", "app:test:enabled=true"))
+	require.NoError(t, cmd.Flags().Set("override", "app:db:port=5432"))
+	require.NoError(t, cmd.Flags().Set("override", "app:gateway:addr=:9090"))
 
 	cfg, err := loadRuntimeConfig(cmd, zap.NewNop())
 	require.NoError(t, err)
@@ -82,7 +84,15 @@ func TestLoadRuntimeConfigAppliesOverridesAndCLISettings(t *testing.T) {
 
 	overrideCfg := cfg.Sub("override")
 	require.NotNil(t, overrideCfg)
-	require.Equal(t, "true", overrideCfg.GetString("app:test:enabled", ""))
+	enabled, ok := overrideCfg.Get("app:test:enabled")
+	require.True(t, ok)
+	require.Equal(t, true, enabled)
+
+	port, ok := overrideCfg.Get("app:db:port")
+	require.True(t, ok)
+	require.Equal(t, 5432, port)
+
+	require.Equal(t, ":9090", overrideCfg.GetString("app:gateway:addr", ""))
 }
 
 func TestLoadRuntimeConfigWithDefaultsAppliesPackDefaultsWhenFileMissingKey(t *testing.T) {


### PR DESCRIPTION
Salvaged from a stale branch.

Boot override stage ignored `-o ns:entry:kind=...` because the mutator only writes entry `Data`, never the top-level `Entry.Kind`. `applyOverrideValue` now routes a `kind` path to `Entry.Kind` (string, non-empty), leaving every other path on `mutator.Set`.

The Postgres `?`->`$N` placeholder rewrite that was originally bundled here was dropped: lib/pq is `$N`-native, and lexically rewriting arbitrary user SQL is silently wrong on the jsonb `?` operator (`data ? 'key'`). Postgres queries use `$N` directly, matching the driver.