### PR TITLE
fix(lua/types): drop phantom methods from stream/future manifests

### DIFF
--- a/runtime/lua/modules/funcs/manifest_consistency_test.go
+++ b/runtime/lua/modules/funcs/manifest_consistency_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package funcs_test
+
+import (
+	"testing"
+
+	"github.com/wippyai/go-lua/types/typ"
+	"github.com/wippyai/runtime/runtime/lua/modules/funcs"
+	"github.com/wippyai/runtime/runtime/lua/modules/future"
+)
+
+// TestFutureManifestMatchesRegisteredMethods proves the funcs.Future type manifest
+// and the methods the future package actually registers describe the same set.
+//
+// The Future type is declared in the funcs package's manifest, but its methods are
+// registered in the separate future package. A method present in the manifest but
+// absent from future.Methods is a phantom: the type system advertises
+// Future:<method>, but the runtime never registers it, so calling it fails.
+func TestFutureManifestMatchesRegisteredMethods(t *testing.T) {
+	target, ok := funcs.ModuleTypes().LookupType("Future")
+	if !ok {
+		t.Fatal("Future type not found in funcs manifest")
+	}
+
+	iface, ok := target.(*typ.Interface)
+	if !ok {
+		t.Fatalf("Future manifest type is %T, want *typ.Interface", target)
+	}
+
+	registered := future.Methods
+
+	manifest := make(map[string]bool, len(iface.Methods))
+	for _, m := range iface.Methods {
+		manifest[m.Name] = true
+		if _, found := registered[m.Name]; !found {
+			t.Errorf("funcs.Future manifest declares %q but the future package does not register it (phantom method; calling it fails at runtime)", m.Name)
+		}
+	}
+
+	for name := range registered {
+		if !manifest[name] {
+			t.Errorf("future package registers %q but the funcs.Future manifest omits it (undocumented method)", name)
+		}
+	}
+}

--- a/runtime/lua/modules/funcs/types.go
+++ b/runtime/lua/modules/funcs/types.go
@@ -16,7 +16,6 @@ var futureType = typ.NewInterface("funcs.Future", []typ.Method{
 	{Name: "result", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "error", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(typ.LuaError), typ.Boolean).Build()},
 	{Name: "cancel", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
-	{Name: "await", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 })
 
 // Forward declaration for self-referential Executor type

--- a/runtime/lua/modules/future/future.go
+++ b/runtime/lua/modules/future/future.go
@@ -20,16 +20,21 @@ const TypeName = "Future"
 // This avoids circular dependency while allowing cancel to be called.
 var CancelFunc func(l *lua.LState) int
 
+// Methods is the set of Lua methods registered on the Future type. Exported so
+// the type manifest (funcs.Future in the funcs package) can be checked against the
+// methods the runtime actually registers.
+var Methods = map[string]lua.LGoFunc{
+	"response":    futureResponse,
+	"channel":     futureResponse, // alias for backwards compatibility
+	"is_complete": futureIsComplete,
+	"is_canceled": futureIsCanceled,
+	"result":      futureResult,
+	"error":       futureError,
+	"cancel":      futureCancel,
+}
+
 func init() {
-	value.RegisterTypeMethods(nil, TypeName, nil, map[string]lua.LGoFunc{
-		"response":    futureResponse,
-		"channel":     futureResponse, // alias for backwards compatibility
-		"is_complete": futureIsComplete,
-		"is_canceled": futureIsCanceled,
-		"result":      futureResult,
-		"error":       futureError,
-		"cancel":      futureCancel,
-	})
+	value.RegisterTypeMethods(nil, TypeName, nil, Methods)
 }
 
 // futureCancel delegates to CancelFunc if set.

--- a/runtime/lua/modules/stream/manifest_consistency_test.go
+++ b/runtime/lua/modules/stream/manifest_consistency_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package stream
+
+import "testing"
+
+// TestManifestMethodsAreRegistered proves the stream type manifest (StreamType,
+// the typ.Interface exposed to the type system / docs) and the actually-registered
+// Lua method table (streamMethods) describe the same method set.
+//
+// A method present in the manifest but absent from streamMethods is a "phantom":
+// the type system advertises Stream:<method>, but the runtime never registers it,
+// so calling it errors at runtime. That makes the manifest a stale, false
+// description of the implementation.
+func TestManifestMethodsAreRegistered(t *testing.T) {
+	registered := make(map[string]bool, len(streamMethods))
+	for name := range streamMethods {
+		registered[name] = true
+	}
+
+	manifest := make(map[string]bool, len(StreamType.Methods))
+	for _, m := range StreamType.Methods {
+		manifest[m.Name] = true
+		if !registered[m.Name] {
+			t.Errorf("manifest declares Stream:%s but it is NOT registered in streamMethods (phantom method; calling it fails at runtime)", m.Name)
+		}
+	}
+
+	for name := range streamMethods {
+		if !manifest[name] {
+			t.Errorf("streamMethods registers Stream:%s but the manifest omits it (undocumented method)", name)
+		}
+	}
+}

--- a/runtime/lua/modules/stream/types.go
+++ b/runtime/lua/modules/stream/types.go
@@ -10,7 +10,6 @@ import (
 // StreamType is exported for use by other modules (fs, http).
 var StreamType = typ.NewInterface("stream.Stream", []typ.Method{
 	{Name: "read", Type: typ.Func().Param("self", typ.Self).OptParam("n", typ.Number).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
-	{Name: "read_all", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "write", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Number, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "seek", Type: typ.Func().Param("self", typ.Self).OptParam("whence", typ.String).OptParam("offset", typ.Number).Returns(typ.Number, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "flush", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},


### PR DESCRIPTION
## Problem

Two Lua type manifests declare methods the runtime never registers — "phantom" methods. The type system and generated docs advertise `Stream:read_all` and `Future:await`, but calling them fails at runtime because they are not in the registered method tables.

- `stream.StreamType` (manifest) lists 8 methods incl. `read_all`; `streamMethods` (registration) has 7 — no `read_all`.
- `funcs.futureType` (manifest) lists 8 methods incl. `await`; the `future` package registers 7 — no `await`.

## Proof (TDD)

Added consistency tests that compare each type manifest to the actually-registered method set. They fail on the current manifests:

```
manifest declares Stream:read_all but it is NOT registered in streamMethods (phantom method)
funcs.Future manifest declares "await" but the future package does not register it (phantom method)
```

## Fix

- Remove `read_all` from `stream.StreamType` and `await` from `funcs.futureType`.
- Expose `future.Methods` so the `funcs.Future` manifest can be checked against the registration (the Future type is declared in `funcs` but registered in `future`, which is how it drifted).
- Tests now pass; existing module/manifest tests unaffected.

## Follow-ups (found during a docs audit; manifests stale vs impl, docs already match impl)

- `security`: `can`/`scope:evaluate`/`policy:evaluate` manifest param order `(resource, action)` is reversed vs impl `(action, resource)`.
- `events`: `send` manifest signature `(source, event_type, payload)` vs impl `(system, kind, path, data)`.
- `registry`: `build_delta` manifest params typed `versionType`; impl takes entry-table arrays.
- `http`: `ERROR` constants registered but missing from manifest; `parse_multipart` missing the optional `maxMemory` param.
- `websocket`: `close`/`receive` manifest returns don't match impl.
- `sql`: `as.*` set and builder-condition params stale in manifest.
- `html`: `on_elements`/`globally` manifest return `Self` but impl returns the Policy.
- `ctx`/`yaml`/`logger`: params typed `Any` but impl enforces a concrete type.