### PR TITLE
fix(cmd): keep app context alive for graceful pack shutdown

### DIFF
--- a/api/supervisor/shutdown.go
+++ b/api/supervisor/shutdown.go
@@ -35,6 +35,8 @@ func GetExitCode() int {
 func SetSignalChannel(ctx context.Context, ch chan<- os.Signal) {
 	ac := ctxapi.AppFromContext(ctx)
 	if ac != nil {
+		setExitCode(0)
+		shutdownSent.Store(false)
 		ac.With(signalChannelKey, ch)
 	}
 }

--- a/api/supervisor/supervisor_test.go
+++ b/api/supervisor/supervisor_test.go
@@ -229,6 +229,23 @@ func TestShutdownContext(t *testing.T) {
 		assert.NotNil(t, retrieved)
 	})
 
+	t.Run("SetSignalChannel_ResetsShutdownState", func(t *testing.T) {
+		setExitCode(9)
+		shutdownSent.Store(true)
+		appCtx := ctxapi.NewAppContext()
+		ctx := ctxapi.WithAppContext(context.Background(), appCtx)
+
+		ch := make(chan os.Signal, 1)
+		SetSignalChannel(ctx, ch)
+
+		assert.Equal(t, 0, GetExitCode())
+		TriggerShutdown(ctx, 3)
+		assert.Equal(t, 3, GetExitCode())
+		assert.Equal(t, 1, len(ch))
+		setExitCode(0)
+		shutdownSent.Store(false)
+	})
+
 	t.Run("getSignalChannel_NoAppContext", func(t *testing.T) {
 		ctx := context.Background()
 		ch := getSignalChannel(ctx)

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -494,7 +494,7 @@ func runPackEntries(
 		}
 	}
 
-	waitForShutdownSignal(sigChan, logger, cancel)
+	waitForShutdownSignal(sigChan, logger, nil)
 
 	exitCode := shutdown.Perform(ctx, loader, logger, silentLogs)
 	if exitCode != 0 {

--- a/cmd/wippy/cmd/run_pack_shutdown_test.go
+++ b/cmd/wippy/cmd/run_pack_shutdown_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	event "github.com/wippyai/runtime/api/event"
+	regapi "github.com/wippyai/runtime/api/registry"
+	supervisorapi "github.com/wippyai/runtime/api/supervisor"
+	supervisorpkg "github.com/wippyai/runtime/system/supervisor"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type fakeShutdownService struct {
+	updates chan any
+	mu      sync.Mutex
+	stopped bool
+}
+
+func (s *fakeShutdownService) Start(_ context.Context) (<-chan any, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updates = make(chan any, 1)
+	return s.updates, nil
+}
+
+func (s *fakeShutdownService) Stop(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.updates != nil {
+		close(s.updates)
+		s.updates = nil
+	}
+	s.stopped = true
+	return nil
+}
+
+func (s *fakeShutdownService) isStopped() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopped
+}
+
+func TestRunPackEntries_GracefulShutdownStopsRunningService(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prevConfigFile })
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	baseLogger := zap.New(core)
+
+	ctx, loader, _, embedReg, err := bootstrapPackRuntime(nil, baseLogger)
+	if err != nil {
+		t.Fatalf("bootstrap pack runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = embedReg.Close() })
+
+	const serviceID = "test.shutdown:service"
+	svc := &fakeShutdownService{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runPackEntries(ctx, loader, baseLogger, nil, nil)
+	}()
+
+	waitForLogMessage(t, logs, "supervisor started")
+
+	sup, ok := supervisorapi.GetSupervisor(ctx).(*supervisorpkg.Supervisor)
+	if !ok || sup == nil {
+		t.Fatal("supervisor not available")
+	}
+
+	bus := event.GetBus(ctx)
+	if bus == nil {
+		t.Fatal("event bus not available")
+	}
+
+	bus.Send(ctx, event.Event{System: regapi.System, Kind: regapi.TxBegin})
+	bus.Send(ctx, event.Event{
+		System: supervisorapi.System,
+		Kind:   supervisorapi.ServiceRegister,
+		Path:   serviceID,
+		Data: &supervisorapi.Entry{
+			Service: svc,
+			Config: supervisorapi.LifecycleConfig{
+				AutoStart:    true,
+				StartTimeout: 5 * time.Second,
+				StopTimeout:  5 * time.Second,
+				RetryPolicy:  supervisorapi.RetryPolicy{MaxAttempts: 3, InitialDelay: 50 * time.Millisecond},
+			},
+		},
+	})
+	bus.Send(ctx, event.Event{System: regapi.System, Kind: regapi.TxCommit})
+
+	waitForServiceStatus(t, sup, serviceID, supervisorapi.StatusRunning)
+
+	supervisorapi.TriggerShutdown(ctx, 0)
+
+	select {
+	case runErr := <-done:
+		if runErr != nil {
+			t.Fatalf("runPackEntries returned error: %v", runErr)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for runPackEntries to return")
+	}
+
+	if !svc.isStopped() {
+		t.Fatal("service was not gracefully stopped during shutdown")
+	}
+
+	for _, entry := range logs.All() {
+		errField, _ := entry.ContextMap()["error"].(string)
+		if strings.Contains(entry.Message, "failed to stop controllers during shutdown") ||
+			strings.Contains(entry.Message, "supervisor is stopped") ||
+			strings.Contains(errField, "supervisor is stopped") {
+			t.Fatalf("graceful shutdown produced a supervisor-stopped error: message=%q error=%q", entry.Message, errField)
+		}
+	}
+}
+
+func TestWaitForShutdownSignal_InvokesOnFirstSignalOnlyWhenSet(t *testing.T) {
+	t.Run("invokes callback when set", func(t *testing.T) {
+		sigChan := make(chan os.Signal, 1)
+		sigChan <- syscall.SIGTERM
+
+		called := make(chan struct{}, 1)
+		waitForShutdownSignal(sigChan, zap.NewNop(), func() { called <- struct{}{} })
+
+		select {
+		case <-called:
+		case <-time.After(time.Second):
+			t.Fatal("onFirstSignal was not invoked")
+		}
+	})
+
+	t.Run("tolerates a nil callback", func(t *testing.T) {
+		sigChan := make(chan os.Signal, 1)
+		sigChan <- syscall.SIGTERM
+
+		waitForShutdownSignal(sigChan, zap.NewNop(), nil)
+	})
+}
+
+func waitForLogMessage(t *testing.T, logs *observer.ObservedLogs, message string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, entry := range logs.All() {
+			if entry.Message == message {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timeout waiting for log message %q", message)
+}
+
+func waitForServiceStatus(t *testing.T, sup *supervisorpkg.Supervisor, serviceID string, status supervisorapi.Status) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		state, err := sup.GetState(serviceID)
+		if err == nil && state.Status == status {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timeout waiting for service %q to reach status %q", serviceID, status)
+}

--- a/cmd/wippy/cmd/run_pack_shutdown_test.go
+++ b/cmd/wippy/cmd/run_pack_shutdown_test.go
@@ -76,7 +76,7 @@ func TestRunPackEntries_GracefulShutdownStopsRunningService(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runPackEntries(ctx, loader, baseLogger, nil, nil)
+		done <- runPackEntries(ctx, loader, baseLogger, nil, nil, defaultUseCase)
 	}()
 
 	waitForLogMessage(t, logs, "supervisor started")


### PR DESCRIPTION
## Why
`wippy run <hub-module>` (and `.wapp` pack files) logged
`failed to stop controllers during shutdown: supervisor is stopped: context canceled`
on exit and abandoned services instead of stopping them gracefully.

## What
The pack runner (`runPackEntries`) passed the `appCtx` cancel func as the
first-signal callback, so the shutdown signal cancelled the context the
supervisor and all its controllers derive from **before** `shutdown.Perform`
ran the graceful stop — making every `controller.Stop()` short-circuit. Pass
`nil` instead, matching the server path in `run.go`. The existing
`defer cancel()` still tears down `appCtx` after shutdown completes.

## Testing
- `make test` — 292 packages, 0 failures; `golangci-lint` v2.8.0 — 0 issues.
- New regression test `TestRunPackEntries_GracefulShutdownStopsRunningService`
  (`-race`, `-count=5`, no flakes): fails when reverted to `cancel`, passes with `nil`.
- Gremlins mutation on `run_pack.go`: 36 killed, 0 lived, 100% efficacy.
- Manual repro on three hub modules (`kickside/kickside`, `keeper/keeper`,
  `userspace/users`): shutdown "supervisor is stopped" errors 3 → 0; services
  now log clean graceful stop.
