### PR TITLE
fix(relay): never panic delivering to a closed receiver

### DIFF
--- a/system/relay/mailbox.go
+++ b/system/relay/mailbox.go
@@ -82,17 +82,6 @@ func NewMailbox(ctx context.Context, opts ...MailboxOption) *Mailbox {
 		go m.worker(i)
 	}
 
-	// Close job queues when context is canceled.
-	// Guard against nil Done channel (context.Background/TODO never cancel).
-	if ctx.Done() != nil {
-		go func() {
-			<-ctx.Done()
-			for i := range jobQueues {
-				close(jobQueues[i])
-			}
-		}()
-	}
-
 	return m
 }
 
@@ -155,12 +144,19 @@ func (m *Mailbox) Send(pkg *api.Package) error {
 	}
 }
 
-// worker processes packages from its dedicated queue.
+// worker processes packages from its dedicated queue until the context is
+// canceled. The queues are never closed (a send racing a close would panic),
+// so the worker exits on ctx.Done rather than ranging over a closed channel.
 func (m *Mailbox) worker(queueIndex int) {
 	queue := m.jobQueues[queueIndex]
 
-	for pkg := range queue {
-		m.deliver(pkg)
+	for {
+		select {
+		case pkg := <-queue:
+			m.deliver(pkg)
+		case <-m.ctx.Done():
+			return
+		}
 	}
 }
 
@@ -186,6 +182,22 @@ func (m *Mailbox) deliver(pkg *api.Package) {
 			zap.String("target", targetKey))
 		return
 	}
+
+	m.deliverTo(ch, pkg, targetKey)
+}
+
+// deliverTo performs the receiver-channel send. The channel is owned by the
+// attached process, which may close it concurrently with this send (Detach only
+// removes the map entry). A send on a closed channel panics, which must never
+// take down the worker, so it is recovered: a closed receiver means the process
+// is gone and the package is dropped.
+func (m *Mailbox) deliverTo(ch chan *api.Package, pkg *api.Package, targetKey string) {
+	defer func() {
+		if r := recover(); r != nil {
+			m.config.logger.Debug("dropped delivery to closed receiver",
+				zap.String("target", targetKey))
+		}
+	}()
 
 	select {
 	case ch <- pkg:

--- a/system/relay/mailbox_test.go
+++ b/system/relay/mailbox_test.go
@@ -197,6 +197,41 @@ func TestMailbox_DetachDuringDelivery(t *testing.T) {
 	// Message should be dropped without error
 }
 
+// A receiver's owner closes its own channel on teardown (Detach only removes the
+// map entry). A delivery racing that close hits a send-on-closed-channel, which
+// must be dropped, never panicking the worker — proven by a subsequent delivery
+// to a live receiver on the same worker still arriving.
+func TestMailbox_ClosedReceiverDoesNotKillWorker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	mailbox := NewMailbox(ctx, WithBufferSize(4), WithWorkerCount(1))
+
+	dead := pidapi.PID{Node: "node1", Host: "host1", UniqID: "dead"}
+	deadCh := make(chan *relay.Package, 1)
+	_, err := mailbox.Attach(dead, deadCh)
+	assert.NoError(t, err)
+	close(deadCh) // owner closed its channel on teardown
+
+	live := pidapi.PID{Node: "node1", Host: "host1", UniqID: "live"}
+	liveCh := make(chan *relay.Package, 1)
+	_, err = mailbox.Attach(live, liveCh)
+	assert.NoError(t, err)
+
+	src := pidapi.PID{Node: "node1", Host: "host1", UniqID: "src"}
+	assert.NoError(t, mailbox.Send(&relay.Package{Source: src, Target: dead,
+		Messages: []*relay.Message{{Topic: "x"}}}))
+	assert.NoError(t, mailbox.Send(&relay.Package{Source: src, Target: live,
+		Messages: []*relay.Message{{Topic: "y"}}}))
+
+	select {
+	case got := <-liveCh:
+		assert.Equal(t, live, got.Target)
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker died after a send to a closed receiver: live delivery never arrived")
+	}
+}
+
 func TestMailbox_MultipleWorkers(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()


### PR DESCRIPTION
## Problem

The relay `Mailbox` delivers to receiver channels it does not own — the attached process owns its channel and closes it on teardown, while `Detach`/the Attach cancel only remove the map entry. A delivery racing that close hit `panic: send on closed channel` in `Mailbox.deliver` and killed the worker goroutine (process crash under load). The same hazard existed on shutdown: `NewMailbox` closed the job queues, so an in-flight `Send` could send on a closed queue.

## Fix

- `deliverTo` performs the receiver-channel send under a `recover` — a closed receiver means the process is gone, so the package is dropped and the worker survives.
- Stop closing the job queues on shutdown; workers now exit on `ctx.Done()` instead of ranging a closed channel, so `Send` can't race a closed queue either.

## Test

`TestMailbox_ClosedReceiverDoesNotKillWorker` reproduces the crash: a send to a closed receiver must not stop a subsequent delivery to a live receiver on the same worker. Full package `go test -race` + `go vet` clean.

Surfaced in production under heavy process churn (containers starting/dying → mailboxes opening/closing).