### PR TITLE
Fix internode payload snapshot race

### DIFF
--- a/api/payload/payload.go
+++ b/api/payload/payload.go
@@ -107,6 +107,63 @@ func NewPayload(data any, format Format) Payload {
 	return payload{data: data, format: format}
 }
 
+// SnapshotData returns a transport-safe copy of common mutable payload data.
+// Payloads frequently carry map[string]any / []any trees assembled by services
+// and then fanned out to multiple peers. Encoding those trees directly lets one
+// goroutine iterate a map while another goroutine mutates or normalizes it. The
+// snapshot copies maps, []any slices, and byte buffers recursively; immutable
+// scalars and structs are returned by value.
+func SnapshotData(data any) any {
+	switch v := data.(type) {
+	case map[string]any:
+		cp := make(map[string]any, len(v))
+		for k, val := range v {
+			cp[k] = SnapshotData(val)
+		}
+		return cp
+	case map[any]any:
+		cp := make(map[any]any, len(v))
+		for k, val := range v {
+			cp[SnapshotData(k)] = SnapshotData(val)
+		}
+		return cp
+	case []any:
+		cp := make([]any, len(v))
+		for i, val := range v {
+			cp[i] = SnapshotData(val)
+		}
+		return cp
+	case []byte:
+		return append([]byte(nil), v...)
+	case Payload:
+		return Snapshot(v)
+	case Payloads:
+		return SnapshotAll(v)
+	default:
+		return data
+	}
+}
+
+// Snapshot returns a payload with SnapshotData applied to its data.
+func Snapshot(p Payload) Payload {
+	if p == nil {
+		return nil
+	}
+	return NewPayload(SnapshotData(p.Data()), p.Format())
+}
+
+// SnapshotAll returns a new payload slice with each payload snapshot-copied.
+func SnapshotAll(in Payloads) Payloads {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(Payloads, len(in))
+	for i, p := range in {
+		out[i] = Snapshot(p)
+	}
+	return out
+}
+
 // New creates a new payload with the given data and assumes the Golang format.
 func New(data any) Payload {
 	return NewPayload(data, Golang)

--- a/api/payload/payload_test.go
+++ b/api/payload/payload_test.go
@@ -62,6 +62,39 @@ func TestNewPayload(t *testing.T) {
 	}
 }
 
+func TestSnapshotData_IsolatesMutableTrees(t *testing.T) {
+	orig := map[string]any{
+		"name": "svc",
+		"nested": map[string]any{
+			"replicas": 3,
+		},
+		"items": []any{
+			map[string]any{"node": "a"},
+			[]byte("abc"),
+		},
+	}
+
+	snap := SnapshotData(orig).(map[string]any)
+	orig["name"] = "changed"
+	orig["nested"].(map[string]any)["replicas"] = 9
+	orig["items"].([]any)[0].(map[string]any)["node"] = "b"
+	orig["items"].([]any)[1].([]byte)[0] = 'z'
+
+	assert.Equal(t, "svc", snap["name"])
+	assert.Equal(t, 3, snap["nested"].(map[string]any)["replicas"])
+	assert.Equal(t, "a", snap["items"].([]any)[0].(map[string]any)["node"])
+	assert.Equal(t, []byte("abc"), snap["items"].([]any)[1].([]byte))
+}
+
+func TestSnapshotData_ScalarsDoNotAllocate(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		if got := SnapshotData("immutable"); got != "immutable" {
+			t.Fatalf("snapshot scalar = %v", got)
+		}
+	})
+	assert.Zero(t, allocs)
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/cluster/internode/codec.go
+++ b/cluster/internode/codec.go
@@ -112,7 +112,7 @@ func (c *MessageCodec) Encode(pkg *relay.Package) ([]byte, error) {
 			}
 			encMsg.Payloads[j] = encodedPayload{
 				Format: normalizedPayload.Format(),
-				Data:   normalizedPayload.Data(),
+				Data:   encodeData(normalizedPayload),
 			}
 		}
 		encPkg.Messages[i] = encMsg
@@ -178,8 +178,15 @@ func (c *MessageCodec) normalizePayload(p payload.Payload) (payload.Payload, err
 	case payload.JSON, payload.Bytes, payload.String, payload.GoError, payload.Golang, payload.MsgPack:
 		return p, nil
 	default:
-		return c.transcoder.Transcode(p, payload.Golang)
+		return c.transcoder.Transcode(payload.Snapshot(p), payload.Golang)
 	}
+}
+
+func encodeData(p payload.Payload) any {
+	if p.Format() == payload.Golang {
+		return payload.SnapshotData(p.Data())
+	}
+	return p.Data()
 }
 
 type pidExtension struct{}

--- a/cluster/internode/codec_test.go
+++ b/cluster/internode/codec_test.go
@@ -3,7 +3,9 @@
 package internode
 
 import (
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	lua "github.com/wippyai/go-lua"
@@ -25,6 +27,28 @@ func (mt *mockTranscoder) Transcode(p payload.Payload, _ payload.Format) (payloa
 }
 
 func (mt *mockTranscoder) Unmarshal(_ payload.Payload, _ any) error {
+	return nil
+}
+
+type mutatingTranscoder struct{}
+
+func (mt *mutatingTranscoder) Transcode(p payload.Payload, _ payload.Format) (payload.Payload, error) {
+	m, ok := p.Data().(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("mutating transcoder got %T", p.Data())
+	}
+	m["normalized"] = true
+	if reps, ok := m["replicas"].([]any); ok {
+		for i, rep := range reps {
+			if rm, ok := rep.(map[string]any); ok {
+				rm["ordinal"] = i
+			}
+		}
+	}
+	return payload.New(m), nil
+}
+
+func (mt *mutatingTranscoder) Unmarshal(_ payload.Payload, _ any) error {
 	return nil
 }
 
@@ -115,6 +139,112 @@ func TestMessageCodec_PackagePIDs_SourceTarget(t *testing.T) {
 	}
 	if decoded.Messages[0].Topic != "test.topic" {
 		t.Errorf("Topic mismatch. Expected 'test.topic', got %q", decoded.Messages[0].Topic)
+	}
+}
+
+func TestMessageCodec_ConcurrentEncodeSharedMapPayload(t *testing.T) {
+	const mutableFormat payload.Format = "test/mutable-map"
+	codec := NewMessageCodec(&mutatingTranscoder{})
+	shared := map[string]any{
+		"service": "qwen-fleet",
+		"replicas": []any{
+			map[string]any{"node": "towers", "port": 8000},
+			map[string]any{"node": "towers", "port": 8001},
+			map[string]any{"node": "mac", "port": 8000},
+		},
+	}
+	pkg := &relay.Package{
+		Source: pid.PID{Node: "leader", Host: "pg", UniqID: "src"},
+		Target: pid.PID{Node: "worker", Host: "pg", UniqID: "dst"},
+		Messages: []*relay.Message{{
+			Topic:    "app.broadcast.deploy",
+			Payloads: []payload.Payload{payload.NewPayload(shared, mutableFormat)},
+		}},
+	}
+
+	const workers = 32
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				encoded, err := codec.Encode(pkg)
+				if err != nil {
+					errs <- err
+					return
+				}
+				decoded, err := codec.Decode(encoded)
+				if err != nil {
+					errs <- err
+					return
+				}
+				data := decoded.Messages[0].Payloads[0].Data().(map[string]any)
+				if data["service"] != "qwen-fleet" {
+					errs <- fmt.Errorf("decoded service = %v", data["service"])
+					relay.ReleasePackage(decoded)
+					return
+				}
+				if data["normalized"] != true {
+					errs <- fmt.Errorf("decoded normalized = %v", data["normalized"])
+					relay.ReleasePackage(decoded)
+					return
+				}
+				relay.ReleasePackage(decoded)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	encoded, err := codec.Encode(pkg)
+	if err != nil {
+		t.Fatalf("encode after fanout: %v", err)
+	}
+	shared["service"] = "mutated-after-encode"
+	decoded, err := codec.Decode(encoded)
+	if err != nil {
+		t.Fatalf("decode after source mutation: %v", err)
+	}
+	defer relay.ReleasePackage(decoded)
+	got := decoded.Messages[0].Payloads[0].Data().(map[string]any)
+	if got["service"] != "qwen-fleet" {
+		t.Fatalf("encoded payload aliased source map, got service=%v", got["service"])
+	}
+	if _, ok := shared["normalized"]; ok {
+		t.Fatalf("transcoder mutated shared source map")
+	}
+}
+
+func TestEncodeData_DoesNotCopyImmutableWireFormats(t *testing.T) {
+	raw := []byte("wire")
+	for _, p := range []payload.Payload{
+		payload.NewPayload(raw, payload.JSON),
+		payload.NewPayload(raw, payload.Bytes),
+		payload.NewPayload(raw, payload.MsgPack),
+		payload.NewString("text"),
+	} {
+		allocs := testing.AllocsPerRun(1000, func() {
+			_ = encodeData(p)
+		})
+		if allocs != 0 {
+			t.Fatalf("encodeData(%s) allocations = %v, want 0", p.Format(), allocs)
+		}
+	}
+}
+
+func TestEncodeData_SnapshotsGolangMap(t *testing.T) {
+	src := map[string]any{"k": "v"}
+	got := encodeData(payload.New(src)).(map[string]any)
+	src["k"] = "mutated"
+	if got["k"] != "v" {
+		t.Fatalf("Golang map payload was not snapshotted: %v", got["k"])
 	}
 }
 

--- a/service/pg/broadcast.go
+++ b/service/pg/broadcast.go
@@ -18,12 +18,10 @@ import (
 )
 
 // sendToMembers sends a message to each member PID via the router.
-// The payloads slice is shared across every recipient's message:
-// relay.ReleaseMessage only nils its Payloads reference (it does not
-// recycle the slice or mutate the payload values), and the codec reads
-// payloads read-only during encode — so there is no aliasing hazard and
-// no need to copy the slice per recipient. Uses circuit breaker pattern
-// to protect against slow nodes.
+// The payload slice is shared across recipients; the internode codec snapshots
+// mutable payload data immediately before wire encoding. Keeping fanout at the
+// slice-reference level avoids an extra per-recipient deep copy while preserving
+// transport safety at the codec boundary.
 func (s *Service) sendToMembers(from pid.PID, topic string, payloads payload.Payloads, members []pid.PID) int {
 	sent := 0
 


### PR DESCRIPTION
## Summary
- fix the runtime pg-broadcast/internode race found during live heterogeneous deploy validation
- snapshot mutable Golang payload map/slice trees at the internode codec boundary before transcoding/msgpack encoding
- keep immutable wire formats on the zero-copy path to avoid unnecessary GC churn
- correct the stale PG fanout comment: fanout may share logical payloads, but the transport codec owns wire-safety snapshots

## Root cause
`service/pg.sendToMembers` fans one logical payload set out to many recipient packages. That is OK only if the transport treats payload data as immutable. `cluster/internode.MessageCodec.Encode` did not: it handed shared payload `Data()` into transcoding/msgpack encoding. Under multi-recipient fanout, concurrent encode paths could iterate/normalize the same `map[string]any` tree, producing the live crash:

`fatal error: concurrent map iteration and map write` at `cluster/internode/codec.go`.

This is not a Raft/memberlist bug. It is a runtime payload aliasing bug at the PG broadcast -> internode codec boundary.

## Performance note
- `encodeData` snapshots only `payload.Golang` data, where mutable map/slice trees exist.
- JSON, bytes, string, error, and msgpack payloads stay on the existing no-copy path.
- Regression coverage asserts zero allocations for immutable wire formats.

## Tests
- `go test ./api/payload ./cluster/internode ./service/pg`
- `go test -race ./cluster/internode -run 'TestMessageCodec_ConcurrentEncodeSharedMapPayload|TestEncodeData' -count=20`
- `git diff --check`
- `make lint`
- `go test -timeout=8m ./...`
