### PR TITLE
Expose memberlist probe tuning

### DIFF
--- a/boot/components/system/cluster.go
+++ b/boot/components/system/cluster.go
@@ -221,6 +221,22 @@ func Cluster() boot.Component {
 					ClusterMembershipDeadNodeReclaimTime,
 					membership.DefaultDeadNodeReclaimTime,
 				),
+				ProbeInterval: clusterCfg.GetDuration(
+					ClusterMembershipProbeInterval,
+					0,
+				),
+				ProbeTimeout: clusterCfg.GetDuration(
+					ClusterMembershipProbeTimeout,
+					0,
+				),
+				TCPTimeout: clusterCfg.GetDuration(
+					ClusterMembershipTCPTimeout,
+					0,
+				),
+				SuspicionMult: clusterCfg.GetInt(
+					ClusterMembershipSuspicionMult,
+					0,
+				),
 				VeryVerbose: false,
 				Meta:        nodeMeta,
 			}

--- a/boot/components/system/constants.go
+++ b/boot/components/system/constants.go
@@ -35,6 +35,10 @@ const (
 	ClusterMembershipGossipInterval      boot.Name = "membership.gossip_interval"
 	ClusterMembershipPushPullInterval    boot.Name = "membership.push_pull_interval"
 	ClusterMembershipDeadNodeReclaimTime boot.Name = "membership.dead_node_reclaim_time"
+	ClusterMembershipProbeInterval       boot.Name = "membership.probe_interval"
+	ClusterMembershipProbeTimeout        boot.Name = "membership.probe_timeout"
+	ClusterMembershipTCPTimeout          boot.Name = "membership.tcp_timeout"
+	ClusterMembershipSuspicionMult       boot.Name = "membership.suspicion_mult"
 	ClusterFailureDomain                 boot.Name = "failure_domain"
 	// ClusterKVCRDTTombstoneRetention bounds store.kv.crdt delete tombstone
 	// retention by age. 0 disables age-only GC; clustered nodes still reclaim

--- a/cluster/membership/membership.go
+++ b/cluster/membership/membership.go
@@ -132,7 +132,11 @@ type Config struct {
 	GossipInterval      time.Duration
 	PushPullInterval    time.Duration
 	DeadNodeReclaimTime time.Duration
+	ProbeInterval       time.Duration
+	ProbeTimeout        time.Duration
+	TCPTimeout          time.Duration
 	BindPort            int
+	SuspicionMult       int
 	VeryVerbose         bool
 }
 
@@ -166,6 +170,18 @@ func applyMemberlistTiming(mlConfig *memberlist.Config, cfg Config) {
 	mlConfig.PushPullInterval = positiveDuration(cfg.PushPullInterval, DefaultPushPullInterval)
 	mlConfig.DeadNodeReclaimTime = positiveDuration(
 		cfg.DeadNodeReclaimTime, DefaultDeadNodeReclaimTime)
+	if cfg.ProbeInterval > 0 {
+		mlConfig.ProbeInterval = cfg.ProbeInterval
+	}
+	if cfg.ProbeTimeout > 0 {
+		mlConfig.ProbeTimeout = cfg.ProbeTimeout
+	}
+	if cfg.TCPTimeout > 0 {
+		mlConfig.TCPTimeout = cfg.TCPTimeout
+	}
+	if cfg.SuspicionMult > 0 {
+		mlConfig.SuspicionMult = cfg.SuspicionMult
+	}
 }
 
 // NewService creates a new membership service.
@@ -200,6 +216,10 @@ func New(opts ...Option) *Service {
 			GossipInterval:      o.gossipInterval,
 			PushPullInterval:    o.pushPullInterval,
 			DeadNodeReclaimTime: o.deadNodeReclaimTime,
+			ProbeInterval:       o.probeInterval,
+			ProbeTimeout:        o.probeTimeout,
+			TCPTimeout:          o.tcpTimeout,
+			SuspicionMult:       o.suspicionMult,
 			NodeName:            o.nodeName,
 			BindAddr:            o.bindAddr,
 			SecretFile:          o.secretFile,

--- a/cluster/membership/membership_test.go
+++ b/cluster/membership/membership_test.go
@@ -44,23 +44,36 @@ func setupService(_ *testing.T) (*Service, *eventbus.Bus, context.Context, conte
 }
 
 func TestApplyMemberlistTiming_DefaultsAndBadValues(t *testing.T) {
+	base := memberlist.DefaultLocalConfig()
 	cfg := memberlist.DefaultLocalConfig()
 	applyMemberlistTiming(cfg, Config{})
 
 	assert.Equal(t, DefaultGossipInterval, cfg.GossipInterval)
 	assert.Equal(t, DefaultPushPullInterval, cfg.PushPullInterval)
 	assert.Equal(t, DefaultDeadNodeReclaimTime, cfg.DeadNodeReclaimTime)
+	assert.Equal(t, base.ProbeInterval, cfg.ProbeInterval)
+	assert.Equal(t, base.ProbeTimeout, cfg.ProbeTimeout)
+	assert.Equal(t, base.TCPTimeout, cfg.TCPTimeout)
+	assert.Equal(t, base.SuspicionMult, cfg.SuspicionMult)
 
 	cfg = memberlist.DefaultLocalConfig()
 	applyMemberlistTiming(cfg, Config{
 		GossipInterval:      -time.Second,
 		PushPullInterval:    -time.Second,
 		DeadNodeReclaimTime: -time.Second,
+		ProbeInterval:       -time.Second,
+		ProbeTimeout:        -time.Second,
+		TCPTimeout:          -time.Second,
+		SuspicionMult:       -1,
 	})
 
 	assert.Equal(t, DefaultGossipInterval, cfg.GossipInterval)
 	assert.Equal(t, DefaultPushPullInterval, cfg.PushPullInterval)
 	assert.Equal(t, DefaultDeadNodeReclaimTime, cfg.DeadNodeReclaimTime)
+	assert.Equal(t, base.ProbeInterval, cfg.ProbeInterval)
+	assert.Equal(t, base.ProbeTimeout, cfg.ProbeTimeout)
+	assert.Equal(t, base.TCPTimeout, cfg.TCPTimeout)
+	assert.Equal(t, base.SuspicionMult, cfg.SuspicionMult)
 }
 
 func TestApplyMemberlistTiming_CustomValues(t *testing.T) {
@@ -69,11 +82,39 @@ func TestApplyMemberlistTiming_CustomValues(t *testing.T) {
 		GossipInterval:      750 * time.Millisecond,
 		PushPullInterval:    10 * time.Second,
 		DeadNodeReclaimTime: 2 * time.Minute,
+		ProbeInterval:       2 * time.Second,
+		ProbeTimeout:        3 * time.Second,
+		TCPTimeout:          10 * time.Second,
+		SuspicionMult:       10,
 	})
 
 	assert.Equal(t, 750*time.Millisecond, cfg.GossipInterval)
 	assert.Equal(t, 10*time.Second, cfg.PushPullInterval)
 	assert.Equal(t, 2*time.Minute, cfg.DeadNodeReclaimTime)
+	assert.Equal(t, 2*time.Second, cfg.ProbeInterval)
+	assert.Equal(t, 3*time.Second, cfg.ProbeTimeout)
+	assert.Equal(t, 10*time.Second, cfg.TCPTimeout)
+	assert.Equal(t, 10, cfg.SuspicionMult)
+}
+
+func TestNew_WithMemberlistTimingOptions(t *testing.T) {
+	service := New(
+		WithGossipInterval(750*time.Millisecond),
+		WithPushPullInterval(10*time.Second),
+		WithDeadNodeReclaimTime(2*time.Minute),
+		WithProbeInterval(2*time.Second),
+		WithProbeTimeout(3*time.Second),
+		WithTCPTimeout(10*time.Second),
+		WithSuspicionMult(10),
+	)
+
+	assert.Equal(t, 750*time.Millisecond, service.config.GossipInterval)
+	assert.Equal(t, 10*time.Second, service.config.PushPullInterval)
+	assert.Equal(t, 2*time.Minute, service.config.DeadNodeReclaimTime)
+	assert.Equal(t, 2*time.Second, service.config.ProbeInterval)
+	assert.Equal(t, 3*time.Second, service.config.ProbeTimeout)
+	assert.Equal(t, 10*time.Second, service.config.TCPTimeout)
+	assert.Equal(t, 10, service.config.SuspicionMult)
 }
 
 func generateSecretKey() string {

--- a/cluster/membership/options.go
+++ b/cluster/membership/options.go
@@ -34,7 +34,11 @@ type options struct {
 	gossipInterval      time.Duration
 	pushPullInterval    time.Duration
 	deadNodeReclaimTime time.Duration
+	probeInterval       time.Duration
+	probeTimeout        time.Duration
+	tcpTimeout          time.Duration
 	bindPort            int
+	suspicionMult       int
 	veryVerbose         bool
 }
 
@@ -101,4 +105,28 @@ func WithPushPullInterval(d time.Duration) Option {
 // values fall back to the production default at Start.
 func WithDeadNodeReclaimTime(d time.Duration) Option {
 	return func(o *options) { o.deadNodeReclaimTime = d }
+}
+
+// WithProbeInterval tunes memberlist's direct probe cadence. Non-positive
+// values keep memberlist's default.
+func WithProbeInterval(d time.Duration) Option {
+	return func(o *options) { o.probeInterval = d }
+}
+
+// WithProbeTimeout tunes how long memberlist waits for a direct probe before
+// suspecting a peer. Non-positive values keep memberlist's default.
+func WithProbeTimeout(d time.Duration) Option {
+	return func(o *options) { o.probeTimeout = d }
+}
+
+// WithTCPTimeout tunes memberlist TCP operations such as push/pull and
+// reliable user messages. Non-positive values keep memberlist's default.
+func WithTCPTimeout(d time.Duration) Option {
+	return func(o *options) { o.tcpTimeout = d }
+}
+
+// WithSuspicionMult tunes memberlist's suspicion timeout multiplier.
+// Non-positive values keep memberlist's default.
+func WithSuspicionMult(mult int) Option {
+	return func(o *options) { o.suspicionMult = mult }
 }

--- a/cluster/stack.go
+++ b/cluster/stack.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	clusterapi "github.com/wippyai/runtime/api/cluster"
 	"github.com/wippyai/runtime/api/event"
@@ -65,16 +66,23 @@ type StackConfig struct {
 	// the harness to avoid disturbing the runtime's raft quorum.
 	Meta clusterapi.NodeMeta
 
-	NodeName            string
-	MembershipBindAddr  string
-	MembershipAdvertise string
-	SecretKey           string
-	SecretFile          string
-	InternodeBindAddr   string
-	JoinAddrs           []string
-	MembershipBindPort  int
-	InternodeBindPort   int
-	InternodeAutoPort   bool
+	NodeName                      string
+	MembershipBindAddr            string
+	MembershipAdvertise           string
+	SecretKey                     string
+	SecretFile                    string
+	InternodeBindAddr             string
+	JoinAddrs                     []string
+	MembershipGossipInterval      time.Duration
+	MembershipPushPullInterval    time.Duration
+	MembershipDeadNodeReclaimTime time.Duration
+	MembershipProbeInterval       time.Duration
+	MembershipProbeTimeout        time.Duration
+	MembershipTCPTimeout          time.Duration
+	MembershipBindPort            int
+	InternodeBindPort             int
+	MembershipSuspicionMult       int
+	InternodeAutoPort             bool
 }
 
 // AssembleStack constructs the relay node, router, membership service,
@@ -137,14 +145,21 @@ func AssembleStack(cfg StackConfig) (*Stack, error) {
 	meta["internode_port"] = strconv.Itoa(actualPort)
 
 	memCfg := membership.Config{
-		NodeName:     cfg.NodeName,
-		BindAddr:     stringOr(cfg.MembershipBindAddr, "0.0.0.0"),
-		BindPort:     intOr(cfg.MembershipBindPort, 7946),
-		JoinAddrs:    cfg.JoinAddrs,
-		SecretFile:   cfg.SecretFile,
-		SecretString: cfg.SecretKey,
-		AdvertiseIP:  cfg.MembershipAdvertise,
-		Meta:         meta,
+		NodeName:            cfg.NodeName,
+		BindAddr:            stringOr(cfg.MembershipBindAddr, "0.0.0.0"),
+		BindPort:            intOr(cfg.MembershipBindPort, 7946),
+		JoinAddrs:           cfg.JoinAddrs,
+		SecretFile:          cfg.SecretFile,
+		SecretString:        cfg.SecretKey,
+		AdvertiseIP:         cfg.MembershipAdvertise,
+		GossipInterval:      cfg.MembershipGossipInterval,
+		PushPullInterval:    cfg.MembershipPushPullInterval,
+		DeadNodeReclaimTime: cfg.MembershipDeadNodeReclaimTime,
+		ProbeInterval:       cfg.MembershipProbeInterval,
+		ProbeTimeout:        cfg.MembershipProbeTimeout,
+		TCPTimeout:          cfg.MembershipTCPTimeout,
+		SuspicionMult:       cfg.MembershipSuspicionMult,
+		Meta:                meta,
 	}
 
 	memSvc := membership.NewService(


### PR DESCRIPTION
## Summary
- expose memberlist probe interval, probe timeout, TCP timeout, and suspicion multiplier through cluster boot config
- add matching membership functional options and cluster stack config fields
- preserve memberlist defaults when the new knobs are omitted or non-positive

## Tests
- go test ./cluster/membership
- go test ./boot/components/system
- go test ./cluster
- make lint
- go vet ./...
- make test