### PR TITLE
fix: lost-wakeup scheduler stall + racy global-registry test

### DIFF
--- a/system/topology/namereg/global/dissem_test.go
+++ b/system/topology/namereg/global/dissem_test.go
@@ -365,10 +365,12 @@ func TestNonMemberResolvesActiveStrongAfterBroadcast(t *testing.T) {
 	leaderDissem := NewDissem("leader", nil)
 	leaderSvc.SetDissem(leaderDissem)
 
-	// Open + ack a Strong pending so it promotes.
+	// Open a Strong pending. On the leader the service's own evaluation
+	// auto-acks and promotes it (the production flow) and queues the
+	// promote-broadcast on a background goroutine; wait for that broadcast
+	// instead of driving a second, racing ack by hand.
 	owner := makePID("worker-1", "host", "strong")
-	epoch := openPending(t, leaderFSM, "svc.strong", owner, "worker-1", []pid.NodeID{"leader"}, 10)
-	applyAt(t, leaderFSM, &Command{Type: CmdRegisterAck, Name: "svc.strong", Epoch: epoch, AckerNode: "leader"}, 11)
+	openPending(t, leaderFSM, "svc.strong", owner, "worker-1", []pid.NodeID{"leader"}, 10)
 
 	// Non-member side.
 	nonMemFSM := NewFSM()
@@ -376,8 +378,11 @@ func TestNonMemberResolvesActiveStrongAfterBroadcast(t *testing.T) {
 	nonMemDissem := NewDissem("non-mem", nil)
 	nonMemSvc.SetDissem(nonMemDissem)
 
-	frames := leaderDissem.GetBroadcasts(40, dissemMaxFrameBytes)
-	require.NotEmpty(t, frames)
+	var frames [][]byte
+	require.Eventually(t, func() bool {
+		frames = leaderDissem.GetBroadcasts(40, dissemMaxFrameBytes)
+		return len(frames) > 0
+	}, 2*time.Second, 5*time.Millisecond, "leader auto-acks the strong pending and queues a broadcast")
 	for _, f := range frames {
 		nonMemDissem.NotifyMsg(f)
 	}


### PR DESCRIPTION
Fixes two intermittent CI failures surfaced while stabilizing the test suite. They are independent and unrelated to any feature work.

## 1. Real lost-wakeup stall in the actor scheduler (production fix)

`TestMultiYieldIndependentCompletion` intermittently failed in CI with "process did not complete". It is **not** a flaky test — it exposes a genuine concurrency bug: a process could stall forever (process never completes, both workers parked).

Root cause: the process state is an atomic int32 (low bits = state, bit 4 = wakeup). `casState` did a single-shot CAS that failed when a concurrent `CompleteYield -> setWakeup` flipped the wakeup bit between its `Load` and `CompareAndSwap`. The owning worker's `StepContinue` transition (`casState Running->Ready`) then dropped on that race and returned without re-queueing, orphaning the processor in `Running|wakeup` with a queued event and no owner.

Fix: `casState` retries the CAS while the masked state still equals `old` (absorbing the concurrent wakeup-bit flip, preserving the bit), returning false only when another transition genuinely won. Reachable only for `old==Running`, so every other caller stays single-shot; bounded because `setWakeup` is idempotent.

## 2. Racy manual ack in a global-registry test (test fix)

`TestNonMemberResolvesActiveStrongAfterBroadcast` flaked (~0.6%) with an empty `GetBroadcasts`. On the leader, `openPending` spawns `evaluatePending -> applySelfAck` that auto-promotes the strong pending on a background goroutine; the test also drove a redundant manual ack racing it. Fix drops the redundant ack and `require.Eventually`s for the real broadcast (also exercises the real auto-ack path).

## Testing

- Scheduler: reproduced deterministically with `GOMAXPROCS=1 go test -race -count=300 -run TestMultiYieldIndependentCompletion ./system/scheduler/actor/`; fix verified **2000x clean** on the repro, full `./system/scheduler/actor/ -race` green, constrained `GOMAXPROCS=1 -race` x15 sweep green. Reviewed by an agent for double-requeue / ABA / single-owner holes — none found.
- Registry: `go test -race -count=3000 -run TestNonMemberResolvesActiveStrongAfterBroadcast ./system/topology/namereg/global/` — 0 failures (was ~5/800); full package green.
- `golangci-lint` 0 issues on both packages.
