### PR TITLE
fix(loader): apply module exclude rules to replacement/source modules

### DIFF
--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -113,6 +113,26 @@ func (c *ModuleConfig) ValidateForLabel() error {
 	return nil
 }
 
+// EntryExcludes returns the exclude patterns that target registry entries in
+// namespace:name form. Patterns without a ':' separator are source-file globs
+// (for example "_old/**", "test/**" or "*.test.lua") consumed when collecting
+// files, not entry-ID patterns; they are omitted here so the entry-disable
+// stage does not reject them as malformed entry patterns.
+func (c *ModuleConfig) EntryExcludes() []string {
+	if len(c.Exclude) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(c.Exclude))
+	for _, pattern := range c.Exclude {
+		if strings.Contains(pattern, ":") {
+			out = append(out, pattern)
+		}
+	}
+
+	return out
+}
+
 func (c *ModuleConfig) Namespace() string {
 	return c.Organization + "." + c.ModuleName
 }

--- a/boot/deps/config/config_test.go
+++ b/boot/deps/config/config_test.go
@@ -293,3 +293,25 @@ metadata:
 	require.True(t, ok)
 	assert.Equal(t, "debug", loggerMap["level"])
 }
+
+// --- EntryExcludes ---
+
+func TestEntryExcludes(t *testing.T) {
+	tests := []struct {
+		name    string
+		exclude []string
+		want    []string
+	}{
+		{name: "nil", exclude: nil, want: nil},
+		{name: "only file globs", exclude: []string{"_old/**", "test/**", "*.test.lua"}, want: []string{}},
+		{name: "only entry patterns", exclude: []string{"app:**", "app.env:**"}, want: []string{"app:**", "app.env:**"}},
+		{name: "mixed file globs and entry patterns", exclude: []string{"_old/**", "app:**"}, want: []string{"app:**"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ModuleConfig{Exclude: tc.exclude}
+			assert.Equal(t, tc.want, cfg.EntryExcludes())
+		})
+	}
+}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -381,23 +381,29 @@ func applyModuleConfigFilters(
 	entries []regapi.Entry,
 	logger *zap.Logger,
 ) ([]regapi.Entry, error) {
-	cfg, err := depconfig.Load(mp.Path)
+	configDir := mp.SourceRoot
+	if configDir == "" {
+		configDir = mp.Path
+	}
+
+	cfg, err := depconfig.Load(configDir)
 	if err != nil {
 		if logger != nil {
 			logger.Debug("module config not loaded for source dependency",
 				zap.String("module", mp.Module),
-				zap.String("path", mp.Path),
+				zap.String("path", configDir),
 				zap.Error(err))
 		}
 		return entries, nil
 	}
-	if len(cfg.Exclude) == 0 && len(cfg.ExcludeMeta) == 0 {
+	entryExcludes := cfg.EntryExcludes()
+	if len(entryExcludes) == 0 && len(cfg.ExcludeMeta) == 0 {
 		return entries, nil
 	}
 
 	filtered := append([]regapi.Entry(nil), entries...)
 	stage := stages.DisableWithOptions(stages.DisableOptions{
-		Entries:     cfg.Exclude,
+		Entries:     entryExcludes,
 		MetaFilters: cfg.ExcludeMeta,
 	})
 	if err := stage.Execute(ctx, &filtered); err != nil {

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -1152,6 +1152,162 @@ entries:
 	}
 }
 
+// A module whose exclude list holds only source-file globs (no entry-ID
+// patterns and no exclude_meta) must load all its entries unchanged: file
+// globs are pack-time file filters, not entry patterns, so they neither drop
+// entries nor error out.
+func TestLoadEntriesFromModuleLoadPaths_OnlyFileGlobExcludesIsNoOp(t *testing.T) {
+	ctx := setupTestContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	moduleRoot := filepath.Join(tmpDir, "events")
+	srcDir := filepath.Join(moduleRoot, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir module src: %v", err)
+	}
+	moduleConfig := `organization: kickside
+module: events
+exclude:
+  - "_old/**"
+  - "test/**"
+`
+	if err := os.WriteFile(filepath.Join(moduleRoot, "wippy.yaml"), []byte(moduleConfig), 0o644); err != nil {
+		t.Fatalf("write module config: %v", err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: kickside.events
+entries:
+  - name: emitter
+    kind: function.lua
+    source: |
+      return {}
+  - name: listener
+    kind: function.lua
+    source: |
+      return {}
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+
+	entries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: srcDir, Module: "kickside/events", SourceRoot: moduleRoot},
+	}, logger)
+	if err != nil {
+		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, e := range entries {
+		found[e.ID.String()] = true
+	}
+	for _, id := range []string{"kickside.events:emitter", "kickside.events:listener"} {
+		if !found[id] {
+			t.Fatalf("entry %s dropped by file-glob-only exclude", id)
+		}
+	}
+}
+
+// A genuinely malformed entry-ID pattern (colon present, empty name) must
+// still surface as an error: EntryExcludes only drops no-colon file globs, it
+// does not swallow real entry-pattern mistakes.
+func TestLoadEntriesFromModuleLoadPaths_MalformedEntryPatternStillErrors(t *testing.T) {
+	ctx := setupTestContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	moduleRoot := filepath.Join(tmpDir, "broken")
+	srcDir := filepath.Join(moduleRoot, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir module src: %v", err)
+	}
+	moduleConfig := `organization: kickside
+module: broken
+exclude:
+  - "app:"
+`
+	if err := os.WriteFile(filepath.Join(moduleRoot, "wippy.yaml"), []byte(moduleConfig), 0o644); err != nil {
+		t.Fatalf("write module config: %v", err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: kickside.broken
+entries:
+  - name: handler
+    kind: function.lua
+    source: |
+      return {}
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+
+	_, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: srcDir, Module: "kickside/broken", SourceRoot: moduleRoot},
+	}, logger)
+	if err == nil {
+		t.Fatalf("expected error for malformed entry pattern \"app:\", got nil")
+	}
+}
+
+// The SourceRoot config fix must also apply exclude_meta (not just entry-ID
+// patterns) for a replacement whose entries live under src/.
+func TestLoadEntriesFromModuleLoadPaths_ExcludeMetaAppliedViaSrcLayout(t *testing.T) {
+	ctx := setupTestContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	moduleRoot := filepath.Join(tmpDir, "contract")
+	srcDir := filepath.Join(moduleRoot, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir module src: %v", err)
+	}
+	moduleConfig := `organization: kickside
+module: contract
+exclude_meta:
+  type:
+    - test
+`
+	if err := os.WriteFile(filepath.Join(moduleRoot, "wippy.yaml"), []byte(moduleConfig), 0o644); err != nil {
+		t.Fatalf("write module config: %v", err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: kickside.contract
+entries:
+  - name: fixture
+    kind: function.lua
+    meta:
+      type: test
+    source: |
+      return {}
+  - name: real_handler
+    kind: function.lua
+    source: |
+      return {}
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+
+	entries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: srcDir, Module: "kickside/contract", SourceRoot: moduleRoot},
+	}, logger)
+	if err != nil {
+		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, e := range entries {
+		found[e.ID.String()] = true
+	}
+	if found["kickside.contract:fixture"] {
+		t.Fatalf("meta.type=test entry leaked despite exclude_meta (src layout)")
+	}
+	if !found["kickside.contract:real_handler"] {
+		t.Fatalf("non-excluded module entry missing")
+	}
+}
+
 func TestNormalizeEntries_PreLinkOverrideAffectsRequirementDefaults(t *testing.T) {
 	ctx := setupTestContext(t)
 	cfg := boot.NewConfig(boot.WithSection("override", map[string]any{

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -1062,6 +1062,96 @@ entries:
 	}
 }
 
+// Mirrors the real replacement layout: the module keeps wippy.yaml at its root
+// while entries live under src/. The load path points at src/ (Path) and the
+// module root is carried separately (SourceRoot). The manifest filter must read
+// the config from SourceRoot, otherwise the publish-excluded app:** test
+// fixture leaks and collides with the host's real app:gateway entry.
+func TestLoadEntriesFromModuleLoadPaths_ReplacementWithSrcLayoutFilters(t *testing.T) {
+	ctx := setupTestContext(t)
+	logger := zap.NewNop()
+	tmpDir := t.TempDir()
+
+	moduleRoot := filepath.Join(tmpDir, "component")
+	srcDir := filepath.Join(moduleRoot, "src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "test"), 0o755); err != nil {
+		t.Fatalf("mkdir module src + test dir: %v", err)
+	}
+	moduleConfig := `organization: kickside
+module: component
+exclude:
+  - "_old/**"
+  - "app:**"
+`
+	if err := os.WriteFile(filepath.Join(moduleRoot, "wippy.yaml"), []byte(moduleConfig), 0o644); err != nil {
+		t.Fatalf("write module config: %v", err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: kickside.component
+entries:
+  - name: real_handler
+    kind: function.lua
+    source: |
+      return {}
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
+		t.Fatalf("write module _index.yaml: %v", err)
+	}
+	testFixtureYAML := `version: "1.0"
+namespace: app
+entries:
+  - name: gateway
+    kind: http.service
+    addr: :19086
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "test", "_index.yaml"), []byte(testFixtureYAML), 0o644); err != nil {
+		t.Fatalf("write module test fixture: %v", err)
+	}
+
+	appDir := filepath.Join(tmpDir, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatalf("mkdir app dir: %v", err)
+	}
+	hostYAML := `version: "1.0"
+namespace: app
+entries:
+  - name: gateway
+    kind: http.service
+    addr: :8087
+`
+	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(hostYAML), 0o644); err != nil {
+		t.Fatalf("write host app _index.yaml: %v", err)
+	}
+
+	entries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: appDir},
+		{Path: srcDir, Module: "kickside/component", SourceRoot: moduleRoot},
+	}, logger)
+	if err != nil {
+		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
+	}
+
+	gatewayCount := 0
+	var gateway regapi.Entry
+	found := map[string]regapi.Entry{}
+	for _, entry := range entries {
+		found[entry.ID.String()] = entry
+		if entry.ID.String() == "app:gateway" {
+			gatewayCount++
+			gateway = entry
+		}
+	}
+	if gatewayCount != 1 {
+		t.Fatalf("app:gateway count = %d, want 1 (src-layout collision not filtered)", gatewayCount)
+	}
+	if got := gateway.Meta.GetString("module", ""); got != "" {
+		t.Fatalf("app:gateway tagged with module=%q, want host (untagged) entry to win", got)
+	}
+	if _, ok := found["kickside.component:real_handler"]; !ok {
+		t.Fatalf("non-excluded module entry missing")
+	}
+}
+
 func TestNormalizeEntries_PreLinkOverrideAffectsRequirementDefaults(t *testing.T) {
 	ctx := setupTestContext(t)
 	cfg := boot.NewConfig(boot.WithSection("override", map[string]any{

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -454,7 +454,7 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 	}
 
 	disableOpts := stages.DisableOptions{
-		Entries:     cfg.Exclude,
+		Entries:     cfg.EntryExcludes(),
 		MetaFilters: cfg.ExcludeMeta,
 	}
 


### PR DESCRIPTION
## Why
Loading a module through a `wippy.lock` `replacements:` path (or any source directory) skipped the module's publish-time `exclude`/`exclude_meta` rules:

- A module's own test fixtures under namespace `app` (e.g. `src/test/_index.yaml`) leaked into the host app and collided with its real entries via last-definition dedup, breaking boot.
- The entry-disable stage rejected file-glob excludes (`_old/**`, `test/**`) that `wippy.yaml` lists alongside entry-ID patterns (`app:**`), erroring with `invalid entry pattern: missing ':' separator`. This broke both source/replacement loading **and `wippy publish`** (it feeds the same list to the same stage).

## What
- `applyModuleConfigFilters` now loads `wippy.yaml` from the module root (`mp.SourceRoot`) instead of the entries dir (`mp.Path`). For a replacement whose entries live under `src/`, the config sits at `<module>/wippy.yaml`, not `<module>/src/wippy.yaml`.
- Added `ModuleConfig.EntryExcludes()` returning only `namespace:name` patterns. File-path globs are pack-time file filters, not entry-ID patterns, so they're excluded from the entry-disable stage. Used by both the runtime loader and `wippy publish`.

## Testing
- `go test ./boot/deps/config/... ./cmd/internal/entries/... ./cmd/wippy/cmd/... ./boot/build/stages/...` — pass.
- New regression test reproduces the real `src/`-layout replacement collision (with a `_old/**` file glob present); verified it **fails** without the fix (`app:gateway count = 2`) and passes with it.
- New unit test for `EntryExcludes()` (nil / file-globs-only / entry-patterns-only / mixed).
- `go vet` clean; `golangci-lint run` clean; whole-repo `go build ./...` OK.
- End-to-end: with this binary, a host app that replaces a private module exposing an `app:`-namespace test harness now boots cleanly (migrations apply, gateway serves, admin login returns a token).