### PR TITLE
Harden cluster registry dissemination

### DIFF
--- a/api/cluster/raft/config.go
+++ b/api/cluster/raft/config.go
@@ -36,7 +36,20 @@ type Config struct {
 	BootstrapExpect   int           `json:"bootstrap_expect,omitempty"`
 	SnapshotRetain    int           `json:"snapshot_retain"`
 	MaxPool           int           `json:"max_pool"`
-	MaxAppendEntries  int           `json:"max_append_entries"`
+	// ShutdownTransferTimeout bounds the best-effort leadership transfer
+	// attempted by Stop() when this node is leader. Zero defaults to one
+	// election timeout. The transfer is an availability optimization, not a
+	// safety requirement, so shutdown must continue if no eligible follower
+	// can take leadership promptly.
+	ShutdownTransferTimeout time.Duration `json:"shutdown_transfer_timeout"`
+	// MaxAppendEntries caps how many log entries the leader packs into a
+	// single AppendEntries RPC. The hashicorp/raft default is 64 which,
+	// when a follower restarts with an empty log and needs to catch up
+	// hundreds of entries, lets the leader queue large batches in
+	// memory simultaneously. Setting this to 16 throttles the catch-up
+	// throughput so under chaos a returning pod doesn't OOM the leader
+	// while it ships history. Zero means use the library default.
+	MaxAppendEntries int `json:"max_append_entries"`
 }
 
 // InitDefaults fills zero-valued fields with sensible defaults.
@@ -77,6 +90,9 @@ func (c *Config) InitDefaults() {
 	}
 	if c.MaxPool == 0 {
 		c.MaxPool = 3
+	}
+	if c.ShutdownTransferTimeout == 0 {
+		c.ShutdownTransferTimeout = c.ElectionTimeout
 	}
 	if c.MaxAppendEntries == 0 {
 		// Default below hashicorp's 64 to cap leader memory during

--- a/api/logs/context_test.go
+++ b/api/logs/context_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/metrics"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -81,6 +82,8 @@ func (m *MockCore) Configure(cfg Config) {
 func (m *MockCore) GetConfig() Config {
 	return m.config
 }
+
+func (m *MockCore) SetCollector(metrics.Collector) {}
 
 // TestCoreInterface tests the Core interface implementation
 func TestCoreInterface(t *testing.T) {
@@ -160,9 +163,10 @@ type mockManager struct {
 	config Config
 }
 
-func (m *mockManager) Start(_ context.Context) error { return nil }
-func (m *mockManager) Stop() error                   { return nil }
-func (m *mockManager) GetConfig() Config             { return m.config }
+func (m *mockManager) Start(_ context.Context) error  { return nil }
+func (m *mockManager) Stop() error                    { return nil }
+func (m *mockManager) GetConfig() Config              { return m.config }
+func (m *mockManager) SetCollector(metrics.Collector) {}
 
 func TestContext_Manager(t *testing.T) {
 	t.Run("with app context", func(t *testing.T) {

--- a/api/logs/logs.go
+++ b/api/logs/logs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/metrics"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -34,6 +35,7 @@ type (
 		zapcore.Core
 		Configure(cfg Config)
 		GetConfig() Config
+		SetCollector(c metrics.Collector)
 	}
 
 	// Manager represents a logging manager that can be started and stopped.
@@ -41,5 +43,6 @@ type (
 		Start(ctx context.Context) error
 		Stop() error
 		GetConfig() Config
+		SetCollector(c metrics.Collector)
 	}
 )

--- a/boot/components/metrics/metrics.go
+++ b/boot/components/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/event"
+	logapi "github.com/wippyai/runtime/api/logs"
 	api "github.com/wippyai/runtime/api/metrics"
 	apicfg "github.com/wippyai/runtime/api/service/metrics"
 	impl "github.com/wippyai/runtime/service/metrics"
@@ -28,11 +29,17 @@ func Metrics() boot.Component {
 			if b, ok := event.GetBus(ctx).(*eventbus.Bus); ok {
 				b.SetCollector(collector)
 			}
+			if mgr := logapi.GetManager(ctx); mgr != nil {
+				mgr.SetCollector(collector)
+			}
 			return ctx, nil
 		},
 		Stop: func(ctx context.Context) error {
 			if b, ok := event.GetBus(ctx).(*eventbus.Bus); ok {
 				b.SetCollector(nil)
+			}
+			if mgr := logapi.GetManager(ctx); mgr != nil {
+				mgr.SetCollector(nil)
 			}
 			if collector != nil {
 				return collector.Close()

--- a/boot/components/system/cluster.example.yaml
+++ b/boot/components/system/cluster.example.yaml
@@ -30,6 +30,9 @@ cluster:
     join_addrs: "node-0:7946,node-1:7946,node-2:7946"  # gossip seeds (any subset works)
     # secret_key / secret_file: shared gossip encryption key. Nodes with
     # different keys never see each other, so this also scopes the cluster.
+    # gossip_interval: 500ms       # UDP gossip cadence; lower is faster but noisier.
+    # push_pull_interval: 5s       # TCP full-state anti-entropy cadence.
+    # dead_node_reclaim_time: 30s  # same-name/different-address reclaim after hard death.
   raft:
     bootstrap_expect: 3    # size of the initial voter quorum
 
@@ -46,6 +49,7 @@ cluster:
   membership:
     join_addrs: "node-0:7946,node-1:7946,node-2:7946"
     secret_key: "${GOSSIP_SECRET}"
+    # dead_node_reclaim_time: 30s # set lower, e.g. 3s, only when same-name pod IP reuse is expected and false-dead probes are rare.
   raft:
     role: server              # "server" (default) runs raft; "client" is gossip-only
     bootstrap_expect: 5       # initial server quorum (set on the server nodes)
@@ -72,3 +76,10 @@ cluster:
 #     max_append_entries: 16
 #     reconcile_debounce: 2s
 #     reconcile_timeout: 2s
+#     # AP delete-retention mode:
+#     #   0    = correctness-first cache fences; no age-only expiry.
+#     #   >0   = memory-bound mode; safe only if it exceeds max offline/partition time.
+#     # Durable per-peer causal ACK / membership-epoch retirement is the stronger
+#     # future compaction mode; do not treat a TTL as causal proof.
+#     global_dissem_tombstone_retention: 0
+#   kv_crdt_tombstone_retention: 0

--- a/boot/components/system/cluster.go
+++ b/boot/components/system/cluster.go
@@ -209,8 +209,20 @@ func Cluster() boot.Component {
 				SecretFile:   clusterCfg.GetString(ClusterMembershipSecretFile, ""),
 				SecretString: clusterCfg.GetString(ClusterMembershipSecret, ""),
 				AdvertiseIP:  clusterCfg.GetString(ClusterMembershipAdvertise, ""),
-				VeryVerbose:  false,
-				Meta:         nodeMeta,
+				GossipInterval: clusterCfg.GetDuration(
+					ClusterMembershipGossipInterval,
+					membership.DefaultGossipInterval,
+				),
+				PushPullInterval: clusterCfg.GetDuration(
+					ClusterMembershipPushPullInterval,
+					membership.DefaultPushPullInterval,
+				),
+				DeadNodeReclaimTime: clusterCfg.GetDuration(
+					ClusterMembershipDeadNodeReclaimTime,
+					membership.DefaultDeadNodeReclaimTime,
+				),
+				VeryVerbose: false,
+				Meta:        nodeMeta,
 			}
 
 			membershipSvc = membership.NewService(

--- a/boot/components/system/constants.go
+++ b/boot/components/system/constants.go
@@ -21,18 +21,26 @@ const (
 	PGName          boot.Name = "pg"
 
 	// ClusterEnabled is a Cluster configuration key
-	ClusterEnabled              boot.Name = "enabled"
-	ClusterNodeName             boot.Name = "name"
-	ClusterInternodeBindAddr    boot.Name = "internode.bind_addr"
-	ClusterInternodeBindPort    boot.Name = "internode.bind_port"
-	ClusterInternodeAutoPort    boot.Name = "internode.auto_port"
-	ClusterMembershipBindAddr   boot.Name = "membership.bind_addr"
-	ClusterMembershipBindPort   boot.Name = "membership.bind_port"
-	ClusterMembershipJoin       boot.Name = "membership.join_addrs"
-	ClusterMembershipSecret     boot.Name = "membership.secret_key"
-	ClusterMembershipSecretFile boot.Name = "membership.secret_file"
-	ClusterMembershipAdvertise  boot.Name = "membership.advertise_addr"
-	ClusterFailureDomain        boot.Name = "failure_domain"
+	ClusterEnabled                       boot.Name = "enabled"
+	ClusterNodeName                      boot.Name = "name"
+	ClusterInternodeBindAddr             boot.Name = "internode.bind_addr"
+	ClusterInternodeBindPort             boot.Name = "internode.bind_port"
+	ClusterInternodeAutoPort             boot.Name = "internode.auto_port"
+	ClusterMembershipBindAddr            boot.Name = "membership.bind_addr"
+	ClusterMembershipBindPort            boot.Name = "membership.bind_port"
+	ClusterMembershipJoin                boot.Name = "membership.join_addrs"
+	ClusterMembershipSecret              boot.Name = "membership.secret_key"
+	ClusterMembershipSecretFile          boot.Name = "membership.secret_file"
+	ClusterMembershipAdvertise           boot.Name = "membership.advertise_addr"
+	ClusterMembershipGossipInterval      boot.Name = "membership.gossip_interval"
+	ClusterMembershipPushPullInterval    boot.Name = "membership.push_pull_interval"
+	ClusterMembershipDeadNodeReclaimTime boot.Name = "membership.dead_node_reclaim_time"
+	ClusterFailureDomain                 boot.Name = "failure_domain"
+	// ClusterKVCRDTTombstoneRetention bounds store.kv.crdt delete tombstone
+	// retention. 0 disables age-only GC and is correctness-first for long
+	// partitions; a positive duration bounds memory by assuming no peer is
+	// offline longer than the retention.
+	ClusterKVCRDTTombstoneRetention boot.Name = "kv_crdt_tombstone_retention"
 
 	// Raft lives under cluster.raft.*. Enabling cluster auto-enables raft
 	// with sensible defaults.
@@ -73,6 +81,11 @@ const (
 	ClusterRaftDataDir             boot.Name = "raft.data_dir"
 	ClusterRaftLeaderProbeInterval boot.Name = "raft.leader_probe_interval"
 	ClusterRaftLeaderProbeGrace    boot.Name = "raft.leader_probe_grace"
+	// ClusterRaftGlobalDissemTombstoneRetention bounds how long the AP
+	// global-name dissemination cache retains delete tombstones as stale-gossip
+	// fences. The Raft FSM remains authoritative; this only tunes cache memory
+	// vs stale delete repair.
+	ClusterRaftGlobalDissemTombstoneRetention boot.Name = "raft.global_dissem_tombstone_retention"
 	// RegistryBackend selects the cluster name-registry implementation:
 	//   "kv" (default) -> the registry on the shared kv keyspace (_sys:registry)
 	//   "fsm"          -> the dedicated global registry raft FSM (fallback)

--- a/boot/components/system/kvcrdt.go
+++ b/boot/components/system/kvcrdt.go
@@ -65,7 +65,12 @@ func KVCRDT() boot.Component {
 			engine = systemkv.NewCRDTEngine(node.ID(), eventapi.GetBus(ctx), logger)
 
 			if cfg := boot.GetConfig(ctx); cfg != nil {
-				if base := nodeDataDir(cfg.Sub(ClusterName)); base != "" {
+				clusterCfg := cfg.Sub(ClusterName)
+				engine.SetTombstoneRetention(clusterCfg.GetDuration(
+					ClusterKVCRDTTombstoneRetention,
+					systemkv.DefaultTombstoneRetention,
+				))
+				if base := nodeDataDir(clusterCfg); base != "" {
 					engine.SetDurability(filepath.Join(base, "_sys", "kvcrdt"), 30*time.Second)
 				}
 			}

--- a/boot/components/system/raft.go
+++ b/boot/components/system/raft.go
@@ -169,6 +169,7 @@ func Raft() boot.Component {
 	var kvReg *kvbacked.Service
 	var useKVRegistry bool
 	var bootstrapExpect int
+	var globalDissemTombstoneRetention time.Duration
 
 	return boot.New(boot.P{
 		Name:      RaftName,
@@ -247,6 +248,7 @@ func Raft() boot.Component {
 				ReconcileDebounce: raftCfg.GetDuration(ClusterRaftReconcileDebounce, 2*time.Second),
 				ReconcileTimeout:  raftCfg.GetDuration(ClusterRaftReconcileTimeout, 2*time.Second),
 			}
+			globalDissemTombstoneRetention = raftCfg.GetDuration(ClusterRaftGlobalDissemTombstoneRetention, 0)
 
 			// Raft rides the internode mesh exclusively. Without a connection
 			// manager (cluster transport not wired — e.g. a single-node
@@ -419,7 +421,8 @@ func Raft() boot.Component {
 			// the cache on FSM-miss so non-members resolve names locally.
 			if mem := clusterapi.GetMembership(ctx); mem != nil {
 				if memSvc, ok := mem.(*membership.Service); ok {
-					dissem := global.NewDissem(node.ID(), logger.Named("dissem"))
+					dissem := global.NewDissem(node.ID(), logger.Named("dissem"),
+						global.WithTombstoneRetention(globalDissemTombstoneRetention))
 					if err := memSvc.RegisterUserDelegate(dissem); err != nil {
 						return ctx, fmt.Errorf("raft: register globalreg dissem delegate: %w", err)
 					}

--- a/cluster/membership/log_writer.go
+++ b/cluster/membership/log_writer.go
@@ -8,13 +8,17 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // memberlistLogWriter routes memberlist's standard-library logger output
-// through zap, preserving severity. Without this, memberlist [ERR] lines
-// (e.g., "Failed to decode user message") get swallowed by io.Discard and
-// real bugs hide for as long as no one runs with VeryVerbose. Symptom-only
-// noise ([DEBUG]/[INFO]) is dropped unless verbose is enabled.
+// through zap with runtime-oriented severity. Without this, memberlist [ERR]
+// lines (e.g., "Failed to decode user message") get swallowed by io.Discard
+// and real bugs hide for as long as no one runs with VeryVerbose. Some
+// memberlist [ERR] lines are normal SWIM failure-detection symptoms under
+// partitions or packet loss; those are telemetry signals, not runtime errors,
+// and are downgraded so chaos/network churn does not poison the error-log SLO.
+// Symptom-only noise ([DEBUG]/[INFO]) is dropped unless verbose is enabled.
 type memberlistLogWriter struct {
 	logger  *zap.Logger
 	buf     bytes.Buffer
@@ -53,19 +57,16 @@ func (w *memberlistLogWriter) emit(line string) {
 	if line == "" {
 		return
 	}
-	// memberlist's stdlib logger prefixes severity like "[ERR]" / "[WARN]" /
-	// "[INFO]" / "[DEBUG]". The standard log.Logger also prefixes a date and
-	// time — strip those by matching the bracketed tag.
-	switch {
-	case strings.Contains(line, "[ERR]"), strings.Contains(line, "[ERROR]"):
+	switch memberlistZapLevel(line) {
+	case zapcore.ErrorLevel:
 		w.logger.Error("memberlist", zap.String("msg", line))
-	case strings.Contains(line, "[WARN]"):
+	case zapcore.WarnLevel:
 		w.logger.Warn("memberlist", zap.String("msg", line))
-	case strings.Contains(line, "[INFO]"):
+	case zapcore.InfoLevel:
 		if w.verbose {
 			w.logger.Info("memberlist", zap.String("msg", line))
 		}
-	case strings.Contains(line, "[DEBUG]"):
+	case zapcore.DebugLevel:
 		if w.verbose {
 			w.logger.Debug("memberlist", zap.String("msg", line))
 		}
@@ -75,4 +76,43 @@ func (w *memberlistLogWriter) emit(line string) {
 			w.logger.Info("memberlist", zap.String("msg", line))
 		}
 	}
+}
+
+func memberlistZapLevel(line string) zapcore.Level {
+	// memberlist's stdlib logger prefixes severity like "[ERR]" / "[WARN]" /
+	// "[INFO]" / "[DEBUG]". The standard log.Logger can also prefix a date and
+	// time, so classify by matching the bracketed tag anywhere in the line.
+	switch {
+	case strings.Contains(line, "[ERR]"), strings.Contains(line, "[ERROR]"):
+		if isExpectedMemberlistNetworkFailure(line) {
+			return zapcore.WarnLevel
+		}
+		return zapcore.ErrorLevel
+	case strings.Contains(line, "[WARN]"):
+		return zapcore.WarnLevel
+	case strings.Contains(line, "[INFO]"):
+		return zapcore.InfoLevel
+	case strings.Contains(line, "[DEBUG]"):
+		return zapcore.DebugLevel
+	default:
+		return zapcore.InvalidLevel
+	}
+}
+
+func isExpectedMemberlistNetworkFailure(line string) bool {
+	msg := strings.ToLower(line)
+	expected := [...]string{
+		"failed fallback tcp ping",
+		"failed to send gossip",
+		"failed to send indirect ping",
+		"failed to send indirect udp ping",
+		"failed to send udp ping",
+		"failed to send udp compound ping",
+	}
+	for _, needle := range expected {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/cluster/membership/log_writer_test.go
+++ b/cluster/membership/log_writer_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package membership
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestMemberlistLogWriter_DowngradesExpectedNetworkFailures(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	writer := newMemberlistLogWriter(zap.New(core), false)
+
+	lines := []string{
+		"2026/06/05 12:00:00 [ERR] memberlist: Failed fallback TCP ping: timeout 1s\n",
+		"2026/06/05 12:00:00 [ERR] memberlist: Failed to send UDP ping: sendto: operation not permitted\n",
+		"2026/06/05 12:00:00 [ERR] memberlist: Failed to send gossip to 10.0.0.2:7946: i/o timeout\n",
+	}
+	for _, line := range lines {
+		_, err := writer.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	require.Len(t, logs.FilterLevelExact(zapcore.ErrorLevel).All(), 0)
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), len(lines))
+}
+
+func TestMemberlistLogWriter_KeepsProtocolErrorsAtError(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	writer := newMemberlistLogWriter(zap.New(core), false)
+
+	_, err := writer.Write([]byte("2026/06/05 12:00:00 [ERR] memberlist: Failed to decode user message: short buffer\n"))
+	require.NoError(t, err)
+
+	require.Len(t, logs.FilterLevelExact(zapcore.ErrorLevel).All(), 1)
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 0)
+}
+
+func TestMemberlistLogWriter_PartialLineAndWrongSeverity(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	writer := newMemberlistLogWriter(zap.New(core), true)
+
+	_, err := writer.Write([]byte("2026/06/05 12:00:00 [WARN] member"))
+	require.NoError(t, err)
+	require.Len(t, logs.All(), 0)
+
+	_, err = writer.Write([]byte("list: suspect node\n"))
+	require.NoError(t, err)
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1)
+
+	_, err = writer.Write([]byte("2026/06/05 12:00:00 [BOGUS] memberlist: unknown severity\n"))
+	require.NoError(t, err)
+	require.Len(t, logs.FilterLevelExact(zapcore.InfoLevel).All(), 1)
+}

--- a/cluster/membership/membership.go
+++ b/cluster/membership/membership.go
@@ -4,6 +4,7 @@ package membership
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -95,11 +96,15 @@ func (s *Service) SendUserMessage(targetNodeID string, kind byte, payload []byte
 	if kind == 0 {
 		return errors.New("membership: SendUserMessage kind 0 is reserved")
 	}
-	if s.memberlist == nil {
-		return errors.New("membership: not started")
-	}
 	if uint64(len(payload)) > uint64(^uint32(0)) {
 		return fmt.Errorf("membership: payload too large: %d", len(payload))
+	}
+	if len(payload) > ReliableUserMessageMaxPayloadBytes {
+		return fmt.Errorf("membership: reliable payload too large: %d > %d",
+			len(payload), ReliableUserMessageMaxPayloadBytes)
+	}
+	if s.memberlist == nil {
+		return errors.New("membership: not started")
 	}
 	wrapped := make([]byte, 0, len(payload)+5)
 	wrapped = append(wrapped, kind)
@@ -116,16 +121,51 @@ func (s *Service) SendUserMessage(targetNodeID string, kind byte, payload []byte
 
 // Config holds membership service configuration
 type Config struct {
-	Transport    memberlist.Transport
-	Meta         cluster.NodeMeta
-	NodeName     string
-	BindAddr     string
-	SecretFile   string
-	SecretString string
-	AdvertiseIP  string
-	JoinAddrs    []string
-	BindPort     int
-	VeryVerbose  bool
+	Transport           memberlist.Transport
+	Meta                cluster.NodeMeta
+	SecretString        string
+	NodeName            string
+	BindAddr            string
+	SecretFile          string
+	AdvertiseIP         string
+	JoinAddrs           []string
+	GossipInterval      time.Duration
+	PushPullInterval    time.Duration
+	DeadNodeReclaimTime time.Duration
+	BindPort            int
+	VeryVerbose         bool
+}
+
+const (
+	DefaultGossipInterval      = 500 * time.Millisecond
+	DefaultPushPullInterval    = 5 * time.Second
+	DefaultDeadNodeReclaimTime = 30 * time.Second
+
+	userBroadcastRetain       = 8192
+	userBroadcastBackpressure = userBroadcastRetain / 2
+	// Match memberlist's conservative UDP buffer. User broadcasts above this
+	// cannot fit once memberlist adds its own user-message/compound headers.
+	userBroadcastMaxPacketBytes = 1400
+	// ReliableUserMessageMaxPayloadBytes bounds the payload carried inside one
+	// targeted TCP user-message. The wire envelope can represent uint32 sizes,
+	// but accepting multi-MiB/GiB repair frames would make bad peers or bad
+	// values translate directly into heap pressure. Larger anti-entropy payloads
+	// must be split by the caller.
+	ReliableUserMessageMaxPayloadBytes = 64 * 1024
+)
+
+func positiveDuration(v, def time.Duration) time.Duration {
+	if v > 0 {
+		return v
+	}
+	return def
+}
+
+func applyMemberlistTiming(mlConfig *memberlist.Config, cfg Config) {
+	mlConfig.GossipInterval = positiveDuration(cfg.GossipInterval, DefaultGossipInterval)
+	mlConfig.PushPullInterval = positiveDuration(cfg.PushPullInterval, DefaultPushPullInterval)
+	mlConfig.DeadNodeReclaimTime = positiveDuration(
+		cfg.DeadNodeReclaimTime, DefaultDeadNodeReclaimTime)
 }
 
 // NewService creates a new membership service.
@@ -156,15 +196,18 @@ func New(opts ...Option) *Service {
 		logger: o.logger,
 		bus:    o.bus,
 		config: Config{
-			NodeName:     o.nodeName,
-			BindAddr:     o.bindAddr,
-			BindPort:     o.bindPort,
-			JoinAddrs:    o.joinAddrs,
-			SecretFile:   o.secretFile,
-			SecretString: o.secretString,
-			AdvertiseIP:  o.advertiseIP,
-			VeryVerbose:  o.veryVerbose,
-			Meta:         o.meta,
+			Meta:                o.meta,
+			GossipInterval:      o.gossipInterval,
+			PushPullInterval:    o.pushPullInterval,
+			DeadNodeReclaimTime: o.deadNodeReclaimTime,
+			NodeName:            o.nodeName,
+			BindAddr:            o.bindAddr,
+			SecretFile:          o.secretFile,
+			SecretString:        o.secretString,
+			AdvertiseIP:         o.advertiseIP,
+			JoinAddrs:           o.joinAddrs,
+			BindPort:            o.bindPort,
+			VeryVerbose:         o.veryVerbose,
 		},
 		transport:  o.transport,
 		nodes:      make(map[string]cluster.NodeInfo),
@@ -190,31 +233,23 @@ func (s *Service) Start(ctx context.Context) error {
 	// DefaultLocalConfig gossips every 100ms — tuned for loopback. On a real
 	// multi-node cluster that is 10 mostly-empty gossip fan-outs/sec/node;
 	// 500ms still propagates deltas promptly and cuts idle wakeups 5x.
-	mlConfig.GossipInterval = 500 * time.Millisecond
 	// PushPullInterval is the anti-entropy full-state sync cadence. It backstops
 	// the epidemic delta path (eventualreg forwards deltas it learns, but a
 	// one-shot gossip wave can probabilistically miss a tail node) and heals
 	// post-partition divergence. DefaultLocalConfig's 15s left a missed tail
 	// resolving in tens of seconds; 5s bounds that worst case while keeping the
 	// small registry state cheap to exchange.
-	mlConfig.PushPullInterval = 5 * time.Second
 	// DeadNodeReclaimTime lets a node that has been dead longer than this be
-	// replaced by a node with the SAME name but a DIFFERENT address. This is
-	// exactly the k8s StatefulSet pod-restart case: a pod is killed (hard,
-	// no graceful Leave, so peers mark it StateDead at its old IP), the
-	// StatefulSet recreates it under the same name with a fresh pod IP, and
-	// it tries to rejoin. With the memberlist default of 0, peers reject the
-	// rejoin with "Conflicting address" until the dead entry ages out via
-	// GossipToTheDeadTime (~30s) — which is a large slice of post-kill
-	// reconvergence latency. 3s is long enough that a brief same-IP flap
-	// won't trigger a spurious reclaim, short enough that a restarted pod
-	// rejoins promptly.
-	mlConfig.DeadNodeReclaimTime = 3 * time.Second
+	// replaced by a node with the SAME name but a DIFFERENT address. Keep it
+	// explicit and conservative: too small a value can turn transient probe
+	// failures into same-name replacement churn; too large a value delays
+	// StatefulSet-style pod rejoin after hard kill/new IP.
+	applyMemberlistTiming(mlConfig, s.config)
 	mlConfig.Name = s.config.NodeName
 	mlConfig.BindAddr = s.config.BindAddr
 	mlConfig.BindPort = s.config.BindPort
 	mlConfig.Events = &eventDelegate{service: s}
-	mlConfig.Delegate = &delegate{service: s}
+	mlConfig.Delegate = newDelegate(s, mlConfig.RetransmitMult)
 
 	// Use custom transport if provided (for testing)
 	if s.transport != nil {
@@ -780,7 +815,86 @@ func (ed *eventDelegate) parseNodeMeta(meta []byte) cluster.NodeMeta {
 
 // delegate handles memberlist delegate functions
 type delegate struct {
-	service *Service
+	queued     map[string]struct{}
+	service    *Service
+	broadcasts memberlist.TransmitLimitedQueue
+	queuedMu   sync.Mutex
+}
+
+func newDelegate(service *Service, retransmitMult int) *delegate {
+	if retransmitMult <= 0 {
+		retransmitMult = 1
+	}
+	d := &delegate{
+		service: service,
+		queued:  make(map[string]struct{}),
+	}
+	d.broadcasts.NumNodes = service.broadcastNodeCount
+	d.broadcasts.RetransmitMult = retransmitMult
+	return d
+}
+
+func (s *Service) broadcastNodeCount() int {
+	if s.memberlist != nil {
+		if n := len(s.memberlist.Members()); n > 0 {
+			return n
+		}
+	}
+	s.mu.RLock()
+	n := len(s.nodes)
+	s.mu.RUnlock()
+	if n > 0 {
+		return n
+	}
+	return 1
+}
+
+type muxBroadcast struct {
+	finished func(string)
+	name     string
+	msg      []byte
+}
+
+func (b *muxBroadcast) Invalidates(other memberlist.Broadcast) bool {
+	o, ok := other.(*muxBroadcast)
+	return ok && b.name == o.name
+}
+
+func (b *muxBroadcast) Name() string { return b.name }
+func (b *muxBroadcast) Message() []byte {
+	return b.msg
+}
+func (b *muxBroadcast) Finished() {
+	if b.finished != nil {
+		b.finished(b.name)
+	}
+}
+
+var _ memberlist.NamedBroadcast = (*muxBroadcast)(nil)
+
+func (d *delegate) queueBroadcast(frame []byte) bool {
+	sum := sha256.Sum256(frame)
+	name := string(sum[:])
+	d.queuedMu.Lock()
+	if _, exists := d.queued[name]; exists {
+		d.queuedMu.Unlock()
+		return false
+	}
+	d.queued[name] = struct{}{}
+	d.queuedMu.Unlock()
+
+	d.broadcasts.QueueBroadcast(&muxBroadcast{
+		name:     name,
+		msg:      frame,
+		finished: d.forgetBroadcast,
+	})
+	return true
+}
+
+func (d *delegate) forgetBroadcast(name string) {
+	d.queuedMu.Lock()
+	delete(d.queued, name)
+	d.queuedMu.Unlock()
 }
 
 func (d *delegate) NodeMeta(limit int) []byte {
@@ -829,12 +943,47 @@ func (d *delegate) NotifyMsg(data []byte) {
 	if int(plen)+5 != len(data) {
 		return
 	}
+	if plen > ReliableUserMessageMaxPayloadBytes {
+		return
+	}
 	if ud := d.service.lookupUserDelegate(kind); ud != nil {
 		ud.NotifyMsg(data[5:])
 	}
 }
 
 func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
+	if d.service.tel != nil && d.service.tel.coll != nil {
+		d.service.tel.coll.CounterInc("gossip_user_getbroadcasts_calls_total", nil)
+	}
+
+	recordOut := func(out [][]byte) {
+		if d.service.tel == nil || d.service.tel.coll == nil || len(out) == 0 {
+			return
+		}
+		totalBytes := 0
+		totalCost := 0
+		for _, frame := range out {
+			totalBytes += len(frame)
+			totalCost += len(frame) + overhead
+		}
+		d.service.tel.coll.CounterAdd("gossip_user_getbroadcasts_frames_total", float64(len(out)), nil)
+		d.service.tel.coll.CounterAdd("gossip_user_getbroadcasts_bytes_total", float64(totalBytes), nil)
+		if totalCost > limit {
+			d.service.tel.coll.CounterInc("gossip_user_getbroadcasts_overshoot_total", nil)
+		}
+	}
+
+	queued := d.broadcasts.NumQueued()
+	if queued > userBroadcastRetain {
+		d.broadcasts.Prune(userBroadcastRetain)
+		queued = userBroadcastRetain
+	}
+	if queued >= userBroadcastBackpressure {
+		out := d.broadcasts.GetBroadcasts(overhead, limit)
+		recordOut(out)
+		return out
+	}
+
 	d.service.userDelegateMu.RLock()
 	dels := make([]UserDelegate, 0, len(d.service.userDelegates))
 	for _, ud := range d.service.userDelegates {
@@ -849,25 +998,31 @@ func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
 	// hogged the cycle).
 	sort.Slice(dels, func(i, j int) bool { return dels[i].Kind() < dels[j].Kind() })
 
-	if d.service.tel != nil && d.service.tel.coll != nil {
-		d.service.tel.coll.CounterInc("gossip_user_getbroadcasts_calls_total", nil)
-	}
-
-	var out [][]byte
-	totalBytes := 0
-	totalCost := 0
+	queuedCost := 0
 	muxOverhead := overhead + 5
 
 	wrap := func(ud UserDelegate, frames [][]byte) {
 		for _, f := range frames {
+			if uint64(len(f)) > uint64(^uint32(0)) {
+				if d.service.tel != nil && d.service.tel.coll != nil {
+					d.service.tel.coll.CounterInc("gossip_user_getbroadcasts_frame_dropped_total", nil)
+				}
+				continue
+			}
 			wrapped := make([]byte, 0, len(f)+5)
 			wrapped = append(wrapped, ud.Kind())
 			n := uint32(len(f))
 			wrapped = append(wrapped, byte(n), byte(n>>8), byte(n>>16), byte(n>>24))
 			wrapped = append(wrapped, f...)
-			totalCost += len(wrapped) + overhead
-			totalBytes += len(wrapped)
-			out = append(out, wrapped)
+			if len(wrapped)+overhead > userBroadcastMaxPacketBytes {
+				if d.service.tel != nil && d.service.tel.coll != nil {
+					d.service.tel.coll.CounterInc("gossip_user_getbroadcasts_frame_dropped_total", nil)
+				}
+				continue
+			}
+			if d.queueBroadcast(wrapped) {
+				queuedCost += len(wrapped) + overhead
+			}
 		}
 	}
 
@@ -890,7 +1045,7 @@ func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
 	// budget contract bounds emission to what fits the remainder. This
 	// recovers throughput when one delegate is silent.
 	for _, ud := range dels {
-		remaining := limit - totalCost
+		remaining := limit - queuedCost
 		if remaining <= muxOverhead {
 			break
 		}
@@ -898,13 +1053,11 @@ func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
 		wrap(ud, frames)
 	}
 
-	if d.service.tel != nil && d.service.tel.coll != nil && len(out) > 0 {
-		d.service.tel.coll.CounterAdd("gossip_user_getbroadcasts_frames_total", float64(len(out)), nil)
-		d.service.tel.coll.CounterAdd("gossip_user_getbroadcasts_bytes_total", float64(totalBytes), nil)
-		if totalCost > limit {
-			d.service.tel.coll.CounterInc("gossip_user_getbroadcasts_overshoot_total", nil)
-		}
+	if d.broadcasts.NumQueued() > userBroadcastRetain {
+		d.broadcasts.Prune(userBroadcastRetain)
 	}
+	out := d.broadcasts.GetBroadcasts(overhead, limit)
+	recordOut(out)
 	return out
 }
 

--- a/cluster/membership/membership_test.go
+++ b/cluster/membership/membership_test.go
@@ -43,6 +43,39 @@ func setupService(_ *testing.T) (*Service, *eventbus.Bus, context.Context, conte
 	return service, bus, ctx, cancel
 }
 
+func TestApplyMemberlistTiming_DefaultsAndBadValues(t *testing.T) {
+	cfg := memberlist.DefaultLocalConfig()
+	applyMemberlistTiming(cfg, Config{})
+
+	assert.Equal(t, DefaultGossipInterval, cfg.GossipInterval)
+	assert.Equal(t, DefaultPushPullInterval, cfg.PushPullInterval)
+	assert.Equal(t, DefaultDeadNodeReclaimTime, cfg.DeadNodeReclaimTime)
+
+	cfg = memberlist.DefaultLocalConfig()
+	applyMemberlistTiming(cfg, Config{
+		GossipInterval:      -time.Second,
+		PushPullInterval:    -time.Second,
+		DeadNodeReclaimTime: -time.Second,
+	})
+
+	assert.Equal(t, DefaultGossipInterval, cfg.GossipInterval)
+	assert.Equal(t, DefaultPushPullInterval, cfg.PushPullInterval)
+	assert.Equal(t, DefaultDeadNodeReclaimTime, cfg.DeadNodeReclaimTime)
+}
+
+func TestApplyMemberlistTiming_CustomValues(t *testing.T) {
+	cfg := memberlist.DefaultLocalConfig()
+	applyMemberlistTiming(cfg, Config{
+		GossipInterval:      750 * time.Millisecond,
+		PushPullInterval:    10 * time.Second,
+		DeadNodeReclaimTime: 2 * time.Minute,
+	})
+
+	assert.Equal(t, 750*time.Millisecond, cfg.GossipInterval)
+	assert.Equal(t, 10*time.Second, cfg.PushPullInterval)
+	assert.Equal(t, 2*time.Minute, cfg.DeadNodeReclaimTime)
+}
+
 func generateSecretKey() string {
 	key := make([]byte, 32)
 	for i := range key {
@@ -108,6 +141,15 @@ func TestService_Start_WithSecretKey(t *testing.T) {
 	defer func() { _ = service.Stop() }()
 
 	assert.NotNil(t, service.memberlist)
+}
+
+func TestService_SendUserMessageRejectsOversizedPayloadBeforeStart(t *testing.T) {
+	service, _, _, cancel := setupService(t)
+	defer cancel()
+
+	err := service.SendUserMessage("peer", 0xE1, make([]byte, ReliableUserMessageMaxPayloadBytes+1))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reliable payload too large")
 }
 
 func TestService_Start_WithAdvertiseIP(t *testing.T) {
@@ -539,7 +581,7 @@ func TestDelegate_NodeMeta_ValidJSON(t *testing.T) {
 	service, _, _, cancel := setupService(t)
 	defer cancel()
 
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	meta := d.NodeMeta(512)
 
@@ -565,7 +607,7 @@ func TestDelegate_NodeMeta_EmptyMeta(t *testing.T) {
 	}
 
 	service := NewService(config, bus, logger, nil, nil, nil)
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	meta := d.NodeMeta(512)
 
@@ -589,7 +631,7 @@ func TestDelegate_NodeMeta_ExceedsLimit(t *testing.T) {
 	}
 
 	service := NewService(config, bus, logger, nil, nil, nil)
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	meta := d.NodeMeta(10)
 
@@ -600,7 +642,7 @@ func TestDelegate_GetBroadcasts(t *testing.T) {
 	service, _, _, cancel := setupService(t)
 	defer cancel()
 
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	broadcasts := d.GetBroadcasts(10, 512)
 
@@ -611,7 +653,7 @@ func TestDelegate_LocalState(t *testing.T) {
 	service, _, _, cancel := setupService(t)
 	defer cancel()
 
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	state := d.LocalState(false)
 
@@ -623,7 +665,7 @@ func TestDelegate_MergeRemoteState(t *testing.T) {
 	service, _, _, cancel := setupService(t)
 	defer cancel()
 
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	d.MergeRemoteState([]byte(`{"key":"value"}`), true)
 }
@@ -632,9 +674,29 @@ func TestDelegate_NotifyMsg(t *testing.T) {
 	service, _, _, cancel := setupService(t)
 	defer cancel()
 
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	d.NotifyMsg([]byte("test message"))
+}
+
+func TestDelegate_NotifyMsgDropsOversizedReliablePayload(t *testing.T) {
+	service, _, _, cancel := setupService(t)
+	defer cancel()
+
+	cap := &captureDelegate{kind: 0xE1}
+	require.NoError(t, service.RegisterUserDelegate(cap))
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
+
+	payload := make([]byte, ReliableUserMessageMaxPayloadBytes+1)
+	wrapped := make([]byte, 0, len(payload)+5)
+	wrapped = append(wrapped, cap.kind)
+	n := uint32(len(payload))
+	wrapped = append(wrapped, byte(n), byte(n>>8), byte(n>>16), byte(n>>24))
+	wrapped = append(wrapped, payload...)
+
+	d.NotifyMsg(wrapped)
+
+	assert.Equal(t, int64(0), cap.rx.Load())
 }
 
 func TestDelegate_NotifyMsg_VeryVerbose(_ *testing.T) {
@@ -649,7 +711,7 @@ func TestDelegate_NotifyMsg_VeryVerbose(_ *testing.T) {
 	}
 
 	service := NewService(config, bus, logger, nil, nil, nil)
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	d.NotifyMsg([]byte("test message"))
 }
@@ -666,7 +728,7 @@ func TestDelegate_MergeRemoteState_VeryVerbose(_ *testing.T) {
 	}
 
 	service := NewService(config, bus, logger, nil, nil, nil)
-	d := &delegate{service: service}
+	d := newDelegate(service, memberlist.DefaultLocalConfig().RetransmitMult)
 
 	d.MergeRemoteState([]byte(`{"key":"value"}`), true)
 }

--- a/cluster/membership/multiplex_test.go
+++ b/cluster/membership/multiplex_test.go
@@ -67,6 +67,173 @@ func (c *captureDelegate) MergeRemoteState(_ []byte, _ bool) {
 	c.mergeRx.Add(1)
 }
 
+type oneShotDelegate struct {
+	body []byte
+	sent atomic.Bool
+	kind byte
+}
+
+func (d *oneShotDelegate) Kind() byte { return d.kind }
+
+func (d *oneShotDelegate) GetBroadcasts(_, _ int) [][]byte {
+	if d.sent.Swap(true) {
+		return nil
+	}
+	return [][]byte{d.body}
+}
+
+func (d *oneShotDelegate) NotifyMsg(_ []byte)                {}
+func (d *oneShotDelegate) LocalState(_ bool) []byte          { return nil }
+func (d *oneShotDelegate) MergeRemoteState(_ []byte, _ bool) {}
+
+type stickyDelegate struct {
+	body  []byte
+	calls atomic.Int64
+	kind  byte
+}
+
+func (d *stickyDelegate) Kind() byte { return d.kind }
+func (d *stickyDelegate) GetBroadcasts(_, _ int) [][]byte {
+	d.calls.Add(1)
+	return [][]byte{d.body}
+}
+func (d *stickyDelegate) NotifyMsg(_ []byte)                {}
+func (d *stickyDelegate) LocalState(_ bool) []byte          { return nil }
+func (d *stickyDelegate) MergeRemoteState(_ []byte, _ bool) {}
+
+func TestDelegate_GetBroadcasts_RetransmitsOneShotUserFrame(t *testing.T) {
+	logger := zap.NewNop()
+	bus := eventbus.NewBus()
+	svc := NewService(Config{NodeName: "node-a"}, bus, logger, nil, nil, nil)
+	ud := &oneShotDelegate{kind: 0xE1, body: []byte("delta")}
+	if err := svc.RegisterUserDelegate(ud); err != nil {
+		t.Fatalf("register delegate: %v", err)
+	}
+
+	d := newDelegate(svc, 3)
+	first := d.GetBroadcasts(10, 512)
+	if len(first) != 1 {
+		t.Fatalf("first GetBroadcasts returned %d frames, want 1", len(first))
+	}
+	second := d.GetBroadcasts(10, 512)
+	if len(second) != 1 {
+		t.Fatalf("second GetBroadcasts returned %d frames, want retransmit of queued frame", len(second))
+	}
+	if string(first[0]) != string(second[0]) {
+		t.Fatalf("retransmit frame mismatch: %q != %q", string(first[0]), string(second[0]))
+	}
+}
+
+func TestDelegate_GetBroadcasts_DuplicateFrameDoesNotResetTransmitLimit(t *testing.T) {
+	logger := zap.NewNop()
+	bus := eventbus.NewBus()
+	svc := NewService(Config{NodeName: "node-a"}, bus, logger, nil, nil, nil)
+	ud := &stickyDelegate{kind: 0xE1, body: []byte("same-delta")}
+	if err := svc.RegisterUserDelegate(ud); err != nil {
+		t.Fatalf("register delegate: %v", err)
+	}
+
+	d := newDelegate(svc, 3)
+	for i := 0; i < 3; i++ {
+		frames := d.GetBroadcasts(10, 512)
+		if len(frames) != 1 {
+			t.Fatalf("GetBroadcasts round %d returned %d frames, want 1", i+1, len(frames))
+		}
+	}
+	if queued := d.broadcasts.NumQueued(); queued != 0 {
+		t.Fatalf("duplicate frame reset transmit limit; queued=%d want 0 after limit", queued)
+	}
+}
+
+func TestDelegate_GetBroadcasts_DuplicateFrameDoesNotConsumeNewWorkBudget(t *testing.T) {
+	logger := zap.NewNop()
+	bus := eventbus.NewBus()
+	svc := NewService(Config{NodeName: "node-a"}, bus, logger, nil, nil, nil)
+	dup := &stickyDelegate{kind: 0xE1, body: []byte("duplicate-delta")}
+	next := &oneShotDelegate{kind: 0xE2, body: []byte("other-delta")}
+	if err := svc.RegisterUserDelegate(dup); err != nil {
+		t.Fatalf("register duplicate delegate: %v", err)
+	}
+	if err := svc.RegisterUserDelegate(next); err != nil {
+		t.Fatalf("register second delegate: %v", err)
+	}
+
+	d := newDelegate(svc, 3)
+	first := d.GetBroadcasts(10, 512)
+	if len(first) != 2 {
+		t.Fatalf("first GetBroadcasts returned %d frames, want 2", len(first))
+	}
+	second := d.GetBroadcasts(10, 512)
+	if len(second) != 2 {
+		t.Fatalf("duplicate should not consume new-work budget; second returned %d frames, want 2", len(second))
+	}
+}
+
+func TestDelegate_GetBroadcasts_RetainsFrameTooLargeForCurrentBudget(t *testing.T) {
+	logger := zap.NewNop()
+	bus := eventbus.NewBus()
+	svc := NewService(Config{NodeName: "node-a"}, bus, logger, nil, nil, nil)
+	ud := &oneShotDelegate{kind: 0xE1, body: make([]byte, 1024)}
+	if err := svc.RegisterUserDelegate(ud); err != nil {
+		t.Fatalf("register delegate: %v", err)
+	}
+
+	d := newDelegate(svc, 3)
+	if frames := d.GetBroadcasts(10, 128); len(frames) != 0 {
+		t.Fatalf("oversized frame returned %d frames, want 0", len(frames))
+	}
+	if queued := d.broadcasts.NumQueued(); queued != 1 {
+		t.Fatalf("frame too large for current budget queued=%d want 1", queued)
+	}
+	if frames := d.GetBroadcasts(10, 2048); len(frames) != 1 {
+		t.Fatalf("retained frame returned %d frames once budget fits, want 1", len(frames))
+	}
+}
+
+func TestDelegate_GetBroadcasts_DropsFrameTooLargeForMemberlistPacket(t *testing.T) {
+	logger := zap.NewNop()
+	bus := eventbus.NewBus()
+	svc := NewService(Config{NodeName: "node-a"}, bus, logger, nil, nil, nil)
+	ud := &oneShotDelegate{kind: 0xE1, body: make([]byte, userBroadcastMaxPacketBytes)}
+	if err := svc.RegisterUserDelegate(ud); err != nil {
+		t.Fatalf("register delegate: %v", err)
+	}
+
+	d := newDelegate(svc, 3)
+	if frames := d.GetBroadcasts(10, userBroadcastMaxPacketBytes*2); len(frames) != 0 {
+		t.Fatalf("impossible-size frame returned %d frames, want 0", len(frames))
+	}
+	if queued := d.broadcasts.NumQueued(); queued != 0 {
+		t.Fatalf("impossible-size frame queued=%d want 0", queued)
+	}
+}
+
+func TestDelegate_GetBroadcasts_BackpressureSkipsDelegatePolling(t *testing.T) {
+	logger := zap.NewNop()
+	bus := eventbus.NewBus()
+	svc := NewService(Config{NodeName: "node-a"}, bus, logger, nil, nil, nil)
+	ud := &stickyDelegate{kind: 0xE1, body: []byte("new-delta")}
+	if err := svc.RegisterUserDelegate(ud); err != nil {
+		t.Fatalf("register delegate: %v", err)
+	}
+
+	d := newDelegate(svc, 3)
+	for i := 0; i < userBroadcastBackpressure; i++ {
+		frame := []byte{0xE1, 2, 0, 0, 0, byte(i), byte(i >> 8)}
+		if !d.queueBroadcast(frame) {
+			t.Fatalf("queue prefill %d was rejected", i)
+		}
+	}
+
+	frames := d.GetBroadcasts(10, 512)
+	if len(frames) == 0 {
+		t.Fatalf("expected queued frames to drain under backpressure")
+	}
+	if got := ud.calls.Load(); got != 0 {
+		t.Fatalf("delegate polled under backpressure: calls=%d", got)
+	}
+}
+
 // TestMultiplex_TwoNodes_UserBroadcastDelivers verifies that when node A
 // produces a user-broadcast via a registered UserDelegate, node B's
 // matching UserDelegate (same Kind byte) receives it through memberlist.

--- a/cluster/membership/options.go
+++ b/cluster/membership/options.go
@@ -3,6 +3,8 @@
 package membership
 
 import (
+	"time"
+
 	"github.com/hashicorp/memberlist"
 	"github.com/wippyai/runtime/api/cluster"
 	"github.com/wippyai/runtime/api/event"
@@ -16,21 +18,24 @@ import (
 type Option func(*options)
 
 type options struct {
-	transport    memberlist.Transport
-	bus          event.Bus
-	meta         cluster.NodeMeta
-	logger       *zap.Logger
-	coll         metrics.Collector
-	mp           otelmetric.MeterProvider
-	tp           trace.TracerProvider
-	nodeName     string
-	bindAddr     string
-	secretFile   string
-	secretString string
-	advertiseIP  string
-	joinAddrs    []string
-	bindPort     int
-	veryVerbose  bool
+	transport           memberlist.Transport
+	bus                 event.Bus
+	coll                metrics.Collector
+	mp                  otelmetric.MeterProvider
+	tp                  trace.TracerProvider
+	meta                cluster.NodeMeta
+	logger              *zap.Logger
+	nodeName            string
+	bindAddr            string
+	secretFile          string
+	secretString        string
+	advertiseIP         string
+	joinAddrs           []string
+	gossipInterval      time.Duration
+	pushPullInterval    time.Duration
+	deadNodeReclaimTime time.Duration
+	bindPort            int
+	veryVerbose         bool
 }
 
 func defaultOptions() *options {
@@ -77,4 +82,23 @@ func WithTelemetry(coll metrics.Collector, mp otelmetric.MeterProvider, tp trace
 		o.mp = mp
 		o.tp = tp
 	}
+}
+
+// WithGossipInterval tunes memberlist's UDP gossip cadence. Non-positive values
+// fall back to the production default at Start.
+func WithGossipInterval(d time.Duration) Option {
+	return func(o *options) { o.gossipInterval = d }
+}
+
+// WithPushPullInterval tunes memberlist's TCP full-state anti-entropy cadence.
+// Non-positive values fall back to the production default at Start.
+func WithPushPullInterval(d time.Duration) Option {
+	return func(o *options) { o.pushPullInterval = d }
+}
+
+// WithDeadNodeReclaimTime tunes how long a dead same-name member must remain
+// dead before a different address can reclaim that node name. Non-positive
+// values fall back to the production default at Start.
+func WithDeadNodeReclaimTime(d time.Duration) Option {
+	return func(o *options) { o.deadNodeReclaimTime = d }
 }

--- a/cluster/raft/config_test.go
+++ b/cluster/raft/config_test.go
@@ -37,6 +37,8 @@ func TestConfigInvariants_AcceptedByHraft(t *testing.T) {
 			cfg.InitDefaults()
 			require.GreaterOrEqual(t, cfg.ElectionTimeout, cfg.HeartbeatTimeout,
 				"InitDefaults must enforce ElectionTimeout >= HeartbeatTimeout")
+			require.Positive(t, cfg.ShutdownTransferTimeout,
+				"InitDefaults must set a bounded shutdown leadership-transfer timeout")
 
 			rc := toHashicorpConfig("node-1", cfg)
 			require.LessOrEqual(t, rc.LeaderLeaseTimeout, rc.HeartbeatTimeout,

--- a/cluster/raft/raft.go
+++ b/cluster/raft/raft.go
@@ -273,9 +273,14 @@ func (n *Node) Stop(_ context.Context) error {
 
 	// Attempt graceful leadership transfer before shutdown.
 	if n.raft.State() == hraft.Leader {
-		n.logger.Info("transferring raft leadership before shutdown")
-		if err := n.raft.LeadershipTransfer().Error(); err != nil {
-			n.logger.Warn("leadership transfer failed", zap.Error(err))
+		timeout := n.config.ShutdownTransferTimeout
+		if timeout <= 0 {
+			timeout = n.config.ElectionTimeout
+		}
+		n.logger.Info("transferring raft leadership before shutdown",
+			zap.Duration("timeout", timeout))
+		if err := n.LeadershipTransfer("", timeout); err != nil {
+			n.logger.Warn("leadership transfer before shutdown failed; continuing shutdown", zap.Error(err))
 		}
 	}
 

--- a/runtime/lua/modules/process/leak_test.go
+++ b/runtime/lua/modules/process/leak_test.go
@@ -230,6 +230,12 @@ func newProcessSubSampler(proc *engine.Process) *processSubSampler {
 		case <-s.stopCh:
 			return
 		}
+		live := s.proc.LiveSubscriptionCount()
+		s.samples++
+		s.lastLive = live
+		if live > s.maxLive {
+			s.maxLive = live
+		}
 		ticker := stdtime.NewTicker(100 * stdtime.Microsecond)
 		defer ticker.Stop()
 		for {

--- a/runtime/lua/modules/process/module.go
+++ b/runtime/lua/modules/process/module.go
@@ -769,20 +769,47 @@ func getEventualRegistrar(ctx context.Context) eventualRegistrar {
 }
 
 func registryLookup(l *lua.LState) int {
-	reg, ok := getRegistry(l)
-	if !ok {
-		return 2
+	ctx := l.Context()
+	if ctx == nil {
+		return pushProcessError(l, lua.LNil, newProcessError(l, lua.Internal, "no context found"))
 	}
 
 	name := l.CheckString(1)
+	checked := false
 
-	p, found := reg.Lookup(name)
-	if !found {
-		return pushProcessError(l, lua.LNil, newProcessError(l, lua.NotFound, "name not registered"))
+	if globalReg := global.GetRegistry(ctx); globalReg != nil {
+		checked = true
+		if res, err := globalReg.Lookup(ctx, name); err != nil {
+			return pushProcessError(l, lua.LNil, wrapProcessError(l, err, "", lua.Internal))
+		} else if res.Found {
+			l.Push(lua.LString(res.PID.String()))
+			return 1
+		}
 	}
 
-	l.Push(lua.LString(p.String()))
-	return 1
+	if eventualReg := topology.GetEventualRegistry(ctx); eventualReg != nil {
+		checked = true
+		if res, err := eventualReg.Lookup(ctx, name); err != nil {
+			return pushProcessError(l, lua.LNil, wrapProcessError(l, err, "", lua.Internal))
+		} else if res.Found {
+			l.Push(lua.LString(res.PID.String()))
+			return 1
+		}
+	}
+
+	if reg := topology.GetRegistry(ctx); reg != nil {
+		checked = true
+		if p, found := reg.Lookup(name); found {
+			l.Push(lua.LString(p.String()))
+			return 1
+		}
+	}
+
+	if !checked {
+		return pushProcessError(l, lua.LNil, newProcessError(l, lua.Internal, "no registry found in context"))
+	}
+
+	return pushProcessError(l, lua.LNil, newProcessError(l, lua.NotFound, "name not registered"))
 }
 
 func registryUnregister(l *lua.LState) int {

--- a/runtime/lua/modules/process/process_edge_test.go
+++ b/runtime/lua/modules/process/process_edge_test.go
@@ -106,6 +106,59 @@ func (r *fakePIDRegistry) Remove(p pid.PID) {
 	}
 }
 
+type fakeEventualRegistry struct {
+	entries map[string]pid.PID
+	mu      sync.Mutex
+}
+
+func (r *fakeEventualRegistry) Register(name string, p pid.PID) (pid.PID, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.entries == nil {
+		r.entries = make(map[string]pid.PID)
+	}
+	if existing, ok := r.entries[name]; ok && existing != p {
+		return existing, fmt.Errorf("name %q already registered", name)
+	}
+	r.entries[name] = p
+	return p, nil
+}
+
+func (r *fakeEventualRegistry) Unregister(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.entries == nil {
+		return false
+	}
+	_, ok := r.entries[name]
+	if ok {
+		delete(r.entries, name)
+	}
+	return ok
+}
+
+func (r *fakeEventualRegistry) Lookup(_ context.Context, name string, opts ...globalapi.LookupOption) (globalapi.LookupResult, error) {
+	var o globalapi.LookupOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if o.ByPID != nil {
+		for _, p := range r.entries {
+			if p == *o.ByPID {
+				return globalapi.LookupResult{PID: *o.ByPID, Found: true}, nil
+			}
+		}
+		return globalapi.LookupResult{PID: *o.ByPID}, nil
+	}
+	p, found := r.entries[name]
+	return globalapi.LookupResult{PID: p, Found: found}, nil
+}
+
+var _ topology.EventualRegistry = (*fakeEventualRegistry)(nil)
+var _ eventualRegistrar = (*fakeEventualRegistry)(nil)
+
 // --- Yield HandleResult edge cases ---
 
 func TestCancelYield_HandleResult_Error(t *testing.T) {
@@ -814,6 +867,90 @@ func newLuaWithScopedRegistry(t *testing.T, p pid.PID, scoped globalapi.Registry
 	require.NoError(t, runtimeapi.SetFramePID(ctx, p))
 	l.SetContext(ctx)
 	return l
+}
+
+func newLuaWithScopedRegistries(t *testing.T, p pid.PID, local topology.PIDRegistry, scoped globalapi.Registry, eventual topology.EventualRegistry) *lua.LState {
+	t.Helper()
+	l := lua.NewState()
+	t.Cleanup(l.Close)
+	bindProcess(l)
+
+	ctx := ctxapi.NewRootContext()
+	security.SetStrictMode(ctx, false)
+	if local != nil {
+		topology.WithRegistry(ctx, local)
+	}
+	if scoped != nil {
+		ctx = globalapi.WithRegistry(ctx, scoped)
+	}
+	if eventual != nil {
+		topology.WithEventualRegistry(ctx, eventual)
+	}
+	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	t.Cleanup(func() { ctxapi.ReleaseFrameContext(fc) })
+	require.NoError(t, runtimeapi.SetFramePID(ctx, p))
+	l.SetContext(ctx)
+	return l
+}
+
+func TestRegistryLookup_GlobalScope(t *testing.T) {
+	globalReg := newFakeScopedRegistry()
+	holder := pid.PID{Host: "h1", UniqID: "global-holder", Node: "node-1"}
+	_, err := globalReg.RegisterScope(context.Background(), "svc-global", holder, globalapi.Consistent)
+	require.NoError(t, err)
+
+	l := newLuaWithScopedRegistries(t, pid.PID{Host: "h1", UniqID: "caller", Node: "node-1"}, &fakePIDRegistry{}, globalReg, nil)
+
+	err = l.DoString(fmt.Sprintf(`
+		local p, err = process.registry.lookup("svc-global")
+		if p ~= %q then error("expected global pid, got " .. tostring(p) .. " err=" .. tostring(err)) end
+	`, holder.String()))
+	require.NoError(t, err)
+}
+
+func TestRegistryLookup_GlobalScopeWithoutLocalRegistry(t *testing.T) {
+	globalReg := newFakeScopedRegistry()
+	holder := pid.PID{Host: "h1", UniqID: "global-holder", Node: "node-1"}
+	_, err := globalReg.RegisterScope(context.Background(), "svc-global-only", holder, globalapi.Consistent)
+	require.NoError(t, err)
+
+	l := newLuaWithScopedRegistries(t, pid.PID{Host: "h1", UniqID: "caller", Node: "node-1"}, nil, globalReg, nil)
+
+	err = l.DoString(fmt.Sprintf(`
+		local p, err = process.registry.lookup("svc-global-only")
+		if p ~= %q then error("expected global pid without local registry, got " .. tostring(p) .. " err=" .. tostring(err)) end
+	`, holder.String()))
+	require.NoError(t, err)
+}
+
+func TestRegistryLookup_EventualScope(t *testing.T) {
+	eventualReg := &fakeEventualRegistry{}
+	holder := pid.PID{Host: "h1", UniqID: "eventual-holder", Node: "node-1"}
+	_, err := eventualReg.Register("svc-eventual", holder)
+	require.NoError(t, err)
+
+	l := newLuaWithScopedRegistries(t, pid.PID{Host: "h1", UniqID: "caller", Node: "node-1"}, &fakePIDRegistry{}, nil, eventualReg)
+
+	err = l.DoString(fmt.Sprintf(`
+		local p, err = process.registry.lookup("svc-eventual")
+		if p ~= %q then error("expected eventual pid, got " .. tostring(p) .. " err=" .. tostring(err)) end
+	`, holder.String()))
+	require.NoError(t, err)
+}
+
+func TestRegistryLookup_EventualScopeWithoutLocalRegistry(t *testing.T) {
+	eventualReg := &fakeEventualRegistry{}
+	holder := pid.PID{Host: "h1", UniqID: "eventual-holder", Node: "node-1"}
+	_, err := eventualReg.Register("svc-eventual-only", holder)
+	require.NoError(t, err)
+
+	l := newLuaWithScopedRegistries(t, pid.PID{Host: "h1", UniqID: "caller", Node: "node-1"}, nil, nil, eventualReg)
+
+	err = l.DoString(fmt.Sprintf(`
+		local p, err = process.registry.lookup("svc-eventual-only")
+		if p ~= %q then error("expected eventual pid without local registry, got " .. tostring(p) .. " err=" .. tostring(err)) end
+	`, holder.String()))
+	require.NoError(t, err)
 }
 
 // TestRegistryUnregister_Strong_ByHolder verifies the holder can drop its

--- a/system/crdt/state.go
+++ b/system/crdt/state.go
@@ -518,9 +518,11 @@ func (s *State) Range(start, end string, fn func(Entry) bool) {
 	}
 }
 
-// ReapTombstones drops tombstones whose origin counter is ≤ the safe
-// counter for that origin. `safeByNode` is keyed by compact node ID.
-// Tombstones with `nowMs - Wall > wallFloorMs` are dropped regardless.
+// ReapTombstones drops tombstones whose origin counter is <= the safe counter
+// for that origin. `safeByNode` is keyed by compact node ID. If wallFloorMs is
+// positive, tombstones with `nowMs - Wall > wallFloorMs` are also dropped as an
+// explicit operator tradeoff. A non-positive wallFloorMs disables time-based
+// expiry because age alone cannot prove that delayed live dots are gone.
 // Returns counts: (gcSafe, gcWallFloor).
 func (s *State) ReapTombstones(safeByNode []uint64, nowMs, wallFloorMs int64) (int, int) {
 	var safe, floor int
@@ -537,7 +539,7 @@ func (s *State) ReapTombstones(safeByNode []uint64, nowMs, wallFloorMs int64) (i
 				safe++
 				continue
 			}
-			if nowMs-e.Wall > wallFloorMs {
+			if wallFloorMs > 0 && nowMs-e.Wall > wallFloorMs {
 				delete(sh.entries, key)
 				s.tombstone.Add(-1)
 				floor++

--- a/system/crdt/state_test.go
+++ b/system/crdt/state_test.go
@@ -249,6 +249,21 @@ func TestState_ReapTombstones_SafeCounter(t *testing.T) {
 	}
 }
 
+func TestState_ReapTombstones_WallFloorDisabled(t *testing.T) {
+	s := NewState("node-A")
+	_, _ = s.Register("k", []byte("v"), 100)
+	_, _ = s.Unregister("k", 200)
+
+	cv := []uint64{0}
+	gcSafe, gcFloor := s.ReapTombstones(cv, 1_000_000_000, 0)
+	if gcSafe != 0 || gcFloor != 0 {
+		t.Errorf("gcSafe=%d gcFloor=%d, want 0/0", gcSafe, gcFloor)
+	}
+	if s.TombstoneCount() != 1 {
+		t.Errorf("tombstone reaped with wall floor disabled")
+	}
+}
+
 func TestState_RangeOrdered(t *testing.T) {
 	s := NewState("node-A")
 	keys := []string{"a", "c", "b", "e", "d"}

--- a/system/kv/crdt_engine.go
+++ b/system/kv/crdt_engine.go
@@ -26,14 +26,13 @@ const crdtReapInterval = time.Second
 // crdtTombstoneGCInterval is how often the local tombstone GC pass runs.
 const crdtTombstoneGCInterval = time.Minute
 
-// crdtTombstoneFloor is the wall-clock age past which a delete tombstone is
-// dropped to bound memory. It must exceed the anti-entropy convergence window by
-// a wide margin so a tombstone is reaped only after every alive peer has
-// certainly observed it via push/pull; the value mirrors the eventual registry's
-// DefaultWallFloor. CV-gated (safe-counter) reaping — which would let healthy
-// clusters drop tombstones sooner — needs a per-origin digest exchange the
-// store.kv.crdt delegate does not run, so the wall floor is the sole bound.
-const crdtTombstoneFloor = 15 * time.Minute
+// DefaultTombstoneRetention is the default age-only delete-tombstone retention
+// for store.kv.crdt. A non-positive value disables age-only GC. That is the
+// correctness-first default: without per-peer delete acknowledgements or
+// per-origin CV digests, any finite wall-clock floor encodes a max-partition
+// assumption and can resurrect deletes on nodes that were offline longer than
+// the floor.
+const DefaultTombstoneRetention time.Duration = 0
 
 // wallScale shifts the real millisecond clock left so a per-node tiebreak fits
 // in the low digits. crdt.State.Apply resolves a cross-origin conflict purely by
@@ -87,7 +86,7 @@ func NewCRDTEngine(localNode string, bus event.Bus, logger *zap.Logger) *CRDTEng
 		durableNS:      make(map[string]struct{}),
 		snapInterval:   30 * time.Second,
 		gcInterval:     crdtTombstoneGCInterval,
-		tombstoneFloor: crdtTombstoneFloor,
+		tombstoneFloor: DefaultTombstoneRetention,
 		leaseKeys:      make(map[kvapi.LeaseID]map[string]struct{}),
 		deadlines:      make(map[kvapi.LeaseID]time.Time),
 		keyLease:       make(map[string]kvapi.LeaseID),
@@ -106,6 +105,16 @@ func (e *CRDTEngine) SetDurability(dataDir string, interval time.Duration) {
 	if interval > 0 {
 		e.snapInterval = interval
 	}
+	e.mu.Unlock()
+}
+
+// SetTombstoneRetention sets the age-only delete tombstone retention. A
+// non-positive duration disables age-only GC and keeps delete fences until the
+// process restarts or a future CV-gated GC mechanism can prove every peer has
+// observed the delete.
+func (e *CRDTEngine) SetTombstoneRetention(retention time.Duration) {
+	e.mu.Lock()
+	e.tombstoneFloor = retention
 	e.mu.Unlock()
 }
 
@@ -446,10 +455,10 @@ func (e *CRDTEngine) reaper() {
 	}
 }
 
-// tombstoneReaper periodically drops delete tombstones older than the wall
-// floor. Without it a churn of put/delete on a store.kv.crdt namespace grows
-// local state — and every gossip frame and durable snapshot — without bound,
-// because every Delete leaves a tombstone that otherwise lives forever.
+// tombstoneReaper periodically drops delete tombstones older than the configured
+// wall floor. With the default non-positive floor it is correctness-first and
+// does not age out tombstones; operators can configure a positive retention to
+// trade max-partition tolerance for bounded delete-churn memory.
 func (e *CRDTEngine) tombstoneReaper() {
 	defer e.wg.Done()
 	ticker := time.NewTicker(e.gcInterval)
@@ -468,11 +477,14 @@ func (e *CRDTEngine) tombstoneReaper() {
 
 // gcTombstones runs one tombstone GC pass. safeByNode is nil because the
 // store.kv.crdt delegate exchanges no per-origin CV digests, so the wall floor
-// is the only drop criterion; now and the floor are in the engine's scaled wall
-// units (real ms * wallScale) to match Entry.Wall.
+// is the only age-based drop criterion; now and the floor are in the engine's
+// scaled wall units (real ms * wallScale) to match Entry.Wall.
 func (e *CRDTEngine) gcTombstones() (int, int) {
+	e.mu.Lock()
+	retention := e.tombstoneFloor
+	e.mu.Unlock()
 	nowScaled := time.Now().UnixMilli() * wallScale
-	floorScaled := e.tombstoneFloor.Milliseconds() * wallScale
+	floorScaled := retention.Milliseconds() * wallScale
 	return e.state.ReapTombstones(nil, nowScaled, floorScaled)
 }
 

--- a/system/kv/crdt_gc_test.go
+++ b/system/kv/crdt_gc_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 // TestCRDTEngine_TombstoneGCBoundsMemory is the B2 regression: every Delete
-// leaves a tombstone, and without GC they accumulate forever in state, in every
-// gossip frame, and in every durable snapshot. The wall-floor reaper bounds that
-// while retaining recent tombstones so a lagging peer cannot resurrect a delete.
+// leaves a tombstone. The default is correctness-first and keeps tombstones
+// because a wall-clock floor can resurrect deletes after long partitions; an
+// explicitly configured positive floor bounds delete-churn memory.
 func TestCRDTEngine_TombstoneGCBoundsMemory(t *testing.T) {
-	// A recent tombstone is retained under the default wall floor.
+	// A tombstone is retained under the default disabled wall floor.
 	retain := newCRDT(t, "n1")
 	if _, err := retain.Set("k", []byte("v")); err != nil {
 		t.Fatalf("set: %v", err)
@@ -24,14 +24,30 @@ func TestCRDTEngine_TombstoneGCBoundsMemory(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 	if safe, floor := retain.gcTombstones(); safe+floor != 0 || retain.state.TombstoneCount() != 1 {
-		t.Fatalf("recent tombstone reaped under default floor: safe=%d floor=%d count=%d",
+		t.Fatalf("tombstone reaped under disabled default floor: safe=%d floor=%d count=%d",
 			safe, floor, retain.state.TombstoneCount())
 	}
 
-	// Past the floor every tombstone is reaped, so put/delete churn cannot grow
-	// state without bound.
-	gc := newCRDT(t, "n2")
-	gc.tombstoneFloor = 0
+	// Wrong/non-positive floors are treated as disabled, not as "reap
+	// everything"; this avoids data loss from bad config values.
+	disabled := newCRDT(t, "n2")
+	disabled.SetTombstoneRetention(-time.Second)
+	if _, err := disabled.Set("k", []byte("v")); err != nil {
+		t.Fatalf("set disabled: %v", err)
+	}
+	if err := disabled.Delete("k"); err != nil {
+		t.Fatalf("delete disabled: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if safe, floor := disabled.gcTombstones(); safe+floor != 0 || disabled.state.TombstoneCount() != 1 {
+		t.Fatalf("negative floor should not reap: safe=%d floor=%d count=%d",
+			safe, floor, disabled.state.TombstoneCount())
+	}
+
+	// Past an explicit positive floor every tombstone is reaped, so put/delete
+	// churn can be bounded when the operator accepts the max-partition tradeoff.
+	gc := newCRDT(t, "n3")
+	gc.SetTombstoneRetention(time.Millisecond)
 	for _, k := range []string{"a", "b", "c"} {
 		if _, err := gc.Set(k, []byte("v")); err != nil {
 			t.Fatalf("set %s: %v", k, err)

--- a/system/logs/core.go
+++ b/system/logs/core.go
@@ -9,6 +9,7 @@ import (
 	api "github.com/wippyai/runtime/api/logs"
 
 	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/metrics"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -16,6 +17,7 @@ type Core struct {
 	downstream zapcore.Core
 	bus        event.Bus
 	config     *atomic.Value
+	collector  atomic.Pointer[metrics.Collector]
 }
 
 func NewCore(downstream zapcore.Core, bus event.Bus) api.Core {
@@ -41,6 +43,17 @@ func (c *Core) GetConfig() api.Config {
 	return c.config.Load().(api.Config)
 }
 
+func (c *Core) SetCollector(coll metrics.Collector) {
+	if coll == nil {
+		c.collector.Store(nil)
+		return
+	}
+	for _, level := range []string{"debug", "info", "warn", "error", "dpanic", "panic", "fatal"} {
+		coll.CounterAdd("runtime_log_emissions_total", 0, metrics.Labels{"level": level})
+	}
+	c.collector.Store(&coll)
+}
+
 func (c *Core) Enabled(level zapcore.Level) bool {
 	cfg := c.config.Load().(api.Config)
 
@@ -56,11 +69,15 @@ func (c *Core) Enabled(level zapcore.Level) bool {
 }
 
 func (c *Core) With(fields []zapcore.Field) zapcore.Core {
-	return &Core{
+	child := &Core{
 		downstream: c.downstream.With(fields),
 		bus:        c.bus,
 		config:     c.config,
 	}
+	if coll := c.collector.Load(); coll != nil {
+		child.collector.Store(coll)
+	}
+	return child
 }
 
 func (c *Core) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
@@ -84,6 +101,7 @@ func (c *Core) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	if cfg.StreamToEvents {
 		c.publishLogEvent(ent, fields)
 	}
+	c.recordEmission(ent.Level)
 
 	return nil
 }
@@ -96,6 +114,12 @@ func (c *Core) Sync() error {
 	}
 
 	return nil
+}
+
+func (c *Core) recordEmission(level zapcore.Level) {
+	if coll := c.collector.Load(); coll != nil {
+		(*coll).CounterInc("runtime_log_emissions_total", metrics.Labels{"level": level.String()})
+	}
 }
 
 type logEntry struct {

--- a/system/logs/core_test.go
+++ b/system/logs/core_test.go
@@ -9,6 +9,7 @@ import (
 	api "github.com/wippyai/runtime/api/logs"
 
 	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/metrics"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -76,6 +77,28 @@ func (t *testEventBus) Send(_ context.Context, event event.Event) {
 	t.sendCalls = append(t.sendCalls, event)
 }
 
+type testMetricsCollector struct {
+	counters map[string]float64
+}
+
+func (t *testMetricsCollector) CounterInc(name string, labels metrics.Labels) {
+	t.CounterAdd(name, 1, labels)
+}
+
+func (t *testMetricsCollector) CounterAdd(name string, delta float64, labels metrics.Labels) {
+	if t.counters == nil {
+		t.counters = make(map[string]float64)
+	}
+	t.counters[name+"/"+labels["level"]] += delta
+}
+
+func (t *testMetricsCollector) GaugeSet(string, float64, metrics.Labels)         {}
+func (t *testMetricsCollector) GaugeInc(string, metrics.Labels)                  {}
+func (t *testMetricsCollector) GaugeDec(string, metrics.Labels)                  {}
+func (t *testMetricsCollector) HistogramObserve(string, float64, metrics.Labels) {}
+func (t *testMetricsCollector) RegisterExporter(metrics.Exporter) error          { return nil }
+func (t *testMetricsCollector) Close() error                                     { return nil }
+
 func TestNewCore(t *testing.T) {
 	downstream := &testDownstreamCore{}
 	bus := &testEventBus{}
@@ -88,6 +111,29 @@ func TestNewCore(t *testing.T) {
 	}
 	if config.StreamToEvents {
 		t.Error("expected StreamToEvents to be false")
+	}
+}
+
+func TestCore_LogEmissionMetric(t *testing.T) {
+	downstream := &testDownstreamCore{}
+	bus := &testEventBus{}
+	core := NewCore(downstream, bus)
+	coll := &testMetricsCollector{}
+	core.SetCollector(coll)
+	core.Configure(api.Config{
+		PropagateDownstream: true,
+		StreamToEvents:      false,
+		MinLevel:            zapcore.DebugLevel,
+	})
+
+	if _, ok := coll.counters["runtime_log_emissions_total/info"]; !ok {
+		t.Fatal("expected info log emission counter to be bootstrapped")
+	}
+	if err := core.Write(zapcore.Entry{Level: zapcore.InfoLevel, Message: "hello"}, nil); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if got := coll.counters["runtime_log_emissions_total/info"]; got != 1 {
+		t.Fatalf("runtime_log_emissions_total/info = %v, want 1", got)
 	}
 }
 

--- a/system/logs/manager.go
+++ b/system/logs/manager.go
@@ -9,6 +9,7 @@ import (
 	api "github.com/wippyai/runtime/api/logs"
 
 	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/metrics"
 	"github.com/wippyai/runtime/system/eventbus"
 	"go.uber.org/zap"
 )
@@ -145,4 +146,8 @@ func (m *Manager) GetConfig() api.Config {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.config
+}
+
+func (m *Manager) SetCollector(c metrics.Collector) {
+	m.core.SetCollector(c)
 }

--- a/system/topology/namereg/eventual/delta.go
+++ b/system/topology/namereg/eventual/delta.go
@@ -124,9 +124,63 @@ func DecodeShardResponseFrame(data []byte) (senderNode string, payload []byte, e
 // limit and start a new frame.
 const MaxFrameBytes = 1400
 
+// ReliableFrameMaxBytes is the cap for one targeted reliable anti-entropy
+// frame. It mirrors membership.ReliableUserMessageMaxPayloadBytes without
+// importing membership into this lower-level package.
+const ReliableFrameMaxBytes = 64 * 1024
+
 // ErrFrameOverflow indicates a delta would exceed MaxFrameBytes by itself.
 // Callers should send the offending entry over TCP instead (digest exchange).
 var ErrFrameOverflow = errors.New("eventualreg: delta exceeds frame size")
+
+// EncodeShardResponseFramesBounded packs shard payloads into one or more
+// FrameTypeShardResponse frames, each at most maxBytes. A single shard payload
+// that cannot fit is skipped: retrying it unchanged would only create an
+// oversized reliable message forever.
+func EncodeShardResponseFramesBounded(senderNode string, payloads [][]byte, maxBytes int) (frames [][]byte, payloadsSent int, payloadsSkipped int, err error) {
+	if len(senderNode) > 0xFF {
+		return nil, 0, 0, fmt.Errorf("eventualreg: sender node too long: %d", len(senderNode))
+	}
+	headerLen := 2 + len(senderNode)
+	if maxBytes <= headerLen {
+		return nil, 0, len(payloads), nil
+	}
+
+	var batch [][]byte
+	batchBytes := headerLen
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		frame, err := EncodeShardResponseFrame(senderNode, batch)
+		if err != nil {
+			return err
+		}
+		frames = append(frames, frame)
+		payloadsSent += len(batch)
+		batch = nil
+		batchBytes = headerLen
+		return nil
+	}
+
+	for _, p := range payloads {
+		if len(p)+headerLen > maxBytes {
+			payloadsSkipped++
+			continue
+		}
+		if batchBytes+len(p) > maxBytes {
+			if err := flush(); err != nil {
+				return nil, 0, 0, err
+			}
+		}
+		batch = append(batch, p)
+		batchBytes += len(p)
+	}
+	if err := flush(); err != nil {
+		return nil, 0, 0, err
+	}
+	return frames, payloadsSent, payloadsSkipped, nil
+}
 
 // EncodeDelta writes one entry into the buffer using a compact format:
 //

--- a/system/topology/namereg/eventual/delta_test.go
+++ b/system/topology/namereg/eventual/delta_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package eventual
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestEncodeShardResponseFramesBoundedSplitsPayloads(t *testing.T) {
+	sender := "node-a"
+	headerLen := 2 + len(sender)
+	maxBytes := headerLen + 20
+	payloads := [][]byte{
+		bytes.Repeat([]byte{1}, 12),
+		bytes.Repeat([]byte{2}, 12),
+		bytes.Repeat([]byte{3}, 4),
+	}
+
+	frames, sent, skipped, err := EncodeShardResponseFramesBounded(sender, payloads, maxBytes)
+	if err != nil {
+		t.Fatalf("encode bounded: %v", err)
+	}
+	if sent != len(payloads) || skipped != 0 {
+		t.Fatalf("sent/skipped=%d/%d, want %d/0", sent, skipped, len(payloads))
+	}
+	if len(frames) != 2 {
+		t.Fatalf("frames=%d, want 2", len(frames))
+	}
+	for _, frame := range frames {
+		if len(frame) > maxBytes {
+			t.Fatalf("frame too large: %d > %d", len(frame), maxBytes)
+		}
+		gotSender, _, err := DecodeShardResponseFrame(frame[1:])
+		if err != nil {
+			t.Fatalf("decode response frame: %v", err)
+		}
+		if gotSender != sender {
+			t.Fatalf("sender=%q, want %q", gotSender, sender)
+		}
+	}
+}
+
+func TestEncodeShardResponseFramesBoundedSkipsImpossiblePayload(t *testing.T) {
+	sender := "node-a"
+	headerLen := 2 + len(sender)
+	maxBytes := headerLen + 8
+	payloads := [][]byte{
+		bytes.Repeat([]byte{1}, 4),
+		bytes.Repeat([]byte{2}, 9),
+	}
+
+	frames, sent, skipped, err := EncodeShardResponseFramesBounded(sender, payloads, maxBytes)
+	if err != nil {
+		t.Fatalf("encode bounded: %v", err)
+	}
+	if sent != 1 || skipped != 1 {
+		t.Fatalf("sent/skipped=%d/%d, want 1/1", sent, skipped)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frames=%d, want 1", len(frames))
+	}
+	if len(frames[0]) > maxBytes {
+		t.Fatalf("frame too large: %d > %d", len(frames[0]), maxBytes)
+	}
+}
+
+func TestEncodeShardPayloadsBoundedSplitsEntries(t *testing.T) {
+	s := NewState("node-a")
+	entries := make([]*Entry, 0, 3)
+	for _, name := range []string{"a", "b", "c"} {
+		e, _ := reg(s, name, makePID("node-a", "h", name), 100)
+		entries = append(entries, e)
+	}
+	first, err := EncodeDelta(nil, entries[0], s.NodeString(entries[0].Node))
+	if err != nil {
+		t.Fatalf("encode first delta: %v", err)
+	}
+	maxBytes := 6 + len(first) + 1
+
+	payloads, skipped, err := EncodeShardPayloadsBounded(3, entries, s.NodeString, maxBytes)
+	if err != nil {
+		t.Fatalf("encode bounded shard payloads: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped=%d, want 0", skipped)
+	}
+	if len(payloads) != len(entries) {
+		t.Fatalf("payloads=%d, want %d", len(payloads), len(entries))
+	}
+	decoded := 0
+	for _, payload := range payloads {
+		if len(payload) > maxBytes {
+			t.Fatalf("payload too large: %d > %d", len(payload), maxBytes)
+		}
+		sp, _, err := DecodeShardPayload(payload)
+		if err != nil {
+			t.Fatalf("decode shard payload: %v", err)
+		}
+		decoded += len(sp.Entries)
+	}
+	if decoded != len(entries) {
+		t.Fatalf("decoded=%d, want %d", decoded, len(entries))
+	}
+}
+
+func TestEncodeShardPayloadsBoundedSkipsImpossibleEntry(t *testing.T) {
+	s := NewState("node-a")
+	e, _ := reg(s, "too-large-for-this-test-budget", makePID("node-a", "h", "p"), 100)
+
+	payloads, skipped, err := EncodeShardPayloadsBounded(3, []*Entry{e}, s.NodeString, 16)
+	if err != nil {
+		t.Fatalf("encode bounded shard payloads: %v", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped=%d, want 1", skipped)
+	}
+	if len(payloads) != 0 {
+		t.Fatalf("payloads=%d, want 0", len(payloads))
+	}
+}
+
+func TestEncodeShardPayloadsBoundedPerformanceEnvelope(t *testing.T) {
+	s := NewState("node-a")
+	const n = 1000
+	entries := make([]*Entry, 0, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("perf-envelope-%04d", i)
+		e, _ := reg(s, name, makePID("node-a", "h", fmt.Sprintf("pid-%04d", i)), 100)
+		entries = append(entries, e)
+	}
+
+	maxBytes := ReliableFrameMaxBytes - 16
+	payloads, skipped, err := EncodeShardPayloadsBounded(7, entries, s.NodeString, maxBytes)
+	if err != nil {
+		t.Fatalf("encode bounded shard payloads: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped=%d, want 0", skipped)
+	}
+	if len(payloads) == 0 || len(payloads) > 4 {
+		t.Fatalf("payload count=%d, want 1..4 for %d entries", len(payloads), n)
+	}
+	for _, payload := range payloads {
+		if len(payload) > maxBytes {
+			t.Fatalf("payload too large: %d > %d", len(payload), maxBytes)
+		}
+	}
+
+	allocs := testing.AllocsPerRun(10, func() {
+		payloads, skipped, err := EncodeShardPayloadsBounded(7, entries, s.NodeString, maxBytes)
+		if err != nil || skipped != 0 || len(payloads) == 0 {
+			t.Fatalf("unexpected encode result: payloads=%d skipped=%d err=%v", len(payloads), skipped, err)
+		}
+	})
+	if allocs > float64(n*2+100) {
+		t.Fatalf("allocations too high: got %.0f for %d entries", allocs, n)
+	}
+}

--- a/system/topology/namereg/eventual/digest.go
+++ b/system/topology/namereg/eventual/digest.go
@@ -113,6 +113,72 @@ func EncodeShardPayload(buf []byte, shardID uint16, entries []*Entry, originLook
 	return buf, nil
 }
 
+// EncodeShardPayloadsBounded serializes a shard into one or more shard payloads,
+// each at most maxBytes. Chunking at entry boundaries keeps the targeted
+// anti-entropy path useful for large shards without allowing a single response
+// to become an unbounded reliable-message allocation. Entries that cannot fit by
+// themselves are skipped.
+func EncodeShardPayloadsBounded(shardID uint16, entries []*Entry, originLookup func(uint32) string, maxBytes int) (payloads [][]byte, skipped int, err error) {
+	const headerLen = 6
+	if maxBytes <= headerLen {
+		return nil, len(entries), nil
+	}
+
+	buf := make([]byte, 0, maxBytes)
+	startPayload := func() {
+		buf = binary.LittleEndian.AppendUint16(buf[:0], shardID)
+		buf = binary.LittleEndian.AppendUint32(buf, 0)
+	}
+	count := uint32(0)
+	startPayload()
+
+	flush := func() {
+		if count == 0 {
+			return
+		}
+		binary.LittleEndian.PutUint32(buf[2:6], count)
+		payloads = append(payloads, append([]byte(nil), buf...))
+		count = 0
+		startPayload()
+	}
+
+	for _, e := range entries {
+		origin := originLookup(e.Node)
+		recLen, err := encodedDeltaLen(e, origin)
+		if err != nil {
+			return nil, 0, err
+		}
+		if recLen+headerLen > maxBytes {
+			skipped++
+			continue
+		}
+		if len(buf)+recLen > maxBytes {
+			flush()
+		}
+		buf, err = EncodeDelta(buf, e, origin)
+		if err != nil {
+			return nil, 0, err
+		}
+		count++
+	}
+	flush()
+	return payloads, skipped, nil
+}
+
+func encodedDeltaLen(e *Entry, originNodeStr string) (int, error) {
+	if len(e.Name) > 0xFFFF {
+		return 0, fmt.Errorf("eventualreg: name too long: %d bytes", len(e.Name))
+	}
+	if len(originNodeStr) > 0xFF {
+		return 0, fmt.Errorf("eventualreg: origin node too long: %d bytes", len(originNodeStr))
+	}
+	if len(e.PID.Node) > 0xFF || len(e.PID.Host) > 0xFF || len(e.PID.UniqID) > 0xFFFF {
+		return 0, fmt.Errorf("eventualreg: pid fields too long")
+	}
+	return 1 + 2 + len(e.Name) + 1 + len(originNodeStr) + 8 + 8 + 4 +
+		1 + len(e.PID.Node) + 1 + len(e.PID.Host) + 2 + len(e.PID.UniqID), nil
+}
+
 // DecodeShardPayload parses a shard bulk-transfer body.
 func DecodeShardPayload(data []byte) (ShardPayload, int, error) {
 	if len(data) < 6 {

--- a/system/topology/namereg/eventual/gc.go
+++ b/system/topology/namereg/eventual/gc.go
@@ -7,10 +7,11 @@ import (
 	"time"
 )
 
-// DefaultWallFloor is the wall-clock cutoff at which a tombstone is dropped
-// regardless of safe-counter ack. Bounds memory if a node never acks back
-// (e.g. permanent partition).
-const DefaultWallFloor = 15 * time.Minute
+// DefaultWallFloor disables age-based tombstone expiry. Tombstones are safely
+// reclaimed by version-vector acks from every alive peer. Operators may set a
+// positive WallFloor as an explicit memory-bound tradeoff, but age alone cannot
+// prove that delayed live dots are gone.
+const DefaultWallFloor = 0
 
 // TombstoneTracker records, per origin node, the highest counter that EVERY
 // alive cluster member has acknowledged. Acknowledgment comes from digest
@@ -124,16 +125,13 @@ type GCConfig struct {
 	OnWallFloor func(int)                  // counter callback for wall-floor drops
 	OnReclaim   func(int)                  // counter callback for reclaimed compact ids
 	Period      time.Duration              // ticker cadence (default 20 s)
-	WallFloor   time.Duration              // age at which tombstones drop (default 15 min)
+	WallFloor   time.Duration              // optional age at which tombstones drop; <=0 disables
 }
 
 // NewGCRunner constructs a runner. Must call Start to begin.
 func NewGCRunner(cfg GCConfig) *GCRunner {
 	if cfg.Period <= 0 {
 		cfg.Period = 20 * time.Second
-	}
-	if cfg.WallFloor <= 0 {
-		cfg.WallFloor = DefaultWallFloor
 	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now

--- a/system/topology/namereg/eventual/gc_test.go
+++ b/system/topology/namereg/eventual/gc_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package eventual
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGCRunner_DefaultWallFloorDisabled(t *testing.T) {
+	state := NewState("node-A")
+	pA := makePID("node-A", "h", "1")
+	_, _ = reg(state, "alice", pA, 100)
+	_ = state.Unregister("alice", 200)
+
+	gc := NewGCRunner(GCConfig{
+		State:   state,
+		Tracker: NewTombstoneTracker(),
+		AliveFn: func() map[string]struct{} {
+			return map[string]struct{}{"node-A": {}}
+		},
+		Now: func() time.Time {
+			return time.UnixMilli(1_000_000_000)
+		},
+	})
+	gc.runOnce()
+
+	if state.TombstoneCount() != 1 {
+		t.Fatalf("default GC reaped an unacked tombstone; wall floor must be disabled by default")
+	}
+}

--- a/system/topology/namereg/eventual/service.go
+++ b/system/topology/namereg/eventual/service.go
@@ -99,7 +99,8 @@ type Config struct {
 	AntiEntropyPeriod time.Duration
 	// GCPeriod is the tombstone reap cadence. Default 20 s.
 	GCPeriod time.Duration
-	// WallFloor caps tombstone age. Default 15 min.
+	// WallFloor caps tombstone age when positive. Default 0 disables
+	// time-based tombstone expiry; safe-counter GC remains enabled.
 	WallFloor time.Duration
 	// ShardRequestCooldown suppresses repeated shard requests to the
 	// same peer within this window — keeps a sustained mismatch from
@@ -139,9 +140,6 @@ func NewService(cfg Config) *Service {
 	}
 	if cfg.GCPeriod <= 0 {
 		cfg.GCPeriod = 20 * time.Second
-	}
-	if cfg.WallFloor <= 0 {
-		cfg.WallFloor = DefaultWallFloor
 	}
 	if cfg.BroadcastCap <= 0 {
 		cfg.BroadcastCap = 4096
@@ -450,28 +448,50 @@ func (s *Service) handleShardRequestFrame(body []byte) {
 		return
 	}
 	payloads := make([][]byte, 0, len(ids))
+	payloadsSkipped := 0
+	maxShardPayloadBytes := ReliableFrameMaxBytes - (2 + len(s.cfg.LocalNodeID))
 	for _, id := range ids {
-		p, err := s.LocalShardPayload(id)
+		entries := s.state.ShardEntries(int(id))
+		chunks, skipped, err := EncodeShardPayloadsBounded(id, entries, s.state.NodeString, maxShardPayloadBytes)
 		if err != nil {
 			s.logger.Warn("eventualreg: encode shard", zap.Uint16("shard", id), zap.Error(err))
 			continue
 		}
-		payloads = append(payloads, p)
+		payloadsSkipped += skipped
+		payloads = append(payloads, chunks...)
 	}
 	if len(payloads) == 0 {
+		if payloadsSkipped > 0 {
+			s.logger.Warn("eventualreg: shard response entries exceeded reliable frame cap",
+				zap.String("to", sender),
+				zap.Int("skipped", payloadsSkipped),
+				zap.Int("max_bytes", ReliableFrameMaxBytes))
+		}
 		return
 	}
-	frame, err := EncodeShardResponseFrame(s.cfg.LocalNodeID, payloads)
+	frames, sent, skipped, err := EncodeShardResponseFramesBounded(s.cfg.LocalNodeID, payloads, ReliableFrameMaxBytes)
 	if err != nil {
 		s.logger.Warn("eventualreg: encode response frame", zap.Error(err))
 		return
 	}
-	if err := s.cfg.Sender.Send(sender, frame); err != nil {
-		s.logger.Debug("eventualreg: send shard response failed",
-			zap.String("to", sender), zap.Error(err))
+	if skipped+payloadsSkipped > 0 {
+		s.logger.Warn("eventualreg: shard response payloads exceeded reliable frame cap",
+			zap.String("to", sender),
+			zap.Int("skipped_payloads", skipped),
+			zap.Int("skipped_entries", payloadsSkipped),
+			zap.Int("max_bytes", ReliableFrameMaxBytes))
+	}
+	if len(frames) == 0 {
 		return
 	}
-	s.tel.recordShardResponse("tx", len(payloads))
+	for _, frame := range frames {
+		if err := s.cfg.Sender.Send(sender, frame); err != nil {
+			s.logger.Debug("eventualreg: send shard response failed",
+				zap.String("to", sender), zap.Error(err))
+			return
+		}
+	}
+	s.tel.recordShardResponse("tx", sent)
 }
 
 func (s *Service) handleShardResponseFrame(body []byte) {

--- a/system/topology/namereg/eventual/state.go
+++ b/system/topology/namereg/eventual/state.go
@@ -668,12 +668,15 @@ func (s *State) LiveCount() int64 { return s.live.Load() }
 // TombstoneCount returns the number of names whose visible winner is a tombstone.
 func (s *State) TombstoneCount() int64 { return s.tombstone.Load() }
 
-// ReapTombstones drops per-origin tombstone dots whose origin counter is ≤ the
-// safe counter for that origin, or older than the wall floor. `safeByNode` is
-// keyed by compact node ID. Wall is a GC retention floor only here — never a
-// conflict-resolution discriminator. A name whose record becomes empty is
-// removed; if reaping changes the visible winner, the live/tombstone gauges
-// are adjusted. Returns counts: (gcSafe, gcWallFloor) of dots dropped.
+// ReapTombstones drops per-origin tombstone dots whose origin counter is <= the
+// safe counter for that origin. If wallFloorMs is positive, old tombstones may
+// also be dropped as an explicit operator memory-bound tradeoff. A non-positive
+// wallFloorMs disables age-based expiry because ORSWOT safety requires either
+// causal dominance or an external guarantee that stale live dots cannot return.
+// `safeByNode` is keyed by compact node ID. Wall is a GC retention floor only
+// here, never a conflict-resolution discriminator. A name whose record becomes
+// empty is removed; if reaping changes the visible winner, the live/tombstone
+// gauges are adjusted. Returns counts: (gcSafe, gcWallFloor) of dots dropped.
 func (s *State) ReapTombstones(safeByNode []uint64, nowMs, wallFloorMs int64) (int, int) {
 	var safe, floor int
 	for i := range s.shards {
@@ -691,7 +694,7 @@ func (s *State) ReapTombstones(safeByNode []uint64, nowMs, wallFloorMs int64) (i
 					safe++
 					continue
 				}
-				if nowMs-e.Wall > wallFloorMs {
+				if wallFloorMs > 0 && nowMs-e.Wall > wallFloorMs {
 					delete(rec.dots, node)
 					s.release(node)
 					floor++

--- a/system/topology/namereg/eventual/state_test.go
+++ b/system/topology/namereg/eventual/state_test.go
@@ -427,6 +427,29 @@ func TestState_ReapTombstones_WallFloor(t *testing.T) {
 	}
 }
 
+func TestState_ReapTombstones_WallFloorDisabled(t *testing.T) {
+	s := NewState("node-A")
+	pA := makePID("node-A", "h", "1")
+	_, _ = reg(s, "alice", pA, 100)
+	_ = s.Unregister("alice", 200)
+
+	cv := make([]uint64, 1)
+	cv[0] = 0
+	gcSafe, gcFloor := s.ReapTombstones(cv, 1_000_000_000, 0)
+	if gcSafe != 0 {
+		t.Errorf("gcSafe=%d, want 0", gcSafe)
+	}
+	if gcFloor != 0 {
+		t.Errorf("gcFloor=%d, want 0", gcFloor)
+	}
+	if s.TombstoneCount() != 1 {
+		t.Errorf("tombstone reaped with wall floor disabled")
+	}
+	if _, found := s.Lookup("alice"); found {
+		t.Errorf("tombstoned name resurrected")
+	}
+}
+
 func TestState_DeltaRoundTrip(t *testing.T) {
 	s := NewState("node-A")
 	pA := makePID("node-A", "h", "1")
@@ -529,6 +552,58 @@ func TestService_ShardPullRecoversDroppedDelta(t *testing.T) {
 	// Cooldown: a second immediate request must be suppressed.
 	if b.RequestShards("node-A", mismatched) {
 		t.Errorf("cooldown should have suppressed second request")
+	}
+}
+
+func TestService_ShardPullLargeResponseChunkedBoundedConverges(t *testing.T) {
+	cfgA := Config{LocalNodeID: "node-A"}
+	cfgB := Config{LocalNodeID: "node-B"}
+	a := NewService(cfgA)
+	b := NewService(cfgB)
+	t.Cleanup(func() { _ = a.Stop(); _ = b.Stop() })
+
+	senderToA := &recordingSender{peer: a}
+	senderToB := &recordingSender{peer: b}
+	a.cfg.Sender = senderToB
+	b.cfg.Sender = senderToA
+
+	const n = 900
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("large-shard-repair-%04d", i)
+		p := makePID("node-A", "host", fmt.Sprintf("pid-with-enough-bytes-to-force-chunking-%04d", i))
+		if _, err := a.Register(name, p); err != nil {
+			t.Fatalf("register %s on A: %v", name, err)
+		}
+	}
+
+	mismatched := b.LocalDigest().Diff(a.LocalDigest())
+	if len(mismatched) == 0 {
+		t.Fatalf("expected digest mismatch with empty B")
+	}
+	if !b.RequestShards("node-A", mismatched) {
+		t.Fatalf("RequestShards should have emitted")
+	}
+
+	responseFrames := 0
+	for _, sent := range senderToB.sent {
+		if len(sent.Payload) == 0 || FrameType(sent.Payload[0]) != FrameTypeShardResponse {
+			continue
+		}
+		responseFrames++
+		if len(sent.Payload) > ReliableFrameMaxBytes {
+			t.Fatalf("response frame too large: %d > %d", len(sent.Payload), ReliableFrameMaxBytes)
+		}
+	}
+	if responseFrames < 2 {
+		t.Fatalf("expected chunked response across multiple frames, got %d", responseFrames)
+	}
+
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("large-shard-repair-%04d", i)
+		res, err := b.Lookup(context.Background(), name)
+		if err != nil || !res.Found {
+			t.Fatalf("%s not recovered on B: err=%v found=%v", name, err, res.Found)
+		}
 	}
 }
 

--- a/system/topology/namereg/global/dissem.go
+++ b/system/topology/namereg/global/dissem.go
@@ -27,15 +27,15 @@ const (
 	// dissemMaxFrameBytes mirrors eventualreg's safe UDP packet ceiling.
 	dissemMaxFrameBytes = 1400
 
-	// tombstoneGCInterval is the period the cache sweeps tombstones older than
-	// tombstoneWallFloor. Cheap walk; intentionally infrequent.
+	// tombstoneGCInterval is the period the cache checks whether tombstone
+	// expiry is explicitly enabled. Cheap walk; intentionally infrequent.
 	tombstoneGCInterval = 5 * time.Minute
 
-	// tombstoneWallFloor is the minimum wall-time a tombstone is retained
-	// before GC drops it. Conservative — a node that missed the broadcast and
-	// anti-entropy for longer than this is rare and would heal via a fresh
-	// authoritative bind anyway.
-	tombstoneWallFloor = 15 * time.Minute
+	// tombstoneWallFloor is the default deleted-binding fence retention for the
+	// AP cache. Zero disables age-only GC by default: without per-peer delete
+	// acknowledgements or a durable delete vector, a finite default TTL is only
+	// an operator assumption about max partition length.
+	tombstoneWallFloor = 0
 
 	// antiEntropyInterval drives the periodic digest exchange with a derived
 	// member. Bounded; one peer per tick.
@@ -70,14 +70,15 @@ type bindingEntry struct {
 //   - LocalApply      (member's own FSM.Apply seeding the cache so members can
 //     use the cache as a fast path alongside their FSM).
 type Dissem struct {
-	logger    *zap.Logger
-	cache     map[string]bindingEntry
-	stopCh    chan struct{}
-	localNode pid.NodeID
-	queue     []bindingDelta
-	qDropped  uint64
-	mu        sync.RWMutex
-	qMu       sync.Mutex
+	cache              map[string]bindingEntry
+	logger             *zap.Logger
+	stopCh             chan struct{}
+	localNode          pid.NodeID
+	queue              []bindingDelta
+	tombstoneRetention time.Duration
+	qDropped           uint64
+	mu                 sync.RWMutex
+	qMu                sync.Mutex
 }
 
 // bindingDelta is the wire form of one cache mutation. Encoded compactly so
@@ -100,17 +101,36 @@ type bindingDelta struct {
 	Deleted   bool
 }
 
+// DissemOption tunes the active-binding dissemination cache.
+type DissemOption func(*Dissem)
+
+// WithTombstoneRetention tunes how long deleted bindings remain in the AP cache
+// to fence stale lower-index live gossip. A non-positive value keeps the
+// default.
+func WithTombstoneRetention(retention time.Duration) DissemOption {
+	return func(d *Dissem) {
+		if retention > 0 {
+			d.tombstoneRetention = retention
+		}
+	}
+}
+
 // NewDissem builds an empty dissemination plane bound to the local node ID.
-func NewDissem(localNode pid.NodeID, logger *zap.Logger) *Dissem {
+func NewDissem(localNode pid.NodeID, logger *zap.Logger, opts ...DissemOption) *Dissem {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &Dissem{
-		localNode: localNode,
-		logger:    logger.Named("global.dissem"),
-		cache:     make(map[string]bindingEntry, 64),
-		stopCh:    make(chan struct{}),
+	d := &Dissem{
+		localNode:          localNode,
+		logger:             logger.Named("global.dissem"),
+		cache:              make(map[string]bindingEntry, 64),
+		stopCh:             make(chan struct{}),
+		tombstoneRetention: tombstoneWallFloor,
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
 }
 
 // Kind reports the multiplex byte for globalreg dissemination frames.
@@ -368,8 +388,10 @@ func (d *Dissem) Stop() {
 	}
 }
 
-// RunGC sweeps tombstones older than tombstoneWallFloor. Bounded; one walk per
-// tick. Safe to call exactly once after construction.
+// RunGC sweeps tombstones older than tombstoneRetention. Bounded retention is
+// safe for this AP cache because Raft/FSM is the source of truth and memberlist
+// retransmission windows are finite; the floor exists only to fence stale
+// lower-index live gossip.
 func (d *Dissem) RunGC() {
 	t := time.NewTicker(tombstoneGCInterval)
 	defer t.Stop()
@@ -383,10 +405,14 @@ func (d *Dissem) RunGC() {
 	}
 }
 
-// sweepTombstones drops every tombstone whose wall-time predates the floor.
-// Held only briefly under the cache write-lock.
+// sweepTombstones drops every tombstone whose wall-time predates the floor. Held
+// only briefly under the cache write-lock.
 func (d *Dissem) sweepTombstones(nowNano int64) int {
-	floor := nowNano - tombstoneWallFloor.Nanoseconds()
+	retention := d.tombstoneRetention
+	if retention <= 0 {
+		return 0
+	}
+	floor := nowNano - retention.Nanoseconds()
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	removed := 0
@@ -402,29 +428,29 @@ func (d *Dissem) sweepTombstones(nowNano int64) int {
 	return removed
 }
 
-// Digest is a compact projection of the cache used by anti-entropy: name -> raftIndex.
-// Sorted in name order so the comparison is deterministic.
+// Digest is a compact projection of the cache used by anti-entropy:
+// name -> (raftIndex, deleted). Sorted in name order so comparison is
+// deterministic.
 type Digest struct {
 	Entries []DigestEntry
 }
 
-// DigestEntry is one name + index in a digest.
+// DigestEntry is one name + index in a digest. Deleted entries are included so
+// anti-entropy can repair peers that missed a tombstone broadcast.
 type DigestEntry struct {
 	Name      string
 	RaftIndex uint64
+	Deleted   bool
 }
 
-// DigestSnapshot returns a sorted snapshot of (name, raftIndex) for active
-// (non-tombstoned) entries. Used by anti-entropy mismatch detection.
+// DigestSnapshot returns a sorted snapshot of (name, raftIndex, deleted) for
+// the cache. Used by anti-entropy mismatch detection.
 func (d *Dissem) DigestSnapshot() Digest {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	out := make([]DigestEntry, 0, len(d.cache))
 	for name, e := range d.cache {
-		if e.Deleted {
-			continue
-		}
-		out = append(out, DigestEntry{Name: name, RaftIndex: e.RaftIndex})
+		out = append(out, DigestEntry{Name: name, RaftIndex: e.RaftIndex, Deleted: e.Deleted})
 	}
 	return Digest{Entries: out}
 }

--- a/system/topology/namereg/global/dissem_test.go
+++ b/system/topology/namereg/global/dissem_test.go
@@ -4,6 +4,8 @@ package global
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clusterapi "github.com/wippyai/runtime/api/cluster"
+	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/relay"
 )
@@ -58,19 +61,196 @@ func TestDissem_TombstoneSurfacesNotFound(t *testing.T) {
 	assert.False(t, ok, "tombstone surfaces as not-found")
 }
 
-// TestDissem_TombstoneGC_WallFloor asserts sweepTombstones drops tombstones
-// older than the wall floor and keeps fresh ones.
-func TestDissem_TombstoneGC_WallFloor(t *testing.T) {
+// TestDissem_TombstoneGC_DefaultDisabled asserts the default does not age out
+// tombstones without an explicit operator retention window.
+func TestDissem_TombstoneGC_DefaultDisabled(t *testing.T) {
 	d := NewDissem("node-a", nil)
 	p := makePID("node-a", "h", "p1")
 
 	now := time.Now().UnixNano()
-	d.merge(bindingDelta{Name: "old.ts", PID: p, RaftIndex: 1, Wall: now - 2*tombstoneWallFloor.Nanoseconds(), Deleted: true})
+	d.merge(bindingDelta{Name: "old.ts", PID: p, RaftIndex: 9, Wall: now - (365 * 24 * time.Hour).Nanoseconds(), Deleted: true})
 	d.merge(bindingDelta{Name: "fresh.ts", PID: p, RaftIndex: 2, Wall: now, Deleted: true})
 
 	removed := d.sweepTombstones(now)
-	assert.Equal(t, 1, removed, "only the old tombstone is GC'd")
-	assert.Equal(t, 1, d.CacheSize(), "fresh tombstone retained")
+	assert.Equal(t, 0, removed, "default retention must not age out delete fences")
+	assert.Equal(t, 2, d.CacheSize(), "tombstones retained")
+}
+
+func TestDissem_TombstoneRetentionOption(t *testing.T) {
+	d := NewDissem("node-a", nil, WithTombstoneRetention(time.Hour))
+	p := makePID("node-a", "h", "p1")
+
+	now := time.Now().UnixNano()
+	d.merge(bindingDelta{Name: "old.ts", PID: p, RaftIndex: 9, Wall: now - (2 * time.Hour).Nanoseconds(), Deleted: true})
+	d.merge(bindingDelta{Name: "fresh.ts", PID: p, RaftIndex: 10, Wall: now - (30 * time.Minute).Nanoseconds(), Deleted: true})
+
+	removed := d.sweepTombstones(now)
+	assert.Equal(t, 1, removed, "custom retention should expire only entries past the configured floor")
+	assert.Equal(t, 1, d.CacheSize())
+}
+
+func TestDissem_TombstoneRetentionOptionRejectsNonPositive(t *testing.T) {
+	d := NewDissem("node-a", nil, WithTombstoneRetention(-time.Hour))
+	p := makePID("node-a", "h", "p1")
+
+	now := time.Now().UnixNano()
+	d.merge(bindingDelta{Name: "old.ts", PID: p, RaftIndex: 9, Wall: now - (365 * 24 * time.Hour).Nanoseconds(), Deleted: true})
+
+	removed := d.sweepTombstones(now)
+	assert.Equal(t, 0, removed, "bad retention values must keep the correctness-first default")
+	assert.Equal(t, 1, d.CacheSize())
+}
+
+func TestDissem_TombstoneFencesStaleLiveAfterSweep(t *testing.T) {
+	d := NewDissem("node-a", nil)
+	p := makePID("node-a", "h", "p1")
+
+	now := time.Now().UnixNano()
+	d.merge(bindingDelta{Name: "svc.gone", PID: p, RaftIndex: 10, Wall: now, Deleted: true})
+	assert.Equal(t, 0, d.sweepTombstones(now))
+
+	d.NotifyMsg(encodeBindingFrame([]bindingDelta{{
+		Name:      "svc.gone",
+		PID:       p,
+		RaftIndex: 7,
+		Wall:      now,
+	}}))
+
+	_, ok := d.Lookup("svc.gone")
+	assert.False(t, ok, "retained tombstone must reject stale lower-index live gossip")
+}
+
+func TestDissem_DigestSnapshotIncludesTombstones(t *testing.T) {
+	d := NewDissem("node-a", nil)
+	p := makePID("node-a", "h", "p1")
+	d.merge(bindingDelta{Name: "svc.live", PID: p, RaftIndex: 7})
+	d.merge(bindingDelta{Name: "svc.dead", PID: p, RaftIndex: 9, Deleted: true})
+
+	snap := d.DigestSnapshot()
+	seen := map[string]DigestEntry{}
+	for _, e := range snap.Entries {
+		seen[e.Name] = e
+	}
+	require.Contains(t, seen, "svc.live")
+	require.Contains(t, seen, "svc.dead")
+	assert.False(t, seen["svc.live"].Deleted)
+	assert.True(t, seen["svc.dead"].Deleted)
+	assert.Equal(t, uint64(9), seen["svc.dead"].RaftIndex)
+}
+
+func TestService_DigestExchangeRepairsMissedTombstone(t *testing.T) {
+	router := &capturingRouter{}
+	fsm := NewFSM()
+	svc := NewService(newDirectApplyRaft(fsm, true), fsm, &nopBus{}, nil, router, &fakeMembership{local: "member", ids: []string{"member"}}, "member", noopLogger(), nil, nil, nil)
+	d := NewDissem("member", nil)
+	svc.SetDissem(d)
+	d.merge(bindingDelta{Name: "svc.dead", RaftIndex: 10, Deleted: true})
+
+	body, err := marshalMsgpack(digestEnvelope{
+		Origin: "peer",
+		Entries: []digestEntry{{
+			Name:      "svc.dead",
+			RaftIndex: 7,
+		}},
+		CorrID: 99,
+	})
+	require.NoError(t, err)
+
+	svc.handleDigestExchange(&relay.Message{
+		Topic:    topicDigestExchange,
+		Payloads: payload.Payloads{payload.New(body)},
+	})
+
+	sent := router.byTopic(topicDigestDelta)
+	require.Len(t, sent, 1)
+	assert.Equal(t, pid.NodeID("peer"), sent[0].target)
+
+	deltas, err := decodeBindingFrame(sent[0].body)
+	require.NoError(t, err)
+	require.Len(t, deltas, 1)
+	assert.Equal(t, "svc.dead", deltas[0].Name)
+	assert.Equal(t, uint64(10), deltas[0].RaftIndex)
+	assert.True(t, deltas[0].Deleted, "missed delete must be repaired as a tombstone delta")
+}
+
+func TestService_DigestExchangeRepairsSameIndexDeleteMismatch(t *testing.T) {
+	router := &capturingRouter{}
+	fsm := NewFSM()
+	svc := NewService(newDirectApplyRaft(fsm, true), fsm, &nopBus{}, nil, router, &fakeMembership{local: "member", ids: []string{"member"}}, "member", noopLogger(), nil, nil, nil)
+	d := NewDissem("member", nil)
+	svc.SetDissem(d)
+	d.merge(bindingDelta{Name: "svc.dead", RaftIndex: 10, Deleted: true})
+
+	body, err := marshalMsgpack(digestEnvelope{
+		Origin: "peer",
+		Entries: []digestEntry{{
+			Name:      "svc.dead",
+			RaftIndex: 10,
+			Deleted:   false,
+		}},
+		CorrID: 99,
+	})
+	require.NoError(t, err)
+
+	svc.handleDigestExchange(&relay.Message{
+		Topic:    topicDigestExchange,
+		Payloads: payload.Payloads{payload.New(body)},
+	})
+
+	sent := router.byTopic(topicDigestDelta)
+	require.Len(t, sent, 1)
+	deltas, err := decodeBindingFrame(sent[0].body)
+	require.NoError(t, err)
+	require.Len(t, deltas, 1)
+	assert.True(t, deltas[0].Deleted)
+	assert.Equal(t, uint64(10), deltas[0].RaftIndex)
+}
+
+func TestEncodeBindingFramesBounded(t *testing.T) {
+	var deltas []bindingDelta
+	for i := 0; i < 20; i++ {
+		deltas = append(deltas, bindingDelta{
+			Name:      fmt.Sprintf("svc.%02d.%s", i, strings.Repeat("x", 40)),
+			PID:       makePID("node", "host", strings.Repeat("u", 20)),
+			RaftIndex: uint64(i + 1),
+			Wall:      1,
+		})
+	}
+
+	frames := encodeBindingFramesBounded(deltas, 256)
+	require.Greater(t, len(frames), 1)
+	total := 0
+	for _, frame := range frames {
+		require.LessOrEqual(t, len(frame), 256)
+		decoded, err := decodeBindingFrame(frame)
+		require.NoError(t, err)
+		total += len(decoded)
+	}
+	assert.Equal(t, len(deltas), total)
+}
+
+func TestEncodeBindingFramesBoundedSkipsImpossibleDelta(t *testing.T) {
+	frames := encodeBindingFramesBounded([]bindingDelta{
+		{
+			Name:      "svc.ok",
+			PID:       makePID("node", "host", "uniq"),
+			RaftIndex: 1,
+			Wall:      1,
+		},
+		{
+			Name:      "svc." + strings.Repeat("x", 512),
+			PID:       makePID("node", "host", "uniq"),
+			RaftIndex: 2,
+			Wall:      1,
+		},
+	}, 128)
+
+	require.Len(t, frames, 1)
+	require.LessOrEqual(t, len(frames[0]), 128)
+	decoded, err := decodeBindingFrame(frames[0])
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	assert.Equal(t, "svc.ok", decoded[0].Name)
 }
 
 // TestDissem_RoundTripEncoding asserts the binary frame format round-trips

--- a/system/topology/namereg/global/dissem_wiring.go
+++ b/system/topology/namereg/global/dissem_wiring.go
@@ -38,6 +38,8 @@ const (
 	topicDigestDelta relay.Topic = "global.dissem.delta"
 )
 
+const digestDeltaMaxFrameBytes = 64 * 1024
+
 // lookupRequestEnvelope is the wire form of a cold-miss forward-resolve.
 type lookupRequestEnvelope struct {
 	Name   string     `codec:"n"`
@@ -55,8 +57,8 @@ type lookupResponseEnvelope struct {
 	Found     bool    `codec:"f"`
 }
 
-// digestEnvelope carries a node's cache digest (name -> raftIndex) for
-// anti-entropy. Sorted name order; only live entries (no tombstones).
+// digestEnvelope carries a node's cache digest (name -> raftIndex, deleted)
+// for anti-entropy. Sorted name order.
 type digestEnvelope struct {
 	Origin  pid.NodeID    `codec:"o"`
 	Entries []digestEntry `codec:"en"`
@@ -66,6 +68,14 @@ type digestEnvelope struct {
 type digestEntry struct {
 	Name      string `codec:"n"`
 	RaftIndex uint64 `codec:"i"`
+	Deleted   bool   `codec:"d,omitempty"`
+}
+
+func peerDigestCurrent(cur digestEntry, local digestEntry) bool {
+	if cur.RaftIndex > local.RaftIndex {
+		return true
+	}
+	return cur.RaftIndex == local.RaftIndex && cur.Deleted == local.Deleted
 }
 
 // SetDissem wires the dissemination plane after construction. The boot path
@@ -362,9 +372,9 @@ func (s *Service) handleDigestExchange(msg *relay.Message) {
 	if d == nil {
 		return
 	}
-	peer := make(map[string]uint64, len(env.Entries))
+	peer := make(map[string]digestEntry, len(env.Entries))
 	for _, e := range env.Entries {
-		peer[e.Name] = e.RaftIndex
+		peer[e.Name] = e
 	}
 
 	var deltas []bindingDelta
@@ -377,7 +387,7 @@ func (s *Service) handleDigestExchange(msg *relay.Message) {
 			if !found {
 				continue
 			}
-			if cur, ok := peer[name]; ok && cur >= idx {
+			if cur, ok := peer[name]; ok && peerDigestCurrent(cur, digestEntry{Name: name, RaftIndex: idx}) {
 				continue
 			}
 			deltas = append(deltas, bindingDelta{
@@ -389,9 +399,10 @@ func (s *Service) handleDigestExchange(msg *relay.Message) {
 		}
 	}
 	// Names present in our dissem cache but not the FSM (or with higher index)
-	// fold in too. The dissem snapshot already excludes tombstones.
+	// fold in too. Tombstones are included so anti-entropy repairs missed
+	// deletes, not just missed live bindings.
 	for _, e := range d.DigestSnapshot().Entries {
-		if cur, ok := peer[e.Name]; ok && cur >= e.RaftIndex {
+		if cur, ok := peer[e.Name]; ok && peerDigestCurrent(cur, digestEntry(e)) {
 			continue
 		}
 		// Avoid double-emitting names the FSM block above already produced at
@@ -404,6 +415,15 @@ func (s *Service) handleDigestExchange(msg *relay.Message) {
 			}
 		}
 		if dup {
+			continue
+		}
+		if e.Deleted {
+			deltas = append(deltas, bindingDelta{
+				Name:      e.Name,
+				RaftIndex: e.RaftIndex,
+				Wall:      time.Now().UnixNano(),
+				Deleted:   true,
+			})
 			continue
 		}
 		if p, found := d.Lookup(e.Name); found {
@@ -419,15 +439,16 @@ func (s *Service) handleDigestExchange(msg *relay.Message) {
 	if len(deltas) == 0 {
 		return
 	}
-	frame := encodeBindingFrame(deltas)
-	pkg := relay.NewServicePackage(
-		s.localNode, HostID,
-		env.Origin, HostID,
-		topicDigestDelta,
-		payload.New(frame),
-	)
-	if err := s.router.Send(pkg); err != nil {
-		relay.ReleasePackage(pkg)
+	for _, frame := range encodeBindingFramesBounded(deltas, digestDeltaMaxFrameBytes) {
+		pkg := relay.NewServicePackage(
+			s.localNode, HostID,
+			env.Origin, HostID,
+			topicDigestDelta,
+			payload.New(frame),
+		)
+		if err := s.router.Send(pkg); err != nil {
+			relay.ReleasePackage(pkg)
+		}
 	}
 }
 
@@ -462,6 +483,43 @@ func encodeBindingFrame(deltas []bindingDelta) []byte {
 		}
 	}
 	return out
+}
+
+func encodeBindingFramesBounded(deltas []bindingDelta, maxBytes int) [][]byte {
+	if len(deltas) == 0 {
+		return nil
+	}
+	if maxBytes <= 0 {
+		maxBytes = digestDeltaMaxFrameBytes
+	}
+	var frames [][]byte
+	var cur []byte
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		frames = append(frames, cur)
+		cur = nil
+	}
+	for _, d := range deltas {
+		encoded, err := encodeBindingDelta(nil, d)
+		if err != nil {
+			continue
+		}
+		if len(encoded) > maxBytes {
+			flush()
+			continue
+		}
+		if len(cur) > 0 && len(cur)+len(encoded) > maxBytes {
+			flush()
+		}
+		cur = append(cur, encoded...)
+		if len(cur) >= maxBytes {
+			flush()
+		}
+	}
+	flush()
+	return frames
 }
 
 // startJoinSnapshotSeedingForConsistent extends the join-epoch snapshot with


### PR DESCRIPTION
## Summary
- fix Lua process.registry.lookup to chain global, eventual, and local registry scopes
- replace drain-once membership user broadcast behavior with bounded memberlist TransmitLimitedQueue retransmission, backpressure, dedupe, and oversized-frame handling
- expose membership gossip, push/pull anti-entropy, and dead-node reclaim timings as explicit configuration with conservative defaults and bad-value fallback
- harden registry tombstone GC and global dissemination delete repair, including tombstones in digests and bounded anti-entropy delta replies
- make store.kv.crdt tombstone retention explicit with correctness-first default and wrong-value/non-positive handling
- add bounded Raft shutdown leadership transfer configuration
- add runtime log emission metrics and classify expected memberlist SWIM probe/send failures below error severity
- bound targeted reliable user-message payloads and split eventual-registry shard-pull responses into bounded chunks so large repairs converge without unbounded allocation
- optimize bounded shard payload packing to avoid per-entry temporary records and add an allocation/frame-count performance envelope regression

## Standards pass
- Raft: follows Ongaro/Ousterhout replicated-log safety model for CP control state and uses bounded operational knobs for snapshots, append batching, trailing logs, and leadership transfer.
- SWIM/memberlist: keeps weakly consistent membership and failure detection in the SWIM/memberlist layer, with bounded retransmission and explicit production timing knobs instead of hidden hardcoded reclaim behavior.
- Dynamo-style AP dissemination: keeps gossip/anti-entropy as AP repair paths with bounded queues and explicit convergence backstops.
- CRDT deletion: defaults are correctness-first; age-only tombstone GC is disabled unless the operator explicitly accepts a max-partition/offline assumption.

References used in final pass:
- Raft extended paper: https://pdos.csail.mit.edu/6.824/papers/raft-extended.pdf
- SWIM paper: https://www.cs.cornell.edu/projects/quicksilver/public_pdfs/SWIM.pdf
- Dynamo paper: https://www.amazon.science/publications/dynamo-amazons-highly-available-key-value-store
- CRDT comprehensive study: https://citeseerx.ist.psu.edu/document?doi=f23bbc1672fe68bf1bfcc8255bf162a4399d82a1&repid=rep1&type=pdf
- HashiCorp Raft operational tuning reference: https://developer.hashicorp.com/vault/docs/configuration/storage/raft

## Operational notes
- cluster.membership.gossip_interval defaults to 500ms; cluster.membership.push_pull_interval defaults to 5s
- cluster.membership.dead_node_reclaim_time defaults to 30s and can be lowered, e.g. 3s, only when same-name pod IP reuse is expected and false-dead probes are rare
- raft.global_dissem_tombstone_retention is configurable; default 0 disables age-only cache tombstone GC for correctness across long partitions
- cluster.kv_crdt_tombstone_retention is configurable; default 0 disables age-only store.kv.crdt tombstone GC, while a positive value bounds delete-churn memory by assuming no peer is offline longer than that retention
- 24h is not hardcoded; using 24h/72h/etc. is an explicit operator tradeoff, not hidden runtime behavior
- durable per-peer causal ACK / version-vector compaction or membership-epoch retirement remains the stronger future AP compaction mode; TTL retention is a clear memory-bound toggle, not causal proof
- dead/offline nodes do not create unbounded per-node gossip backlog; queues are bounded and stale repair comes from retransmit, anti-entropy, and authoritative Raft paths where applicable
- oversized UDP frames too large for the current memberlist budget are retained for a later larger budget; impossible single UDP frames are dropped instead of being retained forever
- targeted reliable TCP user messages are capped at 64 KiB; eventual-registry shard responses are chunked by entry under that cap, and only impossible single entries are skipped

## Tests
- git diff --check
- make lint
- go test ./cluster/membership ./boot/components/system
- go test ./cluster/membership ./cluster/raft ./cluster/internode ./api/cluster/raft ./runtime/lua/modules/process ./system/process ./system/topology ./system/topology/namereg/eventual ./system/topology/namereg/global ./system/crdt ./system/kv ./boot/components/system ./api/logs ./system/logs ./boot/components/metrics ./service/exec/native
- go test -timeout=8m ./...
- monkey runner: rebuilt image sha256:1a3dc568a009478679e015580178dc6e380e8ed53538c97834a62b7456c4cfb5, rolled 30 runtime pods, active chaos validation passed with hard gates green and runtime error-log rate 0.362/s/pod within bound

## Regression coverage added
- membership timing defaults/custom values/bad negative values
- reliable user-message oversize rejection before allocation/send
- oversized reliable receive-frame drop before delegate dispatch
- bounded eventual-registry shard response frame splitting
- bounded shard payload chunking by entry with impossible-entry skip
- large shard-pull stability test: 900-name repair splits into multiple <=64 KiB frames and fully converges
- bounded shard payload performance envelope: 1000-entry packing stays within expected frame count, frame size, and allocation bounds
- existing churn/GC tests cover tombstone retention defaults, negative/wrong values, positive retention, node-id reclaim, safe-counter reaping, listener leak cleanup, and reclaim-race stability

## Monkey caveats
- pg-harness remains unavailable in this local cluster because pg-harness:soak is not present, so harness-specific gates report MISSING
- after chaos was stopped, the validator exits nonzero because no chaos experiments are active; hard gates remained green and all runtime pods were ready