### PR TITLE
sql: normalize Postgres placeholders

### DIFF
--- a/runtime/lua/modules/sql/db.go
+++ b/runtime/lua/modules/sql/db.go
@@ -147,7 +147,7 @@ func dbQuery(l *lua.LState) int {
 	if db == nil {
 		return 0
 	}
-	query := l.CheckString(2)
+	query := normalizePlaceholders(db.dbType, l.CheckString(2))
 	params, err := checkParams(l, 3)
 	if err != nil {
 		l.Push(lua.LNil)
@@ -168,7 +168,7 @@ func dbExecute(l *lua.LState) int {
 	if db == nil {
 		return 0
 	}
-	query := l.CheckString(2)
+	query := normalizePlaceholders(db.dbType, l.CheckString(2))
 	params, err := checkParams(l, 3)
 	if err != nil {
 		l.Push(lua.LNil)
@@ -190,7 +190,7 @@ func dbPrepare(l *lua.LState) int {
 		return 0
 	}
 	ctx := l.Context()
-	query := l.CheckString(2)
+	query := normalizePlaceholders(db.dbType, l.CheckString(2))
 
 	yield := AcquirePrepareYield()
 	yield.DB = db.db

--- a/runtime/lua/modules/sql/placeholders.go
+++ b/runtime/lua/modules/sql/placeholders.go
@@ -142,7 +142,7 @@ func dollarQuoteEnd(query string, start int) (int, bool) {
 			}
 			return i + 1 + end + len(tag), true
 		}
-		if !(ch == '_' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9') {
+		if ch != '_' && (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9') {
 			return 0, false
 		}
 		i++

--- a/runtime/lua/modules/sql/placeholders.go
+++ b/runtime/lua/modules/sql/placeholders.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package sql
+
+import (
+	"strconv"
+	"strings"
+)
+
+func normalizePlaceholders(dbType string, query string) string {
+	if mapDBTypeFromResourceKind(dbType) != TypePostgres {
+		return query
+	}
+	return questionToDollarPlaceholders(query)
+}
+
+func questionToDollarPlaceholders(query string) string {
+	if !strings.Contains(query, "?") {
+		return query
+	}
+
+	var b strings.Builder
+	b.Grow(len(query) + 8)
+	index := 1
+
+	for i := 0; i < len(query); {
+		ch := query[i]
+
+		if ch == '\'' {
+			i = copySingleQuoted(&b, query, i)
+			continue
+		}
+		if ch == '"' {
+			i = copyDoubleQuoted(&b, query, i)
+			continue
+		}
+		if ch == '-' && i+1 < len(query) && query[i+1] == '-' {
+			i = copyLineComment(&b, query, i)
+			continue
+		}
+		if ch == '/' && i+1 < len(query) && query[i+1] == '*' {
+			i = copyBlockComment(&b, query, i)
+			continue
+		}
+		if ch == '$' {
+			if end, ok := dollarQuoteEnd(query, i); ok {
+				b.WriteString(query[i:end])
+				i = end
+				continue
+			}
+		}
+		if ch == '?' {
+			if i+1 < len(query) && (query[i+1] == '|' || query[i+1] == '&') {
+				b.WriteByte(ch)
+				i++
+				continue
+			}
+			b.WriteByte('$')
+			b.WriteString(strconv.Itoa(index))
+			index++
+			i++
+			continue
+		}
+
+		b.WriteByte(ch)
+		i++
+	}
+
+	return b.String()
+}
+
+func copySingleQuoted(b *strings.Builder, query string, start int) int {
+	b.WriteByte(query[start])
+	i := start + 1
+	for i < len(query) {
+		b.WriteByte(query[i])
+		if query[i] == '\'' {
+			if i+1 < len(query) && query[i+1] == '\'' {
+				b.WriteByte(query[i+1])
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+func copyDoubleQuoted(b *strings.Builder, query string, start int) int {
+	b.WriteByte(query[start])
+	i := start + 1
+	for i < len(query) {
+		b.WriteByte(query[i])
+		if query[i] == '"' {
+			if i+1 < len(query) && query[i+1] == '"' {
+				b.WriteByte(query[i+1])
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+func copyLineComment(b *strings.Builder, query string, start int) int {
+	i := start
+	for i < len(query) {
+		b.WriteByte(query[i])
+		if query[i] == '\n' {
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+func copyBlockComment(b *strings.Builder, query string, start int) int {
+	i := start
+	for i < len(query) {
+		b.WriteByte(query[i])
+		if query[i] == '*' && i+1 < len(query) && query[i+1] == '/' {
+			b.WriteByte(query[i+1])
+			return i + 2
+		}
+		i++
+	}
+	return i
+}
+
+func dollarQuoteEnd(query string, start int) (int, bool) {
+	i := start + 1
+	for i < len(query) {
+		ch := query[i]
+		if ch == '$' {
+			tag := query[start : i+1]
+			end := strings.Index(query[i+1:], tag)
+			if end < 0 {
+				return 0, false
+			}
+			return i + 1 + end + len(tag), true
+		}
+		if !(ch == '_' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9') {
+			return 0, false
+		}
+		i++
+	}
+	return 0, false
+}

--- a/runtime/lua/modules/sql/placeholders_test.go
+++ b/runtime/lua/modules/sql/placeholders_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package sql
+
+import "testing"
+
+func TestNormalizePlaceholdersForPostgres(t *testing.T) {
+	got := normalizePlaceholders("db.sql.postgres", "SELECT * FROM users WHERE id = ? AND status = ?")
+	want := "SELECT * FROM users WHERE id = $1 AND status = $2"
+	if got != want {
+		t.Fatalf("unexpected normalized query\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestNormalizePlaceholdersLeavesSQLiteQuestionMarks(t *testing.T) {
+	got := normalizePlaceholders("db.sql.sqlite", "SELECT * FROM users WHERE id = ?")
+	want := "SELECT * FROM users WHERE id = ?"
+	if got != want {
+		t.Fatalf("unexpected sqlite query\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestNormalizePlaceholdersSkipsQuotedTextAndComments(t *testing.T) {
+	query := "SELECT '?' AS literal, \"?\" AS ident -- ?\n/* ? */ WHERE id = ? AND body = $$?$$"
+	got := normalizePlaceholders("db.sql.postgres", query)
+	want := "SELECT '?' AS literal, \"?\" AS ident -- ?\n/* ? */ WHERE id = $1 AND body = $$?$$"
+	if got != want {
+		t.Fatalf("unexpected normalized query\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestNormalizePlaceholdersPreservesPostgresJsonbQuestionOperators(t *testing.T) {
+	got := normalizePlaceholders("db.sql.postgres", "SELECT data ?| array['a'] FROM docs WHERE id = ? AND data ?& array['b']")
+	want := "SELECT data ?| array['a'] FROM docs WHERE id = $1 AND data ?& array['b']"
+	if got != want {
+		t.Fatalf("unexpected normalized query\nwant: %s\n got: %s", want, got)
+	}
+}

--- a/runtime/lua/modules/sql/transaction.go
+++ b/runtime/lua/modules/sql/transaction.go
@@ -111,7 +111,7 @@ func txQuery(l *lua.LState) int {
 	}
 	tx.mu.Unlock()
 
-	query := l.CheckString(2)
+	query := normalizePlaceholders(tx.GetDBType(), l.CheckString(2))
 	params, err := checkParams(l, 3)
 	if err != nil {
 		l.Push(lua.LNil)
@@ -141,7 +141,7 @@ func txExecute(l *lua.LState) int {
 	}
 	tx.mu.Unlock()
 
-	query := l.CheckString(2)
+	query := normalizePlaceholders(tx.GetDBType(), l.CheckString(2))
 	params, err := checkParams(l, 3)
 	if err != nil {
 		l.Push(lua.LNil)
@@ -173,7 +173,7 @@ func txPrepare(l *lua.LState) int {
 	}
 	tx.mu.Unlock()
 
-	query := l.CheckString(2)
+	query := normalizePlaceholders(tx.GetDBType(), l.CheckString(2))
 
 	yield := AcquireTxPrepareYield()
 	yield.Tx = tx.tx


### PR DESCRIPTION
## Summary

- normalize `?` placeholders to Postgres `$n` placeholders in SQL module calls
- skip placeholders inside quoted strings, quoted identifiers, comments, and dollar-quoted strings
- preserve Postgres JSONB question operators such as `?|` and `?&`

## Tests

- `go test ./runtime/lua/modules/sql`
