### PR TITLE
chore(sql): drop unsupported MSSQL/Oracle dialects

### DIFF
--- a/api/service/sql/config.go
+++ b/api/service/sql/config.go
@@ -22,12 +22,6 @@ const (
 
 	// SQLite identifies a SQLite database in the registry
 	SQLite registry.Kind = "db.sql.sqlite"
-
-	// MSSQL identifies a Microsoft SQL Server database in the registry
-	MSSQL registry.Kind = "db.sql.mssql"
-
-	// Oracle identifies an Oracle database in the registry
-	Oracle registry.Kind = "db.sql.oracle"
 )
 
 // Default configuration values

--- a/api/service/sql/config_test.go
+++ b/api/service/sql/config_test.go
@@ -23,8 +23,6 @@ func TestKindConstants(t *testing.T) {
 		{"postgres", Postgres, "db.sql.postgres"},
 		{"mysql", MySQL, "db.sql.mysql"},
 		{"sqlite", SQLite, "db.sql.sqlite"},
-		{"mssql", MSSQL, "db.sql.mssql"},
-		{"oracle", Oracle, "db.sql.oracle"},
 	}
 
 	for _, tt := range tests {

--- a/runtime/lua/modules/sql/db_test.go
+++ b/runtime/lua/modules/sql/db_test.go
@@ -64,8 +64,6 @@ func TestMapDBTypeFromResourceKind(t *testing.T) {
 		{"db.sql.postgres", TypePostgres},
 		{"db.sql.mysql", TypeMySQL},
 		{"db.sql.sqlite", TypeSQLite},
-		{"db.sql.mssql", TypeMSSQL},
-		{"db.sql.oracle", TypeOracle},
 		{"unknown", TypeUnknown},
 		{"", TypeUnknown},
 	}

--- a/runtime/lua/modules/sql/module.go
+++ b/runtime/lua/modules/sql/module.go
@@ -15,8 +15,6 @@ const (
 	TypePostgres = "postgres"
 	TypeMySQL    = "mysql"
 	TypeSQLite   = "sqlite"
-	TypeMSSQL    = "mssql"
-	TypeOracle   = "oracle"
 	TypeUnknown  = "unknown"
 
 	IsolationDefault         = "default"
@@ -50,12 +48,10 @@ func initModuleTable() {
 	nullUD := &lua.LUserData{Value: "SQL_NULL"}
 	mod.RawSetString("NULL", nullUD)
 
-	types := lua.CreateTable(0, 6)
+	types := lua.CreateTable(0, 4)
 	types.RawSetString("POSTGRES", lua.LString(TypePostgres))
 	types.RawSetString("MYSQL", lua.LString(TypeMySQL))
 	types.RawSetString("SQLITE", lua.LString(TypeSQLite))
-	types.RawSetString("MSSQL", lua.LString(TypeMSSQL))
-	types.RawSetString("ORACLE", lua.LString(TypeOracle))
 	types.RawSetString("UNKNOWN", lua.LString(TypeUnknown))
 	types.Immutable = true
 	mod.RawSetString("type", types)
@@ -111,10 +107,6 @@ func mapDBTypeFromResourceKind(dbType string) string {
 		return TypeMySQL
 	case sqlapi.SQLite:
 		return TypeSQLite
-	case sqlapi.MSSQL:
-		return TypeMSSQL
-	case sqlapi.Oracle:
-		return TypeOracle
 	default:
 		return TypeUnknown
 	}

--- a/runtime/lua/modules/sql/module_test.go
+++ b/runtime/lua/modules/sql/module_test.go
@@ -76,7 +76,7 @@ func TestModuleHasTypes(t *testing.T) {
 		t.Fatalf("expected types to be a table, got %T", types)
 	}
 
-	expectedTypes := []string{"POSTGRES", "MYSQL", "SQLITE", "MSSQL", "ORACLE", "UNKNOWN"}
+	expectedTypes := []string{"POSTGRES", "MYSQL", "SQLITE", "UNKNOWN"}
 	for _, name := range expectedTypes {
 		if table.RawGetString(name) == lua.LNil {
 			t.Errorf("expected type table to have '%s'", name)
@@ -359,8 +359,6 @@ func TestModuleConstants(t *testing.T) {
 		{"TypePostgres", TypePostgres, "postgres"},
 		{"TypeMySQL", TypeMySQL, "mysql"},
 		{"TypeSQLite", TypeSQLite, "sqlite"},
-		{"TypeMSSQL", TypeMSSQL, "mssql"},
-		{"TypeOracle", TypeOracle, "oracle"},
 		{"TypeUnknown", TypeUnknown, "unknown"},
 	}
 

--- a/runtime/lua/modules/sql/types.go
+++ b/runtime/lua/modules/sql/types.go
@@ -545,8 +545,6 @@ var sqlTypeConstType = typ.NewRecord().
 	Field("POSTGRES", typ.String).
 	Field("MYSQL", typ.String).
 	Field("SQLITE", typ.String).
-	Field("MSSQL", typ.String).
-	Field("ORACLE", typ.String).
 	Field("UNKNOWN", typ.String).
 	Build()
 

--- a/service/store/sql/sqlstore.go
+++ b/service/store/sql/sqlstore.go
@@ -516,10 +516,8 @@ func statementBuilder(dbType registry.Kind) sq.StatementBuilderType {
 	switch dbType {
 	case sqlconfig.Postgres:
 		return sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
-	case sqlconfig.MySQL, sqlconfig.SQLite, sqlconfig.MSSQL:
+	case sqlconfig.MySQL, sqlconfig.SQLite:
 		return sq.StatementBuilder.PlaceholderFormat(sq.Question)
-	case sqlconfig.Oracle:
-		return sq.StatementBuilder.PlaceholderFormat(sq.Colon)
 	default:
 		// Default to PostgreSQL-style for unknown types
 		return sq.StatementBuilder.PlaceholderFormat(sq.Dollar)


### PR DESCRIPTION
MSSQL and Oracle were advertised (entry kinds `db.sql.mssql`/`db.sql.oracle`, `sql.type.MSSQL`/`ORACLE`, store dialect cases) but non-functional: no driver is bundled (`cmd/wippy` registers only `lib/pq`, `go-sql-driver/mysql`, `go-sqlite3`) and `service/sql/conn.go` returns `UnsupportedDatabaseTypeError` for them. This removes the dead constants/mappings so the supported set is exactly Postgres, MySQL, SQLite. Docs updated in parallel.