### PR TITLE
ci(release): add required description input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
         description: 'Release version, e.g. 0.2.1 or v0.2.1'
         type: string
         required: true
+      description:
+        description: 'Release notes summary (shown at the top of the release and hub changelog)'
+        type: string
+        required: true
       prerelease:
         description: 'Mark as prerelease (does not become Latest)'
         type: boolean
@@ -206,16 +210,23 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
-          sha256sum $(ls wippy-* | grep -v '\.sig$') > SHA256SUMS
+          files=()
+          for f in wippy-*; do
+            [ "${f%.sig}" = "$f" ] && files+=("$f")
+          done
+          sha256sum "${files[@]}" > SHA256SUMS
 
       - name: Release notes
         env:
           PREV_TAG: ${{ needs.validate.outputs.prev_tag }}
           TAG: ${{ needs.validate.outputs.tag }}
+          DESCRIPTION: ${{ inputs.description }}
         run: |
           set -euo pipefail
           {
             echo "## ${TAG}"
+            echo
+            printf '%s\n' "$DESCRIPTION"
             echo
             echo "Commit: ${GITHUB_SHA}"
             echo


### PR DESCRIPTION
## Why

The manual release dispatch only accepted a `version`. The release body and the hub changelog were generated purely from git history, so there was no way to add a human-written summary of what a release is about.

## What

- Add a **required** `description` input to the `workflow_dispatch` form, alongside `version`.
- Prepend it as a summary in `release-notes.md`, between the `## <tag>` title and the `Commit:` line. That single file feeds **both** the GitHub release body (`--notes-file`) and the hub changelog (`CHANGELOG` -> `tools/hubpublish`), so the description reaches both.
- Passed via the step `env:` and emitted with `printf '%s\n' "$DESCRIPTION"`, so the text is verbatim and injection-safe.
- Rewrote the adjacent checksums step (`sha256sum $(ls wippy-* | grep -v '.sig$')`) as a glob loop to clear shellcheck SC2010/SC2046; output is byte-identical.

## Verification (local)

- `actionlint` (Docker): clean, exit 0.
- Checksums rewrite: `diff` of old vs new `SHA256SUMS` is identical; `.sig` files excluded.
- Release notes: simulated with a description containing backticks, `*`, `$HOME`, `&` — placed correctly and emitted verbatim (no shell expansion).
- `hubpublish` dry-run: the description lands verbatim in the payload `changelog` field; `.sig` files excluded from assets.

## Note

A `workflow_dispatch` `type: string` input is single-line in the GitHub UI, so the summary is a single line. Multi-line would require a different mechanism (out of scope).