### PR TITLE
Fix internode connect retry race

### DIFF
--- a/cluster/internode/integration_test.go
+++ b/cluster/internode/integration_test.go
@@ -190,6 +190,37 @@ func TestIntegration_ConnectionRetryOnFailure(t *testing.T) {
 	assert.Greater(t, node2Received.Load(), int32(0), "node-2 should receive message after retry")
 }
 
+func TestIntegration_EnsureConnectionUpdatesDoNotRaceWithDial(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	config := DefaultManagerConfig()
+	config.LocalNodeID = "node-1"
+	config.BindAddr = "127.0.0.1"
+	config.AutoPort = true
+	config.Logger = zap.NewNop()
+	config.HandshakeTimeout = 5 * time.Millisecond
+	config.InitialRetryDelay = time.Millisecond
+	config.MaxRetryDelay = 2 * time.Millisecond
+	config.MaxRetryAttempts = 100
+
+	cm := NewConnectionManager(config, nil)
+	require.NoError(t, cm.Start(ctx, func(cluster.NodeID, []byte) {}))
+	defer func() { _ = cm.Stop() }()
+
+	cm.AddManagedNode("node-2")
+	cm.EnsureConnection("node-2", "127.0.0.1", 19990)
+	time.Sleep(20 * time.Millisecond)
+
+	for i := 0; i < 100; i++ {
+		cm.EnsureConnection("node-2", "127.0.0.1", 19990+i%8)
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func TestIntegration_GracefulDisconnect(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -645,10 +645,11 @@ func (loop *nodeControlLoop) handleConnect(data connectData) {
 	loop.isOutbound = true
 	loop.manager.nodeStates.SetNodeState(loop.nodeID, loop.state)
 
+	addr, port := loop.addr, loop.port
 	loop.manager.wg.Add(1)
 	go func() {
 		defer loop.manager.wg.Done()
-		loop.attemptConnection()
+		loop.attemptConnection(addr, port)
 	}()
 }
 
@@ -736,10 +737,11 @@ func (loop *nodeControlLoop) handleDisconnected(data disconnectedData) {
 		if loop.retryDelay < loop.manager.config.MaxRetryDelay {
 			loop.retryDelay *= 2
 		}
+		fallbackAddr, fallbackPort := loop.addr, loop.port
 		time.AfterFunc(loop.retryDelay, func() {
 			addr, port, hasAddr := loop.manager.nodeStates.GetNodeAddress(loop.nodeID)
 			if !hasAddr {
-				addr, port = loop.addr, loop.port
+				addr, port = fallbackAddr, fallbackPort
 			}
 			loop.sendCommandToSelf(nodeCommand{Type: cmdConnect, Data: connectData{Addr: addr, Port: port}})
 		})
@@ -767,12 +769,12 @@ func (loop *nodeControlLoop) sendCommandToSelf(cmd nodeCommand) {
 	}
 }
 
-func (loop *nodeControlLoop) attemptConnection() {
+func (loop *nodeControlLoop) attemptConnection(addr string, port int) {
 	if loop.ctx.Err() != nil {
 		return
 	}
-	addr := net.JoinHostPort(loop.addr, fmt.Sprintf("%d", loop.port))
-	loop.logger.Debug("Attempting outbound connection", zap.String("target_addr", addr))
+	targetAddr := net.JoinHostPort(addr, fmt.Sprintf("%d", port))
+	loop.logger.Debug("Attempting outbound connection", zap.String("target_addr", targetAddr))
 	var conn net.Conn
 	var err error
 	if loop.manager.tlsConfig != nil {
@@ -780,10 +782,10 @@ func (loop *nodeControlLoop) attemptConnection() {
 			NetDialer: &net.Dialer{Timeout: loop.manager.config.HandshakeTimeout},
 			Config:    loop.manager.tlsConfig,
 		}
-		conn, err = dialer.DialContext(loop.ctx, "tcp", addr)
+		conn, err = dialer.DialContext(loop.ctx, "tcp", targetAddr)
 	} else {
 		dialer := &net.Dialer{Timeout: loop.manager.config.HandshakeTimeout}
-		conn, err = dialer.DialContext(loop.ctx, "tcp", addr)
+		conn, err = dialer.DialContext(loop.ctx, "tcp", targetAddr)
 	}
 	if err != nil {
 		loop.sendDisconnected(err, true)


### PR DESCRIPTION
## Summary
- snapshot outbound dial address/port before launching async connection attempts
- snapshot retry fallback address/port before scheduling retry timers
- add a non-short integration regression that churns EnsureConnection updates while retry dials are active

## Root cause
The internode control loop owns node connection state, but handleConnect launched attemptConnection as an async goroutine that read loop.addr and loop.port directly. A later EnsureConnection command could update those fields while the previous goroutine was dialing. Retry timers had the same issue when they fell back to loop.addr/loop.port from outside the control-loop goroutine.

## Why existing tests missed it
The normal short CI path skips this integration timing case, and most internode unit tests do not run repeated target updates while a retry dial goroutine is active. The race surfaced only in the non-short internode package under -race.

## Validation
- make lint
- go test -race -count=20 ./cluster/internode -run 'TestIntegration_(ConnectionRetryOnFailure|EnsureConnectionUpdatesDoNotRaceWithDial)'
- go test -race -count=1 ./cluster/internode ./cluster/membership ./cluster/raft/... ./service/pg

## Notes
This keeps the control-loop fields single-owned and avoids adding locks to the dial hot path.