### PR TITLE
Fix documentation link to wippy.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,5 +264,5 @@ Mozilla Public License 2.0
 - [Documentation][documentation]
 - [Issues](https://github.com/wippyai/runtime/issues)
 
-[documentation]: https://docs.wippy.ai
+[documentation]: https://wippy.ai/en/
 


### PR DESCRIPTION
docs.wippy.ai serves a redirect stub; point the documentation reference at the actual docs site.

<!-- SPDX-License-Identifier: MPL-2.0 -->

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`
