### PR TITLE
Fix CDC command ID collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test:
 	go test ./cluster/... -v -race -short
 	go test --tags "fts5 sqlite_vec treesitter" ./runtime/... -v -race -short
 	go test ./boot/... -v -race -short
+	go test --tags "fts5 sqlite_vec treesitter" ./cmd/... -v -race -short
 
 test-system:
 	go test ./internal/... -v -race

--- a/api/service/cdc/command.go
+++ b/api/service/cdc/command.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 const (
-	Subscribe dispatcher.CommandID = 170
+	Subscribe dispatcher.CommandID = 172
 )
 
 type StreamOptions struct {

--- a/api/service/cdc/command_test.go
+++ b/api/service/cdc/command_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cdc
+
+import (
+	"testing"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+)
+
+func TestCommandIDs(t *testing.T) {
+	if Subscribe != dispatcher.CommandID(172) {
+		t.Fatalf("Subscribe = %d, want 172", Subscribe)
+	}
+}


### PR DESCRIPTION
## Summary
- move CDC Subscribe command ID out of evalhost's 170/171 range
- add a CDC command ID assertion
- include ./cmd/... in make test so CLI init-time command registration panics are caught before release

## Tests
- make lint
- env GOEXPERIMENT=jsonv2 GOFLAGS=-buildvcs=false go vet -tags "fts5 sqlite_vec treesitter" ./...
- go test --tags "fts5 sqlite_vec treesitter" ./cmd/...
- go test ./api/service/cdc
- make build-wippy-local WIPPY_VERSION=v0.3.6a WIPPY_COMMIT=local WIPPY_DATE=2026-06-14T00:00:00Z
- ./dist/wippy-linux-amd64 --help
- grep -a -- v0.3.6a dist/wippy-linux-amd64
- env GORACE=halt_on_error=1 SKIP_TEMPORAL_TESTS=1 SKIP_CLOUDSTORAGE_TESTS=1 SKIP_DOCKER_TESTS=1 make test
- git diff --check