### PR TITLE
ci: pin GitHub Actions Go patch version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
 
       - name: Run linter
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
         env:
           MSYSTEM: MINGW64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
         env:
           MSYSTEM: MINGW64
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
 
       - name: Download binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
         env:
           MSYSTEM: MINGW64
@@ -191,7 +191,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
 
       - name: Download binaries


### PR DESCRIPTION
## Summary
- pin CI, nightly, and release workflows to Go 1.26.4 to match go.mod
- fixes release matrix failures where ARM runners resolve go-version 1.26 to Go 1.26.3

## Validation
- git diff --check
- failed release evidence: run 27050874871 linux/arm64 exited with go.mod requires go >= 1.26.4 while setup-go installed 1.26.3

This is workflow-only and should be included before rerunning v0.3.4a.