### PR TITLE
Add CDC Lua stream subscriptions

### DIFF
--- a/api/service/cdc/command.go
+++ b/api/service/cdc/command.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cdc
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/pid"
+)
+
+func init() {
+	dispatcher.MustRegisterCommands("cdc", Subscribe)
+}
+
+const (
+	Subscribe dispatcher.CommandID = 170
+)
+
+type StreamOptions struct {
+	Tables []string
+	Ops    []string
+	Buffer int
+}
+
+type Change struct {
+	Before    map[string]any `json:"before,omitempty"`
+	After     map[string]any `json:"after,omitempty"`
+	Source    string         `json:"source"`
+	Op        string         `json:"op"`
+	Schema    string         `json:"schema"`
+	Table     string         `json:"table"`
+	Relation  string         `json:"relation"`
+	LSN       string         `json:"lsn"`
+	CommitLSN string         `json:"commit_lsn,omitempty"`
+	XID       uint32         `json:"xid,omitempty"`
+}
+
+type SubscribeCmd struct {
+	PID     pid.PID
+	Source  string
+	Topic   string
+	Options StreamOptions
+}
+
+func (c SubscribeCmd) CmdID() dispatcher.CommandID {
+	return Subscribe
+}
+
+type Subscription struct {
+	Stop   func()
+	Topic  string
+	Source string
+}
+
+type ChangeStream interface {
+	Changes() <-chan Change
+	Close()
+}
+
+type SourceStreamer interface {
+	Stream(ctx context.Context, source string, opts StreamOptions) (ChangeStream, SourceInfo, error)
+}

--- a/api/service/cdc/config.go
+++ b/api/service/cdc/config.go
@@ -14,12 +14,8 @@ const (
 )
 
 const (
-	DefaultEventSystem = "postgres_cdc"
-	ChangeKind         = "change"
-	StatusKind         = "status"
-	ErrorKind          = "error"
-	OutputPlugin       = "pgoutput"
-	ProtocolVersion    = 1
+	OutputPlugin    = "pgoutput"
+	ProtocolVersion = 1
 
 	StreamingProtocolVersion = 2
 )
@@ -37,7 +33,6 @@ type Config struct {
 	PasswordEnv       string                     `json:"password_env,omitempty"`
 	SlotName          string                     `json:"slot_name"`
 	Publication       string                     `json:"publication,omitempty"`
-	EventSystem       string                     `json:"event_system,omitempty"`
 	StandbyInterval   string                     `json:"standby_interval,omitempty"`
 	StatusInterval    string                     `json:"status_interval,omitempty"`
 	Tables            []string                   `json:"tables,omitempty"`
@@ -53,9 +48,6 @@ type Config struct {
 func (c *Config) InitDefaults() {
 	if c.Options == nil {
 		c.Options = make(map[string]string)
-	}
-	if c.EventSystem == "" {
-		c.EventSystem = DefaultEventSystem
 	}
 	c.Lifecycle.InitDefaults()
 }

--- a/api/service/cdc/config_test.go
+++ b/api/service/cdc/config_test.go
@@ -148,7 +148,6 @@ func TestConfigFailoverRequiresPersistentSlot(t *testing.T) {
 func TestConfigInitDefaults(t *testing.T) {
 	c := &Config{}
 	c.InitDefaults()
-	assert.Equal(t, DefaultEventSystem, c.EventSystem)
 	assert.NotNil(t, c.Options)
 	assert.Equal(t, supervisor.StartupRequired, c.Lifecycle.StartupMode())
 }

--- a/api/service/cdc/context.go
+++ b/api/service/cdc/context.go
@@ -7,7 +7,6 @@ import "context"
 type SourceInfo struct {
 	Name        string   `json:"name"`
 	Slot        string   `json:"slot"`
-	EventSystem string   `json:"event_system"`
 	Publication string   `json:"publication,omitempty"`
 	Tables      []string `json:"tables,omitempty"`
 	Streaming   bool     `json:"streaming,omitempty"`
@@ -22,6 +21,7 @@ type SourceInspector interface {
 }
 
 type sourceInspectorKey struct{}
+type sourceStreamerKey struct{}
 
 func WithSourceInspector(ctx context.Context, inspector SourceInspector) context.Context {
 	if inspector == nil {
@@ -32,5 +32,17 @@ func WithSourceInspector(ctx context.Context, inspector SourceInspector) context
 
 func GetSourceInspector(ctx context.Context) SourceInspector {
 	v, _ := ctx.Value(sourceInspectorKey{}).(SourceInspector)
+	return v
+}
+
+func WithSourceStreamer(ctx context.Context, streamer SourceStreamer) context.Context {
+	if streamer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, sourceStreamerKey{}, streamer)
+}
+
+func GetSourceStreamer(ctx context.Context) SourceStreamer {
+	v, _ := ctx.Value(sourceStreamerKey{}).(SourceStreamer)
 	return v
 }

--- a/api/service/cdc/context_test.go
+++ b/api/service/cdc/context_test.go
@@ -10,9 +10,13 @@ import (
 )
 
 type stubInspector struct{}
+type stubStreamer struct{}
 
 func (stubInspector) List() []SourceInfo            { return nil }
 func (stubInspector) Get(string) (SourceInfo, bool) { return SourceInfo{}, false }
+func (stubStreamer) Stream(context.Context, string, StreamOptions) (ChangeStream, SourceInfo, error) {
+	return nil, SourceInfo{}, nil
+}
 
 func TestWithSourceInspectorRoundTrip(t *testing.T) {
 	ctx := WithSourceInspector(context.Background(), stubInspector{})
@@ -27,4 +31,19 @@ func TestWithSourceInspectorNilDoesNotAttach(t *testing.T) {
 
 func TestGetSourceInspectorEmptyCtx(t *testing.T) {
 	assert.Nil(t, GetSourceInspector(context.Background()))
+}
+
+func TestWithSourceStreamerRoundTrip(t *testing.T) {
+	ctx := WithSourceStreamer(context.Background(), stubStreamer{})
+	got := GetSourceStreamer(ctx)
+	assert.NotNil(t, got)
+}
+
+func TestWithSourceStreamerNilDoesNotAttach(t *testing.T) {
+	ctx := WithSourceStreamer(context.Background(), nil)
+	assert.Nil(t, GetSourceStreamer(ctx))
+}
+
+func TestGetSourceStreamerEmptyCtx(t *testing.T) {
+	assert.Nil(t, GetSourceStreamer(context.Background()))
 }

--- a/boot/components/dispatchers/all.go
+++ b/boot/components/dispatchers/all.go
@@ -19,6 +19,7 @@ func All() []boot.Component {
 		Stream(),
 		TTY(),
 		SQL(),
+		CDC(),
 		Events(),
 	}
 }

--- a/boot/components/dispatchers/cdc_dispatcher.go
+++ b/boot/components/dispatchers/cdc_dispatcher.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package dispatchers
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/boot"
+	dispatcherapi "github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/service/cdc/postgres"
+)
+
+const CDCDefaultWorkers = 4
+
+func CDC() boot.Component {
+	var d *postgres.Dispatcher
+
+	return boot.New(boot.P{
+		Name:      CDCDispatcherName,
+		DependsOn: []boot.Name{DispatcherName},
+		Load: func(ctx context.Context) (context.Context, error) {
+			reg := dispatcherapi.GetRegistrar(ctx)
+			if reg == nil {
+				return ctx, ErrDispatcherNotFound
+			}
+
+			d = postgres.NewDispatcher(postgres.WithWorkers(CDCDefaultWorkers))
+			d.RegisterAll(reg.Register)
+			return ctx, nil
+		},
+		Start: func(ctx context.Context) error {
+			return d.Start(ctx)
+		},
+		Stop: func(ctx context.Context) error {
+			return d.Stop(ctx)
+		},
+	})
+}

--- a/boot/components/dispatchers/constants.go
+++ b/boot/components/dispatchers/constants.go
@@ -23,6 +23,7 @@ const (
 	StreamDispatcherName       boot.Name = "dispatcher.stream"
 	TTYDispatcherName          boot.Name = "dispatcher.tty"
 	SQLDispatcherName          boot.Name = "dispatcher.sql"
+	CDCDispatcherName          boot.Name = "dispatcher.cdc"
 	EventsDispatcherName       boot.Name = "dispatcher.events"
 	SocketDispatcherName       boot.Name = "dispatcher.socket"
 	PGDispatcherName           boot.Name = "dispatcher.pg"

--- a/boot/components/service/storage/cdc.go
+++ b/boot/components/service/storage/cdc.go
@@ -33,7 +33,9 @@ func CDC() boot.Component {
 			}
 
 			handlers.RegisterListener("db.cdc.*", manager)
-			return cdcapi.WithSourceInspector(ctx, manager), nil
+			ctx = cdcapi.WithSourceInspector(ctx, manager)
+			ctx = cdcapi.WithSourceStreamer(ctx, manager)
+			return ctx, nil
 		},
 	})
 }

--- a/runtime/lua/modules/cdc/module.go
+++ b/runtime/lua/modules/cdc/module.go
@@ -3,23 +3,58 @@
 package cdc
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
 	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/runtime"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	cdcapi "github.com/wippyai/runtime/api/service/cdc"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
 )
+
+const cdcStreamTypeName = "cdc.Stream"
+
+var subscriptionCounter uint64
 
 var Module = &luaapi.ModuleDef{
 	Name:        "cdc",
-	Description: "Postgres CDC source introspection",
+	Description: "Postgres CDC source streams",
 	Class:       []string{luaapi.ClassStorage, luaapi.ClassNondeterministic},
 	Build: func() (*lua.LTable, []luaapi.YieldType) {
-		mod := lua.CreateTable(0, 2)
+		value.RegisterTypeMethods(nil, cdcStreamTypeName, nil, streamMethods)
+
+		mod := lua.CreateTable(0, 3)
 		mod.RawSetString("list_sources", lua.LGoFunc(listSources))
 		mod.RawSetString("source", lua.LGoFunc(getSource))
+		mod.RawSetString("stream", lua.LGoFunc(openStream))
 		mod.Immutable = true
-		return mod, nil
+		return mod, []luaapi.YieldType{
+			{Sample: &SubscribeYield{}, CmdID: cdcapi.Subscribe},
+		}
 	},
 	Types: ModuleTypes,
+}
+
+type Stream struct {
+	Channel       *engine.Channel
+	proc          *engine.Process
+	cancelCleanup func()
+	Source        string
+	topic         string
+	Options       cdcapi.StreamOptions
+	mu            sync.Mutex
+	subscribed    bool
+	closed        bool
+}
+
+var streamMethods = map[string]lua.LGoFunc{
+	"channel": streamChannel,
+	"receive": streamChannel,
+	"close":   streamClose,
+	"release": streamClose,
 }
 
 func listSources(l *lua.LState) int {
@@ -91,11 +126,147 @@ func getSource(l *lua.LState) int {
 	return 2
 }
 
+func openStream(l *lua.LState) int {
+	ctx := l.Context()
+	if ctx == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no context found").
+			WithKind(lua.Internal).
+			WithRetryable(false))
+		return 2
+	}
+
+	name := l.CheckString(1)
+	if name == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "source name is required").
+			WithKind(lua.Invalid).
+			WithRetryable(false))
+		return 2
+	}
+	opts, luaErr := streamOptionsFromLua(l, 2)
+	if luaErr != nil {
+		l.Push(lua.LNil)
+		l.Push(luaErr)
+		return 2
+	}
+
+	ch := engine.NewChannel(64)
+	engine.PushChannel(l, ch)
+	l.Pop(1)
+
+	ud := value.PushTypedUserData(l, &Stream{
+		Source:  name,
+		Options: opts,
+		Channel: ch,
+	}, cdcStreamTypeName)
+	l.Pop(1)
+
+	l.Push(ud)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func checkStream(l *lua.LState) *Stream {
+	ud := l.CheckUserData(1)
+	if stream, ok := ud.Value.(*Stream); ok {
+		return stream
+	}
+	l.ArgError(1, "cdc.Stream expected")
+	return nil
+}
+
+func streamChannel(l *lua.LState) int {
+	stream := checkStream(l)
+	if stream == nil {
+		return 0
+	}
+
+	stream.mu.Lock()
+	if stream.closed {
+		stream.mu.Unlock()
+		l.RaiseError("cdc stream is closed")
+		return 0
+	}
+	if stream.subscribed && stream.Channel != nil {
+		ch := stream.Channel.Value()
+		stream.mu.Unlock()
+		l.Push(ch)
+		return 1
+	}
+	if stream.Channel == nil {
+		stream.mu.Unlock()
+		l.RaiseError("cdc stream has no channel")
+		return 0
+	}
+	stream.mu.Unlock()
+
+	ctx := l.Context()
+	if ctx == nil {
+		l.RaiseError("no context found")
+		return 0
+	}
+	pidVal, ok := runtime.GetFramePID(ctx)
+	if !ok {
+		l.RaiseError("no process PID")
+		return 0
+	}
+
+	topic := fmt.Sprintf("cdc@%d", atomic.AddUint64(&subscriptionCounter, 1))
+	l.Push(AcquireSubscribeYield(stream.Source, stream.Options, stream.Channel, pidVal, topic, stream))
+	return -1
+}
+
+func streamClose(l *lua.LState) int {
+	stream := checkStream(l)
+	if stream == nil {
+		return 0
+	}
+	stream.close()
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func (s *Stream) close() {
+	s.closeWithUnsubscribe(true)
+}
+
+func (s *Stream) cleanup() {
+	s.closeWithUnsubscribe(false)
+}
+
+func (s *Stream) closeWithUnsubscribe(unsubscribe bool) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	cancel := s.cancelCleanup
+	s.cancelCleanup = nil
+	proc := s.proc
+	ch := s.Channel
+	s.proc = nil
+	s.subscribed = false
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if unsubscribe && proc != nil && ch != nil {
+		proc.UnsubscribeChannel(ch)
+		return
+	}
+	if ch != nil && !ch.IsClosed() {
+		_ = ch.Close(nil)
+	}
+}
+
 func sourceInfoToTable(l *lua.LState, info cdcapi.SourceInfo) *lua.LTable {
-	t := l.CreateTable(0, 9)
+	t := l.CreateTable(0, 8)
 	t.RawSetString("name", lua.LString(info.Name))
 	t.RawSetString("slot", lua.LString(info.Slot))
-	t.RawSetString("event_system", lua.LString(info.EventSystem))
 	if info.Publication != "" {
 		t.RawSetString("publication", lua.LString(info.Publication))
 	}
@@ -111,4 +282,69 @@ func sourceInfoToTable(l *lua.LState, info cdcapi.SourceInfo) *lua.LTable {
 	t.RawSetString("temporary", lua.LBool(info.Temporary))
 	t.RawSetString("snapshot", lua.LBool(info.Snapshot))
 	return t
+}
+
+func streamOptionsFromLua(l *lua.LState, idx int) (cdcapi.StreamOptions, *lua.Error) {
+	var opts cdcapi.StreamOptions
+	if l.GetTop() < idx || l.Get(idx) == lua.LNil {
+		return opts, nil
+	}
+	table, ok := l.Get(idx).(*lua.LTable)
+	if !ok {
+		return opts, lua.NewLuaError(l, "stream options must be a table").
+			WithKind(lua.Invalid).
+			WithRetryable(false)
+	}
+
+	opts.Tables = stringArrayField(table, "tables")
+	opts.Ops = stringArrayField(table, "ops")
+	if v := table.RawGetString("buffer"); v != lua.LNil {
+		if v.Type() != lua.LTNumber && v.Type() != lua.LTInteger {
+			return opts, lua.NewLuaError(l, "buffer must be a number").
+				WithKind(lua.Invalid).
+				WithRetryable(false)
+		}
+		n := int(lua.LVAsNumber(v))
+		if n <= 0 || n > 65536 {
+			return opts, lua.NewLuaError(l, "buffer must be between 1 and 65536").
+				WithKind(lua.Invalid).
+				WithRetryable(false)
+		}
+		opts.Buffer = n
+	}
+	return opts, nil
+}
+
+func stringArrayField(table *lua.LTable, field string) []string {
+	v := table.RawGetString(field)
+	if v == lua.LNil {
+		return nil
+	}
+	t, ok := v.(*lua.LTable)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, t.Len())
+	t.ForEach(func(_, value lua.LValue) {
+		if value.Type() == lua.LTString {
+			out = append(out, value.String())
+		}
+	})
+	return out
+}
+
+func markSubscribed(stream *Stream, proc *engine.Process, topic string, cancelCleanup func()) error {
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	if stream.closed {
+		if cancelCleanup != nil {
+			cancelCleanup()
+		}
+		return fmt.Errorf("cdc stream is closed")
+	}
+	stream.proc = proc
+	stream.topic = topic
+	stream.cancelCleanup = cancelCleanup
+	stream.subscribed = true
+	return nil
 }

--- a/runtime/lua/modules/cdc/module_test.go
+++ b/runtime/lua/modules/cdc/module_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
 	cdcapi "github.com/wippyai/runtime/api/service/cdc"
 )
 
@@ -50,7 +52,7 @@ func TestModuleLoad(t *testing.T) {
 	mod := l.GetGlobal("cdc")
 	require.Equal(t, lua.LTTable, mod.Type())
 	modTbl := mod.(*lua.LTable)
-	for _, fn := range []string{"list_sources", "source"} {
+	for _, fn := range []string{"list_sources", "source", "stream"} {
 		require.Equal(t, lua.LTFunction, modTbl.RawGetString(fn).Type(), "%s missing", fn)
 	}
 }
@@ -58,8 +60,8 @@ func TestModuleLoad(t *testing.T) {
 func TestListSourcesReturnsAllInfos(t *testing.T) {
 	l := newStateWithInspector(t, &fakeInspector{
 		all: []cdcapi.SourceInfo{
-			{Name: "id-a", Slot: "slot_a", EventSystem: "postgres_cdc", Publication: "pub_a", Streaming: true},
-			{Name: "id-b", Slot: "slot_b", EventSystem: "postgres_cdc", Tables: []string{"public.t"}, Failover: true},
+			{Name: "id-a", Slot: "slot_a", Publication: "pub_a", Streaming: true},
+			{Name: "id-b", Slot: "slot_b", Tables: []string{"public.t"}, Failover: true},
 		},
 	})
 
@@ -82,18 +84,17 @@ func TestListSourcesReturnsAllInfos(t *testing.T) {
 func TestSourceByName(t *testing.T) {
 	l := newStateWithInspector(t, &fakeInspector{
 		all: []cdcapi.SourceInfo{
-			{Name: "id-a", Slot: "slot_a", EventSystem: "postgres_cdc"},
+			{Name: "id-a", Slot: "slot_a"},
 		},
 	})
 
 	require.NoError(t, l.DoString(`
 		local info, err = cdc.source("slot_a")
-		assert(err == nil, "unexpected error: " .. tostring(err))
-		assert(info.slot == "slot_a")
-		assert(info.event_system == "postgres_cdc")
+			assert(err == nil, "unexpected error: " .. tostring(err))
+			assert(info.slot == "slot_a")
 
-		local missing, err2 = cdc.source("nope")
-		assert(err2 == nil)
+			local missing, err2 = cdc.source("nope")
+			assert(err2 == nil)
 		assert(missing == nil, "expected nil for unknown source")
 	`))
 }
@@ -106,6 +107,75 @@ func TestSourceRequiresName(t *testing.T) {
 		if err == nil then error("expected error for empty name") end
 	`)
 	require.NoError(t, err)
+}
+
+func TestStreamOpenAndRelease(t *testing.T) {
+	l := newStateWithInspector(t, &fakeInspector{})
+
+	require.NoError(t, l.DoString(`
+		local stream, err = cdc.stream("slot_a", {
+			tables = {"public.accounts"},
+			ops = {"insert", "update"},
+			buffer = 4,
+		})
+		assert(err == nil, "unexpected error: " .. tostring(err))
+		assert(stream ~= nil)
+		local ok, close_err = stream:release()
+		assert(ok == true)
+		assert(close_err == nil)
+	`))
+}
+
+func TestStreamRequiresName(t *testing.T) {
+	l := newStateWithInspector(t, &fakeInspector{})
+
+	require.NoError(t, l.DoString(`
+		local stream, err = cdc.stream("")
+		assert(stream == nil)
+		assert(err ~= nil)
+	`))
+}
+
+func TestStreamRejectsInvalidBuffer(t *testing.T) {
+	l := newStateWithInspector(t, &fakeInspector{})
+
+	require.NoError(t, l.DoString(`
+		local stream, err = cdc.stream("slot_a", { buffer = "bad" })
+		assert(stream == nil)
+		assert(err ~= nil)
+	`))
+}
+
+func TestChangeHandlerUsesCanonicalLuaKeys(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	got := cdcChangeHandler(context.Background(), l, pid.Zero(), "cdc@1", []payload.Payload{
+		payload.New(cdcapi.Change{
+			Source:    "test:cdc",
+			Op:        "insert",
+			Schema:    "public",
+			Table:     "accounts",
+			Relation:  "public.accounts",
+			LSN:       "0/16B6C50",
+			CommitLSN: "0/16B6C98",
+			XID:       42,
+			After:     map[string]any{"email": "a@w.ai"},
+		}),
+	})
+
+	tbl, ok := got.(*lua.LTable)
+	require.True(t, ok)
+	require.Equal(t, "test:cdc", tbl.RawGetString("source").String())
+	require.Equal(t, "insert", tbl.RawGetString("op").String())
+	require.Equal(t, "public.accounts", tbl.RawGetString("relation").String())
+	require.Equal(t, "0/16B6C98", tbl.RawGetString("commit_lsn").String())
+	require.Equal(t, lua.LNil, tbl.RawGetString("commit_lsn,omitempty"))
+	require.Equal(t, lua.LNil, tbl.RawGetString("after,omitempty"))
+
+	after, ok := tbl.RawGetString("after").(*lua.LTable)
+	require.True(t, ok)
+	require.Equal(t, "a@w.ai", after.RawGetString("email").String())
 }
 
 func TestListSourcesFailsWithoutInspector(t *testing.T) {

--- a/runtime/lua/modules/cdc/types.go
+++ b/runtime/lua/modules/cdc/types.go
@@ -10,7 +10,6 @@ import (
 var sourceInfoType = typ.NewRecord().
 	Field("name", typ.String).
 	Field("slot", typ.String).
-	Field("event_system", typ.String).
 	OptField("publication", typ.String).
 	OptField("tables", typ.NewArray(typ.String)).
 	Field("streaming", typ.Boolean).
@@ -19,12 +18,26 @@ var sourceInfoType = typ.NewRecord().
 	Field("snapshot", typ.Boolean).
 	Build()
 
+var streamOptionsType = typ.NewRecord().
+	OptField("tables", typ.NewArray(typ.String)).
+	OptField("ops", typ.NewArray(typ.String)).
+	OptField("buffer", typ.Number).
+	Build()
+
+var cdcStreamType = typ.NewInterface("cdc.Stream", []typ.Method{
+	{Name: "channel", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
+	{Name: "receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
+	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "release", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+})
+
 func ModuleTypes() *io.Manifest {
 	m := io.NewManifest("cdc")
 
 	moduleType := typ.NewInterface("cdc", []typ.Method{
 		{Name: "list_sources", Type: typ.Func().Returns(typ.NewArray(sourceInfoType), typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "source", Type: typ.Func().Param("name", typ.String).Returns(typ.NewOptional(sourceInfoType), typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "stream", Type: typ.Func().Param("name", typ.String).OptParam("opts", streamOptionsType).Returns(cdcStreamType, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
 	m.SetExport(moduleType)

--- a/runtime/lua/modules/cdc/yields.go
+++ b/runtime/lua/modules/cdc/yields.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cdc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	cdcapi "github.com/wippyai/runtime/api/service/cdc"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	luapayload "github.com/wippyai/runtime/runtime/lua/engine/payload"
+)
+
+type SubscribeYield struct {
+	Channel *engine.Channel
+	Stream  *Stream
+	PID     pid.PID
+	Source  string
+	Topic   string
+	Options cdcapi.StreamOptions
+}
+
+var cdcSubscribeYieldPool = sync.Pool{
+	New: func() any { return &SubscribeYield{} },
+}
+
+func AcquireSubscribeYield(source string, opts cdcapi.StreamOptions, ch *engine.Channel, p pid.PID, topic string, stream *Stream) *SubscribeYield {
+	y := cdcSubscribeYieldPool.Get().(*SubscribeYield)
+	y.Source = source
+	y.Options = opts
+	y.Channel = ch
+	y.PID = p
+	y.Topic = topic
+	y.Stream = stream
+	return y
+}
+
+func ReleaseSubscribeYield(y *SubscribeYield) {
+	y.Channel = nil
+	y.Stream = nil
+	y.Options = cdcapi.StreamOptions{}
+	y.PID = pid.PID{}
+	y.Source = ""
+	y.Topic = ""
+	cdcSubscribeYieldPool.Put(y)
+}
+
+func (y *SubscribeYield) String() string       { return "<cdc_subscribe_yield>" }
+func (y *SubscribeYield) Type() lua.LValueType { return lua.LTUserData }
+
+func (y *SubscribeYield) CmdID() dispatcher.CommandID {
+	return cdcapi.Subscribe
+}
+
+func (y *SubscribeYield) ToCommand() dispatcher.Command {
+	return cdcapi.SubscribeCmd{
+		Source:  y.Source,
+		Options: y.Options,
+		PID:     y.PID,
+		Topic:   y.Topic,
+	}
+}
+
+func (y *SubscribeYield) Release() { ReleaseSubscribeYield(y) }
+
+func (y *SubscribeYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "cdc stream")}
+	}
+
+	sub, ok := data.(cdcapi.Subscription)
+	if !ok || sub.Stop == nil {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid cdc subscription").WithKind(lua.Internal).WithRetryable(false)}
+	}
+
+	proc := engine.GetProcess(l)
+	if proc == nil {
+		sub.Stop()
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "no process context").WithKind(lua.Internal).WithRetryable(false)}
+	}
+
+	if err := proc.SubscribeExisting(y.Topic, y.Channel); err != nil {
+		sub.Stop()
+		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "cdc stream")}
+	}
+	proc.SetTopicHandler(y.Topic, cdcChangeHandler)
+	if !proc.SetSubscriptionCleanup(y.Channel, sub.Stop) {
+		sub.Stop()
+		proc.UnsubscribeChannel(y.Channel)
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "failed to register cdc subscription cleanup").WithKind(lua.Internal).WithRetryable(true)}
+	}
+
+	var cancelCleanup func()
+	if ctx := l.Context(); ctx != nil {
+		if store := resource.GetStore(ctx); store != nil && y.Stream != nil {
+			stream := y.Stream
+			cancelCleanup = store.AddCleanup(func() error {
+				stream.cleanup()
+				return nil
+			})
+		}
+	}
+
+	if y.Stream != nil {
+		if err := markSubscribed(y.Stream, proc, y.Topic, cancelCleanup); err != nil {
+			sub.Stop()
+			proc.UnsubscribeChannel(y.Channel)
+			return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "cdc stream")}
+		}
+	}
+
+	return []lua.LValue{y.Channel.Value()}
+}
+
+func cdcChangeHandler(_ context.Context, l *lua.LState, _ pid.PID, _ string, payloads []payload.Payload) lua.LValue {
+	if len(payloads) == 0 {
+		return lua.LNil
+	}
+	change, ok := payloads[0].Data().(cdcapi.Change)
+	if !ok {
+		if ptr, ptrOK := payloads[0].Data().(*cdcapi.Change); ptrOK && ptr != nil {
+			change = *ptr
+			ok = true
+		}
+	}
+	if !ok {
+		return lua.NewLuaError(l, fmt.Sprintf("cdc change payload has invalid type %T", payloads[0].Data())).
+			WithKind(lua.Internal).
+			WithRetryable(false)
+	}
+
+	lv, err := changeToLua(l, change)
+	if err != nil {
+		return lua.NewLuaError(l, fmt.Sprintf("cdc change conversion failed: %v", err)).
+			WithKind(lua.Internal).
+			WithRetryable(false)
+	}
+	return lv
+}
+
+func changeToLua(l *lua.LState, change cdcapi.Change) (lua.LValue, error) {
+	tbl := l.CreateTable(0, 10)
+	tbl.RawSetString("source", lua.LString(change.Source))
+	tbl.RawSetString("op", lua.LString(change.Op))
+	tbl.RawSetString("schema", lua.LString(change.Schema))
+	tbl.RawSetString("table", lua.LString(change.Table))
+	tbl.RawSetString("relation", lua.LString(change.Relation))
+	tbl.RawSetString("lsn", lua.LString(change.LSN))
+	if change.CommitLSN != "" {
+		tbl.RawSetString("commit_lsn", lua.LString(change.CommitLSN))
+	}
+	if change.XID != 0 {
+		tbl.RawSetString("xid", lua.LInteger(change.XID))
+	}
+	if change.Before != nil {
+		before, err := luapayload.GoToLua(change.Before)
+		if err != nil {
+			return nil, err
+		}
+		tbl.RawSetString("before", before)
+	}
+	if change.After != nil {
+		after, err := luapayload.GoToLua(change.After)
+		if err != nil {
+			return nil, err
+		}
+		tbl.RawSetString("after", after)
+	}
+	return tbl, nil
+}

--- a/service/cdc/postgres/config_decode_test.go
+++ b/service/cdc/postgres/config_decode_test.go
@@ -49,7 +49,6 @@ func TestConfigWireFormatMapsAndBuildsDSN(t *testing.T) {
 	assert.True(t, cfg.Snapshot)
 	assert.Equal(t, "5s", cfg.StandbyInterval)
 	assert.Equal(t, []string{"public.accounts", "public.orders"}, cfg.Tables)
-	assert.Equal(t, config.DefaultEventSystem, cfg.EventSystem)
 
 	standby, err := cfg.StandbyDuration()
 	require.NoError(t, err)

--- a/service/cdc/postgres/dispatcher.go
+++ b/service/cdc/postgres/dispatcher.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres
+
+import (
+	"context"
+	"sync"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	config "github.com/wippyai/runtime/api/service/cdc"
+	"go.uber.org/zap"
+)
+
+type Dispatcher struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	jobs    chan dispatchJob
+	log     *zap.Logger
+	wg      sync.WaitGroup
+	workers int
+}
+
+type dispatchJob struct {
+	ctx      context.Context
+	cmd      dispatcher.Command
+	receiver dispatcher.ResultReceiver
+	tag      uint64
+}
+
+type DispatcherOption func(*Dispatcher)
+
+func WithWorkers(n int) DispatcherOption {
+	return func(d *Dispatcher) {
+		if n > 0 {
+			d.workers = n
+		}
+	}
+}
+
+func WithLogger(log *zap.Logger) DispatcherOption {
+	return func(d *Dispatcher) {
+		d.log = log
+	}
+}
+
+func NewDispatcher(opts ...DispatcherOption) *Dispatcher {
+	d := &Dispatcher{workers: 4}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.log == nil {
+		d.log = zap.NewNop()
+	}
+	return d
+}
+
+func (d *Dispatcher) Start(ctx context.Context) error {
+	d.ctx, d.cancel = context.WithCancel(ctx)
+	d.jobs = make(chan dispatchJob, d.workers*2)
+	for i := 0; i < d.workers; i++ {
+		d.wg.Add(1)
+		go d.worker()
+	}
+	return nil
+}
+
+func (d *Dispatcher) Stop(context.Context) error {
+	if d.cancel != nil {
+		d.cancel()
+	}
+	if d.jobs != nil {
+		close(d.jobs)
+	}
+	d.wg.Wait()
+	return nil
+}
+
+func (d *Dispatcher) worker() {
+	defer d.wg.Done()
+	for job := range d.jobs {
+		d.execute(job)
+	}
+}
+
+func (d *Dispatcher) execute(job dispatchJob) {
+	if cmd, ok := job.cmd.(config.SubscribeCmd); ok {
+		d.executeSubscribe(job.ctx, cmd, job.tag, job.receiver)
+	}
+}
+
+func (d *Dispatcher) executeSubscribe(ctx context.Context, cmd config.SubscribeCmd, tag uint64, receiver dispatcher.ResultReceiver) {
+	streamer := config.GetSourceStreamer(ctx)
+	if streamer == nil {
+		receiver.CompleteYield(tag, nil, ErrNoSourceStreamer)
+		return
+	}
+
+	node := relay.GetNode(ctx)
+	if node == nil {
+		receiver.CompleteYield(tag, nil, ErrNoRelayNode)
+		return
+	}
+
+	stream, _, err := streamer.Stream(ctx, cmd.Source, cmd.Options)
+	if err != nil {
+		receiver.CompleteYield(tag, nil, err)
+		return
+	}
+
+	loopCtx, cancelLoop := context.WithCancel(ctx)
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			cancelLoop()
+			stream.Close()
+		})
+	}
+
+	go func() {
+		for {
+			select {
+			case change, ok := <-stream.Changes():
+				if !ok {
+					d.sendTerminal(node, cmd.PID, cmd.Topic, "source close")
+					return
+				}
+				pkg := relay.NewPackage(pid.Zero(), cmd.PID, cmd.Topic, payload.New(change))
+				if err := node.Send(pkg); err != nil {
+					d.log.Debug("failed to relay cdc change",
+						zap.String("source", cmd.Source),
+						zap.Error(err))
+				}
+			case <-loopCtx.Done():
+				return
+			}
+		}
+	}()
+
+	receiver.CompleteYield(tag, config.Subscription{Source: cmd.Source, Topic: cmd.Topic, Stop: stop}, nil)
+}
+
+func (d *Dispatcher) sendTerminal(node relay.Node, target pid.PID, topic string, reason string) {
+	pkg := relay.NewPackage(pid.Zero(), target, topic, payload.NewTerminal())
+	if err := node.Send(pkg); err != nil {
+		d.log.Debug("failed to send cdc terminal", zap.String("reason", reason), zap.Error(err))
+	}
+}
+
+func (d *Dispatcher) handle(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	select {
+	case d.jobs <- dispatchJob{ctx: ctx, cmd: cmd, tag: tag, receiver: receiver}:
+	case <-d.ctx.Done():
+	}
+	return nil
+}
+
+func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispatcher.Handler)) {
+	register(config.Subscribe, dispatcher.HandlerFunc(d.handle))
+}

--- a/service/cdc/postgres/dispatcher_test.go
+++ b/service/cdc/postgres/dispatcher_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	cdcapi "github.com/wippyai/runtime/api/service/cdc"
+)
+
+type fakeCDCStream struct {
+	changes chan cdcapi.Change
+	closed  atomic.Bool
+}
+
+func (s *fakeCDCStream) Changes() <-chan cdcapi.Change {
+	return s.changes
+}
+
+func (s *fakeCDCStream) Close() {
+	s.closed.Store(true)
+}
+
+type fakeCDCStreamer struct {
+	stream *fakeCDCStream
+	source string
+	opts   cdcapi.StreamOptions
+}
+
+func (s *fakeCDCStreamer) Stream(_ context.Context, source string, opts cdcapi.StreamOptions) (cdcapi.ChangeStream, cdcapi.SourceInfo, error) {
+	s.source = source
+	s.opts = opts
+	return s.stream, cdcapi.SourceInfo{Name: "test:cdc", Slot: source}, nil
+}
+
+type captureCDCNode struct {
+	packages chan *relay.Package
+}
+
+func (n *captureCDCNode) ID() pid.NodeID { return "cdc-test-node" }
+
+func (n *captureCDCNode) Send(pkg *relay.Package) error {
+	n.packages <- pkg
+	return nil
+}
+
+func (n *captureCDCNode) RegisterHost(pid.HostID, relay.Receiver) error { return nil }
+func (n *captureCDCNode) UnregisterHost(pid.HostID)                     {}
+func (n *captureCDCNode) GetHost(pid.HostID) (relay.Receiver, bool)     { return nil, false }
+func (n *captureCDCNode) Attach(pid.PID, chan *relay.Package) (context.CancelFunc, error) {
+	return func() {}, nil
+}
+func (n *captureCDCNode) Detach(pid.PID) {}
+
+type cdcResultReceiver struct {
+	done chan struct{}
+	data any
+	err  error
+}
+
+func (r *cdcResultReceiver) CompleteYield(_ uint64, data any, err error) {
+	r.data = data
+	r.err = err
+	close(r.done)
+}
+
+func TestDispatcherSubscribeRelaysChangesAndCleanupStopsStream(t *testing.T) {
+	root := ctxapi.NewRootContext()
+	node := &captureCDCNode{packages: make(chan *relay.Package, 2)}
+	root = relay.WithNode(root, node)
+	ctx, _ := ctxapi.OpenFrameContext(root)
+
+	stream := &fakeCDCStream{changes: make(chan cdcapi.Change, 1)}
+	streamer := &fakeCDCStreamer{stream: stream}
+	ctx = cdcapi.WithSourceStreamer(ctx, streamer)
+
+	d := NewDispatcher(WithWorkers(1))
+	require.NoError(t, d.Start(ctx))
+	defer func() { require.NoError(t, d.Stop(ctx)) }()
+
+	target := pid.PID{Host: "cdc-test", UniqID: "p1"}
+	target = target.Precomputed()
+	receiver := &cdcResultReceiver{done: make(chan struct{})}
+	err := d.handle(ctx, cdcapi.SubscribeCmd{
+		Source: "slot_a",
+		Topic:  "cdc@1",
+		PID:    target,
+		Options: cdcapi.StreamOptions{
+			Ops:    []string{"insert"},
+			Buffer: 2,
+		},
+	}, 1, receiver)
+	require.NoError(t, err)
+
+	select {
+	case <-receiver.done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subscribe result")
+	}
+	require.NoError(t, receiver.err)
+	sub, ok := receiver.data.(cdcapi.Subscription)
+	require.True(t, ok)
+	assert.Equal(t, "slot_a", streamer.source)
+	assert.Equal(t, []string{"insert"}, streamer.opts.Ops)
+
+	stream.changes <- cdcapi.Change{Source: "test:cdc", Op: "insert", Relation: "public.accounts"}
+	select {
+	case pkg := <-node.packages:
+		require.Equal(t, target, pkg.Target)
+		require.Len(t, pkg.Messages, 1)
+		require.Equal(t, "cdc@1", pkg.Messages[0].Topic)
+		require.Len(t, pkg.Messages[0].Payloads, 1)
+		got, ok := pkg.Messages[0].Payloads[0].Data().(cdcapi.Change)
+		require.True(t, ok)
+		assert.Equal(t, "public.accounts", got.Relation)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for relayed cdc change")
+	}
+
+	sub.Stop()
+	require.Eventually(t, stream.closed.Load, time.Second, 10*time.Millisecond)
+}
+
+func TestDispatcherSubscribeRelaysTerminalOnSourceClose(t *testing.T) {
+	root := ctxapi.NewRootContext()
+	node := &captureCDCNode{packages: make(chan *relay.Package, 2)}
+	root = relay.WithNode(root, node)
+	ctx, _ := ctxapi.OpenFrameContext(root)
+
+	stream := &fakeCDCStream{changes: make(chan cdcapi.Change)}
+	ctx = cdcapi.WithSourceStreamer(ctx, &fakeCDCStreamer{stream: stream})
+
+	d := NewDispatcher(WithWorkers(1))
+	require.NoError(t, d.Start(ctx))
+	defer func() { require.NoError(t, d.Stop(ctx)) }()
+
+	receiver := &cdcResultReceiver{done: make(chan struct{})}
+	target := pid.PID{Host: "cdc-test", UniqID: "p1"}
+	target = target.Precomputed()
+	require.NoError(t, d.handle(ctx, cdcapi.SubscribeCmd{
+		Source: "slot_a",
+		Topic:  "cdc@1",
+		PID:    target,
+	}, 1, receiver))
+	select {
+	case <-receiver.done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subscribe result")
+	}
+	require.NoError(t, receiver.err)
+
+	close(stream.changes)
+	select {
+	case pkg := <-node.packages:
+		require.Len(t, pkg.Messages, 1)
+		require.Len(t, pkg.Messages[0].Payloads, 1)
+		assert.True(t, payload.IsTerminal(pkg.Messages[0].Payloads[0]))
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for terminal package")
+	}
+}

--- a/service/cdc/postgres/errors.go
+++ b/service/cdc/postgres/errors.go
@@ -16,6 +16,8 @@ var (
 	ErrNoPublication      = errors.New("cdc: no publication and no tables configured")
 	ErrTranscoderRequired = apierror.New(apierror.Invalid, "transcoder is required").WithRetryable(apierror.False)
 	ErrEventBusRequired   = apierror.New(apierror.Invalid, "event bus is required").WithRetryable(apierror.False)
+	ErrNoSourceStreamer   = apierror.New(apierror.Internal, "cdc source streamer not available").WithRetryable(apierror.False)
+	ErrNoRelayNode        = apierror.New(apierror.Internal, "relay node not available").WithRetryable(apierror.False)
 )
 
 func NewUnsupportedEntryKindError(kind registry.Kind) apierror.Error {

--- a/service/cdc/postgres/integration_failover_test.go
+++ b/service/cdc/postgres/integration_failover_test.go
@@ -23,10 +23,9 @@ func TestFailoverSlotIsMarked(t *testing.T) {
 	dropNamedSlot(t, repl, failoverSlot)
 	defer dropNamedSlot(t, repl, failoverSlot)
 
-	bus := newCaptureBus()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: failoverSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, Failover: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Failover: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/service/cdc/postgres/integration_lua_test.go
+++ b/service/cdc/postgres/integration_lua_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,16 +13,51 @@ import (
 	lua "github.com/wippyai/go-lua"
 	"go.uber.org/zap"
 
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/relay"
+	apiruntime "github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/security"
 	cdcapi "github.com/wippyai/runtime/api/service/cdc"
 	apisup "github.com/wippyai/runtime/api/supervisor"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	luapayload "github.com/wippyai/runtime/runtime/lua/engine/payload"
 	cdcmod "github.com/wippyai/runtime/runtime/lua/modules/cdc"
 	"github.com/wippyai/runtime/system/eventbus"
+	systempayload "github.com/wippyai/runtime/system/payload"
+	sysrelay "github.com/wippyai/runtime/system/relay"
+	"github.com/wippyai/runtime/system/scheduler"
+	"github.com/wippyai/runtime/system/scheduler/pool/inline"
 	syssup "github.com/wippyai/runtime/system/supervisor"
 )
 
 const luaSlot = "wippy_cdc_lua"
+
+type signalingSourceStreamer struct {
+	inner cdcapi.SourceStreamer
+	ready chan struct{}
+	once  sync.Once
+}
+
+func newSignalingSourceStreamer(inner cdcapi.SourceStreamer) *signalingSourceStreamer {
+	return &signalingSourceStreamer{
+		inner: inner,
+		ready: make(chan struct{}),
+	}
+}
+
+func (s *signalingSourceStreamer) Stream(ctx context.Context, source string, opts cdcapi.StreamOptions) (cdcapi.ChangeStream, cdcapi.SourceInfo, error) {
+	stream, info, err := s.inner.Stream(ctx, source, opts)
+	if err == nil {
+		s.once.Do(func() { close(s.ready) })
+	}
+	return stream, info, err
+}
 
 func TestLuaSeesRealRunningSourceAndItsChanges(t *testing.T) {
 	repl, admin := dsns(t)
@@ -30,7 +66,15 @@ func TestLuaSeesRealRunningSourceAndItsChanges(t *testing.T) {
 	defer func() { _ = db.Close() }()
 	setupSchema(t, db)
 	dropNamedSlot(t, repl, luaSlot)
-	defer dropNamedSlot(t, repl, luaSlot)
+	var src *Source
+	defer func() {
+		if src != nil {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = src.Stop(stopCtx)
+			stopCancel()
+		}
+		dropNamedSlot(t, repl, luaSlot)
+	}()
 	_, err = db.ExecContext(context.Background(), `DELETE FROM accounts`)
 	require.NoError(t, err)
 
@@ -52,19 +96,14 @@ func TestLuaSeesRealRunningSourceAndItsChanges(t *testing.T) {
 	cfg := &cdcapi.Config{
 		Host: "localhost", Port: 5432, Username: "u", Password: "p",
 		Database: "d", SlotName: luaSlot, Publication: "wippy_cdc_pub",
-		Streaming: true, EventSystem: cdcapi.DefaultEventSystem,
+		Streaming: true,
 	}
-	src := NewSource(SourceOptions{
+	src = NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: luaSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Name: entryID.String(), StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	manager.sources[entryID] = src
 	manager.storeInfo(registry.Entry{ID: entryID, Kind: cdcapi.Postgres}, cfg)
-
-	ch := make(chan event.Event, 64)
-	subID, err := bus.SubscribeP(supCtx, "postgres_cdc", "change", ch)
-	require.NoError(t, err)
-	defer bus.Unsubscribe(supCtx, subID)
 
 	lc := apisup.LifecycleConfig{AutoStart: true}
 	lc.InitDefaults()
@@ -83,70 +122,139 @@ func TestLuaSeesRealRunningSourceAndItsChanges(t *testing.T) {
 		return n == 1
 	}, 15*time.Second, 100*time.Millisecond, "supervisor must auto-start the registered source")
 
-	l := lua.NewState()
-	defer l.Close()
-	l.SetContext(cdcapi.WithSourceInspector(supCtx, manager))
-	tbl, _ := cdcmod.Module.Build()
-	l.SetGlobal(cdcmod.Module.Name, tbl)
+	streamer := newSignalingSourceStreamer(manager)
+	root := security.SetStrictMode(ctxapi.NewRootContext(), false)
+	transcoder := systempayload.NewTranscoder()
+	luapayload.Register(transcoder)
+	payload.WithTranscoder(root, transcoder)
+	root = cdcapi.WithSourceInspector(root, manager)
+	root = cdcapi.WithSourceStreamer(root, streamer)
 
-	require.NoError(t, l.DoString(`
-		local rows, err = cdc.list_sources()
-		assert(err == nil, "list_sources error: " .. tostring(err))
-		assert(#rows == 1, "expected 1 source, got " .. tostring(#rows))
-		local r = rows[1]
-		assert(r.slot == "`+luaSlot+`", "wrong slot: " .. tostring(r.slot))
-		assert(r.publication == "wippy_cdc_pub", "wrong publication: " .. tostring(r.publication))
-		assert(r.streaming == true, "expected streaming=true")
-		assert(r.failover == false, "expected failover=false")
-		assert(r.event_system == "postgres_cdc", "wrong event_system: " .. tostring(r.event_system))
+	node := sysrelay.NewNode("cdc-lua-test-node")
+	root = relay.WithNode(root, node)
 
-		local by_slot, err2 = cdc.source("`+luaSlot+`")
-		assert(err2 == nil, "source error: " .. tostring(err2))
-		assert(by_slot ~= nil, "lookup by slot returned nil")
-		assert(by_slot.slot == "`+luaSlot+`")
+	runCtx, runCancel := context.WithTimeout(root, 30*time.Second)
+	defer runCancel()
 
-		local by_id, err3 = cdc.source("test:cdc-lua-e2e")
-		assert(err3 == nil, "source by id error: " .. tostring(err3))
-		assert(by_id ~= nil, "lookup by entry id returned nil")
-		assert(by_id.slot == "`+luaSlot+`")
-	`))
-	t.Log("Lua introspection passed against the live Manager")
+	dispReg := scheduler.NewRegistry()
+	cdcDisp := NewDispatcher(WithWorkers(1))
+	require.NoError(t, cdcDisp.Start(runCtx))
+	defer func() { require.NoError(t, cdcDisp.Stop(context.Background())) }()
+	cdcDisp.RegisterAll(func(id dispatcher.CommandID, h dispatcher.Handler) {
+		dispReg.Register(id, h)
+	})
 
-	res, err := db.ExecContext(supCtx, `INSERT INTO accounts (email, balance) VALUES ($1, $2)`,
-		"lua-e2e@wippy.ai", 42)
+	const expectedEmail = "lua-e2e@wippy.ai"
+	const hostID = "test.cdc.lua"
+	factory := func() (process.Process, error) {
+		cfg := engine.FactoryConfig{
+			ScriptName: "cdc_lua_e2e",
+			Script: `
+local cdc = require("cdc")
+
+local function main()
+    local rows, err = cdc.list_sources()
+    if err ~= nil then return nil, "list_sources error: " .. tostring(err) end
+    if #rows ~= 1 then return nil, "expected 1 source, got " .. tostring(#rows) end
+
+    local r = rows[1]
+    if r.slot ~= "` + luaSlot + `" then return nil, "wrong slot: " .. tostring(r.slot) end
+    if r.publication ~= "wippy_cdc_pub" then return nil, "wrong publication: " .. tostring(r.publication) end
+    if r.streaming ~= true then return nil, "expected streaming=true" end
+
+    local by_slot, source_err = cdc.source("` + luaSlot + `")
+    if source_err ~= nil then return nil, "source error: " .. tostring(source_err) end
+    if by_slot == nil then return nil, "lookup by slot returned nil" end
+
+    local stream, stream_err = cdc.stream("` + luaSlot + `", {
+        tables = {"public.accounts"},
+        ops = {"insert"},
+        buffer = 8,
+    })
+    if stream_err ~= nil then return nil, "stream error: " .. tostring(stream_err) end
+
+    local ch = stream:channel()
+    local change, ok = ch:receive()
+    local released, release_err = stream:release()
+    if released ~= true or release_err ~= nil then
+        return nil, "release error: " .. tostring(release_err)
+    end
+    if ok ~= true then return nil, "stream closed before change" end
+    if change.op ~= "insert" then return nil, "wrong op: " .. tostring(change.op) end
+    if change.source ~= "test:cdc-lua-e2e" then return nil, "wrong source: " .. tostring(change.source) end
+    if change.relation ~= "public.accounts" then return nil, "wrong relation: " .. tostring(change.relation) end
+    if change.after == nil then return nil, "missing after table" end
+    if change.after.email ~= "` + expectedEmail + `" then
+        return nil, "wrong email: " .. tostring(change.after.email)
+    end
+
+    return change.after.email
+end
+
+return { main = main }
+`,
+			ModuleBinders: append(engine.CoreBinders(), func(l *lua.LState) error {
+				engine.LoadModuleDef(l, cdcmod.Module)
+				return nil
+			}),
+		}
+		return engine.NewFactory(cfg)()
+	}
+
+	pool, err := inline.New(factory, dispReg)
+	require.NoError(t, err)
+	defer pool.Stop()
+	require.NoError(t, node.RegisterHost(hostID, pool))
+
+	frameCtx, frame := ctxapi.OpenFrameContext(runCtx)
+	defer ctxapi.ReleaseFrameContext(frame)
+	testPID := pid.PID{Host: hostID, UniqID: "cdc-lua-e2e"}
+	testPID = testPID.Precomputed()
+	require.NoError(t, apiruntime.SetFramePID(frameCtx, testPID))
+
+	resultCh := make(chan *apiruntime.Result, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := pool.Call(frameCtx, "main", nil)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resultCh <- result
+	}()
+
+	select {
+	case <-streamer.ready:
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-runCtx.Done():
+		t.Fatal("timed out waiting for Lua CDC stream subscription")
+	}
+
+	res, err := db.ExecContext(runCtx, `INSERT INTO accounts (email, balance) VALUES ($1, $2)`,
+		expectedEmail, 42)
 	require.NoError(t, err)
 	rows, _ := res.RowsAffected()
 	require.Equal(t, int64(1), rows)
 
-	deadline := time.After(15 * time.Second)
-	var changeFromBus RowChange
-	for {
-		select {
-		case e := <-ch:
-			rc, ok := e.Data.(RowChange)
-			if !ok {
-				continue
-			}
-			if em, _ := rc.After["email"].(string); em == "lua-e2e@wippy.ai" {
-				changeFromBus = rc
-				goto received
-			}
-		case <-deadline:
-			t.Fatal("change did not flow through the real bus + supervisor chain")
-		}
+	var result *apiruntime.Result
+	select {
+	case result = <-resultCh:
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-runCtx.Done():
+		t.Fatal("timed out waiting for Lua to receive CDC change")
 	}
+	require.NotNil(t, result)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Value)
+	got, ok := result.Value.Data().(lua.LString)
+	require.True(t, ok, "expected Lua string result, got %T", result.Value.Data())
+	require.Equal(t, expectedEmail, string(got))
 
-received:
-	require.Equal(t, OpInsert, changeFromBus.Op)
-	require.Equal(t, "accounts", changeFromBus.Table)
-	t.Logf("Bus received RowChange: op=%s schema=%s table=%s lsn=%s after=%v",
-		changeFromBus.Op, changeFromBus.Schema, changeFromBus.Table,
-		changeFromBus.LSN, changeFromBus.After)
-
-	require.NoError(t, l.DoString(`
-		local row = cdc.source("`+luaSlot+`")
-		assert(row ~= nil, "Lua cannot find the source that just emitted a change")
-		assert(row.event_system == "postgres_cdc")
-	`))
-	t.Log("Lua resolves the still-running source by slot after a real PG mutation flowed through the bus")
+	require.Eventually(t, func() bool {
+		src.subMu.RLock()
+		defer src.subMu.RUnlock()
+		return len(src.subs) == 0
+	}, 2*time.Second, 10*time.Millisecond, "Lua stream release must stop the source subscription")
 }

--- a/service/cdc/postgres/integration_metrics_test.go
+++ b/service/cdc/postgres/integration_metrics_test.go
@@ -70,7 +70,7 @@ func TestReportLagRecordsGauge(t *testing.T) {
 
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: newCaptureBus(), StandbyInterval: 200 * time.Millisecond, StatusInterval: 200 * time.Millisecond,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: 200 * time.Millisecond,
 	})
 	ctx, cancel := context.WithCancel(base)
 	defer cancel()

--- a/service/cdc/postgres/integration_multitable_test.go
+++ b/service/cdc/postgres/integration_multitable_test.go
@@ -40,13 +40,14 @@ func TestMultiTablePublicationRoutesByRelation(t *testing.T) {
 	dropNamedSlot(t, repl, multiSlot)
 	defer dropNamedSlot(t, repl, multiSlot)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: multiSlot, Publication: "multi_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, runCtx, src, capture)
 	_, err = src.Start(runCtx)
 	require.NoError(t, err)
 
@@ -59,8 +60,8 @@ func TestMultiTablePublicationRoutesByRelation(t *testing.T) {
 	deadline := time.After(15 * time.Second)
 	for len(byTable) < 2 {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.Op == OpInsert {
+		case rc := <-capture.ch:
+			if rc.Op == OpInsert {
 				byTable[rc.Table] = rc
 			}
 		case <-deadline:

--- a/service/cdc/postgres/integration_restart_test.go
+++ b/service/cdc/postgres/integration_restart_test.go
@@ -23,20 +23,21 @@ func TestRestartSameInstanceAfterFailure(t *testing.T) {
 	_, err = db.Exec(`DELETE FROM accounts WHERE email IN ('rs1@w.ai','rs2@w.ai')`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, ctx, src, capture)
 
 	status, err := src.Start(ctx)
 	require.NoError(t, err)
 
 	_, err = db.Exec(`INSERT INTO accounts (email, balance) VALUES ('rs1@w.ai', 1)`)
 	require.NoError(t, err)
-	waitForEmail(t, bus, "rs1@w.ai", 15*time.Second)
+	waitForEmail(t, capture, "rs1@w.ai", 15*time.Second)
 
 	_, err = db.Exec(`SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots
 		WHERE slot_name = $1 AND active_pid IS NOT NULL`, itSlot)
@@ -48,12 +49,13 @@ func TestRestartSameInstanceAfterFailure(t *testing.T) {
 		t.Fatal("run goroutine did not exit after backend termination")
 	}
 
+	attachCapture(t, ctx, src, capture)
 	_, err = src.Start(ctx)
 	require.NoError(t, err, "Start must succeed on the same instance after a failure (supervisor retry contract)")
 
 	_, err = db.Exec(`INSERT INTO accounts (email, balance) VALUES ('rs2@w.ai', 2)`)
 	require.NoError(t, err)
-	waitForEmail(t, bus, "rs2@w.ai", 15*time.Second)
+	waitForEmail(t, capture, "rs2@w.ai", 15*time.Second)
 
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	require.NoError(t, src.Stop(stopCtx))

--- a/service/cdc/postgres/integration_resume_test.go
+++ b/service/cdc/postgres/integration_resume_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func waitForEmail(t *testing.T, b *captureBus, email string, timeout time.Duration) {
+func waitForEmail(t *testing.T, b *changeCapture, email string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.After(timeout)
 	for {
 		select {
-		case e := <-b.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.After["email"] == email {
+		case rc := <-b.ch:
+			if rc.After["email"] == email {
 				return
 			}
 		case <-deadline:
@@ -38,18 +38,19 @@ func TestResumeDeliversChangesMadeWhileDown(t *testing.T) {
 	_, err = adminDB.Exec(`DELETE FROM accounts WHERE email IN ('down0@w.ai','down1@w.ai')`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
+	attachCapture(t, ctx, src, capture)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
 
 	_, err = adminDB.Exec(`INSERT INTO accounts (email, balance) VALUES ('down0@w.ai', 1)`)
 	require.NoError(t, err)
-	waitForEmail(t, bus, "down0@w.ai", 15*time.Second)
+	waitForEmail(t, capture, "down0@w.ai", 15*time.Second)
 
 	require.Eventually(t, func() bool {
 		var raw string
@@ -66,17 +67,18 @@ func TestResumeDeliversChangesMadeWhileDown(t *testing.T) {
 	_, err = adminDB.Exec(`INSERT INTO accounts (email, balance) VALUES ('down1@w.ai', 2)`)
 	require.NoError(t, err)
 
-	bus2 := newCaptureBus()
+	capture2 := newChangeCapture()
 	src2 := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus2, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
+	attachCapture(t, ctx2, src2, capture2)
 	_, err = src2.Start(ctx2)
 	require.NoError(t, err)
 
-	waitForEmail(t, bus2, "down1@w.ai", 15*time.Second)
+	waitForEmail(t, capture2, "down1@w.ai", 15*time.Second)
 
 	stopCtx2, stopCancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 	require.NoError(t, src2.Stop(stopCtx2))

--- a/service/cdc/postgres/integration_slot_test.go
+++ b/service/cdc/postgres/integration_slot_test.go
@@ -23,7 +23,7 @@ func startBriefSource(t *testing.T, repl, admin string) *Source {
 	t.Helper()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: newCaptureBus(), StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	_, err := src.Start(context.Background())
 	require.NoError(t, err)

--- a/service/cdc/postgres/integration_snapshot_test.go
+++ b/service/cdc/postgres/integration_snapshot_test.go
@@ -13,17 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func waitForSnapshotEmail(t *testing.T, b *captureBus, email string, op Op, timeout time.Duration) RowChange {
+func waitForSnapshotEmail(t *testing.T, b *changeCapture, email string, op Op, timeout time.Duration) RowChange {
 	t.Helper()
 	deadline := time.After(timeout)
 	for {
 		select {
-		case e := <-b.ch:
-			if rc, ok := e.Data.(RowChange); ok {
-				if em, _ := rc.After["email"].(string); em == email {
-					require.Equal(t, op, rc.Op)
-					return rc
-				}
+		case rc := <-b.ch:
+			if em, _ := rc.After["email"].(string); em == email {
+				require.Equal(t, op, rc.Op)
+				return rc
 			}
 		case <-deadline:
 			t.Fatalf("no %s change for %q within %s", op, email, timeout)
@@ -45,13 +43,14 @@ func TestSnapshotBootstrapsExistingRows(t *testing.T) {
 	_, err = db.Exec(`INSERT INTO accounts (email, balance) VALUES ('snap1@w.ai', 1), ('snap2@w.ai', 2)`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, ctx, src, capture)
 
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
@@ -60,11 +59,9 @@ func TestSnapshotBootstrapsExistingRows(t *testing.T) {
 	deadline := time.After(15 * time.Second)
 	for len(seen) < 2 {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok {
-				if em, _ := rc.After["email"].(string); em == "snap1@w.ai" || em == "snap2@w.ai" {
-					seen[em] = rc.Op
-				}
+		case rc := <-capture.ch:
+			if em, _ := rc.After["email"].(string); em == "snap1@w.ai" || em == "snap2@w.ai" {
+				seen[em] = rc.Op
 			}
 		case <-deadline:
 			t.Fatalf("snapshot incomplete, saw: %v", seen)
@@ -80,12 +77,10 @@ func TestSnapshotBootstrapsExistingRows(t *testing.T) {
 	deadline2 := time.After(15 * time.Second)
 	for !gotSnap3 {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok {
-				if em, _ := rc.After["email"].(string); em == "snap3@w.ai" {
-					assert.Equal(t, OpInsert, rc.Op, "post-snapshot change must stream as insert")
-					gotSnap3 = true
-				}
+		case rc := <-capture.ch:
+			if em, _ := rc.After["email"].(string); em == "snap3@w.ai" {
+				assert.Equal(t, OpInsert, rc.Op, "post-snapshot change must stream as insert")
+				gotSnap3 = true
 			}
 		case <-deadline2:
 			t.Fatal("post-snapshot insert not streamed")
@@ -111,17 +106,18 @@ func TestSnapshotPreservesNull(t *testing.T) {
 	_, err = db.Exec(`INSERT INTO accounts (email, balance, note) VALUES ('null@w.ai', 1, NULL)`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, ctx, src, capture)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
 
-	rc := waitForSnapshotEmail(t, bus, "null@w.ai", OpSnapshot, 15*time.Second)
+	rc := waitForSnapshotEmail(t, capture, "null@w.ai", OpSnapshot, 15*time.Second)
 	assert.Nil(t, rc.After["note"], "NULL column must map to nil in snapshot row")
 
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -143,18 +139,19 @@ func TestSnapshotSkippedOnResume(t *testing.T) {
 	_, err = db.Exec(`INSERT INTO accounts (email, balance) VALUES ('resume-base@w.ai', 1)`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
-	mk := func(b *captureBus) *Source {
+	capture := newChangeCapture()
+	mk := func(b *changeCapture) *Source {
 		return NewSource(SourceOptions{
 			ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-			Bus: b, Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+			Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 		})
 	}
-	src := mk(bus)
+	src := mk(capture)
 	ctx, cancel := context.WithCancel(context.Background())
+	attachCapture(t, ctx, src, capture)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
-	waitForSnapshotEmail(t, bus, "resume-base@w.ai", OpSnapshot, 15*time.Second)
+	waitForSnapshotEmail(t, capture, "resume-base@w.ai", OpSnapshot, 15*time.Second)
 	require.Eventually(t, func() bool {
 		var raw string
 		e := db.QueryRow(`SELECT lsn FROM wippy_cdc_offsets WHERE slot=$1`, itSlot).Scan(&raw)
@@ -165,10 +162,11 @@ func TestSnapshotSkippedOnResume(t *testing.T) {
 	sc()
 	cancel()
 
-	bus2 := newCaptureBus()
-	src2 := mk(bus2)
+	capture2 := newChangeCapture()
+	src2 := mk(capture2)
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
+	attachCapture(t, ctx2, src2, capture2)
 	_, err = src2.Start(ctx2)
 	require.NoError(t, err)
 
@@ -179,13 +177,11 @@ func TestSnapshotSkippedOnResume(t *testing.T) {
 	got := false
 	for !got {
 		select {
-		case e := <-bus2.ch:
-			if rc, ok := e.Data.(RowChange); ok {
-				assert.NotEqual(t, OpSnapshot, rc.Op, "resume must not re-snapshot existing rows")
-				if em, _ := rc.After["email"].(string); em == "resume-new@w.ai" {
-					assert.Equal(t, OpInsert, rc.Op)
-					got = true
-				}
+		case rc := <-capture2.ch:
+			assert.NotEqual(t, OpSnapshot, rc.Op, "resume must not re-snapshot existing rows")
+			if em, _ := rc.After["email"].(string); em == "resume-new@w.ai" {
+				assert.Equal(t, OpInsert, rc.Op)
+				got = true
 			}
 		case <-deadline:
 			t.Fatal("resumed source did not stream the new insert")
@@ -214,10 +210,9 @@ func TestSnapshotFailureDropsSlotForCleanRetry(t *testing.T) {
 	snapshotFailpoint = func() error { return errors.New("injected snapshot failure") }
 	defer func() { snapshotFailpoint = nil }()
 
-	bus := newCaptureBus()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	status, err := src.Start(ctx)
@@ -236,16 +231,17 @@ func TestSnapshotFailureDropsSlotForCleanRetry(t *testing.T) {
 	assert.Equal(t, 0, offsets, "snapshot failure must delete the checkpoint")
 
 	snapshotFailpoint = nil
-	bus2 := newCaptureBus()
+	capture2 := newChangeCapture()
 	src2 := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus2, Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Snapshot: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
+	attachCapture(t, ctx2, src2, capture2)
 	_, err = src2.Start(ctx2)
 	require.NoError(t, err)
-	waitForSnapshotEmail(t, bus2, "retry@w.ai", OpSnapshot, 15*time.Second)
+	waitForSnapshotEmail(t, capture2, "retry@w.ai", OpSnapshot, 15*time.Second)
 
 	stopCtx, sc := context.WithTimeout(context.Background(), 5*time.Second)
 	require.NoError(t, src2.Stop(stopCtx))

--- a/service/cdc/postgres/integration_streaming_test.go
+++ b/service/cdc/postgres/integration_streaming_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/wippyai/runtime/api/event"
 )
 
 const streamSlot = "wippy_cdc_stream"
@@ -38,13 +36,14 @@ func TestStreamingLargeTransactionDelivers(t *testing.T) {
 	dropNamedSlot(t, repl, streamSlot)
 	defer dropNamedSlot(t, repl, streamSlot)
 
-	bus := &captureBus{ch: make(chan event.Event, 8192)}
+	capture := newChangeCapture(8192)
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: streamSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, Streaming: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Streaming: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, ctx, src, capture, 8192)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
 
@@ -58,8 +57,8 @@ func TestStreamingLargeTransactionDelivers(t *testing.T) {
 	deadline := time.After(30 * time.Second)
 	for len(seen) < 2000 {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.Op == OpInsert {
+		case rc := <-capture.ch:
+			if rc.Op == OpInsert {
 				if em, _ := rc.After["email"].(string); strings.HasPrefix(em, "st") {
 					seen[em] = true
 				}
@@ -87,13 +86,14 @@ func TestStreamingAbortedTransactionDiscarded(t *testing.T) {
 	dropNamedSlot(t, repl, streamSlot)
 	defer dropNamedSlot(t, repl, streamSlot)
 
-	bus := &captureBus{ch: make(chan event.Event, 8192)}
+	capture := newChangeCapture(8192)
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: streamSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, Streaming: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		Streaming: true, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, ctx, src, capture, 8192)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
 
@@ -110,8 +110,8 @@ func TestStreamingAbortedTransactionDiscarded(t *testing.T) {
 	deadline := time.After(30 * time.Second)
 	for !gotMarker {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.Op == OpInsert {
+		case rc := <-capture.ch:
+			if rc.Op == OpInsert {
 				em, _ := rc.After["email"].(string)
 				require.False(t, strings.HasPrefix(em, "ab"), "aborted streamed changes must not be delivered")
 				if em == "marker@w.ai" {

--- a/service/cdc/postgres/integration_supervisor_test.go
+++ b/service/cdc/postgres/integration_supervisor_test.go
@@ -39,13 +39,11 @@ func TestSupervisorStartsSourceAndDelivers(t *testing.T) {
 
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: superSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 
-	ch := make(chan event.Event, 64)
-	subID, err := bus.SubscribeP(supCtx, "postgres_cdc", "change", ch)
-	require.NoError(t, err)
-	defer bus.Unsubscribe(supCtx, subID)
+	capture := newChangeCapture()
+	attachCapture(t, supCtx, src, capture)
 
 	lc := apisup.LifecycleConfig{AutoStart: true}
 	lc.InitDefaults()
@@ -70,14 +68,12 @@ func TestSupervisorStartsSourceAndDelivers(t *testing.T) {
 	deadline := time.After(15 * time.Second)
 	for {
 		select {
-		case e := <-ch:
-			if rc, ok := e.Data.(RowChange); ok {
-				if em, _ := rc.After["email"].(string); em == "super@w.ai" {
-					return
-				}
+		case rc := <-capture.ch:
+			if em, _ := rc.After["email"].(string); em == "super@w.ai" {
+				return
 			}
 		case <-deadline:
-			t.Fatal("change did not flow through the real bus + supervisor chain")
+			t.Fatal("change did not flow through the supervised cdc source stream")
 		}
 	}
 }

--- a/service/cdc/postgres/integration_test.go
+++ b/service/cdc/postgres/integration_test.go
@@ -13,35 +13,68 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wippyai/runtime/api/event"
+	cdcapi "github.com/wippyai/runtime/api/service/cdc"
 
 	_ "github.com/lib/pq"
 )
 
 const itSlot = "wippy_cdc_it"
 
-type captureBus struct {
-	ch chan event.Event
+type changeCapture struct {
+	ch chan RowChange
 }
 
-func newCaptureBus() *captureBus { return &captureBus{ch: make(chan event.Event, 256)} }
+func newChangeCapture(capacity ...int) *changeCapture {
+	size := 256
+	if len(capacity) > 0 && capacity[0] > 0 {
+		size = capacity[0]
+	}
+	return &changeCapture{ch: make(chan RowChange, size)}
+}
 
-func (b *captureBus) Send(_ context.Context, e event.Event) {
+func (c *changeCapture) send(change RowChange) {
 	select {
-	case b.ch <- e:
+	case c.ch <- change:
 	default:
 	}
 }
 
-func (b *captureBus) Subscribe(context.Context, event.System, chan<- event.Event) (event.SubscriberID, error) {
-	return "", nil
+func attachCapture(t *testing.T, ctx context.Context, src *Source, capture *changeCapture, capacity ...int) {
+	t.Helper()
+	size := 8192
+	if len(capacity) > 0 && capacity[0] > 0 {
+		size = capacity[0]
+	}
+	stream := src.Subscribe(cdcapi.StreamOptions{Buffer: size})
+	t.Cleanup(stream.Close)
+	go func() {
+		for {
+			select {
+			case change, ok := <-stream.Changes():
+				if !ok {
+					return
+				}
+				capture.send(rowChangeFromAPI(change))
+			case <-ctx.Done():
+				stream.Close()
+				return
+			}
+		}
+	}()
 }
 
-func (b *captureBus) SubscribeP(context.Context, event.System, event.Kind, chan<- event.Event) (event.SubscriberID, error) {
-	return "", nil
+func rowChangeFromAPI(change cdcapi.Change) RowChange {
+	return RowChange{
+		Before:    change.Before,
+		After:     change.After,
+		Op:        Op(change.Op),
+		Schema:    change.Schema,
+		Table:     change.Table,
+		LSN:       change.LSN,
+		CommitLSN: change.CommitLSN,
+		XID:       change.XID,
+	}
 }
-
-func (b *captureBus) Unsubscribe(context.Context, event.SubscriberID) {}
 
 func dsns(t *testing.T) (repl, admin string) {
 	t.Helper()
@@ -84,20 +117,18 @@ func dropSlot(t *testing.T, repl string) {
 	_ = conn.Exec(ctx, `SELECT pg_drop_replication_slot('`+itSlot+`')`).Close()
 }
 
-func collectOps(t *testing.T, b *captureBus, timeout time.Duration) []RowChange {
+func collectOps(t *testing.T, capture *changeCapture, timeout time.Duration) []RowChange {
 	t.Helper()
 	deadline := time.After(timeout)
 	var got []RowChange
 	seen := map[Op]bool{}
 	for {
 		select {
-		case e := <-b.ch:
-			if rc, ok := e.Data.(RowChange); ok {
-				got = append(got, rc)
-				seen[rc.Op] = true
-				if seen[OpInsert] && seen[OpUpdate] && seen[OpDelete] {
-					return got
-				}
+		case rc := <-capture.ch:
+			got = append(got, rc)
+			seen[rc.Op] = true
+			if seen[OpInsert] && seen[OpUpdate] && seen[OpDelete] {
+				return got
 			}
 		case <-deadline:
 			return got
@@ -117,12 +148,13 @@ func TestSourceStreamsAndResumes(t *testing.T) {
 	_, err = adminDB.Exec(`DELETE FROM accounts WHERE email IN ('it@w.ai','it2@w.ai')`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
+	attachCapture(t, ctx, src, capture)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
 
@@ -133,7 +165,7 @@ func TestSourceStreamsAndResumes(t *testing.T) {
 	_, err = adminDB.Exec(`DELETE FROM accounts WHERE email='it@w.ai'`)
 	require.NoError(t, err)
 
-	got := collectOps(t, bus, 15*time.Second)
+	got := collectOps(t, capture, 15*time.Second)
 	ops := map[Op]int{}
 	for _, c := range got {
 		ops[c.Op]++
@@ -159,13 +191,14 @@ func TestSourceStreamsAndResumes(t *testing.T) {
 	stopCancel()
 	cancel()
 
-	bus2 := newCaptureBus()
+	capture2 := newChangeCapture()
 	src2 := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus2, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
+	attachCapture(t, ctx2, src2, capture2)
 	_, err = src2.Start(ctx2)
 	require.NoError(t, err)
 
@@ -176,8 +209,8 @@ func TestSourceStreamsAndResumes(t *testing.T) {
 	gotNew := false
 	for !gotNew {
 		select {
-		case e := <-bus2.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.After["email"] == "it2@w.ai" {
+		case rc := <-capture2.ch:
+			if rc.After["email"] == "it2@w.ai" {
 				gotNew = true
 			}
 		case <-deadline:

--- a/service/cdc/postgres/integration_toast_test.go
+++ b/service/cdc/postgres/integration_toast_test.go
@@ -42,13 +42,14 @@ func TestUnchangedToastIsMarked(t *testing.T) {
 	dropNamedSlot(t, repl, toastSlot)
 	defer dropNamedSlot(t, repl, toastSlot)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: toastSlot, Publication: "toasty_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	runCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, runCtx, src, capture)
 	_, err = src.Start(runCtx)
 	require.NoError(t, err)
 
@@ -61,8 +62,8 @@ func TestUnchangedToastIsMarked(t *testing.T) {
 	var upd *RowChange
 	for upd == nil {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.Op == OpUpdate && rc.Table == "toasty" {
+		case rc := <-capture.ch:
+			if rc.Op == OpUpdate && rc.Table == "toasty" {
 				c := rc
 				upd = &c
 			}

--- a/service/cdc/postgres/integration_truncate_test.go
+++ b/service/cdc/postgres/integration_truncate_test.go
@@ -24,19 +24,20 @@ func TestTruncateIsStreamed(t *testing.T) {
 	_, err = db.Exec(`DELETE FROM accounts`)
 	require.NoError(t, err)
 
-	bus := newCaptureBus()
+	capture := newChangeCapture()
 	src := NewSource(SourceOptions{
 		ReplDSN: repl, AdminDSN: admin, Slot: itSlot, Publication: "wippy_cdc_pub",
-		Bus: bus, StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
+		StandbyInterval: 200 * time.Millisecond, StatusInterval: time.Hour,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	attachCapture(t, ctx, src, capture)
 	_, err = src.Start(ctx)
 	require.NoError(t, err)
 
 	_, err = db.Exec(`INSERT INTO accounts (email, balance) VALUES ('trunc@w.ai', 1)`)
 	require.NoError(t, err)
-	waitForEmail(t, bus, "trunc@w.ai", 15*time.Second)
+	waitForEmail(t, capture, "trunc@w.ai", 15*time.Second)
 
 	_, err = db.Exec(`TRUNCATE accounts`)
 	require.NoError(t, err)
@@ -45,8 +46,8 @@ func TestTruncateIsStreamed(t *testing.T) {
 	var got *RowChange
 	for got == nil {
 		select {
-		case e := <-bus.ch:
-			if rc, ok := e.Data.(RowChange); ok && rc.Op == OpTruncate {
+		case rc := <-capture.ch:
+			if rc.Op == OpTruncate {
 				c := rc
 				got = &c
 			}

--- a/service/cdc/postgres/manager.go
+++ b/service/cdc/postgres/manager.go
@@ -80,10 +80,10 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 	src := NewSource(SourceOptions{
 		ReplDSN:           replDSN,
 		AdminDSN:          adminDSN,
+		Name:              entry.ID.String(),
 		Slot:              cfg.SlotName,
 		Publication:       cfg.Publication,
 		Tables:            cfg.Tables,
-		EventSystem:       cfg.EventSystem,
 		Temporary:         cfg.Temporary,
 		Snapshot:          cfg.Snapshot,
 		Streaming:         cfg.Streaming,
@@ -91,7 +91,6 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 		StandbyInterval:   standby,
 		StatusInterval:    status,
 		SnapshotFetchSize: cfg.SnapshotFetchSize,
-		Bus:               m.bus,
 		Log:               m.log.With(zap.String("id", entry.ID.String())),
 	})
 
@@ -123,6 +122,10 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 		return NewInvalidConfigError(err)
 	}
 
+	old := m.sources[entry.ID]
+	if old != nil {
+		old.closeSubscriptions()
+	}
 	m.removeInfo(entry.ID)
 	m.unregister(ctx, entry)
 
@@ -132,10 +135,10 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 	src := NewSource(SourceOptions{
 		ReplDSN:           replDSN,
 		AdminDSN:          adminDSN,
+		Name:              entry.ID.String(),
 		Slot:              cfg.SlotName,
 		Publication:       cfg.Publication,
 		Tables:            cfg.Tables,
-		EventSystem:       cfg.EventSystem,
 		Temporary:         cfg.Temporary,
 		Snapshot:          cfg.Snapshot,
 		Streaming:         cfg.Streaming,
@@ -143,7 +146,6 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 		StandbyInterval:   standby,
 		StatusInterval:    status,
 		SnapshotFetchSize: cfg.SnapshotFetchSize,
-		Bus:               m.bus,
 		Log:               m.log.With(zap.String("id", entry.ID.String())),
 	})
 	m.sources[entry.ID] = src
@@ -161,6 +163,7 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 		return NewServiceNotFoundError(entry.ID)
 	}
 	src.MarkForSlotDrop()
+	src.closeSubscriptions()
 	m.removeInfo(entry.ID)
 	m.unregister(ctx, entry)
 	delete(m.sources, entry.ID)
@@ -171,16 +174,12 @@ func (m *Manager) storeInfo(entry registry.Entry, cfg *config.Config) {
 	info := config.SourceInfo{
 		Name:        entry.ID.String(),
 		Slot:        cfg.SlotName,
-		EventSystem: cfg.EventSystem,
 		Publication: cfg.Publication,
 		Tables:      append([]string(nil), cfg.Tables...),
 		Streaming:   cfg.Streaming,
 		Failover:    cfg.Failover,
 		Temporary:   cfg.Temporary,
 		Snapshot:    cfg.Snapshot,
-	}
-	if info.EventSystem == "" {
-		info.EventSystem = config.DefaultEventSystem
 	}
 	m.infos[entry.ID] = info
 	m.infosByKey[info.Slot] = entry.ID
@@ -221,6 +220,32 @@ func (m *Manager) Get(name string) (config.SourceInfo, bool) {
 		}
 	}
 	return config.SourceInfo{}, false
+}
+
+func (m *Manager) Stream(_ context.Context, name string, opts config.StreamOptions) (config.ChangeStream, config.SourceInfo, error) {
+	m.mu.Lock()
+	src, info, ok := m.lookupSourceLocked(name)
+	m.mu.Unlock()
+	if !ok {
+		return nil, config.SourceInfo{}, NewServiceNotFoundError(registry.ParseID(name))
+	}
+	return src.Subscribe(opts), info, nil
+}
+
+func (m *Manager) lookupSourceLocked(name string) (*Source, config.SourceInfo, bool) {
+	if id, ok := m.infosByKey[name]; ok {
+		if src := m.sources[id]; src != nil {
+			return src, m.infos[id], true
+		}
+	}
+	for id, info := range m.infos {
+		if info.Name == name {
+			if src := m.sources[id]; src != nil {
+				return src, info, true
+			}
+		}
+	}
+	return nil, config.SourceInfo{}, false
 }
 
 func (m *Manager) register(ctx context.Context, entry registry.Entry, src *Source, lifecycle supervisor.LifecycleConfig) {

--- a/service/cdc/postgres/manager_test.go
+++ b/service/cdc/postgres/manager_test.go
@@ -3,6 +3,7 @@
 package postgres
 
 import (
+	"context"
 	"net/url"
 	"sort"
 	"testing"
@@ -56,9 +57,8 @@ func TestManagerStoreAndListInfos(t *testing.T) {
 		Streaming:   true,
 	})
 	m.storeInfo(registry.Entry{ID: registry.NewID("test", "id-b"), Kind: config.Postgres}, &config.Config{
-		SlotName:    "slot_b",
-		Tables:      []string{"public.t"},
-		EventSystem: "custom_system",
+		SlotName: "slot_b",
+		Tables:   []string{"public.t"},
 	})
 
 	infos := m.List()
@@ -71,12 +71,10 @@ func TestManagerStoreAndListInfos(t *testing.T) {
 	a, ok := m.Get("slot_a")
 	require.True(t, ok)
 	assert.Equal(t, "pub_a", a.Publication)
-	assert.Equal(t, config.DefaultEventSystem, a.EventSystem)
 	assert.True(t, a.Streaming)
 
 	b, ok := m.Get("slot_b")
 	require.True(t, ok)
-	assert.Equal(t, "custom_system", b.EventSystem)
 	assert.Equal(t, []string{"public.t"}, b.Tables)
 
 	_, ok = m.Get("unknown")
@@ -85,6 +83,26 @@ func TestManagerStoreAndListInfos(t *testing.T) {
 	byID, ok := m.Get(infos[0].Name)
 	require.True(t, ok)
 	assert.Equal(t, infos[0].Slot, byID.Slot)
+}
+
+func TestManagerStreamBySlotAndID(t *testing.T) {
+	m := newInspectorManager()
+	id := registry.NewID("test", "id-stream")
+	src := NewSource(SourceOptions{Name: id.String(), Slot: "slot_stream"})
+	m.sources[id] = src
+	m.storeInfo(registry.Entry{ID: id, Kind: config.Postgres}, &config.Config{SlotName: "slot_stream", Tables: []string{"public.accounts"}})
+
+	stream, info, err := m.Stream(context.Background(), "slot_stream", config.StreamOptions{Buffer: 2})
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	assert.Equal(t, "slot_stream", info.Slot)
+	stream.Close()
+
+	stream, info, err = m.Stream(context.Background(), id.String(), config.StreamOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	assert.Equal(t, id.String(), info.Name)
+	stream.Close()
 }
 
 func TestManagerRemoveInfo(t *testing.T) {

--- a/service/cdc/postgres/service.go
+++ b/service/cdc/postgres/service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lib/pq"
 	"go.uber.org/zap"
 
-	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/metrics"
 	config "github.com/wippyai/runtime/api/service/cdc"
 )
@@ -40,14 +39,13 @@ const (
 )
 
 type SourceOptions struct {
-	Bus               event.Bus
 	Checkpoint        Checkpointer
 	Log               *zap.Logger
 	ReplDSN           string
 	AdminDSN          string
+	Name              string
 	Slot              string
 	Publication       string
-	EventSystem       string
 	Tables            []string
 	StandbyInterval   time.Duration
 	StatusInterval    time.Duration
@@ -59,22 +57,23 @@ type SourceOptions struct {
 }
 
 type Source struct {
-	bus         event.Bus
-	log         *zap.Logger
-	injectedCP  Checkpointer
-	cancel      context.CancelFunc
-	done        chan struct{}
-	replDSN     string
-	adminDSN    string
-	slot        string
-	publication string
-	eventSystem string
-	tables      []string
-
+	log               *zap.Logger
+	injectedCP        Checkpointer
+	cancel            context.CancelFunc
+	done              chan struct{}
+	subs              map[uint64]*sourceSubscription
+	replDSN           string
+	adminDSN          string
+	name              string
+	slot              string
+	publication       string
+	tables            []string
 	standbyInterval   time.Duration
 	statusInterval    time.Duration
-	snapshotFetchSize int
 	mu                sync.Mutex
+	subMu             sync.RWMutex
+	nextSubID         uint64
+	snapshotFetchSize int
 	temporary         bool
 	snapshot          bool
 	streaming         bool
@@ -94,10 +93,6 @@ func NewSource(opts SourceOptions) *Source {
 	if log == nil {
 		log = zap.NewNop()
 	}
-	system := opts.EventSystem
-	if system == "" {
-		system = config.DefaultEventSystem
-	}
 	standby := opts.StandbyInterval
 	if standby <= 0 {
 		standby = defaultStandbyInterval
@@ -111,15 +106,15 @@ func NewSource(opts SourceOptions) *Source {
 		fetch = defaultSnapshotFetchSize
 	}
 	return &Source{
-		bus:               opts.Bus,
 		log:               log,
 		injectedCP:        opts.Checkpoint,
 		replDSN:           opts.ReplDSN,
 		adminDSN:          opts.AdminDSN,
+		name:              opts.Name,
 		slot:              opts.Slot,
 		publication:       opts.Publication,
-		eventSystem:       system,
 		tables:            opts.Tables,
+		subs:              make(map[uint64]*sourceSubscription),
 		temporary:         opts.Temporary,
 		snapshot:          opts.Snapshot,
 		streaming:         opts.Streaming,
@@ -209,6 +204,7 @@ func (s *Source) Stop(ctx context.Context) error {
 	if !s.stopped.CompareAndSwap(false, true) {
 		return nil
 	}
+	defer s.closeSubscriptions()
 
 	s.mu.Lock()
 	cancel := s.cancel
@@ -246,6 +242,7 @@ func (s *Source) run(
 ) {
 	defer close(done)
 	defer close(status)
+	defer s.closeSubscriptions()
 	defer func() { _ = adminDB.Close() }()
 	defer func() { _ = conn.Close(context.Background()) }()
 
@@ -383,11 +380,17 @@ func (s *Source) run(
 }
 
 func (s *Source) emitChange(ctx context.Context, c RowChange) {
-	s.bus.Send(ctx, event.Event{
-		System: s.eventSystem,
-		Kind:   config.ChangeKind,
-		Path:   c.Relation(),
-		Data:   c,
+	s.publishChange(ctx, config.Change{
+		Source:    s.name,
+		Op:        string(c.Op),
+		Schema:    c.Schema,
+		Table:     c.Table,
+		Relation:  c.Relation(),
+		LSN:       c.LSN,
+		CommitLSN: c.CommitLSN,
+		XID:       c.XID,
+		Before:    c.Before,
+		After:     c.After,
 	})
 }
 
@@ -403,25 +406,10 @@ func (s *Source) reportLag(ctx context.Context, adminDB *sql.DB, mc metrics.Coll
 	if mc != nil {
 		mc.GaugeSet(retainedWALGauge, float64(retained), metrics.Labels{"slot": s.slot})
 	}
-	s.bus.Send(ctx, event.Event{
-		System: s.eventSystem,
-		Kind:   config.StatusKind,
-		Path:   s.slot,
-		Data: map[string]any{
-			"slot":               s.slot,
-			"retained_wal_bytes": retained,
-		},
-	})
 }
 
-func (s *Source) fail(ctx context.Context, status chan any, err error) {
+func (s *Source) fail(_ context.Context, status chan any, err error) {
 	s.log.Error("cdc stream error", zap.String("slot", s.slot), zap.Error(err))
-	s.bus.Send(context.WithoutCancel(ctx), event.Event{
-		System: s.eventSystem,
-		Kind:   config.ErrorKind,
-		Path:   s.slot,
-		Data:   map[string]any{"slot": s.slot, "error": err.Error()},
-	})
 	select {
 	case status <- err:
 	default:

--- a/service/cdc/postgres/service_test.go
+++ b/service/cdc/postgres/service_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	config "github.com/wippyai/runtime/api/service/cdc"
 )
 
 func TestNewSourceDefaults(t *testing.T) {
@@ -18,7 +16,6 @@ func TestNewSourceDefaults(t *testing.T) {
 	assert.Equal(t, defaultStandbyInterval, s.standbyInterval)
 	assert.Equal(t, defaultStatusInterval, s.statusInterval)
 	assert.Equal(t, defaultSnapshotFetchSize, s.snapshotFetchSize)
-	assert.Equal(t, config.DefaultEventSystem, s.eventSystem)
 	assert.NotNil(t, s.log)
 }
 
@@ -27,12 +24,10 @@ func TestNewSourceHonorsOverrides(t *testing.T) {
 		StandbyInterval:   1 * time.Second,
 		StatusInterval:    2 * time.Second,
 		SnapshotFetchSize: 4096,
-		EventSystem:       "custom_system",
 	})
 	assert.Equal(t, 1*time.Second, s.standbyInterval)
 	assert.Equal(t, 2*time.Second, s.statusInterval)
 	assert.Equal(t, 4096, s.snapshotFetchSize)
-	assert.Equal(t, "custom_system", s.eventSystem)
 }
 
 func TestStopBeforeStartIsSafe(t *testing.T) {

--- a/service/cdc/postgres/stream.go
+++ b/service/cdc/postgres/stream.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	config "github.com/wippyai/runtime/api/service/cdc"
+)
+
+const (
+	defaultStreamBuffer = 128
+	maxStreamBuffer     = 65536
+)
+
+type sourceSubscription struct {
+	source *Source
+	in     chan config.Change
+	out    chan config.Change
+	done   chan struct{}
+	tables map[string]struct{}
+	ops    map[string]struct{}
+	id     uint64
+	once   sync.Once
+	closed atomic.Bool
+}
+
+func (s *Source) Subscribe(opts config.StreamOptions) config.ChangeStream {
+	buffer := opts.Buffer
+	if buffer <= 0 {
+		buffer = defaultStreamBuffer
+	}
+	if buffer > maxStreamBuffer {
+		buffer = maxStreamBuffer
+	}
+
+	s.subMu.Lock()
+	s.nextSubID++
+	sub := &sourceSubscription{
+		source: s,
+		id:     s.nextSubID,
+		in:     make(chan config.Change, buffer),
+		out:    make(chan config.Change, buffer),
+		done:   make(chan struct{}),
+		tables: filterSet(opts.Tables),
+		ops:    filterSet(opts.Ops),
+	}
+	s.subs[sub.id] = sub
+	s.subMu.Unlock()
+
+	go sub.run()
+	return sub
+}
+
+func (s *Source) publishChange(ctx context.Context, change config.Change) {
+	s.subMu.RLock()
+	subs := make([]*sourceSubscription, 0, len(s.subs))
+	for _, sub := range s.subs {
+		if sub.matches(change) {
+			subs = append(subs, sub)
+		}
+	}
+	s.subMu.RUnlock()
+
+	for _, sub := range subs {
+		sub.send(ctx, change)
+	}
+}
+
+func (s *Source) removeSubscription(id uint64) {
+	s.subMu.Lock()
+	delete(s.subs, id)
+	s.subMu.Unlock()
+}
+
+func (s *Source) closeSubscriptions() {
+	s.subMu.Lock()
+	subs := make([]*sourceSubscription, 0, len(s.subs))
+	for id, sub := range s.subs {
+		subs = append(subs, sub)
+		delete(s.subs, id)
+	}
+	s.subMu.Unlock()
+
+	for _, sub := range subs {
+		sub.Close()
+	}
+}
+
+func (s *sourceSubscription) Changes() <-chan config.Change {
+	return s.out
+}
+
+func (s *sourceSubscription) Close() {
+	s.once.Do(func() {
+		s.closed.Store(true)
+		if s.source != nil {
+			s.source.removeSubscription(s.id)
+		}
+		close(s.done)
+	})
+}
+
+func (s *sourceSubscription) run() {
+	defer close(s.out)
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+		select {
+		case change := <-s.in:
+			select {
+			case <-s.done:
+				return
+			case s.out <- change:
+			}
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *sourceSubscription) send(ctx context.Context, change config.Change) {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.in <- change:
+	case <-s.done:
+	case <-ctx.Done():
+	}
+}
+
+func (s *sourceSubscription) matches(change config.Change) bool {
+	if len(s.ops) > 0 {
+		if _, ok := s.ops[strings.ToLower(change.Op)]; !ok {
+			return false
+		}
+	}
+	if len(s.tables) > 0 {
+		if _, ok := s.tables[strings.ToLower(change.Relation)]; ok {
+			return true
+		}
+		if _, ok := s.tables[strings.ToLower(change.Table)]; ok {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
+func filterSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		v = strings.ToLower(strings.TrimSpace(v))
+		if v != "" {
+			out[v] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/service/cdc/postgres/stream_test.go
+++ b/service/cdc/postgres/stream_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cdcapi "github.com/wippyai/runtime/api/service/cdc"
+)
+
+func TestSourceSubscribePublishesMatchingChanges(t *testing.T) {
+	src := NewSource(SourceOptions{Name: "test:cdc", Slot: "slot_a"})
+	stream := src.Subscribe(cdcapi.StreamOptions{
+		Tables: []string{"public.accounts"},
+		Ops:    []string{"insert"},
+		Buffer: 2,
+	})
+	defer stream.Close()
+
+	src.publishChange(context.Background(), cdcapi.Change{
+		Source:   "test:cdc",
+		Op:       "insert",
+		Schema:   "public",
+		Table:    "accounts",
+		Relation: "public.accounts",
+		After:    map[string]any{"id": int64(1)},
+	})
+
+	select {
+	case got := <-stream.Changes():
+		assert.Equal(t, "insert", got.Op)
+		assert.Equal(t, "public.accounts", got.Relation)
+		assert.Equal(t, int64(1), got.After["id"])
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cdc change")
+	}
+}
+
+func TestSourceSubscribeFiltersChanges(t *testing.T) {
+	src := NewSource(SourceOptions{Name: "test:cdc", Slot: "slot_a"})
+	stream := src.Subscribe(cdcapi.StreamOptions{
+		Tables: []string{"public.accounts"},
+		Ops:    []string{"update"},
+		Buffer: 2,
+	})
+	defer stream.Close()
+
+	src.publishChange(context.Background(), cdcapi.Change{Op: "insert", Table: "accounts", Relation: "public.accounts"})
+	src.publishChange(context.Background(), cdcapi.Change{Op: "update", Table: "orders", Relation: "public.orders"})
+
+	select {
+	case got := <-stream.Changes():
+		t.Fatalf("unexpected change delivered: %#v", got)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func TestSourceSubscriptionCloseReleasesChannel(t *testing.T) {
+	src := NewSource(SourceOptions{Name: "test:cdc", Slot: "slot_a"})
+	stream := src.Subscribe(cdcapi.StreamOptions{})
+
+	src.subMu.RLock()
+	require.Len(t, src.subs, 1)
+	src.subMu.RUnlock()
+
+	stream.Close()
+
+	src.subMu.RLock()
+	assert.Empty(t, src.subs)
+	src.subMu.RUnlock()
+
+	select {
+	case _, ok := <-stream.Changes():
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for closed cdc stream")
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+use_docker="${WIPPY_CDC_TEST_DOCKER:-0}"
+for arg in "$@"; do
+	case "$arg" in
+		--docker)
+			use_docker=1
+			;;
+		--help|-h)
+			echo "usage: $0 [--docker]"
+			echo
+			echo "Default: run focused CDC unit tests and compile integration tests."
+			echo "--docker: start a temporary Postgres with logical replication and run live CDC integration tests."
+			exit 0
+			;;
+		*)
+			echo "unknown argument: $arg" >&2
+			echo "usage: $0 [--docker]" >&2
+			exit 2
+			;;
+	esac
+done
+
+go test ./api/service/cdc ./service/cdc/postgres ./runtime/lua/modules/cdc ./boot/components/dispatchers
+
+if [[ -n "${WIPPY_CDC_IT_REPL_DSN:-}" && -n "${WIPPY_CDC_IT_ADMIN_DSN:-}" ]]; then
+	go test -tags integration ./service/cdc/postgres
+	exit 0
+fi
+
+if [[ "$use_docker" != "1" ]]; then
+	echo "WIPPY_CDC_IT_REPL_DSN/WIPPY_CDC_IT_ADMIN_DSN not set; running CDC integration compile check only."
+	echo "Run '$0 --docker' for a live logical-replication Postgres proof."
+	go test -tags integration -run '^$' ./service/cdc/postgres
+	exit 0
+fi
+
+container="wippy-cdc-it-$$"
+cleanup() {
+	if [[ "${WIPPY_CDC_KEEP_DOCKER:-0}" != "1" ]]; then
+		docker rm -f "$container" >/dev/null 2>&1 || true
+	fi
+}
+trap cleanup EXIT
+
+docker run -d \
+	--name "$container" \
+	--label ai.wippy.owner=wippy \
+	--label ai.wippy.cdc-test=1 \
+	-e POSTGRES_PASSWORD=postgres \
+	-e POSTGRES_DB=wippy \
+	-p 127.0.0.1::5432 \
+	postgres:17 \
+	-c wal_level=logical \
+	-c max_wal_senders=16 \
+	-c max_replication_slots=32 >/dev/null
+
+for _ in {1..60}; do
+	if docker exec "$container" pg_isready -U postgres -d wippy >/dev/null 2>&1; then
+		break
+	fi
+	sleep 1
+done
+
+docker exec "$container" pg_isready -U postgres -d wippy >/dev/null
+docker exec "$container" psql -U postgres -d wippy -v ON_ERROR_STOP=1 \
+	-c "CREATE ROLE cdc_repl WITH REPLICATION LOGIN PASSWORD 'cdc_repl';" \
+	-c "GRANT ALL PRIVILEGES ON DATABASE wippy TO cdc_repl;" >/dev/null
+
+port="$(docker port "$container" 5432/tcp | sed -n 's/.*://p' | head -n1)"
+export WIPPY_CDC_IT_ADMIN_DSN="postgres://postgres:postgres@127.0.0.1:${port}/wippy?sslmode=disable"
+export WIPPY_CDC_IT_REPL_DSN="postgres://cdc_repl:cdc_repl@127.0.0.1:${port}/wippy?sslmode=disable&replication=database"
+
+go test -tags integration ./service/cdc/postgres


### PR DESCRIPTION
## Summary
- Add CDC source stream subscription command, Postgres source fanout, and dispatcher wiring to relay changes to subscribed process channels.
- Add Lua `cdc.stream()` with `channel`, `close`, and `release`, returning canonical CDC change tables.
- Replace the Lua integration proof with a Docker-backed test where Lua subscribes, Go writes to Postgres, and Lua receives/asserts that inserted row.

## Tests
- `make lint`
- `env GOEXPERIMENT=jsonv2 GOFLAGS=-buildvcs=false go vet -tags "fts5 sqlite_vec treesitter" ./...`
- `env GORACE=halt_on_error=1 SKIP_TEMPORAL_TESTS=1 SKIP_CLOUDSTORAGE_TESTS=1 SKIP_DOCKER_TESTS=1 make test`
- `./test.sh`
- `./test.sh --docker`
- `go test ./boot/components/service/storage`
- `git diff --check`