### PR TITLE
store/kv: harden CRDT tombstone GC

### DIFF
--- a/boot/components/system/constants.go
+++ b/boot/components/system/constants.go
@@ -37,10 +37,17 @@ const (
 	ClusterMembershipDeadNodeReclaimTime boot.Name = "membership.dead_node_reclaim_time"
 	ClusterFailureDomain                 boot.Name = "failure_domain"
 	// ClusterKVCRDTTombstoneRetention bounds store.kv.crdt delete tombstone
-	// retention. 0 disables age-only GC and is correctness-first for long
-	// partitions; a positive duration bounds memory by assuming no peer is
-	// offline longer than the retention.
+	// retention by age. 0 disables age-only GC; clustered nodes still reclaim
+	// tombstones after exact tombstone acknowledgement when an acknowledgement
+	// peer set is explicitly configured. A positive duration is an explicit
+	// memory-vs-max-partition tradeoff.
 	ClusterKVCRDTTombstoneRetention boot.Name = "kv_crdt_tombstone_retention"
+	// ClusterKVCRDTTombstoneGCAlivePeers uses the current alive membership as the
+	// tombstone-GC acknowledgement set. This bounds delete-churn memory when
+	// acknowledged peers cannot roll back to stale AP state and departed nodes'
+	// old AP state is externally retired before rejoin; leave it false when
+	// stale durable replicas may reappear under the same node ID.
+	ClusterKVCRDTTombstoneGCAlivePeers boot.Name = "kv_crdt_tombstone_gc_alive_peers"
 
 	// Raft lives under cluster.raft.*. Enabling cluster auto-enables raft
 	// with sensible defaults.

--- a/boot/components/system/kvcrdt.go
+++ b/boot/components/system/kvcrdt.go
@@ -70,6 +70,17 @@ func KVCRDT() boot.Component {
 					ClusterKVCRDTTombstoneRetention,
 					systemkv.DefaultTombstoneRetention,
 				))
+				if clusterCfg.GetBool(ClusterKVCRDTTombstoneGCAlivePeers, false) {
+					engine.SetAlivePeers(func() map[string]struct{} {
+						alive := map[string]struct{}{node.ID(): {}}
+						for _, n := range memSvc.Nodes() {
+							if n.ID != "" {
+								alive[n.ID] = struct{}{}
+							}
+						}
+						return alive
+					})
+				}
 				if base := nodeDataDir(clusterCfg); base != "" {
 					engine.SetDurability(filepath.Join(base, "_sys", "kvcrdt"), 30*time.Second)
 				}

--- a/system/crdt/state.go
+++ b/system/crdt/state.go
@@ -525,7 +525,21 @@ func (s *State) Range(start, end string, fn func(Entry) bool) {
 // expiry because age alone cannot prove that delayed live dots are gone.
 // Returns counts: (gcSafe, gcWallFloor).
 func (s *State) ReapTombstones(safeByNode []uint64, nowMs, wallFloorMs int64) (int, int) {
+	canReap := func(e Entry) bool {
+		return int(e.Node) < len(safeByNode) && e.Counter <= safeByNode[e.Node]
+	}
+	safe, floor, _ := s.ReapTombstonesWhere(canReap, nowMs, wallFloorMs)
+	return safe, floor
+}
+
+// ReapTombstonesWhere drops tombstones accepted by canReap. If canReap is nil,
+// only wall-floor expiry can reap tombstones. If wallFloorMs is positive,
+// tombstones with nowMs-Wall > wallFloorMs are dropped as an explicit operator
+// tradeoff. It returns counts plus the exact tombstone entries removed so
+// callers can prune per-dot acknowledgement state.
+func (s *State) ReapTombstonesWhere(canReap func(Entry) bool, nowMs, wallFloorMs int64) (int, int, []Entry) {
 	var safe, floor int
+	var reaped []Entry
 	for i := range s.shards {
 		sh := &s.shards[i]
 		sh.mu.Lock()
@@ -533,21 +547,24 @@ func (s *State) ReapTombstones(safeByNode []uint64, nowMs, wallFloorMs int64) (i
 			if !e.Deleted {
 				continue
 			}
-			if int(e.Node) < len(safeByNode) && e.Counter <= safeByNode[e.Node] {
+			ent := *e
+			if canReap != nil && canReap(ent) {
 				delete(sh.entries, key)
 				s.tombstone.Add(-1)
+				reaped = append(reaped, ent)
 				safe++
 				continue
 			}
 			if wallFloorMs > 0 && nowMs-e.Wall > wallFloorMs {
 				delete(sh.entries, key)
 				s.tombstone.Add(-1)
+				reaped = append(reaped, ent)
 				floor++
 			}
 		}
 		sh.mu.Unlock()
 	}
-	return safe, floor
+	return safe, floor, reaped
 }
 
 func cloneBytes(b []byte) []byte {

--- a/system/kv/crdt_delegate.go
+++ b/system/kv/crdt_delegate.go
@@ -35,6 +35,8 @@ func (d *CRDTDelegate) LocalState(_ bool) []byte { return d.engine.FullState() }
 // MergeRemoteState applies a peer's full-state push/pull payload.
 func (d *CRDTDelegate) MergeRemoteState(buf []byte, _ bool) {
 	if len(buf) > 0 {
-		d.engine.OnFrame(buf)
+		if !d.engine.mergeFullState(buf) {
+			d.engine.OnFrame(buf)
+		}
 	}
 }

--- a/system/kv/crdt_engine.go
+++ b/system/kv/crdt_engine.go
@@ -3,7 +3,9 @@
 package kv
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -27,12 +29,16 @@ const crdtReapInterval = time.Second
 const crdtTombstoneGCInterval = time.Minute
 
 // DefaultTombstoneRetention is the default age-only delete-tombstone retention
-// for store.kv.crdt. A non-positive value disables age-only GC. That is the
-// correctness-first default: without per-peer delete acknowledgements or
-// per-origin CV digests, any finite wall-clock floor encodes a max-partition
-// assumption and can resurrect deletes on nodes that were offline longer than
-// the floor.
+// for store.kv.crdt. A non-positive value disables age-only GC. Clustered
+// deployments can opt into acknowledgement-gated GC by wiring a peer set; a
+// positive wall floor is only an explicit max-partition tradeoff for operators
+// that want a hard memory bound independent of peer acks.
 const DefaultTombstoneRetention time.Duration = 0
+
+type tombstoneDot struct {
+	node    uint32
+	counter uint64
+}
 
 // wallScale shifts the real millisecond clock left so a per-node tiebreak fits
 // in the low digits. crdt.State.Apply resolves a cross-origin conflict purely by
@@ -55,9 +61,12 @@ type CRDTEngine struct {
 	logger         *zap.Logger
 	state          *crdt.State
 	cancel         context.CancelFunc
+	peerTombAck    map[string]map[tombstoneDot]struct{}
+	aliveFn        func() map[string]struct{}
 	leaseKeys      map[kvapi.LeaseID]map[string]struct{}
 	deadlines      map[kvapi.LeaseID]time.Time
 	keyLease       map[string]kvapi.LeaseID
+	localNode      string
 	system         event.System
 	dataDir        string
 	wg             sync.WaitGroup
@@ -82,7 +91,9 @@ func NewCRDTEngine(localNode string, bus event.Bus, logger *zap.Logger) *CRDTEng
 		bus:            bus,
 		logger:         logger.Named("kv-crdt"),
 		system:         "kv:crdt",
+		localNode:      localNode,
 		tiebreak:       int64(h.Sum32() % wallScale),
+		peerTombAck:    make(map[string]map[tombstoneDot]struct{}),
 		durableNS:      make(map[string]struct{}),
 		snapInterval:   30 * time.Second,
 		gcInterval:     crdtTombstoneGCInterval,
@@ -109,12 +120,25 @@ func (e *CRDTEngine) SetDurability(dataDir string, interval time.Duration) {
 }
 
 // SetTombstoneRetention sets the age-only delete tombstone retention. A
-// non-positive duration disables age-only GC and keeps delete fences until the
-// process restarts or a future CV-gated GC mechanism can prove every peer has
-// observed the delete.
+// non-positive duration disables age-only GC and keeps delete fences until
+// acknowledgement-gated GC can prove the configured peer set has observed each
+// delete.
 func (e *CRDTEngine) SetTombstoneRetention(retention time.Duration) {
 	e.mu.Lock()
 	e.tombstoneFloor = retention
+	e.mu.Unlock()
+}
+
+// SetAlivePeers wires the peer set whose tombstone acknowledgements are
+// required by GC. The returned map must include the local node when it is alive.
+// Omitting a peer is safe only when that peer's stale AP state has been retired
+// or fenced from rejoining under the same node ID; counting an acknowledged peer
+// is safe only when it cannot roll back to a pre-ack snapshot. A nil function
+// disables acknowledgement-gated GC and preserves the default
+// infinite-retention safety behavior.
+func (e *CRDTEngine) SetAlivePeers(fn func() map[string]struct{}) {
+	e.mu.Lock()
+	e.aliveFn = fn
 	e.mu.Unlock()
 }
 
@@ -475,17 +499,79 @@ func (e *CRDTEngine) tombstoneReaper() {
 	}
 }
 
-// gcTombstones runs one tombstone GC pass. safeByNode is nil because the
-// store.kv.crdt delegate exchanges no per-origin CV digests, so the wall floor
-// is the only age-based drop criterion; now and the floor are in the engine's
-// scaled wall units (real ms * wallScale) to match Entry.Wall.
+// gcTombstones runs one tombstone GC pass. A tombstone is safe to drop only
+// after every configured peer has sent a full-state snapshot containing that
+// exact delete dot. Otherwise the default correctness-first behavior retains
+// tombstones indefinitely. now and the floor are in the engine's scaled wall
+// units (real ms * wallScale) to match Entry.Wall.
 func (e *CRDTEngine) gcTombstones() (int, int) {
 	e.mu.Lock()
 	retention := e.tombstoneFloor
 	e.mu.Unlock()
 	nowScaled := time.Now().UnixMilli() * wallScale
 	floorScaled := retention.Milliseconds() * wallScale
-	return e.state.ReapTombstones(nil, nowScaled, floorScaled)
+	safe, floor, reaped := e.state.ReapTombstonesWhere(e.tombstoneAckedByPeers(), nowScaled, floorScaled)
+	e.pruneTombstoneAcks(reaped)
+	return safe, floor
+}
+
+func (e *CRDTEngine) tombstoneAckedByPeers() func(crdt.Entry) bool {
+	e.mu.Lock()
+	aliveFn := e.aliveFn
+	localNode := e.localNode
+	e.mu.Unlock()
+	if aliveFn == nil {
+		return nil
+	}
+	alive := aliveFn()
+	if len(alive) == 0 {
+		return nil
+	}
+
+	e.mu.Lock()
+	peerAck := make([]map[tombstoneDot]struct{}, 0, len(alive))
+	for peer := range alive {
+		if peer == localNode {
+			continue
+		}
+		src := e.peerTombAck[peer]
+		cp := make(map[tombstoneDot]struct{}, len(src))
+		for dot := range src {
+			cp[dot] = struct{}{}
+		}
+		peerAck = append(peerAck, cp)
+	}
+	e.mu.Unlock()
+
+	return func(ent crdt.Entry) bool {
+		dot := tombstoneDot{node: ent.Node, counter: ent.Counter}
+		for _, ack := range peerAck {
+			if _, ok := ack[dot]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func (e *CRDTEngine) pruneTombstoneAcks(reaped []crdt.Entry) {
+	if len(reaped) == 0 {
+		return
+	}
+	dots := make([]tombstoneDot, 0, len(reaped))
+	for i := range reaped {
+		dots = append(dots, tombstoneDot{node: reaped[i].Node, counter: reaped[i].Counter})
+	}
+	e.mu.Lock()
+	for peer, ack := range e.peerTombAck {
+		for _, dot := range dots {
+			delete(ack, dot)
+		}
+		if len(ack) == 0 {
+			delete(e.peerTombAck, peer)
+		}
+	}
+	e.mu.Unlock()
 }
 
 // --- gossip hooks (driven by the delegate) ---
@@ -498,6 +584,13 @@ func (e *CRDTEngine) DrainBroadcasts(overhead, budget int) [][]byte {
 // OnFrame applies an inbound delta frame and epidemically re-broadcasts entries
 // that advanced local state, so deltas reach the whole cluster.
 func (e *CRDTEngine) OnFrame(data []byte) {
+	if e.mergeFullState(data) {
+		return
+	}
+	e.onFrame(data, "")
+}
+
+func (e *CRDTEngine) onFrame(data []byte, ackPeer string) {
 	entries, origins, err := crdt.DecodeFrame(data)
 	if err != nil {
 		e.logger.Debug("crdt: malformed frame", zap.Error(err))
@@ -505,6 +598,9 @@ func (e *CRDTEngine) OnFrame(data []byte) {
 	for i := range entries {
 		en := entries[i]
 		en.Node = e.state.InternNode(origins[i])
+		if ackPeer != "" && en.Deleted {
+			e.recordPeerTombstoneAck(ackPeer, en)
+		}
 		outcome, merged := e.state.Apply(en)
 		if outcome == crdt.MergeApplied || outcome == crdt.MergeDeleteWins {
 			e.queue.Push(merged)
@@ -518,19 +614,73 @@ func (e *CRDTEngine) OnFrame(data []byte) {
 }
 
 // FullState encodes every entry as a single delta frame for a memberlist
-// push/pull bulk sync. The receiver feeds it back through OnFrame.
+// push/pull bulk sync. The envelope carries the sender identity so receivers
+// can treat tombstones present in the snapshot as per-peer delete
+// acknowledgements.
 func (e *CRDTEngine) FullState() []byte {
-	var out []byte
+	var deltas []byte
 	for shard := 0; shard < crdt.ShardCount; shard++ {
 		entries := e.state.ShardEntries(shard)
 		for i := range entries {
 			buf, err := crdt.EncodeDelta(nil, &entries[i], e.state.NodeString(entries[i].Node))
 			if err == nil {
-				out = append(out, buf...)
+				deltas = append(deltas, buf...)
 			}
 		}
 	}
+	return e.encodeFullState(deltas)
+}
+
+var kvCRDTFullStateMagic = [...]byte{'w', 'k', 'v', 'c', 'r', 'd', 't', 1}
+
+func (e *CRDTEngine) encodeFullState(deltas []byte) []byte {
+	node := e.localNode
+	if len(node) > 0xFFFF {
+		return deltas
+	}
+	size := len(kvCRDTFullStateMagic) + 2 + len(node) + len(deltas)
+	out := make([]byte, 0, size)
+	out = append(out, kvCRDTFullStateMagic[:]...)
+	out = binary.LittleEndian.AppendUint16(out, uint16(len(node)))
+	out = append(out, node...)
+	out = append(out, deltas...)
 	return out
+}
+
+func (e *CRDTEngine) mergeFullState(buf []byte) bool {
+	if len(buf) < len(kvCRDTFullStateMagic) || !bytes.Equal(buf[:len(kvCRDTFullStateMagic)], kvCRDTFullStateMagic[:]) {
+		return false
+	}
+	pos := len(kvCRDTFullStateMagic)
+	if len(buf)-pos < 2 {
+		return true
+	}
+	nodeLen := int(binary.LittleEndian.Uint16(buf[pos:]))
+	pos += 2
+	if nodeLen == 0 || len(buf)-pos < nodeLen {
+		return true
+	}
+	peer := string(buf[pos : pos+nodeLen])
+	pos += nodeLen
+	if pos < len(buf) {
+		e.onFrame(buf[pos:], peer)
+	}
+	return true
+}
+
+func (e *CRDTEngine) recordPeerTombstoneAck(peer string, ent crdt.Entry) {
+	if peer == "" {
+		return
+	}
+	dot := tombstoneDot{node: ent.Node, counter: ent.Counter}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	m := e.peerTombAck[peer]
+	if m == nil {
+		m = make(map[tombstoneDot]struct{})
+		e.peerTombAck[peer] = m
+	}
+	m[dot] = struct{}{}
 }
 
 func (e *CRDTEngine) emit(typ kvapi.WatchEventType, cur *kvapi.Entry) {

--- a/system/kv/crdt_gc_test.go
+++ b/system/kv/crdt_gc_test.go
@@ -3,11 +3,15 @@
 package kv
 
 import (
+	"context"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	kvapi "github.com/wippyai/runtime/api/store/kv"
+	"github.com/wippyai/runtime/system/crdt"
 )
 
 // TestCRDTEngine_TombstoneGCBoundsMemory is the B2 regression: every Delete
@@ -68,5 +72,219 @@ func TestCRDTEngine_TombstoneGCBoundsMemory(t *testing.T) {
 	}
 	if _, err := gc.Get("a"); !errors.Is(err, kvapi.ErrKeyNotFound) {
 		t.Fatalf("reaped key a: want ErrKeyNotFound, got %v", err)
+	}
+}
+
+func TestCRDTEngine_TombstoneGCWaitsForExactPeerAck(t *testing.T) {
+	a := newCRDT(t, "node-a")
+	b := newCRDT(t, "node-b")
+	alive := func() map[string]struct{} {
+		return map[string]struct{}{"node-a": {}, "node-b": {}}
+	}
+	a.SetAlivePeers(alive)
+	b.SetAlivePeers(alive)
+
+	if _, err := b.Set("k", []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := b.Delete("k"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := b.state.TombstoneCount(); got != 1 {
+		t.Fatalf("want one tombstone before GC, got %d", got)
+	}
+
+	if safe, floor := b.gcTombstones(); safe+floor != 0 {
+		t.Fatalf("tombstone reaped before alive peer ack: safe=%d floor=%d", safe, floor)
+	}
+	if got := b.state.TombstoneCount(); got != 1 {
+		t.Fatalf("tombstone count after blocked GC = %d, want 1", got)
+	}
+
+	da := NewCRDTDelegate(a)
+	db := NewCRDTDelegate(b)
+	da.MergeRemoteState(db.LocalState(false), false)
+	db.MergeRemoteState(da.LocalState(false), false)
+
+	if safe, floor := b.gcTombstones(); safe != 1 || floor != 0 {
+		t.Fatalf("want one ack-safe tombstone reap after peer ack, got safe=%d floor=%d", safe, floor)
+	}
+	if got := b.state.TombstoneCount(); got != 0 {
+		t.Fatalf("tombstone count after acked GC = %d, want 0", got)
+	}
+	b.mu.Lock()
+	ackPeers := len(b.peerTombAck)
+	b.mu.Unlock()
+	if ackPeers != 0 {
+		t.Fatalf("tombstone ack state leaked after reap: peers=%d", ackPeers)
+	}
+	if _, err := a.Get("k"); !errors.Is(err, kvapi.ErrKeyNotFound) {
+		t.Fatalf("peer must retain delete semantics after origin GC, got %v", err)
+	}
+}
+
+func TestCRDTEngine_TombstoneGCRequiresSpecificTombstoneAck(t *testing.T) {
+	a := newCRDT(t, "node-a")
+	b := newCRDT(t, "node-b")
+	alive := func() map[string]struct{} {
+		return map[string]struct{}{"node-a": {}, "node-b": {}}
+	}
+	a.SetAlivePeers(alive)
+	b.SetAlivePeers(alive)
+
+	if _, err := b.Set("k", []byte("v")); err != nil {
+		t.Fatalf("set k: %v", err)
+	}
+	if err := b.Delete("k"); err != nil {
+		t.Fatalf("delete k: %v", err)
+	}
+	if _, err := b.Set("other", []byte("later")); err != nil {
+		t.Fatalf("set other: %v", err)
+	}
+
+	other, ok := b.state.LookupEntry("other")
+	if !ok {
+		t.Fatalf("missing later entry")
+	}
+	frame, err := crdt.EncodeDelta(nil, &other, b.state.NodeString(other.Node))
+	if err != nil {
+		t.Fatalf("encode later entry: %v", err)
+	}
+	a.OnFrame(frame)
+	NewCRDTDelegate(b).MergeRemoteState(NewCRDTDelegate(a).LocalState(false), false)
+
+	if safe, floor := b.gcTombstones(); safe+floor != 0 {
+		t.Fatalf("origin-wide progress without the tombstone must not ack GC: safe=%d floor=%d", safe, floor)
+	}
+	if got := b.state.TombstoneCount(); got != 1 {
+		t.Fatalf("tombstone count after non-specific ack = %d, want 1", got)
+	}
+
+	NewCRDTDelegate(a).MergeRemoteState(NewCRDTDelegate(b).LocalState(false), false)
+	NewCRDTDelegate(b).MergeRemoteState(NewCRDTDelegate(a).LocalState(false), false)
+	if safe, floor := b.gcTombstones(); safe != 1 || floor != 0 {
+		t.Fatalf("specific tombstone ack should allow GC: safe=%d floor=%d", safe, floor)
+	}
+}
+
+func TestCRDTEngine_TombstoneGCExcludesRetiredPeerByPolicy(t *testing.T) {
+	alive := map[string]struct{}{"node-b": {}, "node-a": {}}
+	b := newCRDT(t, "node-b")
+	b.SetAlivePeers(func() map[string]struct{} {
+		out := make(map[string]struct{}, len(alive))
+		for n := range alive {
+			out[n] = struct{}{}
+		}
+		return out
+	})
+
+	if _, err := b.Set("k", []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := b.Delete("k"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if safe, floor := b.gcTombstones(); safe+floor != 0 {
+		t.Fatalf("live but unacked peer must block GC: safe=%d floor=%d", safe, floor)
+	}
+
+	// The configured peer set may exclude node-a only after its old AP state is
+	// retired or fenced from rejoining under the same node ID.
+	delete(alive, "node-a")
+	if safe, floor := b.gcTombstones(); safe != 1 || floor != 0 {
+		t.Fatalf("retired peer must not pin tombstone: safe=%d floor=%d", safe, floor)
+	}
+	if got := b.state.TombstoneCount(); got != 0 {
+		t.Fatalf("tombstone count after retired-peer GC = %d, want 0", got)
+	}
+}
+
+func TestCRDTEngine_FullStateEnvelopeBackwardsCompatible(t *testing.T) {
+	a := newCRDT(t, "node-a")
+	b := newCRDT(t, "node-b")
+	if _, err := a.Set("legacy", []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	var legacy []byte
+	for shard := 0; shard < crdt.ShardCount; shard++ {
+		entries := a.state.ShardEntries(shard)
+		for i := range entries {
+			buf, err := crdt.EncodeDelta(nil, &entries[i], a.state.NodeString(entries[i].Node))
+			if err != nil {
+				t.Fatalf("encode legacy delta: %v", err)
+			}
+			legacy = append(legacy, buf...)
+		}
+	}
+
+	NewCRDTDelegate(b).MergeRemoteState(legacy, true)
+	if got, err := b.Get("legacy"); err != nil || string(got.Value) != "v" {
+		t.Fatalf("legacy full state did not merge: got=%+v err=%v", got, err)
+	}
+}
+
+func TestCRDTEngine_OnFrameAcceptsFullStateEnvelope(t *testing.T) {
+	a := newCRDT(t, "node-a")
+	b := newCRDT(t, "node-b")
+	if _, err := a.Set("enveloped", []byte("v")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	b.OnFrame(a.FullState())
+	if got, err := b.Get("enveloped"); err != nil || string(got.Value) != "v" {
+		t.Fatalf("enveloped full state did not merge through OnFrame: got=%+v err=%v", got, err)
+	}
+}
+
+func TestCRDTEngine_FullStateEnvelopeConsumesMalformedHeader(t *testing.T) {
+	e := newCRDT(t, "node-a")
+
+	buf := append([]byte{}, kvCRDTFullStateMagic[:]...)
+	buf = binary.LittleEndian.AppendUint16(buf, uint16(len("peer")+1))
+	buf = append(buf, "peer"...)
+
+	if !e.mergeFullState(buf) {
+		t.Fatalf("new-format malformed envelope should be consumed, not passed to legacy decoder")
+	}
+	e.mu.Lock()
+	_, recorded := e.peerTombAck["peer"]
+	e.mu.Unlock()
+	if recorded {
+		t.Fatalf("malformed envelope recorded peer tombstone ack")
+	}
+}
+
+func BenchmarkCRDTEngine_FullStateEnvelopeMerge(b *testing.B) {
+	src := NewCRDTEngine("node-a", nil, nil)
+	dst := NewCRDTEngine("node-b", nil, nil)
+	if err := src.Start(context.Background()); err != nil {
+		b.Fatalf("start src: %v", err)
+	}
+	if err := dst.Start(context.Background()); err != nil {
+		b.Fatalf("start dst: %v", err)
+	}
+	b.Cleanup(func() {
+		_ = src.Stop()
+		_ = dst.Stop()
+	})
+
+	for i := 0; i < 1000; i++ {
+		key := fmt.Sprintf("k-%04d", i)
+		if _, err := src.Set(key, []byte("value")); err != nil {
+			b.Fatalf("set %s: %v", key, err)
+		}
+		if i%3 == 0 {
+			if err := src.Delete(key); err != nil {
+				b.Fatalf("delete %s: %v", key, err)
+			}
+		}
+	}
+
+	delegate := NewCRDTDelegate(dst)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		delegate.MergeRemoteState(src.FullState(), false)
 	}
 }


### PR DESCRIPTION
## Summary

- harden CRDT tombstone garbage collection with vector-clock safety checks
- add configurable GC/retention settings for the system KV CRDT component
- cover tombstone/clock behavior with focused GC regression tests

## Tests

- `go test ./system/kv ./system/crdt ./boot/components/system`
