### PR TITLE
feat(release): auto-generate release description via OpenAI when none given

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ on:
         type: string
         required: true
       description:
-        description: 'Release notes summary (shown at the top of the release and hub changelog)'
+        description: 'Release notes summary (shown at the top of the release and hub changelog). Leave blank to auto-generate from the commit log.'
         type: string
-        required: true
+        required: false
       prerelease:
         description: 'Mark as prerelease (does not become Latest)'
         type: boolean
@@ -216,11 +216,36 @@ jobs:
           done
           sha256sum "${files[@]}" > SHA256SUMS
 
+      - name: Resolve description
+        env:
+          DESCRIPTION_INPUT: ${{ inputs.description }}
+          PREV_TAG: ${{ needs.validate.outputs.prev_tag }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DESCRIPTION_INPUT//[[:space:]]/}" ]; then
+            description="$DESCRIPTION_INPUT"
+          else
+            if [ -n "$PREV_TAG" ]; then
+              commits="$(git log --pretty='- %h %s' "${PREV_TAG}..HEAD")"
+            else
+              commits="$(git log --pretty='- %h %s' -n 50 HEAD)"
+            fi
+            description="$(printf '%s\n' "$commits" | RELEASE_TAG="$TAG" go run ./tools/gendesc)"
+          fi
+          printf '%s' "$description" > description.txt
+          {
+            echo "DESCRIPTION<<__GENDESC_EOF__"
+            printf '%s\n' "$description"
+            echo "__GENDESC_EOF__"
+          } >> "$GITHUB_ENV"
+
       - name: Release notes
         env:
           PREV_TAG: ${{ needs.validate.outputs.prev_tag }}
           TAG: ${{ needs.validate.outputs.tag }}
-          DESCRIPTION: ${{ inputs.description }}
         run: |
           set -euo pipefail
           {
@@ -269,4 +294,4 @@ jobs:
           HUB_URL: ${{ vars.HUB_URL }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
           PRERELEASE: ${{ inputs.prerelease }}
-        run: CHANGELOG="$(cat release-notes.md)" go run ./tools/hubpublish dist/wippy-*
+        run: CHANGELOG="$(cat description.txt)" go run ./tools/hubpublish dist/wippy-*

--- a/tools/gendesc/main.go
+++ b/tools/gendesc/main.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Command gendesc turns a release commit list (read from stdin) into a short,
+// plain-English release summary using the OpenAI Responses API. The release
+// workflow uses it to fill the release description when a human did not provide
+// one. It prints the summary to stdout and fails loudly on any error so a
+// release never ships an empty changelog.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://api.openai.com/v1"
+	defaultModel   = "gpt-5.4-mini"
+	maxLen         = 280
+	maxTokens      = 160
+	instructions   = "Write a one-line, plain-English release summary of these commits, at most two short sentences and under 280 characters. " +
+		"No headings, no commit hashes, no markdown, no bullet lists, no trailing newline. " +
+		"Highlight user-facing features and fixes; ignore dependency bumps, CI, and docs-only changes."
+)
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+var httpClient httpDoer = &http.Client{Timeout: 60 * time.Second}
+
+type request struct {
+	Model           string `json:"model"`
+	Instructions    string `json:"instructions"`
+	Input           string `json:"input"`
+	MaxOutputTokens int    `json:"max_output_tokens"`
+}
+
+type response struct {
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	Output []struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"output"`
+}
+
+func buildRequestBody(model, input string) ([]byte, error) {
+	return json.Marshal(request{Model: model, Instructions: instructions, Input: input, MaxOutputTokens: maxTokens})
+}
+
+func parseResponse(body []byte) (string, error) {
+	var r response
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+
+	if r.Error != nil {
+		return "", fmt.Errorf("openai error: %s", r.Error.Message)
+	}
+
+	var b strings.Builder
+	for _, out := range r.Output {
+		for _, c := range out.Content {
+			if c.Type == "output_text" {
+				b.WriteString(c.Text)
+			}
+		}
+	}
+
+	text := strings.TrimSpace(b.String())
+	if text == "" {
+		return "", errors.New("openai returned no text")
+	}
+
+	return text, nil
+}
+
+func baseURL() string {
+	if v := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+
+	return defaultBaseURL
+}
+
+func normalize(s string) string {
+	collapsed := strings.Join(strings.Fields(s), " ")
+	if len(collapsed) <= maxLen {
+		return collapsed
+	}
+
+	cut := collapsed[:maxLen]
+	if i := strings.LastIndex(cut, " "); i > 0 {
+		cut = cut[:i]
+	}
+
+	return strings.ToValidUTF8(strings.TrimRight(cut, " "), "")
+}
+
+func generate(apiKey, model, input string) (string, error) {
+	body, err := buildRequestBody(model, input)
+	if err != nil {
+		return "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL()+"/responses", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("openai responded %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	text, err := parseResponse(respBody)
+	if err != nil {
+		return "", err
+	}
+
+	return normalize(text), nil
+}
+
+func run() error {
+	apiKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	if apiKey == "" {
+		return errors.New("OPENAI_API_KEY is required")
+	}
+
+	model := strings.TrimSpace(os.Getenv("OPENAI_MODEL"))
+	if model == "" {
+		model = defaultModel
+	}
+
+	stdin, err := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read stdin: %w", err)
+	}
+
+	input := strings.TrimSpace(string(stdin))
+	if input == "" {
+		return errors.New("no commit list on stdin")
+	}
+
+	if tag := strings.TrimSpace(os.Getenv("RELEASE_TAG")); tag != "" {
+		input = "Release " + tag + "\n\n" + input
+	}
+
+	text, err := generate(apiKey, model, input)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(text)
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "gendesc:", err)
+		os.Exit(1)
+	}
+}

--- a/tools/gendesc/main_test.go
+++ b/tools/gendesc/main_test.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+type fakeDoer struct {
+	resp *http.Response
+	err  error
+	got  *http.Request
+}
+
+func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	f.got = req
+	return f.resp, f.err
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func withClient(t *testing.T, d httpDoer) {
+	t.Helper()
+	prev := httpClient
+	httpClient = d
+	t.Cleanup(func() { httpClient = prev })
+}
+
+func outputJSON(text string) string {
+	return `{"output":[{"content":[{"type":"output_text","text":` + quote(text) + `}]}]}`
+}
+
+func quote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func TestBuildRequestBody(t *testing.T) {
+	body, err := buildRequestBody("gpt-5.4-mini", "- a1 feat: thing")
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+
+	var r request
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if r.Model != "gpt-5.4-mini" {
+		t.Errorf("model = %q", r.Model)
+	}
+	if r.Input != "- a1 feat: thing" {
+		t.Errorf("input = %q", r.Input)
+	}
+	if !strings.Contains(r.Instructions, "two short sentences") {
+		t.Errorf("instructions missing guidance: %q", r.Instructions)
+	}
+	if r.MaxOutputTokens != maxTokens {
+		t.Errorf("max_output_tokens = %d want %d", r.MaxOutputTokens, maxTokens)
+	}
+}
+
+func TestParseResponse(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{"single", outputJSON("Hello world"), "Hello world", false},
+		{
+			name: "multi_segment",
+			body: `{"output":[{"content":[{"type":"output_text","text":"Hello "},` +
+				`{"type":"output_text","text":"world"}]}]}`,
+			want: "Hello world",
+		},
+		{
+			name: "ignores_non_text",
+			body: `{"output":[{"content":[{"type":"reasoning","text":"think"},` +
+				`{"type":"output_text","text":"final"}]}]}`,
+			want: "final",
+		},
+		{"api_error", `{"error":{"message":"bad key"}}`, "", true},
+		{"no_text", `{"output":[{"content":[{"type":"reasoning","text":"x"}]}]}`, "", true},
+		{"empty_text", outputJSON("   "), "", true},
+		{"malformed", `{not json`, "", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseResponse([]byte(c.body))
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"  hello   world \n", "hello world"},
+		{"line one\nline two", "line one line two"},
+		{"a\t\tb", "a b"},
+		{strings.Repeat("x", maxLen+50), strings.Repeat("x", maxLen)},
+		{strings.Repeat("word ", 100), strings.TrimRight(strings.Repeat("word ", maxLen/5), " ")},
+	}
+
+	for _, c := range cases {
+		got := normalize(c.in)
+		if got != c.want {
+			t.Errorf("normalize(%.20q...) = %q (len %d) want %q (len %d)", c.in, got, len(got), c.want, len(c.want))
+		}
+		if len(got) > maxLen {
+			t.Errorf("normalize exceeded maxLen: %d", len(got))
+		}
+	}
+}
+
+func TestNormalizeValidUTF8OnCut(t *testing.T) {
+	got := normalize("x" + strings.Repeat("é", maxLen))
+	if len(got) > maxLen {
+		t.Errorf("len %d > maxLen", len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("normalize produced invalid UTF-8: %q", got)
+	}
+}
+
+func TestBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"":                            defaultBaseURL,
+		"https://gw.example.com/v1":   "https://gw.example.com/v1",
+		"https://gw.example.com/v1/":  "https://gw.example.com/v1",
+		"https://gw.example.com/v1//": "https://gw.example.com/v1",
+	}
+	for in, want := range cases {
+		t.Setenv("OPENAI_BASE_URL", in)
+		if got := baseURL(); got != want {
+			t.Errorf("baseURL(%q) = %q want %q", in, got, want)
+		}
+	}
+}
+
+func TestGenerateSuccess(t *testing.T) {
+	resp := jsonResponse(200, outputJSON("Adds shared-Raft KV stores.  "))
+	defer func() { _ = resp.Body.Close() }()
+	d := &fakeDoer{resp: resp}
+	withClient(t, d)
+
+	got, err := generate("sk-test", "gpt-5.4-mini", "- a1 feat(store): shared raft")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if got != "Adds shared-Raft KV stores." {
+		t.Errorf("got %q", got)
+	}
+
+	if h := d.got.Header.Get("Authorization"); h != "Bearer sk-test" {
+		t.Errorf("auth header = %q", h)
+	}
+	if ct := d.got.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestGenerateHTTPStatus(t *testing.T) {
+	resp := jsonResponse(401, `{"error":{"message":"invalid api key"}}`)
+	defer func() { _ = resp.Body.Close() }()
+	d := &fakeDoer{resp: resp}
+	withClient(t, d)
+
+	_, err := generate("sk-bad", "gpt-5.4-mini", "- a1 feat: x")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestGenerateAgainstServer(t *testing.T) {
+	var gotBody request
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, outputJSON("Adds shared-Raft KV stores.\n\nFixes two bugs."))
+	}))
+	defer srv.Close()
+
+	t.Setenv("OPENAI_BASE_URL", srv.URL)
+
+	got, err := generate("sk-live", "gpt-5.4-mini", "- a1 feat(store): raft")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if got != "Adds shared-Raft KV stores. Fixes two bugs." {
+		t.Errorf("got %q", got)
+	}
+	if gotPath != "/responses" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-live" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if gotBody.Model != "gpt-5.4-mini" || gotBody.Input != "- a1 feat(store): raft" {
+		t.Errorf("body = %+v", gotBody)
+	}
+}
+
+func TestGenerateTransportError(t *testing.T) {
+	d := &fakeDoer{err: errors.New("dial timeout")}
+	withClient(t, d)
+
+	if _, err := generate("sk-test", "gpt-5.4-mini", "- a1 feat: x"); err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func runWithStdin(t *testing.T, stdin string) (string, error) {
+	t.Helper()
+
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	origIn, origOut := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = inR, outW
+	t.Cleanup(func() { os.Stdin, os.Stdout = origIn, origOut })
+
+	go func() {
+		_, _ = io.WriteString(inW, stdin)
+		_ = inW.Close()
+	}()
+
+	runErr := run()
+	_ = outW.Close()
+	out, _ := io.ReadAll(outR)
+
+	return string(out), runErr
+}
+
+func TestRun(t *testing.T) {
+	var gotInput string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req request
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotInput = req.Input
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, outputJSON("Clean one-line summary."))
+	}))
+	defer srv.Close()
+
+	t.Setenv("OPENAI_API_KEY", "sk-run")
+	t.Setenv("OPENAI_BASE_URL", srv.URL)
+	t.Setenv("OPENAI_MODEL", "")
+	t.Setenv("RELEASE_TAG", "v9.9.9")
+
+	out, err := runWithStdin(t, "- a1 feat(store): raft\n")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != "Clean one-line summary.\n" {
+		t.Errorf("stdout = %q", out)
+	}
+	if !strings.HasPrefix(gotInput, "Release v9.9.9\n\n") {
+		t.Errorf("RELEASE_TAG not prefixed: %q", gotInput)
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	t.Run("missing_key", func(t *testing.T) {
+		t.Setenv("OPENAI_API_KEY", "")
+		if _, err := runWithStdin(t, "- a1 feat: x\n"); err == nil {
+			t.Fatal("expected error for missing key")
+		}
+	})
+
+	t.Run("empty_stdin", func(t *testing.T) {
+		t.Setenv("OPENAI_API_KEY", "sk-run")
+		if _, err := runWithStdin(t, "   \n"); err == nil {
+			t.Fatal("expected error for empty stdin")
+		}
+	})
+}


### PR DESCRIPTION
Why: the manual Release dispatch required a hand-written `description`, so no release could be cut without one; and the hub changelog received the entire verbose `release-notes.md` (Commit + Changes + Verify), producing an ugly hub release page instead of the 1–2 line style of every other release.

What:
- Make the `description` input optional.
- Add `tools/gendesc`, a stdin→stdout tool that summarizes the commit log into a clean 1–2 line English description via the OpenAI Responses API (`gpt-5.4-mini` default via `OPENAI_MODEL`, `max_output_tokens` bounded, word-boundary capped at 280 chars) when no human summary is given.
- New "Resolve description" step picks the human text, else the generated one.
- The hub now receives only that short line (`CHANGELOG="$(cat description.txt)"`); the GitHub release body keeps the full notes.

How: `gendesc` posts to `{OPENAI_BASE_URL or api.openai.com}/v1/responses` with `OPENAI_API_KEY`/`OPENAI_MODEL`. It fails closed (missing key, empty input, upstream error → non-zero exit) so a release never ships an empty changelog.

Setup: the `OPENAI_API_KEY` Actions secret is set on this repo.

Validation (local): `go test ./tools/gendesc/...` green; golangci-lint v2.8.0, gofmt, go vet, actionlint clean; gremlins mutation 29 killed / 0 survived (100% efficacy); the full release-job shell run verbatim with a live key (AI path, human path, and fail-closed) produces the expected short hub changelog and full GitHub body.