### PR TITLE
Fix EVENTUAL registry Lua registrar wiring

### DIFF
--- a/api/topology/topology.go
+++ b/api/topology/topology.go
@@ -134,6 +134,8 @@ type (
 	// user-session-class names. The Lookup surface reuses globalreg's option
 	// types for API parity.
 	EventualRegistry interface {
+		Register(name string, p pid.PID) (pid.PID, error)
+		Unregister(name string) bool
 		Lookup(ctx context.Context, name string, opts ...global.LookupOption) (global.LookupResult, error)
 	}
 

--- a/runtime/lua/modules/process/eventual_registrar_test.go
+++ b/runtime/lua/modules/process/eventual_registrar_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/topology"
+	"github.com/wippyai/runtime/system/topology/namereg/eventual"
+)
+
+func TestEventualServiceBoundInContextSatisfiesLuaRegistrar(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	svc := eventual.NewService(eventual.Config{LocalNodeID: "node-1"})
+	ctx = topology.WithEventualRegistry(ctx, svc)
+
+	require.NotNil(t, topology.GetEventualRegistry(ctx))
+	require.NotNil(t, getEventualRegistrar(ctx))
+}

--- a/runtime/lua/modules/process/module.go
+++ b/runtime/lua/modules/process/module.go
@@ -746,26 +746,13 @@ func scopeLabel(m topology.RegistrationMode) string {
 	}
 }
 
-// eventualRegistrar is the minimal API the Lua surface needs from the
-// EVENTUAL registry. The shape decouples the module from the concrete
-// eventual.Service type so tests can substitute fakes.
-type eventualRegistrar interface {
-	Register(name string, p pidapi.PID) (pidapi.PID, error)
-	Unregister(name string) bool
-}
+// eventualRegistrar is the EVENTUAL registry surface the Lua module needs.
+type eventualRegistrar = topology.EventualRegistry
 
-// getEventualRegistrar walks the topology context for an EventualRegistry
-// and type-asserts the Register/Unregister surface the Lua glue needs.
+// getEventualRegistrar walks the topology context for an EventualRegistry.
 // Returns nil when no eventual registry is bound.
 func getEventualRegistrar(ctx context.Context) eventualRegistrar {
-	er := topology.GetEventualRegistry(ctx)
-	if er == nil {
-		return nil
-	}
-	if reg, ok := er.(eventualRegistrar); ok {
-		return reg
-	}
-	return nil
+	return topology.GetEventualRegistry(ctx)
 }
 
 func registryLookup(l *lua.LState) int {

--- a/system/process/resolve_test.go
+++ b/system/process/resolve_test.go
@@ -80,6 +80,19 @@ func (r *fakeEventualReg) put(name string, p pidapi.PID) {
 	r.entries[name] = p
 }
 
+func (r *fakeEventualReg) Register(name string, p pidapi.PID) (pidapi.PID, error) {
+	r.entries[name] = p
+	return p, nil
+}
+
+func (r *fakeEventualReg) Unregister(name string) bool {
+	if _, ok := r.entries[name]; !ok {
+		return false
+	}
+	delete(r.entries, name)
+	return true
+}
+
 func (r *fakeEventualReg) Lookup(_ context.Context, name string, _ ...global.LookupOption) (global.LookupResult, error) {
 	p, ok := r.entries[name]
 	if !ok {

--- a/system/topology/namereg/eventual/revoke_test.go
+++ b/system/topology/namereg/eventual/revoke_test.go
@@ -173,7 +173,7 @@ func TestRevoke_NotEmittedWhenLocalWins(t *testing.T) {
 
 	localPID := pid.PID{Node: "node-A", Host: "h", UniqID: "local"}
 	// Local registers with high priority — it must beat a lower-priority remote.
-	_, err := svc.Register("svc.leader", localPID, eventual.WithPriority(10))
+	_, err := svc.RegisterWithOptions("svc.leader", localPID, eventual.WithPriority(10))
 	require.NoError(t, err)
 
 	loserPID := pid.PID{Node: "node-B", Host: "h", UniqID: "remote"}

--- a/system/topology/namereg/eventual/service.go
+++ b/system/topology/namereg/eventual/service.go
@@ -237,7 +237,16 @@ func WithPriority(p uint32) RegisterOption {
 // when a different-origin entry out-ranks this fresh claim (the caller lost the
 // concurrent conflict — a name_revoked is also signaled to `p`). Cross-scope
 // conflicts (CONSISTENT/LOCAL) are rejected.
-func (s *Service) Register(name string, p pid.PID, opts ...RegisterOption) (pid.PID, error) {
+func (s *Service) Register(name string, p pid.PID) (pid.PID, error) {
+	return s.register(name, p)
+}
+
+// RegisterWithOptions is Register with conflict-resolution options.
+func (s *Service) RegisterWithOptions(name string, p pid.PID, opts ...RegisterOption) (pid.PID, error) {
+	return s.register(name, p, opts...)
+}
+
+func (s *Service) register(name string, p pid.PID, opts ...RegisterOption) (pid.PID, error) {
 	if s.stopped.Load() {
 		return pid.PID{}, ErrServiceStopped
 	}

--- a/system/topology/pid_registry_test.go
+++ b/system/topology/pid_registry_test.go
@@ -41,6 +41,22 @@ type fakeEventualRegistry struct {
 	active map[string]pidapi.PID
 }
 
+func (f *fakeEventualRegistry) Register(name string, p pidapi.PID) (pidapi.PID, error) {
+	if f.active == nil {
+		f.active = map[string]pidapi.PID{}
+	}
+	f.active[name] = p
+	return p, nil
+}
+
+func (f *fakeEventualRegistry) Unregister(name string) bool {
+	if _, ok := f.active[name]; !ok {
+		return false
+	}
+	delete(f.active, name)
+	return true
+}
+
 func (f *fakeEventualRegistry) Lookup(_ context.Context, name string, _ ...globalapi.LookupOption) (globalapi.LookupResult, error) {
 	if p, ok := f.active[name]; ok {
 		return globalapi.LookupResult{PID: p, Found: true}, nil


### PR DESCRIPTION
## Summary

- make `topology.EventualRegistry` expose the register/unregister surface Lua needs
- split `eventual.Service.Register` into the interface-compatible default call plus `RegisterWithOptions` for priority registration
- add a regression test proving a boot-bound eventual service is accepted by the Lua registrar path

## Tests

- `go test ./runtime/lua/modules/process -run TestEventualServiceBoundInContextSatisfiesLuaRegistrar -count=1`
- `go test ./system/topology/namereg/eventual -run 'TestEventualScope|TestRevoke' -count=1`
- `go test ./system/topology ./system/process -count=1`
- `go test ./...`
