### PR TITLE
Add application template link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Documentation](https://img.shields.io/badge/docs-wippy.ai-0F6640.svg?style=for-the-badge)][documentation]
 [![Go Version](https://img.shields.io/badge/go-1.26+-00ADD8.svg?style=for-the-badge&logo=go)](#installation)
 [![License](https://img.shields.io/badge/license-MPL%202.0-brightgreen.svg?style=for-the-badge)](LICENSE)
+[![App Template](https://img.shields.io/badge/app%20template-wippyai%2Fapp-FF8C42.svg?style=for-the-badge)](https://github.com/wippyai/app)
 
 </div>
 


### PR DESCRIPTION
Link to the application template (wippyai/app) from the README badge row.