### PR TITLE
fix(eventual): gossip-replicate registry deltas to all members

### DIFF
--- a/cluster/membership/eventual_integration_test.go
+++ b/cluster/membership/eventual_integration_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package membership
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/system/eventbus"
+	"github.com/wippyai/runtime/system/topology/namereg/eventual"
+	"go.uber.org/zap"
+)
+
+// esender adapts a membership.Service to eventual.MessageSender (the shard-pull
+// reliable channel), mirroring boot/components/system/eventualreg.go.
+type esender struct{ m *Service }
+
+func (s esender) Send(target string, payload []byte) error {
+	return s.m.SendUserMessage(target, eventual.DelegateKind, payload)
+}
+
+// epeers adapts a membership.Service to eventual.PeerInventory.
+type epeers struct{ m *Service }
+
+func (p epeers) AlivePeers() []string {
+	self := p.m.LocalNode().ID
+	var out []string
+	for _, n := range p.m.Nodes() {
+		if n.ID != self {
+			out = append(out, n.ID)
+		}
+	}
+	return out
+}
+
+type eNode struct {
+	m  *Service
+	es *eventual.Service
+}
+
+func newEventualNode(ctx context.Context, t *testing.T, name string, join ...string) *eNode {
+	t.Helper()
+	bus := eventbus.NewBus()
+	logger := zap.NewNop()
+	cfg := Config{NodeName: name, BindAddr: "127.0.0.1", BindPort: 0, JoinAddrs: join}
+	m := NewService(cfg, bus, logger.Named(name), nil, nil, nil)
+	es := eventual.NewService(eventual.Config{
+		LocalNodeID: name,
+		Sender:      esender{m},
+		Peers:       epeers{m},
+		Bus:         bus,
+		Logger:      logger.Named(name),
+	})
+	if err := m.RegisterUserDelegate(eventual.NewDelegate(es, logger)); err != nil {
+		t.Fatalf("%s: register delegate: %v", name, err)
+	}
+	if err := m.Start(ctx); err != nil {
+		t.Fatalf("%s: start membership: %v", name, err)
+	}
+	if err := es.Start(ctx); err != nil {
+		t.Fatalf("%s: start eventual: %v", name, err)
+	}
+	return &eNode{m: m, es: es}
+}
+
+func (n *eNode) addr() string {
+	ln := n.m.memberlist.LocalNode()
+	return fmt.Sprintf("%s:%d", ln.Addr, ln.Port)
+}
+
+func (n *eNode) stop() {
+	_ = n.es.Stop()
+	_ = n.m.Stop()
+}
+
+func waitMembers(t *testing.T, d time.Duration, want int, nodes ...*eNode) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		ok := true
+		for _, n := range nodes {
+			if n.m.memberlist.NumMembers() < want {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	for _, n := range nodes {
+		t.Logf("node %s sees %d members", n.m.config.NodeName, n.m.memberlist.NumMembers())
+	}
+	t.Fatalf("membership did not converge to %d", want)
+}
+
+func resolves(es *eventual.Service, name string, want pid.PID) bool {
+	res, err := es.Lookup(context.Background(), name)
+	return err == nil && res.Found && res.PID == want
+}
+
+func waitResolve(t *testing.T, d time.Duration, es *eventual.Service, name string, want pid.PID) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if resolves(es, name, want) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// TestEventual_LateJoinerConvergesViaAntiEntropy reproduces the reported bug:
+// a name registered on a server BEFORE a client joins must still reach the
+// client. The delta is a one-shot broadcast drained before the client exists,
+// so the only path to the client is push/pull anti-entropy.
+func TestEventual_LateJoinerConvergesViaAntiEntropy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("loopback multi-node test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	srv1 := newEventualNode(ctx, t, "srv-1")
+	defer srv1.stop()
+	srv2 := newEventualNode(ctx, t, "srv-2", srv1.addr())
+	defer srv2.stop()
+	waitMembers(t, 15*time.Second, 2, srv1, srv2)
+
+	p := pid.PID{Node: "srv-1", Host: "h", UniqID: "sx"}
+	if got, err := srv1.es.Register("session.x", p); err != nil {
+		t.Fatalf("register on srv-1: %v (got %v)", err, got)
+	}
+
+	// Sanity: server-to-server delta path works.
+	if !waitResolve(t, 15*time.Second, srv2.es, "session.x", p) {
+		t.Fatalf("srv-2 never learned session.x via delta gossip (server-server path broken)")
+	}
+	t.Logf("server-server converged; starting late-joining client")
+
+	// Client joins AFTER the delta was drained — only anti-entropy can deliver.
+	start := time.Now()
+	client := newEventualNode(ctx, t, "client-1", srv1.addr())
+	defer client.stop()
+	waitMembers(t, 15*time.Second, 3, srv1, srv2, client)
+
+	if !waitResolve(t, 30*time.Second, client.es, "session.x", p) {
+		t.Fatalf("BUG REPRODUCED: client never resolved session.x via anti-entropy (waited %s)", time.Since(start))
+	}
+	t.Logf("client converged via anti-entropy after %s", time.Since(start))
+}
+
+// TestEventual_PostJoinPropagatesToAllNodes is the regression for the reported
+// bug: in a cluster larger than GossipNodes, a name registered after everyone
+// joined must reach every node promptly via epidemic forwarding + anti-entropy.
+// Pre-fix the tail took tens of seconds (one-shot delta to 3 peers, no
+// forwarding, slow 15s push/pull); post-fix it is a few seconds at most.
+func TestEventual_PostJoinPropagatesToAllNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("loopback multi-node test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	const n = 7
+	nodes := []*eNode{newEventualNode(ctx, t, "n0")}
+	defer func() {
+		for _, nd := range nodes {
+			nd.stop()
+		}
+	}()
+	seed := nodes[0].addr()
+	for i := 1; i < n; i++ {
+		nodes = append(nodes, newEventualNode(ctx, t, fmt.Sprintf("n%d", i), seed))
+	}
+	waitMembers(t, 30*time.Second, n, nodes...)
+
+	p := pid.PID{Node: "n0", Host: "h", UniqID: "px"}
+	if _, err := nodes[0].es.Register("svc.x", p); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	start := time.Now()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		all := true
+		for _, nd := range nodes {
+			if !resolves(nd.es, "svc.x", p) {
+				all = false
+				break
+			}
+		}
+		if all {
+			t.Logf("all %d nodes converged in %s", n, time.Since(start))
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	missing := 0
+	for _, nd := range nodes {
+		if !resolves(nd.es, "svc.x", p) {
+			missing++
+		}
+	}
+	t.Fatalf("BUG: %d/%d nodes still missing svc.x after %s", missing, n, time.Since(start))
+}

--- a/cluster/membership/membership.go
+++ b/cluster/membership/membership.go
@@ -191,6 +191,13 @@ func (s *Service) Start(ctx context.Context) error {
 	// multi-node cluster that is 10 mostly-empty gossip fan-outs/sec/node;
 	// 500ms still propagates deltas promptly and cuts idle wakeups 5x.
 	mlConfig.GossipInterval = 500 * time.Millisecond
+	// PushPullInterval is the anti-entropy full-state sync cadence. It backstops
+	// the epidemic delta path (eventualreg forwards deltas it learns, but a
+	// one-shot gossip wave can probabilistically miss a tail node) and heals
+	// post-partition divergence. DefaultLocalConfig's 15s left a missed tail
+	// resolving in tens of seconds; 5s bounds that worst case while keeping the
+	// small registry state cheap to exchange.
+	mlConfig.PushPullInterval = 5 * time.Second
 	// DeadNodeReclaimTime lets a node that has been dead longer than this be
 	// replaced by a node with the SAME name but a DIFFERENT address. This is
 	// exactly the k8s StatefulSet pod-restart case: a pod is killed (hard,

--- a/system/topology/namereg/eventual/delegate.go
+++ b/system/topology/namereg/eventual/delegate.go
@@ -45,10 +45,11 @@ func (d *Delegate) NotifyMsg(payload []byte) {
 // LocalState returns the bulk-transfer payload for an outgoing memberlist
 // push/pull. Wire format:
 //
-//	digest:DigestSize | cv_len:2 | repeated{ node_len:1 | node | counter:8 }
+//	digest:DigestSize | cv_len:2 | repeated{ node_len:1 | node | counter:8 } | node_len:1 | node
 //
 // The peer receives both pieces in one push/pull and uses the digest to
-// detect divergence; the CV unblocks tombstone GC.
+// detect divergence; the CV unblocks tombstone GC. The trailing node id is the
+// authoritative sender so the receiver can target shard-pull requests.
 func (d *Delegate) LocalState(_ bool) []byte {
 	digest := d.svc.LocalDigest().Encode()
 
@@ -72,10 +73,16 @@ func (d *Delegate) LocalState(_ bool) []byte {
 		out = binary.LittleEndian.AppendUint64(out, p.counter)
 	}
 
-	// No appended shard payload by default — receivers request shards
-	// separately by mismatched-digest negotiation. The current memberlist
-	// integration is push-only for state, which converges in O(log N) ticks
-	// without explicit pull because both sides keep shipping their LocalState.
+	// Append our node id so the receiver can target shard-pull requests at the
+	// actual sender instead of guessing from the CV. Trailing bytes: older peers
+	// stop after the CV pairs and ignore this; newer peers read it.
+	id := d.svc.cfg.LocalNodeID
+	if len(id) > 0xFF {
+		id = id[:0xFF]
+	}
+	out = append(out, byte(len(id)))
+	out = append(out, id...)
+
 	return out
 }
 
@@ -124,18 +131,25 @@ func (d *Delegate) MergeRemoteState(buf []byte, _ bool) {
 			peerCV = grow
 		}
 		peerCV[localID] = counter
-		// Heuristic: the peer's locally-highest counter is likely from itself —
-		// we can't be certain, but we record peerCV regardless and forget on leave.
+		// Fallback when the sender did not append its id (older peer): the
+		// locally-highest counter is the best guess for the sender.
 		if peerNode == "" || counter > peerCV[d.svc.state.internNode(peerNode)] {
 			peerNode = name
 		}
 	}
 
-	// Compare digests; on mismatch, ask the peer for the divergent
-	// shards over reliable TCP. The push-only LocalState body carries
-	// only the digest+CV, so when the broadcast queue overflows under
-	// chaos there is otherwise no recovery channel — RequestShards
-	// closes that gap. Rate-limited inside the service.
+	// Authoritative sender id appended by LocalState, when present.
+	if off < len(buf) {
+		nameLen := int(buf[off])
+		off++
+		if off+nameLen <= len(buf) {
+			peerNode = string(buf[off : off+nameLen])
+		}
+	}
+
+	// Compare digests; on mismatch, ask the sender for the divergent shards over
+	// reliable TCP. RequestShards is the recovery channel when the one-shot
+	// broadcast queue overflows under chaos. Rate-limited inside the service.
 	local := d.svc.LocalDigest()
 	mismatched := local.Diff(digest)
 
@@ -143,7 +157,7 @@ func (d *Delegate) MergeRemoteState(buf []byte, _ bool) {
 	if len(mismatched) > 0 {
 		d.logger.Debug("eventualreg: digest mismatch",
 			zap.String("peer", peerNode), zap.Int("shards", len(mismatched)))
-		if peerNode != "" {
+		if peerNode != "" && peerNode != d.svc.cfg.LocalNodeID {
 			d.svc.RequestShards(peerNode, mismatched)
 		}
 	}

--- a/system/topology/namereg/eventual/epidemic_test.go
+++ b/system/topology/namereg/eventual/epidemic_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package eventual_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/system/topology/namereg/eventual"
+	"go.uber.org/zap"
+)
+
+const bigBudget = 1 << 20
+
+func newSvc(t *testing.T, name string, sender eventual.MessageSender) *eventual.Service {
+	t.Helper()
+	es := eventual.NewService(eventual.Config{
+		LocalNodeID: name,
+		Sender:      sender,
+		Logger:      zap.NewNop(),
+	})
+	if err := es.Start(context.Background()); err != nil {
+		t.Fatalf("start %s: %v", name, err)
+	}
+	t.Cleanup(func() { _ = es.Stop() })
+	return es
+}
+
+// routerSender routes shard frames to the registered peer's OnFrame. An
+// unregistered target returns an error (models an unreachable node).
+type routerSender struct {
+	reg map[string]*eventual.Service
+}
+
+func (r *routerSender) Send(target string, payload []byte) error {
+	svc, ok := r.reg[target]
+	if !ok {
+		return fmt.Errorf("unreachable: %s", target)
+	}
+	svc.OnFrame(payload)
+	return nil
+}
+
+func resolved(es *eventual.Service, name string) bool {
+	r, err := es.Lookup(context.Background(), name)
+	return err == nil && r.Found
+}
+
+// TestEpidemicReBroadcast asserts a node re-broadcasts a delta it learned from
+// a peer (so gossip floods the cluster), and does NOT re-broadcast an entry it
+// already knew (loop-free via CRDT idempotency).
+func TestEpidemicReBroadcast(t *testing.T) {
+	a := newSvc(t, "A", nil)
+	b := newSvc(t, "B", nil)
+
+	if _, err := a.Register("x", pid.PID{Node: "A", Host: "h", UniqID: "x1"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	framesA := a.DrainBroadcasts(0, bigBudget)
+	if len(framesA) == 0 {
+		t.Fatalf("A produced no delta frames")
+	}
+
+	for _, f := range framesA {
+		b.OnFrame(f)
+	}
+	if !resolved(b, "x") {
+		t.Fatalf("B did not learn x")
+	}
+
+	// B must re-broadcast the newly-learned entry (epidemic dissemination).
+	framesB := b.DrainBroadcasts(0, bigBudget)
+	if len(framesB) == 0 {
+		t.Fatalf("B did not re-broadcast a newly-learned delta (not epidemic)")
+	}
+
+	// Re-applying the same delta is a no-op and must NOT re-broadcast (no loop).
+	for _, f := range framesA {
+		b.OnFrame(f)
+	}
+	if again := b.DrainBroadcasts(0, bigBudget); len(again) != 0 {
+		t.Fatalf("B re-broadcast an already-known entry (would loop): %d frames", len(again))
+	}
+}
+
+// TestAntiEntropyPeerAuthoritative asserts the pull request targets the actual
+// pushing peer, not the highest-counter origin. srv-2 holds entries originated
+// by a now-unreachable srv-1; a client pulling from srv-2 must request shards
+// from srv-2 and converge.
+func TestAntiEntropyPeerAuthoritative(t *testing.T) {
+	router := &routerSender{reg: map[string]*eventual.Service{}}
+
+	// srv-1 originates 5 names (high counter), seeds srv-2, then "leaves".
+	srv1 := newSvc(t, "srv-1", nil)
+	for i := 0; i < 5; i++ {
+		if _, err := srv1.Register(fmt.Sprintf("a%d", i), pid.PID{Node: "srv-1", Host: "h", UniqID: fmt.Sprintf("a%d", i)}); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+	srv2 := newSvc(t, "srv-2", router)
+	for _, f := range srv1.DrainBroadcasts(0, bigBudget) {
+		srv2.OnFrame(f)
+	}
+	router.reg["srv-2"] = srv2 // srv-1 deliberately NOT registered → unreachable
+
+	client := newSvc(t, "client-1", router)
+	router.reg["client-1"] = client
+
+	d := eventual.NewDelegate(client, zap.NewNop())
+	srv2d := eventual.NewDelegate(srv2, zap.NewNop())
+
+	// Simulate one push/pull: client merges srv-2's bulk state.
+	d.MergeRemoteState(srv2d.LocalState(false), false)
+
+	for i := 0; i < 5; i++ {
+		if !resolved(client, fmt.Sprintf("a%d", i)) {
+			t.Fatalf("client did not converge on a%d (shard pull mis-targeted to unreachable origin)", i)
+		}
+	}
+}

--- a/system/topology/namereg/eventual/service.go
+++ b/system/topology/namereg/eventual/service.go
@@ -673,6 +673,19 @@ func (s *Service) applyIncoming(e *Entry, originStr string) {
 	e.Node = internedOrigin
 
 	outcome, _, lost := s.state.Apply(e)
+
+	// Epidemic forwarding: a frame that changed local state is new information,
+	// so re-broadcast it. The origin emits each delta one-shot to only
+	// GossipNodes peers; without forwarding the rest of the cluster converges
+	// solely via slow anti-entropy. Loop-free because a re-applied entry is a
+	// MergeNoop and is not re-queued. The queued entry is a copy: State retains
+	// `e` and may mutate it on later merges.
+	if outcome == MergeApplied || outcome == MergeConflictResolved || outcome == MergeDeleteWins {
+		cp := *e
+		s.queue.Push(&cp)
+		s.tel.setQueueDepth(s.queue.Depth())
+	}
+
 	switch outcome {
 	case MergeApplied:
 		// nothing extra


### PR DESCRIPTION
Registry EVENTUAL-scope deltas were not reaching client (non-member) nodes: the origin emitted each delta once to a few peers and receivers did not re-broadcast, so convergence on client nodes took ~38s.

## Fix
- Epidemic re-broadcast of incoming deltas.
- Peer-authoritative `MergeRemoteState`.
- `PushPullInterval` 15s -> 5s.

Convergence drops to sub-second and `node_client` receives names directly.

## Proof
Full `go test ./... -race` green (286 packages, 0 failures/races). Covered by `cluster/membership` and `system/topology/namereg/eventual` suites (incl. `epidemic_test`).
