### PR TITLE
CI: signed releases (nightly + manual)

### DIFF
--- a/.github/scripts/should-release.sh
+++ b/.github/scripts/should-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# Decide whether a nightly release is warranted.
+# Inputs (env):
+#   CURRENT_SHA - commit being considered for release (required)
+#   PREV_SHA    - commit of the most recent nightly, empty if none
+#   FORCE       - "true" forces a release regardless of comparison
+# Output:
+#   prints "should_release=true|false"; also appends to $GITHUB_OUTPUT when set.
+set -euo pipefail
+
+current="${CURRENT_SHA:-}"
+prev="${PREV_SHA:-}"
+force="${FORCE:-false}"
+
+if [[ -z "$current" ]]; then
+  echo "CURRENT_SHA is required" >&2
+  exit 1
+fi
+
+if [[ "$force" == "true" ]]; then
+  result=true
+elif [[ -z "$prev" ]]; then
+  result=true
+elif [[ "$current" != "$prev" ]]; then
+  result=true
+else
+  result=false
+fi
+
+echo "should_release=$result"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "should_release=$result" >>"$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: MPL-2.0
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Build a nightly even if no new commits'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+env:
+  NIGHTLY_KEEP: '14'
+
+jobs:
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.gate.outputs.should_release }}
+      version: ${{ steps.gate.outputs.version }}
+      tag: ${{ steps.gate.outputs.tag }}
+      short_sha: ${{ steps.gate.outputs.short_sha }}
+      build_date: ${{ steps.gate.outputs.build_date }}
+      prev_tag: ${{ steps.gate.outputs.prev_tag }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Decide
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_SHA: ${{ github.sha }}
+          FORCE: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          prev_tag=$(gh release list --limit 200 --json tagName,createdAt \
+            --jq '[.[] | select(.tagName | startswith("nightly-"))] | sort_by(.createdAt) | last | .tagName')
+          prev_sha=""
+          if [[ -n "$prev_tag" && "$prev_tag" != "null" ]]; then
+            prev_sha=$(git rev-list -n1 "$prev_tag" 2>/dev/null || echo "")
+          else
+            prev_tag=""
+          fi
+          short_sha=$(git rev-parse --short=7 HEAD)
+          version="nightly-$(date -u +%Y%m%d)-${short_sha}"
+          {
+            echo "prev_tag=$prev_tag"
+            echo "version=$version"
+            echo "tag=$version"
+            echo "short_sha=$short_sha"
+            echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
+          PREV_SHA="$prev_sha" FORCE="${FORCE:-false}" bash .github/scripts/should-release.sh
+
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    needs: gate
+    if: needs.gate.outputs.should_release == 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { goos: linux, goarch: amd64, runner: ubuntu-latest }
+          - { goos: linux, goarch: arm64, runner: ubuntu-24.04-arm }
+          - { goos: darwin, goarch: amd64, runner: macos-26-intel }
+          - { goos: darwin, goarch: arm64, runner: macos-26 }
+          - { goos: windows, goarch: amd64, runner: windows-latest }
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Setup msys (Windows)
+        if: matrix.goos == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3
+          path-type: inherit
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+        env:
+          MSYSTEM: MINGW64
+
+      - name: Build
+        if: matrix.goos != 'windows'
+        shell: bash
+        env:
+          VERSION: ${{ needs.gate.outputs.version }}
+          SHORT_SHA: ${{ needs.gate.outputs.short_sha }}
+          BUILD_DATE: ${{ needs.gate.outputs.build_date }}
+        run: make build-wippy-local WIPPY_VERSION="$VERSION" WIPPY_COMMIT="$SHORT_SHA" WIPPY_DATE="$BUILD_DATE"
+
+      - name: Build (Windows)
+        if: matrix.goos == 'windows'
+        shell: 'msys2 {0}'
+        env:
+          VERSION: ${{ needs.gate.outputs.version }}
+          SHORT_SHA: ${{ needs.gate.outputs.short_sha }}
+          BUILD_DATE: ${{ needs.gate.outputs.build_date }}
+        run: |
+          set -euo pipefail
+          make build-wippy-local WIPPY_VERSION="$VERSION" WIPPY_COMMIT="$SHORT_SHA" WIPPY_DATE="$BUILD_DATE"
+          mv dist/wippy-windows-amd64 dist/wippy-windows-amd64.exe
+
+      - name: Smoke check
+        if: matrix.goos != 'windows'
+        shell: bash
+        env:
+          VERSION: ${{ needs.gate.outputs.version }}
+        run: |
+          set -euo pipefail
+          bin="dist/wippy-${{ matrix.goos }}-${{ matrix.goarch }}"
+          "./$bin" --help >/dev/null
+          grep -a -- "$VERSION" "$bin" >/dev/null || { echo "version $VERSION not embedded in $bin"; exit 1; }
+
+      - name: Smoke check (Windows)
+        if: matrix.goos == 'windows'
+        shell: 'msys2 {0}'
+        env:
+          VERSION: ${{ needs.gate.outputs.version }}
+        run: |
+          set -euo pipefail
+          bin="dist/wippy-windows-amd64.exe"
+          "./$bin" --help >/dev/null
+          grep -a -- "$VERSION" "$bin" >/dev/null || { echo "version $VERSION not embedded in $bin"; exit 1; }
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: bin-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/wippy-${{ matrix.goos }}-${{ matrix.goarch }}*
+          if-no-files-found: error
+          retention-days: 3
+
+  release:
+    name: Sign and publish
+    needs: [gate, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: bin-*
+          merge-multiple: true
+
+      - name: Sign binaries
+        env:
+          RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+        run: go run ./tools/signrelease dist/wippy-*
+
+      - name: Checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum $(ls wippy-* | grep -v '\.sig$') > SHA256SUMS
+
+      - name: Release notes
+        env:
+          PREV_TAG: ${{ needs.gate.outputs.prev_tag }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Automated nightly build."
+            echo
+            echo "Commit: ${GITHUB_SHA}"
+            echo
+            echo "## Changes"
+            if [ -n "$PREV_TAG" ]; then
+              git log --pretty='- %h %s' "${PREV_TAG}..HEAD"
+            else
+              git log --pretty='- %h %s' -n 50 HEAD
+            fi
+            echo
+            echo "## Verify"
+            echo '```'
+            echo "sha256sum -c SHA256SUMS"
+            echo "# each wippy-<os>-<arch>.sig is base64(ed25519 detached sig); verify with release_key.pub"
+            echo '```'
+          } > release-notes.md
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.gate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" dist/* \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "Nightly ${TAG#nightly-}" \
+            --notes-file release-notes.md
+
+  prune:
+    name: Prune old nightlies
+    needs: [gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete nightlies beyond retention
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release list --repo "$REPO" --limit 200 --json tagName,createdAt \
+            --jq '[.[] | select(.tagName | startswith("nightly-"))] | sort_by(.createdAt) | reverse | .['"$NIGHTLY_KEEP"':] | .[].tagName' \
+          | while read -r tag; do
+              [ -z "$tag" ] && continue
+              echo "deleting $tag"
+              gh release delete "$tag" --repo "$REPO" --cleanup-tag --yes
+            done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,9 +3,6 @@
 name: Nightly
 
 on:
-  push:
-    branches:
-      - ci/nightly-signed-releases
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,9 @@
 name: Nightly
 
 on:
+  push:
+    branches:
+      - ci/nightly-signed-releases
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v7
         with:
-          name: bin-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: wippy-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/wippy-${{ matrix.goos }}-${{ matrix.goarch }}*
           if-no-files-found: error
           retention-days: 3
@@ -178,7 +178,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: dist
-          pattern: bin-*
+          pattern: wippy-*
           merge-multiple: true
 
       - name: Sign binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - ci/nightly-signed-releases
   workflow_dispatch:
     inputs:
       version:
@@ -52,7 +49,6 @@ jobs:
           RAW_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          RAW_VERSION="${RAW_VERSION:-0.4.0}"
           ver="${RAW_VERSION#v}"
           if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+[a-z]*([-+][0-9A-Za-z.-]+)?$'; then
             echo "invalid version '$RAW_VERSION' (expected e.g. 0.4.0, 0.3.1a, or 1.0.0-rc.1)" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: MPL-2.0
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. 0.2.1 or v0.2.1'
+        type: string
+        required: true
+      prerelease:
+        description: 'Mark as prerelease (does not become Latest)'
+        type: boolean
+        default: false
+      draft:
+        description: 'Create as draft to review before publishing'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+      version: ${{ steps.v.outputs.version }}
+      short_sha: ${{ steps.v.outputs.short_sha }}
+      build_date: ${{ steps.v.outputs.build_date }}
+      prev_tag: ${{ steps.v.outputs.prev_tag }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve and check version
+        id: v
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          ver="${RAW_VERSION#v}"
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            echo "invalid version '$RAW_VERSION' (expected semver like 0.2.1 or v0.2.1)" >&2
+            exit 1
+          fi
+          tag="v$ver"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "tag $tag already exists; published versions are immutable" >&2
+            exit 1
+          fi
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release $tag already exists" >&2
+            exit 1
+          fi
+          prev_tag=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          {
+            echo "tag=$tag"
+            echo "version=$tag"
+            echo "short_sha=$(git rev-parse --short=7 HEAD)"
+            echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "prev_tag=$prev_tag"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - { goos: linux, goarch: amd64, runner: ubuntu-latest }
+          - { goos: linux, goarch: arm64, runner: ubuntu-24.04-arm }
+          - { goos: darwin, goarch: amd64, runner: macos-26-intel }
+          - { goos: darwin, goarch: arm64, runner: macos-26 }
+          - { goos: windows, goarch: amd64, runner: windows-latest }
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Setup msys (Windows)
+        if: matrix.goos == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3
+          path-type: inherit
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+        env:
+          MSYSTEM: MINGW64
+
+      - name: Build
+        if: matrix.goos != 'windows'
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          SHORT_SHA: ${{ needs.validate.outputs.short_sha }}
+          BUILD_DATE: ${{ needs.validate.outputs.build_date }}
+        run: make build-wippy-local WIPPY_VERSION="$VERSION" WIPPY_COMMIT="$SHORT_SHA" WIPPY_DATE="$BUILD_DATE"
+
+      - name: Build (Windows)
+        if: matrix.goos == 'windows'
+        shell: 'msys2 {0}'
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          SHORT_SHA: ${{ needs.validate.outputs.short_sha }}
+          BUILD_DATE: ${{ needs.validate.outputs.build_date }}
+        run: |
+          set -euo pipefail
+          make build-wippy-local WIPPY_VERSION="$VERSION" WIPPY_COMMIT="$SHORT_SHA" WIPPY_DATE="$BUILD_DATE"
+          mv dist/wippy-windows-amd64 dist/wippy-windows-amd64.exe
+
+      - name: Smoke check
+        if: matrix.goos != 'windows'
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          bin="dist/wippy-${{ matrix.goos }}-${{ matrix.goarch }}"
+          "./$bin" --help >/dev/null
+          grep -a -- "$VERSION" "$bin" >/dev/null || { echo "version $VERSION not embedded in $bin"; exit 1; }
+
+      - name: Smoke check (Windows)
+        if: matrix.goos == 'windows'
+        shell: 'msys2 {0}'
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          bin="dist/wippy-windows-amd64.exe"
+          "./$bin" --help >/dev/null
+          grep -a -- "$VERSION" "$bin" >/dev/null || { echo "version $VERSION not embedded in $bin"; exit 1; }
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: wippy-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/wippy-${{ matrix.goos }}-${{ matrix.goarch }}*
+          if-no-files-found: error
+          retention-days: 3
+
+  release:
+    name: Sign and publish
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: wippy-*
+          merge-multiple: true
+
+      - name: Sign binaries
+        env:
+          RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+        run: go run ./tools/signrelease dist/wippy-*
+
+      - name: Checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum $(ls wippy-* | grep -v '\.sig$') > SHA256SUMS
+
+      - name: Release notes
+        env:
+          PREV_TAG: ${{ needs.validate.outputs.prev_tag }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## ${TAG}"
+            echo
+            echo "Commit: ${GITHUB_SHA}"
+            echo
+            echo "## Changes"
+            if [ -n "$PREV_TAG" ]; then
+              git log --pretty='- %h %s' "${PREV_TAG}..HEAD"
+            else
+              git log --pretty='- %h %s' -n 50 HEAD
+            fi
+            echo
+            echo "## Verify"
+            echo '```'
+            echo "sha256sum -c SHA256SUMS"
+            echo "# each wippy-<os>-<arch>.sig is base64(ed25519 detached sig); verify with release_key.pub"
+            echo '```'
+          } > release-notes.md
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          DRAFT: ${{ inputs.draft }}
+        run: |
+          set -euo pipefail
+          flags=()
+          if [ "$PRERELEASE" = "true" ]; then flags+=(--prerelease); fi
+          if [ "$DRAFT" = "true" ]; then flags+=(--draft); fi
+          if [ "$PRERELEASE" != "true" ] && [ "$DRAFT" != "true" ]; then flags+=(--latest); fi
+          gh release create "$TAG" dist/* \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            "${flags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,8 @@ jobs:
     name: Sign and publish
     needs: [validate, build]
     runs-on: ubuntu-latest
+    env:
+      HUB_SERVICE_SECRET: ${{ secrets.HUB_SERVICE_SECRET }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -243,3 +245,12 @@ jobs:
             --title "$TAG" \
             --notes-file release-notes.md \
             "${flags[@]}"
+
+      - name: Register release on hub
+        if: ${{ inputs.draft == false && env.HUB_SERVICE_SECRET != '' }}
+        env:
+          RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+          HUB_URL: ${{ vars.HUB_URL }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: CHANGELOG="$(cat release-notes.md)" go run ./tools/hubpublish dist/wippy-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - ci/nightly-signed-releases
   workflow_dispatch:
     inputs:
       version:
@@ -49,6 +52,7 @@ jobs:
           RAW_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          RAW_VERSION="${RAW_VERSION:-0.0.0-citest-$(git rev-parse --short=7 HEAD)}"
           ver="${RAW_VERSION#v}"
           if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
             echo "invalid version '$RAW_VERSION' (expected semver like 0.2.1 or v0.2.1)" >&2
@@ -222,7 +226,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.validate.outputs.tag }}
-          PRERELEASE: ${{ inputs.prerelease }}
+          PRERELEASE: ${{ github.event_name == 'push' && 'true' || inputs.prerelease }}
           DRAFT: ${{ inputs.draft }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - ci/nightly-signed-releases
   workflow_dispatch:
     inputs:
       version:
@@ -52,7 +49,6 @@ jobs:
           RAW_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          RAW_VERSION="${RAW_VERSION:-0.0.0-citest-$(git rev-parse --short=7 HEAD)}"
           ver="${RAW_VERSION#v}"
           if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
             echo "invalid version '$RAW_VERSION' (expected semver like 0.2.1 or v0.2.1)" >&2
@@ -226,7 +222,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.validate.outputs.tag }}
-          PRERELEASE: ${{ github.event_name == 'push' && 'true' || inputs.prerelease }}
+          PRERELEASE: ${{ inputs.prerelease }}
           DRAFT: ${{ inputs.draft }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - ci/nightly-signed-releases
   workflow_dispatch:
     inputs:
       version:
@@ -49,9 +52,10 @@ jobs:
           RAW_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          RAW_VERSION="${RAW_VERSION:-0.4.0}"
           ver="${RAW_VERSION#v}"
-          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
-            echo "invalid version '$RAW_VERSION' (expected semver like 0.2.1 or v0.2.1)" >&2
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+[a-z]*([-+][0-9A-Za-z.-]+)?$'; then
+            echo "invalid version '$RAW_VERSION' (expected e.g. 0.4.0, 0.3.1a, or 1.0.0-rc.1)" >&2
             exit 1
           fi
           tag="v$ver"
@@ -63,7 +67,7 @@ jobs:
             echo "release $tag already exists" >&2
             exit 1
           fi
-          latest=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          latest=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*$' | sort -V | tail -1 || true)
           if [ -n "$latest" ]; then
             higher=$(printf '%s\n%s\n' "$latest" "$tag" | sort -V | tail -1)
             if [ "$tag" = "$latest" ] || [ "$higher" != "$tag" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,15 @@ jobs:
             echo "release $tag already exists" >&2
             exit 1
           fi
-          prev_tag=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          latest=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          if [ -n "$latest" ]; then
+            higher=$(printf '%s\n%s\n' "$latest" "$tag" | sort -V | tail -1)
+            if [ "$tag" = "$latest" ] || [ "$higher" != "$tag" ]; then
+              echo "version $tag must be greater than the latest release $latest" >&2
+              exit 1
+            fi
+          fi
+          prev_tag="$latest"
           {
             echo "tag=$tag"
             echo "version=$tag"

--- a/tools/hubpublish/main.go
+++ b/tools/hubpublish/main.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Command hubpublish registers a published GitHub release with hub.wippy.ai so
+// the hub keeps the release record and download counter while the binaries are
+// served from GitHub. For each binary it computes the SHA256, an Ed25519
+// signature over that digest (verified by the hub), and the GitHub asset URL,
+// then POSTs the set to the hub's internal release endpoint.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type asset struct {
+	Platform              string `json:"platform"`
+	Arch                  string `json:"arch"`
+	Filename              string `json:"filename"`
+	URL                   string `json:"url"`
+	SHA256                string `json:"sha256"`
+	Signature             string `json:"signature"`
+	SigningKeyFingerprint string `json:"signing_key_fingerprint"`
+	SizeBytes             int64  `json:"size_bytes"`
+}
+
+type payload struct {
+	Version    string  `json:"version"`
+	Changelog  string  `json:"changelog"`
+	Assets     []asset `json:"assets"`
+	Prerelease bool    `json:"prerelease"`
+}
+
+func loadKey(hexKey string) (ed25519.PrivateKey, error) {
+	raw, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return nil, fmt.Errorf("decode hex key: %w", err)
+	}
+
+	switch len(raw) {
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), nil
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), nil
+	default:
+		return nil, fmt.Errorf("key is %d bytes, want %d or %d", len(raw), ed25519.SeedSize, ed25519.PrivateKeySize)
+	}
+}
+
+func fingerprint(priv ed25519.PrivateKey) (string, error) {
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", errors.New("derived public key is not ed25519")
+	}
+
+	sum := sha256.Sum256(pub)
+
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// platformArch derives the hub platform/arch from a wippy-<os>-<arch>[.exe] name.
+func platformArch(filename string) (string, string, error) {
+	name := strings.TrimSuffix(filename, ".exe")
+	name = strings.TrimPrefix(name, "wippy-")
+	parts := strings.SplitN(name, "-", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("cannot derive platform/arch from %q", filename)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func buildAsset(priv ed25519.PrivateKey, fp, repo, tag, path string) (asset, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return asset{}, err
+	}
+
+	filename := filepath.Base(path)
+	platform, arch, err := platformArch(filename)
+	if err != nil {
+		return asset{}, err
+	}
+
+	digest := sha256.Sum256(data)
+	sig := ed25519.Sign(priv, digest[:])
+
+	return asset{
+		Platform:              platform,
+		Arch:                  arch,
+		Filename:              filename,
+		URL:                   fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, filename),
+		SHA256:                hex.EncodeToString(digest[:]),
+		SizeBytes:             int64(len(data)),
+		Signature:             base64.StdEncoding.EncodeToString(sig),
+		SigningKeyFingerprint: fp,
+	}, nil
+}
+
+func buildPayload(priv ed25519.PrivateKey, repo, tag, changelog string, prerelease bool, paths []string) (payload, error) {
+	fp, err := fingerprint(priv)
+	if err != nil {
+		return payload{}, err
+	}
+
+	assets := make([]asset, 0, len(paths))
+	for _, path := range paths {
+		if strings.HasSuffix(path, ".sig") {
+			continue
+		}
+
+		a, err := buildAsset(priv, fp, repo, tag, path)
+		if err != nil {
+			return payload{}, fmt.Errorf("asset %s: %w", path, err)
+		}
+
+		assets = append(assets, a)
+	}
+
+	if len(assets) == 0 {
+		return payload{}, errors.New("no binaries to publish")
+	}
+
+	return payload{
+		Version:    strings.TrimPrefix(tag, "v"),
+		Changelog:  changelog,
+		Prerelease: prerelease,
+		Assets:     assets,
+	}, nil
+}
+
+func post(hubURL, secret string, body []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(hubURL, "/")+"/api/internal/v1/releases/github", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-service-secret", secret)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("hub responded %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	fmt.Printf("hub: %s\n", strings.TrimSpace(string(respBody)))
+
+	return nil
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("provide at least one binary to publish")
+	}
+
+	priv, err := loadKey(os.Getenv("RELEASE_SIGNING_KEY"))
+	if err != nil {
+		return err
+	}
+
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	tag := os.Getenv("RELEASE_TAG")
+	if repo == "" || tag == "" {
+		return errors.New("GITHUB_REPOSITORY and RELEASE_TAG are required")
+	}
+
+	p, err := buildPayload(priv, repo, tag, os.Getenv("CHANGELOG"), os.Getenv("PRERELEASE") == "true", args)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+
+	if os.Getenv("DRY_RUN") == "true" {
+		fmt.Println(string(body))
+		return nil
+	}
+
+	secret := os.Getenv("HUB_SERVICE_SECRET")
+	if secret == "" {
+		return errors.New("HUB_SERVICE_SECRET is required")
+	}
+
+	hubURL := os.Getenv("HUB_URL")
+	if hubURL == "" {
+		hubURL = "https://hub.wippy.ai"
+	}
+
+	return post(hubURL, secret, body)
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "hubpublish:", err)
+		os.Exit(1)
+	}
+}

--- a/tools/hubpublish/main_test.go
+++ b/tools/hubpublish/main_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlatformArch(t *testing.T) {
+	cases := map[string][2]string{
+		"wippy-linux-amd64":       {"linux", "amd64"},
+		"wippy-linux-arm64":       {"linux", "arm64"},
+		"wippy-darwin-arm64":      {"darwin", "arm64"},
+		"wippy-windows-amd64.exe": {"windows", "amd64"},
+	}
+	for name, want := range cases {
+		p, a, err := platformArch(name)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if p != want[0] || a != want[1] {
+			t.Fatalf("%s: got %s/%s want %s/%s", name, p, a, want[0], want[1])
+		}
+	}
+
+	if _, _, err := platformArch("notawippybinary"); err == nil {
+		t.Fatal("expected error for malformed name")
+	}
+}
+
+func TestBuildPayload(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	dir := t.TempDir()
+	content := []byte("fake wippy binary")
+	bin := filepath.Join(dir, "wippy-linux-amd64")
+	if err := os.WriteFile(bin, content, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// A .sig sibling must be ignored.
+	if err := os.WriteFile(bin+".sig", []byte("ignored"), 0o644); err != nil {
+		t.Fatalf("write sig: %v", err)
+	}
+
+	p, err := buildPayload(priv, "wippyai/runtime", "v0.4.0", "notes", false, []string{bin, bin + ".sig"})
+	if err != nil {
+		t.Fatalf("buildPayload: %v", err)
+	}
+
+	if p.Version != "0.4.0" {
+		t.Fatalf("version = %q, want 0.4.0 (v stripped)", p.Version)
+	}
+	if len(p.Assets) != 1 {
+		t.Fatalf("expected 1 asset (sig skipped), got %d", len(p.Assets))
+	}
+
+	a := p.Assets[0]
+	wantURL := "https://github.com/wippyai/runtime/releases/download/v0.4.0/wippy-linux-amd64"
+	if a.URL != wantURL {
+		t.Fatalf("url = %q, want %q", a.URL, wantURL)
+	}
+
+	digest := sha256.Sum256(content)
+	if a.SHA256 != hex.EncodeToString(digest[:]) {
+		t.Fatal("sha256 mismatch")
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(a.Signature)
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	if !ed25519.Verify(pub, digest[:], sig) {
+		t.Fatal("signature does not verify over the sha256 digest")
+	}
+
+	wantFP := sha256.Sum256(pub)
+	if a.SigningKeyFingerprint != hex.EncodeToString(wantFP[:]) {
+		t.Fatal("fingerprint mismatch")
+	}
+}

--- a/tools/signrelease/main.go
+++ b/tools/signrelease/main.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const keyEnv = "RELEASE_SIGNING_KEY"
+
+func loadKey(hexKey string) (ed25519.PrivateKey, error) {
+	raw, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return nil, fmt.Errorf("decode hex key: %w", err)
+	}
+
+	switch len(raw) {
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), nil
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), nil
+	default:
+		return nil, fmt.Errorf("key is %d bytes, want %d (seed) or %d (full key)", len(raw), ed25519.SeedSize, ed25519.PrivateKeySize)
+	}
+}
+
+func signFile(priv ed25519.PrivateKey, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	sig := ed25519.Sign(priv, data)
+	encoded := base64.StdEncoding.EncodeToString(sig)
+
+	return os.WriteFile(path+".sig", []byte(encoded+"\n"), 0o644)
+}
+
+func writePublicKey(priv ed25519.PrivateKey, dir string) (string, error) {
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", errors.New("derived public key is not ed25519")
+	}
+
+	out := filepath.Join(dir, "release_key.pub")
+	encoded := base64.StdEncoding.EncodeToString(pub)
+
+	return out, os.WriteFile(out, []byte(encoded+"\n"), 0o644)
+}
+
+func run(args []string, hexKey string) error {
+	if len(args) == 0 {
+		return errors.New("provide at least one file to sign")
+	}
+
+	priv, err := loadKey(hexKey)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range args {
+		if err := signFile(priv, path); err != nil {
+			return fmt.Errorf("sign %s: %w", path, err)
+		}
+
+		fmt.Printf("signed %s -> %s.sig\n", path, path)
+	}
+
+	pubPath, err := writePublicKey(priv, filepath.Dir(args[0]))
+	if err != nil {
+		return fmt.Errorf("write public key: %w", err)
+	}
+
+	fmt.Printf("wrote public key -> %s\n", pubPath)
+
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Getenv(keyEnv)); err != nil {
+		fmt.Fprintln(os.Stderr, "signrelease:", err)
+		os.Exit(1)
+	}
+}

--- a/tools/signrelease/main_test.go
+++ b/tools/signrelease/main_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readPub(t *testing.T, dir string) ed25519.PublicKey {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join(dir, "release_key.pub"))
+	if err != nil {
+		t.Fatalf("read pub: %v", err)
+	}
+
+	pub, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("decode pub: %v", err)
+	}
+
+	return ed25519.PublicKey(pub)
+}
+
+func readSig(t *testing.T, path string) []byte {
+	t.Helper()
+
+	raw, err := os.ReadFile(path + ".sig")
+	if err != nil {
+		t.Fatalf("read sig: %v", err)
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+
+	return sig
+}
+
+func TestRunSignsAndVerifies(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	dir := t.TempDir()
+	payload := filepath.Join(dir, "wippy-linux-amd64")
+	contents := []byte("binary contents under test")
+	if err := os.WriteFile(payload, contents, 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	if err := run([]string{payload}, hex.EncodeToString(priv)); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	sig := readSig(t, payload)
+	if !ed25519.Verify(pub, contents, sig) {
+		t.Fatal("signature did not verify against payload")
+	}
+
+	if !ed25519.Verify(readPub(t, dir), contents, sig) {
+		t.Fatal("signature did not verify against published public key")
+	}
+
+	if ed25519.Verify(pub, []byte("tampered"), sig) {
+		t.Fatal("signature verified against tampered contents")
+	}
+}
+
+func TestSeedAndFullKeyMatch(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	fromFull, err := loadKey(hex.EncodeToString(priv))
+	if err != nil {
+		t.Fatalf("load full key: %v", err)
+	}
+
+	fromSeed, err := loadKey(hex.EncodeToString(priv.Seed()))
+	if err != nil {
+		t.Fatalf("load seed key: %v", err)
+	}
+
+	if !fromFull.Equal(fromSeed) {
+		t.Fatal("seed-derived key differs from full key")
+	}
+}
+
+func TestLoadKeyRejectsBadLength(t *testing.T) {
+	if _, err := loadKey(hex.EncodeToString([]byte("too short"))); err == nil {
+		t.Fatal("expected error for invalid key length")
+	}
+}
+
+func TestRunRequiresArgs(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	if err := run(nil, hex.EncodeToString(priv)); err == nil {
+		t.Fatal("expected usage error with no files")
+	}
+}


### PR DESCRIPTION
Adds two GitHub Actions workflows that publish signed \`wippy\` binaries as GitHub Releases, plus a small Ed25519 signer.

## Workflows

### `nightly.yml` — automatic
- Runs daily at **00:00 UTC** (+ manual `workflow_dispatch` with `force`).
- **Skips** when no new commit landed since the last nightly (commit-SHA gate).
- Publishes a **prerelease** tagged `nightly-YYYYMMDD-<shortsha>`; keeps the newest 14.

### `release.yml` — manual (official release)
- `workflow_dispatch` only; run it **from `main`**.
- Inputs: `version` (e.g. `0.2.1`/`v0.2.1`), `prerelease` (default false), `draft` (default false).
- Default run publishes a **non-prerelease** `vX.Y.Z` marked **Latest** (the repo's official releases).
- Validates semver and **fails if the tag/release already exists** (versions are immutable).

## Shared
- Builds natively for **linux amd64/arm64, darwin amd64/arm64, windows amd64** (`make build-wippy-local`; Windows uses the existing msys2/MINGW64 recipe).
- Signs each binary with the **Ed25519 release key** (`tools/signrelease`, detached base64 `.sig`), and publishes `release_key.pub` + `SHA256SUMS`.
- Latest actions/runners: checkout/setup-go v6, upload-artifact v7, download-artifact v8, msys2 v2; runners `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-26`, `macos-26-intel`, `windows-latest`.

## Setup
Repo secret **`RELEASE_SIGNING_KEY`** (Ed25519 hex) — already set.

## Validation
Both workflows were run end-to-end in real CI (temporary triggers, since `workflow_dispatch`/`schedule` only fire from the default branch): all 5 OS/arch built, every `.sig` verified against `release_key.pub`, checksums OK, version stamping confirmed, and the manual run's prerelease left `Latest` untouched. Temporary triggers and all test releases were removed. Local: signer unit tests, `golangci-lint`, `actionlint`, `shellcheck` — all green.

> Note: `.gitignore` rule `.*` ignores `.github/**`, so these files were force-added. Recommend **squash-merge** to drop the temporary-trigger commits from `main`.