### PR TITLE
fix(pg): reset peer circuit breaker on NodeJoined so re-discovery isn't gated

### DIFF
--- a/service/pg/circuit_breaker.go
+++ b/service/pg/circuit_breaker.go
@@ -116,6 +116,23 @@ func (cb *circuitBreaker) RecordSuccess() {
 	}
 }
 
+// Reset forces the breaker closed with a clean failure count. Used when an
+// authoritative signal — a membership NodeJoined for the peer — confirms the
+// downstream is reachable again, so the breaker's open assumption is stale and
+// must not gate the immediate re-discovery (which would otherwise wait out the
+// full reset window, leaving the registry stale for up to resetTimeout).
+func (cb *circuitBreaker) Reset() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if cb.state == CircuitClosed && cb.failures == 0 {
+		return
+	}
+	cb.state = CircuitClosed
+	cb.failures = 0
+	cb.tel.recordCircuitBreakerState(cb.nodeID, "closed")
+}
+
 // RecordFailure records a failed request, potentially opening the circuit.
 func (cb *circuitBreaker) RecordFailure() {
 	cb.mu.Lock()

--- a/service/pg/dispatch.go
+++ b/service/pg/dispatch.go
@@ -256,6 +256,11 @@ func (s *Service) handleNodeJoinedEvent(e event.Event) {
 	}
 
 	s.submit(func() {
+		// A rejoin is authoritative proof the peer is reachable again, so clear
+		// any open breaker from the prior outage; otherwise sendDiscover (and the
+		// anti-entropy reconcile) would stay gated until the reset window elapses
+		// and the registry would converge late.
+		s.cbManager.GetCircuitBreaker(nodeID).Reset()
 		s.sendDiscover(nodeID)
 	})
 }

--- a/service/pg/service_test.go
+++ b/service/pg/service_test.go
@@ -934,6 +934,43 @@ func TestServiceHandleNodeJoinedEvent(t *testing.T) {
 	assert.True(t, found, "should send discover on node joined event")
 }
 
+// TestServiceNodeJoinedResetsCircuitBreaker verifies that a NodeJoined event —
+// authoritative evidence from membership that a peer is reachable again —
+// resets that peer's circuit breaker so re-discovery proceeds immediately,
+// rather than being gated by the still-open breaker until its reset window
+// elapses (which would leave the registry stale for up to resetTimeout).
+func TestServiceNodeJoinedResetsCircuitBreaker(t *testing.T) {
+	svc, router, _ := startTestService(t)
+
+	// Open the breaker for a peer (a sustained send fault under partition).
+	cb := svc.cbManager.GetCircuitBreaker("node-down")
+	for i := 0; i < 10; i++ {
+		cb.RecordFailure()
+	}
+	require.Equal(t, CircuitOpen, cb.State(), "breaker should be open after repeated failures")
+
+	router.reset()
+
+	// The peer rejoins — memberlist gossip surfaces NodeJoined.
+	svc.handleNodeJoinedEvent(event.Event{
+		Data: cluster.NodeEvent{Node: cluster.NodeInfo{ID: "node-down"}},
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, CircuitClosed, svc.cbManager.GetCircuitBreaker("node-down").State(),
+		"node-joined should reset the peer circuit breaker")
+
+	found := false
+	for _, s := range router.getSends() {
+		for _, msg := range s.Messages {
+			if msg.Topic == pgapi.TopicDiscover {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "re-discovery must be sent on rejoin despite a previously-open breaker")
+}
+
 func TestServiceHandleNodeJoinedEventLocalNode(t *testing.T) {
 	svc, router, _ := startTestService(t)
 


### PR DESCRIPTION
## Why
When a peer rejoins after a fault that opened its pg circuit breaker, `handleNodeJoinedEvent` → `sendDiscover` was gated by the still-open breaker. An open breaker only closes via `RecordSuccess` (unreachable while it blocks every send) or the timer-based half-open transition — so despite memberlist positively confirming the peer reachable again (`NodeJoined`), the pg layer refused to re-discover/re-sync it for up to the breaker reset window (**default 10s**), leaving the process-group registry stale. The anti-entropy reconcile (`sendSync`) shares the same per-node breaker and was blocked too.

Surfaced while validating `harden/process-registry-lookup-scopes` under chaos — this is a **post-fault convergence-latency** gap, not steady-state delivery (which the soak gates measure and which stayed clean).

## What
A `NodeJoined` is authoritative reachability, so reset the peer's breaker before re-discovering. Adds `circuitBreaker.Reset()` (force-close + clear failures, idempotent on the closed path) and calls it in `handleNodeJoinedEvent` prior to `sendDiscover`. A genuinely flapping peer re-trips the breaker via `RecordFailure` after the reset, so the protection self-restores; `NodeJoined` only fires on an actual membership transition, so no thrash.

## Testing
- `TestServiceNodeJoinedResetsCircuitBreaker`: opens the breaker, fires `NodeJoined`, asserts the breaker is closed **and** a discover is emitted. Fails before this change, passes after.
- Full `--tags "fts5 sqlite_vec treesitter" -race` suite green; `make lint` 0 issues; build green. All local.