### PR TITLE
fix(cmd): auto-run sole pack command when none is marked main

### DIFF
--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -31,8 +32,15 @@ import (
 var hubModulePattern = regexp.MustCompile(`^([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)(?:@(.+))?$`)
 var hubIdentPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
+type packCommand struct {
+	name    string
+	entryID string
+	main    bool
+}
+
 // findPackCommand finds a command entry in the pack.
-// If commandName is empty, it only auto-selects a command marked as main.
+// If commandName is empty, it auto-selects the command marked as main, or the
+// only command when the pack defines exactly one.
 func findPackCommand(ctx context.Context, commandName string) (string, error) {
 	reg := registry.GetRegistry(ctx)
 	if reg == nil {
@@ -44,11 +52,7 @@ func findPackCommand(ctx context.Context, commandName string) (string, error) {
 		return "", fmt.Errorf("failed to query registry for pack commands: %w", err)
 	}
 
-	var commands []struct {
-		name    string
-		entryID string
-		main    bool
-	}
+	var commands []packCommand
 
 	for _, e := range allEntries {
 		if !isProcessKind(e.Kind) {
@@ -60,21 +64,13 @@ func findPackCommand(ctx context.Context, commandName string) (string, error) {
 			continue
 		}
 
-		commands = append(commands, struct {
-			name    string
-			entryID string
-			main    bool
-		}{name: cmdMeta.Name, entryID: e.ID.String(), main: cmdMeta.Main})
+		commands = append(commands, packCommand{name: cmdMeta.Name, entryID: e.ID.String(), main: cmdMeta.Main})
 	}
 
 	return selectPackCommand(commands, commandName)
 }
 
-func selectPackCommand(commands []struct {
-	name    string
-	entryID string
-	main    bool
-}, commandName string) (string, error) {
+func selectPackCommand(commands []packCommand, commandName string) (string, error) {
 	if len(commands) == 0 {
 		return "", nil
 	}
@@ -99,10 +95,20 @@ func selectPackCommand(commands []struct {
 	}
 
 	switch len(mainCommands) {
-	case 0:
-		return "", nil
 	case 1:
 		return mainEntryID, nil
+	case 0:
+		if len(commands) == 1 {
+			return commands[0].entryID, nil
+		}
+
+		names := make([]string, len(commands))
+		for i, c := range commands {
+			names[i] = c.name
+		}
+
+		sort.Strings(names)
+		return "", fmt.Errorf("no command is marked as main; specify one of: %s", strings.Join(names, ", "))
 	default:
 		return "", fmt.Errorf("multiple commands marked as main in pack: %s", strings.Join(mainCommands, ", "))
 	}

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -149,6 +149,76 @@ func TestIsHubModuleRef_WithUppercaseWappExtension(t *testing.T) {
 	}
 }
 
+func TestSelectPackCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandName string
+		wantEntry   string
+		wantErr     string
+		commands    []packCommand
+	}{
+		{name: "no commands", commands: nil, wantEntry: ""},
+		{
+			name:        "explicit name match",
+			commands:    []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
+			commandName: "edit",
+			wantEntry:   "snake:edit",
+		},
+		{
+			name:        "explicit name missing",
+			commands:    []packCommand{{name: "snake", entryID: "snake:play"}},
+			commandName: "nope",
+			wantErr:     `command "nope" not found in pack`,
+		},
+		{
+			name:      "single command without main auto-runs",
+			commands:  []packCommand{{name: "snake", entryID: "snake:play"}},
+			wantEntry: "snake:play",
+		},
+		{
+			name:      "single command with main auto-runs",
+			commands:  []packCommand{{name: "snake", entryID: "snake:play", main: true}},
+			wantEntry: "snake:play",
+		},
+		{
+			name:      "multiple commands one main",
+			commands:  []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit", main: true}},
+			wantEntry: "snake:edit",
+		},
+		{
+			name:     "multiple commands no main errors with sorted names",
+			commands: []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
+			wantErr:  "no command is marked as main; specify one of: edit, snake",
+		},
+		{
+			name:     "multiple main commands error",
+			commands: []packCommand{{name: "snake", entryID: "snake:play", main: true}, {name: "edit", entryID: "snake:edit", main: true}},
+			wantErr:  "multiple commands marked as main in pack: snake, edit",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectPackCommand(tc.commands, tc.commandName)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("selectPackCommand error = %v, want %q", err, tc.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("selectPackCommand unexpected error: %v", err)
+			}
+
+			if got != tc.wantEntry {
+				t.Fatalf("selectPackCommand = %q, want %q", got, tc.wantEntry)
+			}
+		})
+	}
+}
+
 func TestBootstrapPackRuntimeWithDefaults_Harness(t *testing.T) {
 	t.Run("applies runtime defaults when config key is missing", func(t *testing.T) {
 		tmpDir := t.TempDir()


### PR DESCRIPTION
## Why
`wippy run <org>/<module>` silently launched nothing when a pack defined commands but none was marked `main: true`. This regressed in #191, which replaced the prior "run the only/first command" behavior with "only auto-select a `main` command, else return `("", nil)`". Single-command apps published before that convention (e.g. `wolfy-j/snake`) now boot the runtime and idle — no command runs, no error printed.

## What
`selectPackCommand`:
- runs the **only** command when a pack defines exactly one and none is marked `main`;
- for **multi-command** packs with no `main`, returns a clear error instead of doing nothing:
  `no command is marked as main; specify one of: ...`.

Also extracts the thrice-repeated anonymous struct into a named `packCommand` type and adds `TestSelectPackCommand` (8 cases).

## Proof
Before (this branch's parent), bare invocation does nothing; after, it runs:

```
$ wippy run wolfy-j/snake          # single command "snake", not marked main
# before: runtime boots, terminal host idles, no game, no error
# after:  snake board renders and is playable
```

Local validation (darwin/arm64, built with `--tags "fts5 sqlite_vec treesitter"`):
- `go test ./cmd/...` — pass
- `golangci-lint run` (v2.8.0) on the package — 0 issues
- `gofmt`/`go vet` — clean
- end-to-end: bare `wippy run wolfy-j/snake` renders the game (board, score, GAME OVER), zero errors
