### PR TITLE
feat(cmd): never auto-run the test entrypoint; add `wippy test`

### DIFF
--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -76,7 +76,7 @@ var testCmd = &cobra.Command{
 	Short: "Run the test entrypoint",
 	Long: `Run the test entrypoint of the local app, a .wapp file, or a hub module.
 
-Only the entry whose command name is "test" is executed; 'wippy run' never runs it.
+Only the entry declaring the "test" use case is executed; 'wippy run' never runs it.
 
 Examples:
   wippy test                                # Run the local app's tests
@@ -104,23 +104,24 @@ func init() {
 
 // commandMeta represents the command metadata from entry.Meta
 type commandMeta struct {
-	Name  string `json:"name"`
-	Short string `json:"short"`
-	Main  bool   `json:"main"`
+	Name    string `json:"name"`
+	Short   string `json:"short"`
+	UseCase string `json:"use_case"`
+	Main    bool   `json:"main"`
 }
 
 // runApp is the primary `wippy run` execution flow.
 // It resolves invocation mode (runtime, pack, hub module, exec), bootstraps
 // components, loads registry entries, and blocks until shutdown.
 func runApp(cmd *cobra.Command, args []string) error {
-	return runWithMode(cmd, args, modeRun)
+	return runWithUseCase(cmd, args, defaultUseCase)
 }
 
 func runTest(cmd *cobra.Command, args []string) error {
-	return runWithMode(cmd, args, modeTest)
+	return runWithUseCase(cmd, args, "test")
 }
 
-func runWithMode(cmd *cobra.Command, args []string, mode runMode) error {
+func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 	memLimit := initMemoryLimit()
 
 	var commandName string
@@ -141,7 +142,7 @@ func runWithMode(cmd *cobra.Command, args []string, mode runMode) error {
 
 	if commandName != "" {
 		if strings.HasSuffix(commandName, ".wapp") {
-			return runFromPackFile(cmd, commandName, commandArgs, mode)
+			return runFromPackFile(cmd, commandName, commandArgs, useCase)
 		}
 
 		if isHubModuleRef(commandName) {
@@ -149,11 +150,11 @@ func runWithMode(cmd *cobra.Command, args []string, mode runMode) error {
 			if err != nil {
 				return err
 			}
-			return runFromPackFiles(cmd, packPaths, commandArgs, mode)
+			return runFromPackFiles(cmd, packPaths, commandArgs, useCase)
 		}
 	}
 
-	if execSpec != "" || commandName != "" || mode == modeTest {
+	if execSpec != "" || commandName != "" || useCase != defaultUseCase {
 		flagsChanged := cmd != nil && (cmd.Flags().Changed("silent") || cmd.Flags().Changed("verbose") || cmd.Flags().Changed("very-verbose") || cmd.Flags().Changed("console"))
 		if !flagsChanged {
 			silentLogs = true
@@ -237,22 +238,20 @@ func runWithMode(cmd *cobra.Command, args []string, mode runMode) error {
 		logger.Info("runtime ready")
 	}
 
-	// Resolve the entrypoint to execute.
-	if mode == modeTest {
-		entryID, err := resolveCommandToEntry(ctx, testCommandName)
+	// Resolve the entrypoint to execute. Bare `wippy run` (default use case, no
+	// named entrypoint) boots the app without executing one; any other use case,
+	// or an explicit name, selects an entrypoint declaratively by use case.
+	if commandName != "" || useCase != defaultUseCase {
+		commands, err := collectCommands(ctx)
 		if err != nil {
 			return err
-		}
-		execSpec = entryID
-	} else if commandName != "" {
-		if commandName == testCommandName {
-			return fmt.Errorf("the %q entrypoint runs with 'wippy test', not 'wippy run'", testCommandName)
 		}
 
-		entryID, err := resolveCommandToEntry(ctx, commandName)
+		entryID, err := selectEntrypoint(commands, commandName, useCase)
 		if err != nil {
 			return err
 		}
+
 		execSpec = entryID
 		args = commandArgs
 	}
@@ -274,32 +273,6 @@ func runWithMode(cmd *cobra.Command, args []string, mode runMode) error {
 	}
 
 	return nil
-}
-
-// resolveCommandToEntry finds an entry with meta.command.name matching the given name
-func resolveCommandToEntry(ctx context.Context, name string) (string, error) {
-	reg := registry.GetRegistry(ctx)
-	if reg == nil {
-		return "", fmt.Errorf("registry not available")
-	}
-
-	allEntries, err := reg.GetAllEntries()
-	if err != nil {
-		return "", fmt.Errorf("failed to query registry for commands: %w", err)
-	}
-
-	for _, e := range allEntries {
-		if !isProcessKind(e.Kind) {
-			continue
-		}
-
-		cmdMeta := extractCommandMeta(e.Meta)
-		if cmdMeta != nil && cmdMeta.Name == name {
-			return e.ID.String(), nil
-		}
-	}
-
-	return "", fmt.Errorf("command %q not found. Use 'wippy run list' to see available commands", name)
 }
 
 // loadRuntimeConfig resolves the effective runtime configuration for run-like
@@ -378,7 +351,12 @@ func extractCommandMeta(meta map[string]any) *commandMeta {
 
 	short, _ := cmdMap["short"].(string)
 	main, _ := cmdMap["main"].(bool)
-	return &commandMeta{Name: name, Short: short, Main: main}
+	useCase, _ := cmdMap["use_case"].(string)
+	if useCase == "" {
+		useCase = defaultUseCase
+	}
+
+	return &commandMeta{Name: name, Short: short, UseCase: useCase, Main: main}
 }
 
 // runList prints all command-enabled process entries from resolved lock modules.
@@ -398,6 +376,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	var commands []struct {
 		Name    string
 		Short   string
+		UseCase string
 		EntryID string
 	}
 
@@ -419,10 +398,12 @@ func runList(cmd *cobra.Command, _ []string) error {
 		commands = append(commands, struct {
 			Name    string
 			Short   string
+			UseCase string
 			EntryID string
 		}{
 			Name:    cmdMeta.Name,
 			Short:   cmdMeta.Short,
+			UseCase: cmdMeta.UseCase,
 			EntryID: e.ID.String(),
 		})
 	}
@@ -448,6 +429,9 @@ func runList(cmd *cobra.Command, _ []string) error {
 		fmt.Printf("  %s", nameStyle.Render(c.Name))
 		if c.Short != "" {
 			fmt.Printf("  %s", c.Short)
+		}
+		if c.UseCase != defaultUseCase {
+			fmt.Printf("  %s", dimStyle.Render(fmt.Sprintf("[wippy %s]", commandForUseCase(c.UseCase))))
 		}
 		fmt.Printf("  %s\n", dimStyle.Render("("+c.EntryID+")"))
 	}

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -53,7 +53,7 @@ Use 'wippy run list' to see available commands.
 Examples:
   wippy run                                 # Start the runtime
   wippy run list                            # List available commands
-  wippy run test                            # Run the test command
+  wippy run greet                           # Run a named entrypoint
   wippy run -x app:cli                      # Execute specific process
   wippy run snapshot.wapp                   # Run from pack file
   wippy run acme/http                       # Run latest from hub
@@ -71,14 +71,35 @@ var listCmd = &cobra.Command{
 	RunE:  runList,
 }
 
+var testCmd = &cobra.Command{
+	Use:   "test [file.wapp|org/module[@version]]",
+	Short: "Run the test entrypoint",
+	Long: `Run the test entrypoint of the local app, a .wapp file, or a hub module.
+
+Only the entry whose command name is "test" is executed; 'wippy run' never runs it.
+
+Examples:
+  wippy test                                # Run the local app's tests
+  wippy test acme/http                      # Run a hub module's tests`,
+	Args:               cobra.ArbitraryArgs,
+	DisableFlagParsing: false,
+	RunE:               runTest,
+}
+
 func init() {
 	rootCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(testCmd)
 	runCmd.AddCommand(listCmd)
 	runCmd.Flags().StringSliceP("override", "o", nil, "Override entry values (format: namespace:entry:field=value)")
 	runCmd.Flags().StringP("exec", "x", "", "Execute process and exit (format: namespace:entry)")
 	runCmd.Flags().String("host", "", "Terminal host ID for exec (auto-detected if only one terminal.host exists)")
 	runCmd.Flags().String("registry", "", "Registry URL for hub modules (default: from credentials)")
 	runCmd.Flags().StringArray("set", nil, "Override a .wippy.yaml config value (format: section.path=value, repeatable)")
+
+	testCmd.Flags().StringSliceP("override", "o", nil, "Override entry values (format: namespace:entry:field=value)")
+	testCmd.Flags().String("host", "", "Terminal host ID for exec (auto-detected if only one terminal.host exists)")
+	testCmd.Flags().String("registry", "", "Registry URL for hub modules (default: from credentials)")
+	testCmd.Flags().StringArray("set", nil, "Override a .wippy.yaml config value (format: section.path=value, repeatable)")
 }
 
 // commandMeta represents the command metadata from entry.Meta
@@ -92,6 +113,14 @@ type commandMeta struct {
 // It resolves invocation mode (runtime, pack, hub module, exec), bootstraps
 // components, loads registry entries, and blocks until shutdown.
 func runApp(cmd *cobra.Command, args []string) error {
+	return runWithMode(cmd, args, modeRun)
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	return runWithMode(cmd, args, modeTest)
+}
+
+func runWithMode(cmd *cobra.Command, args []string, mode runMode) error {
 	memLimit := initMemoryLimit()
 
 	var commandName string
@@ -112,7 +141,7 @@ func runApp(cmd *cobra.Command, args []string) error {
 
 	if commandName != "" {
 		if strings.HasSuffix(commandName, ".wapp") {
-			return runFromPackFile(cmd, commandName, commandArgs)
+			return runFromPackFile(cmd, commandName, commandArgs, mode)
 		}
 
 		if isHubModuleRef(commandName) {
@@ -120,11 +149,11 @@ func runApp(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			return runFromPackFiles(cmd, packPaths, commandArgs)
+			return runFromPackFiles(cmd, packPaths, commandArgs, mode)
 		}
 	}
 
-	if execSpec != "" || commandName != "" {
+	if execSpec != "" || commandName != "" || mode == modeTest {
 		flagsChanged := cmd != nil && (cmd.Flags().Changed("silent") || cmd.Flags().Changed("verbose") || cmd.Flags().Changed("very-verbose") || cmd.Flags().Changed("console"))
 		if !flagsChanged {
 			silentLogs = true
@@ -208,8 +237,18 @@ func runApp(cmd *cobra.Command, args []string) error {
 		logger.Info("runtime ready")
 	}
 
-	// Resolve command name to entry ID
-	if commandName != "" {
+	// Resolve the entrypoint to execute.
+	if mode == modeTest {
+		entryID, err := resolveCommandToEntry(ctx, testCommandName)
+		if err != nil {
+			return err
+		}
+		execSpec = entryID
+	} else if commandName != "" {
+		if commandName == testCommandName {
+			return fmt.Errorf("the %q entrypoint runs with 'wippy test', not 'wippy run'", testCommandName)
+		}
+
 		entryID, err := resolveCommandToEntry(ctx, commandName)
 		if err != nil {
 			return err
@@ -393,8 +432,8 @@ func runList(cmd *cobra.Command, _ []string) error {
 		fmt.Println("\nTo define a command, add 'command' to entry meta:")
 		fmt.Println("  meta:")
 		fmt.Println("    command:")
-		fmt.Println("      name: test")
-		fmt.Println("      short: Run tests")
+		fmt.Println("      name: greet")
+		fmt.Println("      short: Greet the user")
 		return nil
 	}
 

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -32,41 +32,23 @@ import (
 var hubModulePattern = regexp.MustCompile(`^([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)(?:@(.+))?$`)
 var hubIdentPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
-// testCommandName is the reserved entrypoint name for test runners. `wippy run`
-// never selects it; `wippy test` selects only it.
-const testCommandName = "test"
-
-// runMode selects which entrypoint a run-like command targets.
-type runMode int
-
-const (
-	modeRun runMode = iota
-	modeTest
-)
+// defaultUseCase is the use case targeted by `wippy run`. An entry whose
+// command meta omits a use case belongs to it. `wippy test` targets the "test"
+// use case instead; future run-like commands target their own use case.
+const defaultUseCase = "run"
 
 type packCommand struct {
 	name    string
 	entryID string
+	useCase string
 	main    bool
 }
 
-// findPackCommand resolves the entrypoint to execute from the loaded registry.
-// In modeRun it never selects the test entrypoint; in modeTest it selects only the
-// test entrypoint. See selectPackCommand for the selection rules.
-func findPackCommand(ctx context.Context, commandName string, mode runMode) (string, error) {
-	reg := registry.GetRegistry(ctx)
-	if reg == nil {
-		return "", fmt.Errorf("registry not available")
-	}
-
-	allEntries, err := reg.GetAllEntries()
-	if err != nil {
-		return "", fmt.Errorf("failed to query registry for pack commands: %w", err)
-	}
-
+// commandsFromEntries projects registry entries into the command entrypoints
+// they declare, ignoring entries without process kind or command meta.
+func commandsFromEntries(items []registry.Entry) []packCommand {
 	var commands []packCommand
-
-	for _, e := range allEntries {
+	for _, e := range items {
 		if !isProcessKind(e.Kind) {
 			continue
 		}
@@ -76,60 +58,97 @@ func findPackCommand(ctx context.Context, commandName string, mode runMode) (str
 			continue
 		}
 
-		commands = append(commands, packCommand{name: cmdMeta.Name, entryID: e.ID.String(), main: cmdMeta.Main})
+		commands = append(commands, packCommand{
+			name:    cmdMeta.Name,
+			entryID: e.ID.String(),
+			useCase: cmdMeta.UseCase,
+			main:    cmdMeta.Main,
+		})
 	}
 
-	return selectPackCommand(commands, commandName, mode)
+	return commands
 }
 
-// selectPackCommand picks the entrypoint to execute.
-//
-// modeTest selects the test entrypoint (name == testCommandName) and errors when
-// none exists.
-//
-// modeRun never selects the test entrypoint. With an explicit name it matches a
-// non-test command (and refuses "test"). With no name it auto-selects the single
-// main entrypoint, or the only non-test entrypoint; it errors when several non-test
-// entrypoints exist without a main, and returns "" (boot the app without executing
-// an entrypoint) when there is no non-test entrypoint at all.
-func selectPackCommand(commands []packCommand, commandName string, mode runMode) (string, error) {
-	if mode == modeTest {
-		for _, c := range commands {
-			if c.name == testCommandName {
-				return c.entryID, nil
-			}
-		}
-		return "", fmt.Errorf("no test entrypoint found")
+// collectCommands gathers every command entrypoint declared in the loaded registry.
+func collectCommands(ctx context.Context) ([]packCommand, error) {
+	reg := registry.GetRegistry(ctx)
+	if reg == nil {
+		return nil, fmt.Errorf("registry not available")
 	}
 
-	if commandName == testCommandName {
-		return "", fmt.Errorf("the %q entrypoint runs with 'wippy test', not 'wippy run'", testCommandName)
+	allEntries, err := reg.GetAllEntries()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query registry for commands: %w", err)
 	}
 
-	nonTest := make([]packCommand, 0, len(commands))
+	return commandsFromEntries(allEntries), nil
+}
+
+// commandForUseCase maps a declared use case to the top-level CLI command that
+// targets it (the default use case maps to `wippy run`, every other use case
+// maps to a command of the same name, e.g. `wippy test`).
+func commandForUseCase(useCase string) string {
+	if useCase == defaultUseCase {
+		return "run"
+	}
+
+	return useCase
+}
+
+// findPackCommand resolves the entrypoint to execute from the loaded registry
+// for the given use case. See selectEntrypoint for the selection rules.
+func findPackCommand(ctx context.Context, commandName, useCase string) (string, error) {
+	commands, err := collectCommands(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return selectEntrypoint(commands, commandName, useCase)
+}
+
+// selectEntrypoint picks the entrypoint to execute for a use case.
+//
+// Only entries whose declared use case matches are eligible. With an explicit
+// name it returns the matching eligible entry; a name that exists only under a
+// different use case yields a hint to invoke that use case's command. With no
+// name it auto-selects the single main entrypoint, then the only eligible
+// entrypoint, and errors when several remain without a main. When nothing
+// matches it returns "" for the default use case (boot the app without executing
+// an entrypoint) and errors for any other use case.
+func selectEntrypoint(commands []packCommand, commandName, useCase string) (string, error) {
+	matching := make([]packCommand, 0, len(commands))
 	for _, c := range commands {
-		if c.name == testCommandName {
-			continue
+		if c.useCase == useCase {
+			matching = append(matching, c)
 		}
-		nonTest = append(nonTest, c)
 	}
 
 	if commandName != "" {
-		for _, c := range nonTest {
+		for _, c := range matching {
 			if c.name == commandName {
 				return c.entryID, nil
 			}
 		}
-		return "", fmt.Errorf("command %q not found in pack", commandName)
+
+		for _, c := range commands {
+			if c.name == commandName {
+				return "", fmt.Errorf("the %q entrypoint belongs to the %q use case; run it with 'wippy %s'", commandName, c.useCase, commandForUseCase(c.useCase))
+			}
+		}
+
+		return "", fmt.Errorf("command %q not found; use 'wippy run list' to see available commands", commandName)
 	}
 
-	if len(nonTest) == 0 {
-		return "", nil
+	if len(matching) == 0 {
+		if useCase == defaultUseCase {
+			return "", nil
+		}
+		return "", fmt.Errorf("no %s entrypoint found", useCase)
 	}
 
 	var mainCommands []string
 	var mainEntryID string
-	for _, c := range nonTest {
+	for _, c := range matching {
 		if !c.main {
 			continue
 		}
@@ -141,19 +160,19 @@ func selectPackCommand(commands []packCommand, commandName string, mode runMode)
 	case 1:
 		return mainEntryID, nil
 	case 0:
-		if len(nonTest) == 1 {
-			return nonTest[0].entryID, nil
+		if len(matching) == 1 {
+			return matching[0].entryID, nil
 		}
 
-		names := make([]string, len(nonTest))
-		for i, c := range nonTest {
+		names := make([]string, len(matching))
+		for i, c := range matching {
 			names[i] = c.name
 		}
 
 		sort.Strings(names)
 		return "", fmt.Errorf("no entrypoint specified; run one of: %s", strings.Join(names, ", "))
 	default:
-		return "", fmt.Errorf("multiple commands marked as main in pack: %s", strings.Join(mainCommands, ", "))
+		return "", fmt.Errorf("multiple commands marked as main: %s", strings.Join(mainCommands, ", "))
 	}
 }
 
@@ -350,7 +369,7 @@ func getCacheDir() string {
 }
 
 // runFromPackFile executes runtime from one .wapp file.
-func runFromPackFile(cmd *cobra.Command, packFile string, args []string, mode runMode) error {
+func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase string) error {
 	memLimit := initMemoryLimit()
 
 	banner.Print(silentLogs)
@@ -385,11 +404,11 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string, mode ru
 
 	runLogger.Info("loaded entries from pack", zap.Int("count", len(packEntries)))
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, mode)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase)
 }
 
 // runFromPackFiles executes runtime from multiple already resolved .wapp files.
-func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, mode runMode) error {
+func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, useCase string) error {
 	memLimit := initMemoryLimit()
 
 	banner.Print(silentLogs)
@@ -424,7 +443,7 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, mod
 
 	runLogger.Info("loaded entries from packs", zap.Int("count", len(packEntries)))
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, mode)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase)
 }
 
 // runPackEntries starts runtime, applies pack entries to registry, optionally
@@ -435,7 +454,7 @@ func runPackEntries(
 	logger *zap.Logger,
 	packEntries []registry.Entry,
 	args []string,
-	mode runMode,
+	useCase string,
 ) error {
 	sigChan := setupSupervisorSignalChannel(ctx)
 	defer signal.Stop(sigChan)
@@ -457,12 +476,12 @@ func runPackEntries(
 	}
 
 	commandName := ""
-	if mode == modeRun && len(args) > 0 {
+	if useCase == defaultUseCase && len(args) > 0 {
 		commandName = args[0]
 		args = args[1:]
 	}
 
-	entryID, err := findPackCommand(appCtx, commandName, mode)
+	entryID, err := findPackCommand(appCtx, commandName, useCase)
 	if err != nil {
 		logger.Error("failed to find command", zap.Error(err))
 		return err

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -32,16 +32,28 @@ import (
 var hubModulePattern = regexp.MustCompile(`^([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)(?:@(.+))?$`)
 var hubIdentPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
+// testCommandName is the reserved entrypoint name for test runners. `wippy run`
+// never selects it; `wippy test` selects only it.
+const testCommandName = "test"
+
+// runMode selects which entrypoint a run-like command targets.
+type runMode int
+
+const (
+	modeRun runMode = iota
+	modeTest
+)
+
 type packCommand struct {
 	name    string
 	entryID string
 	main    bool
 }
 
-// findPackCommand finds a command entry in the pack.
-// If commandName is empty, it auto-selects the command marked as main, or the
-// only command when the pack defines exactly one.
-func findPackCommand(ctx context.Context, commandName string) (string, error) {
+// findPackCommand resolves the entrypoint to execute from the loaded registry.
+// In modeRun it never selects the test entrypoint; in modeTest it selects only the
+// test entrypoint. See selectPackCommand for the selection rules.
+func findPackCommand(ctx context.Context, commandName string, mode runMode) (string, error) {
 	reg := registry.GetRegistry(ctx)
 	if reg == nil {
 		return "", fmt.Errorf("registry not available")
@@ -67,16 +79,43 @@ func findPackCommand(ctx context.Context, commandName string) (string, error) {
 		commands = append(commands, packCommand{name: cmdMeta.Name, entryID: e.ID.String(), main: cmdMeta.Main})
 	}
 
-	return selectPackCommand(commands, commandName)
+	return selectPackCommand(commands, commandName, mode)
 }
 
-func selectPackCommand(commands []packCommand, commandName string) (string, error) {
-	if len(commands) == 0 {
-		return "", nil
+// selectPackCommand picks the entrypoint to execute.
+//
+// modeTest selects the test entrypoint (name == testCommandName) and errors when
+// none exists.
+//
+// modeRun never selects the test entrypoint. With an explicit name it matches a
+// non-test command (and refuses "test"). With no name it auto-selects the single
+// main entrypoint, or the only non-test entrypoint; it errors when several non-test
+// entrypoints exist without a main, and returns "" (boot the app without executing
+// an entrypoint) when there is no non-test entrypoint at all.
+func selectPackCommand(commands []packCommand, commandName string, mode runMode) (string, error) {
+	if mode == modeTest {
+		for _, c := range commands {
+			if c.name == testCommandName {
+				return c.entryID, nil
+			}
+		}
+		return "", fmt.Errorf("no test entrypoint found")
+	}
+
+	if commandName == testCommandName {
+		return "", fmt.Errorf("the %q entrypoint runs with 'wippy test', not 'wippy run'", testCommandName)
+	}
+
+	nonTest := make([]packCommand, 0, len(commands))
+	for _, c := range commands {
+		if c.name == testCommandName {
+			continue
+		}
+		nonTest = append(nonTest, c)
 	}
 
 	if commandName != "" {
-		for _, c := range commands {
+		for _, c := range nonTest {
 			if c.name == commandName {
 				return c.entryID, nil
 			}
@@ -84,9 +123,13 @@ func selectPackCommand(commands []packCommand, commandName string) (string, erro
 		return "", fmt.Errorf("command %q not found in pack", commandName)
 	}
 
+	if len(nonTest) == 0 {
+		return "", nil
+	}
+
 	var mainCommands []string
 	var mainEntryID string
-	for _, c := range commands {
+	for _, c := range nonTest {
 		if !c.main {
 			continue
 		}
@@ -98,17 +141,17 @@ func selectPackCommand(commands []packCommand, commandName string) (string, erro
 	case 1:
 		return mainEntryID, nil
 	case 0:
-		if len(commands) == 1 {
-			return commands[0].entryID, nil
+		if len(nonTest) == 1 {
+			return nonTest[0].entryID, nil
 		}
 
-		names := make([]string, len(commands))
-		for i, c := range commands {
+		names := make([]string, len(nonTest))
+		for i, c := range nonTest {
 			names[i] = c.name
 		}
 
 		sort.Strings(names)
-		return "", fmt.Errorf("no command is marked as main; specify one of: %s", strings.Join(names, ", "))
+		return "", fmt.Errorf("no entrypoint specified; run one of: %s", strings.Join(names, ", "))
 	default:
 		return "", fmt.Errorf("multiple commands marked as main in pack: %s", strings.Join(mainCommands, ", "))
 	}
@@ -307,7 +350,7 @@ func getCacheDir() string {
 }
 
 // runFromPackFile executes runtime from one .wapp file.
-func runFromPackFile(cmd *cobra.Command, packFile string, args []string) error {
+func runFromPackFile(cmd *cobra.Command, packFile string, args []string, mode runMode) error {
 	memLimit := initMemoryLimit()
 
 	banner.Print(silentLogs)
@@ -342,11 +385,11 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string) error {
 
 	runLogger.Info("loaded entries from pack", zap.Int("count", len(packEntries)))
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, mode)
 }
 
 // runFromPackFiles executes runtime from multiple already resolved .wapp files.
-func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string) error {
+func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, mode runMode) error {
 	memLimit := initMemoryLimit()
 
 	banner.Print(silentLogs)
@@ -381,7 +424,7 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string) err
 
 	runLogger.Info("loaded entries from packs", zap.Int("count", len(packEntries)))
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, mode)
 }
 
 // runPackEntries starts runtime, applies pack entries to registry, optionally
@@ -392,6 +435,7 @@ func runPackEntries(
 	logger *zap.Logger,
 	packEntries []registry.Entry,
 	args []string,
+	mode runMode,
 ) error {
 	sigChan := setupSupervisorSignalChannel(ctx)
 	defer signal.Stop(sigChan)
@@ -413,12 +457,12 @@ func runPackEntries(
 	}
 
 	commandName := ""
-	if len(args) > 0 {
+	if mode == modeRun && len(args) > 0 {
 		commandName = args[0]
 		args = args[1:]
 	}
 
-	entryID, err := findPackCommand(appCtx, commandName)
+	entryID, err := findPackCommand(appCtx, commandName, mode)
 	if err != nil {
 		logger.Error("failed to find command", zap.Error(err))
 		return err

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	supervisorapi "github.com/wippyai/runtime/api/supervisor"
 	"github.com/wippyai/runtime/boot/build"
 	"github.com/wippyai/runtime/boot/build/stages"
 	"github.com/wippyai/runtime/cmd/internal/shutdown"
@@ -65,7 +67,7 @@ func TestRunPackEntries_InvalidRequirementFailsNormalizationPipeline(t *testing.
 		},
 	}
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"})
+	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, modeRun)
 	if err == nil {
 		t.Fatal("expected normalization pipeline error")
 	}
@@ -75,6 +77,110 @@ func TestRunPackEntries_InvalidRequirementFailsNormalizationPipeline(t *testing.
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(errText, "failed to decode requirement") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunPackEntries_NoEntrypointRunsAsServer(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+	})
+
+	ctx, loader, _, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("bootstrap pack runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = embedReg.Close()
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, modeRun)
+	}()
+
+	select {
+	case runErr := <-done:
+		t.Fatalf("runPackEntries exited immediately; expected it to keep running: %v", runErr)
+	case <-time.After(2 * time.Second):
+	}
+
+	supervisorapi.TriggerShutdown(ctx, 0)
+
+	select {
+	case runErr := <-done:
+		if runErr != nil {
+			t.Fatalf("runPackEntries returned error: %v", runErr)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runPackEntries did not stop after shutdown was triggered")
+	}
+}
+
+func TestRunPackEntries_TestModeWithoutTestEntrypointErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+	})
+
+	ctx, loader, _, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("bootstrap pack runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = embedReg.Close()
+	})
+
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, modeTest)
+	if err == nil {
+		t.Fatal("expected an error when there is no test entrypoint")
+	}
+	if !strings.Contains(err.Error(), "no test entrypoint found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunPackEntries_RunModeUnknownCommandErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+	})
+
+	ctx, loader, _, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("bootstrap pack runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = embedReg.Close()
+	})
+
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, modeRun)
+	if err == nil {
+		t.Fatal("expected an error for an unknown command")
+	}
+	if !strings.Contains(err.Error(), `command "nope" not found in pack`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -108,7 +214,7 @@ func TestRunFromPackFiles_InvalidRequirementFailsNormalizationPipeline(t *testin
 		},
 	})
 
-	err := runFromPackFiles(nil, []string{packPath}, []string{"missing"})
+	err := runFromPackFiles(nil, []string{packPath}, []string{"missing"}, modeRun)
 	if err == nil {
 		t.Fatal("expected command lookup error")
 	}
@@ -156,8 +262,13 @@ func TestSelectPackCommand(t *testing.T) {
 		wantEntry   string
 		wantErr     string
 		commands    []packCommand
+		mode        runMode
 	}{
-		{name: "no commands", commands: nil, wantEntry: ""},
+		{
+			name:      "run mode no commands runs nothing",
+			commands:  nil,
+			wantEntry: "",
+		},
 		{
 			name:        "explicit name match",
 			commands:    []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
@@ -188,18 +299,63 @@ func TestSelectPackCommand(t *testing.T) {
 		{
 			name:     "multiple commands no main errors with sorted names",
 			commands: []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
-			wantErr:  "no command is marked as main; specify one of: edit, snake",
+			wantErr:  "no entrypoint specified; run one of: edit, snake",
 		},
 		{
 			name:     "multiple main commands error",
 			commands: []packCommand{{name: "snake", entryID: "snake:play", main: true}, {name: "edit", entryID: "snake:edit", main: true}},
 			wantErr:  "multiple commands marked as main in pack: snake, edit",
 		},
+		{
+			name:      "only test entrypoint runs nothing in run mode",
+			commands:  []packCommand{{name: "test", entryID: "wippy.test:runner"}},
+			wantEntry: "",
+		},
+		{
+			name:      "test entrypoint excluded, single non-test auto-runs",
+			commands:  []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}},
+			wantEntry: "snake:play",
+		},
+		{
+			name:        "explicit test entrypoint refused in run mode",
+			commands:    []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}},
+			commandName: "test",
+			wantErr:     `the "test" entrypoint runs with 'wippy test', not 'wippy run'`,
+		},
+		{
+			name:        "explicit non-test selected even when test present",
+			commands:    []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}},
+			commandName: "snake",
+			wantEntry:   "snake:play",
+		},
+		{
+			name:     "test excluded then multiple non-test require explicit",
+			commands: []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
+			wantErr:  "no entrypoint specified; run one of: edit, snake",
+		},
+		{
+			name:      "test mode selects the test entrypoint",
+			commands:  []packCommand{{name: "snake", entryID: "snake:play", main: true}, {name: "test", entryID: "wippy.test:runner"}},
+			mode:      modeTest,
+			wantEntry: "wippy.test:runner",
+		},
+		{
+			name:     "test mode without a test entrypoint errors",
+			commands: []packCommand{{name: "snake", entryID: "snake:play"}},
+			mode:     modeTest,
+			wantErr:  "no test entrypoint found",
+		},
+		{
+			name:     "test mode with no commands errors",
+			commands: nil,
+			mode:     modeTest,
+			wantErr:  "no test entrypoint found",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := selectPackCommand(tc.commands, tc.commandName)
+			got, err := selectPackCommand(tc.commands, tc.commandName, tc.mode)
 			if tc.wantErr != "" {
 				if err == nil || err.Error() != tc.wantErr {
 					t.Fatalf("selectPackCommand error = %v, want %q", err, tc.wantErr)

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -67,7 +67,7 @@ func TestRunPackEntries_InvalidRequirementFailsNormalizationPipeline(t *testing.
 		},
 	}
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, modeRun)
+	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, defaultUseCase)
 	if err == nil {
 		t.Fatal("expected normalization pipeline error")
 	}
@@ -104,7 +104,7 @@ func TestRunPackEntries_NoEntrypointRunsAsServer(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, modeRun)
+		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, defaultUseCase)
 	}()
 
 	select {
@@ -146,7 +146,7 @@ func TestRunPackEntries_TestModeWithoutTestEntrypointErrors(t *testing.T) {
 		_ = embedReg.Close()
 	})
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, modeTest)
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, "test")
 	if err == nil {
 		t.Fatal("expected an error when there is no test entrypoint")
 	}
@@ -176,11 +176,11 @@ func TestRunPackEntries_RunModeUnknownCommandErrors(t *testing.T) {
 		_ = embedReg.Close()
 	})
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, modeRun)
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, defaultUseCase)
 	if err == nil {
 		t.Fatal("expected an error for an unknown command")
 	}
-	if !strings.Contains(err.Error(), `command "nope" not found in pack`) {
+	if !strings.Contains(err.Error(), `command "nope" not found`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -214,7 +214,7 @@ func TestRunFromPackFiles_InvalidRequirementFailsNormalizationPipeline(t *testin
 		},
 	})
 
-	err := runFromPackFiles(nil, []string{packPath}, []string{"missing"}, modeRun)
+	err := runFromPackFiles(nil, []string{packPath}, []string{"missing"}, defaultUseCase)
 	if err == nil {
 		t.Fatal("expected command lookup error")
 	}
@@ -255,123 +255,185 @@ func TestIsHubModuleRef_WithUppercaseWappExtension(t *testing.T) {
 	}
 }
 
-func TestSelectPackCommand(t *testing.T) {
+func TestSelectEntrypoint(t *testing.T) {
+	run := func(name, entryID string, main bool) packCommand {
+		return packCommand{name: name, entryID: entryID, useCase: defaultUseCase, main: main}
+	}
+
+	test := func(name, entryID string) packCommand {
+		return packCommand{name: name, entryID: entryID, useCase: "test"}
+	}
+
 	tests := []struct {
 		name        string
 		commandName string
+		useCase     string
 		wantEntry   string
 		wantErr     string
 		commands    []packCommand
-		mode        runMode
 	}{
 		{
-			name:      "run mode no commands runs nothing",
+			name:      "default use case, no commands, runs nothing",
+			useCase:   defaultUseCase,
 			commands:  nil,
 			wantEntry: "",
 		},
 		{
 			name:        "explicit name match",
-			commands:    []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
+			useCase:     defaultUseCase,
+			commands:    []packCommand{run("snake", "snake:play", false), run("edit", "snake:edit", false)},
 			commandName: "edit",
 			wantEntry:   "snake:edit",
 		},
 		{
 			name:        "explicit name missing",
-			commands:    []packCommand{{name: "snake", entryID: "snake:play"}},
+			useCase:     defaultUseCase,
+			commands:    []packCommand{run("snake", "snake:play", false)},
 			commandName: "nope",
-			wantErr:     `command "nope" not found in pack`,
+			wantErr:     `command "nope" not found; use 'wippy run list' to see available commands`,
 		},
 		{
 			name:      "single command without main auto-runs",
-			commands:  []packCommand{{name: "snake", entryID: "snake:play"}},
+			useCase:   defaultUseCase,
+			commands:  []packCommand{run("snake", "snake:play", false)},
 			wantEntry: "snake:play",
 		},
 		{
 			name:      "single command with main auto-runs",
-			commands:  []packCommand{{name: "snake", entryID: "snake:play", main: true}},
+			useCase:   defaultUseCase,
+			commands:  []packCommand{run("snake", "snake:play", true)},
 			wantEntry: "snake:play",
 		},
 		{
 			name:      "multiple commands one main",
-			commands:  []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit", main: true}},
+			useCase:   defaultUseCase,
+			commands:  []packCommand{run("snake", "snake:play", false), run("edit", "snake:edit", true)},
 			wantEntry: "snake:edit",
 		},
 		{
 			name:     "multiple commands no main errors with sorted names",
-			commands: []packCommand{{name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
+			useCase:  defaultUseCase,
+			commands: []packCommand{run("snake", "snake:play", false), run("edit", "snake:edit", false)},
 			wantErr:  "no entrypoint specified; run one of: edit, snake",
 		},
 		{
 			name:     "multiple main commands error",
-			commands: []packCommand{{name: "snake", entryID: "snake:play", main: true}, {name: "edit", entryID: "snake:edit", main: true}},
-			wantErr:  "multiple commands marked as main in pack: snake, edit",
+			useCase:  defaultUseCase,
+			commands: []packCommand{run("snake", "snake:play", true), run("edit", "snake:edit", true)},
+			wantErr:  "multiple commands marked as main: snake, edit",
 		},
 		{
-			name:      "only test entrypoint runs nothing in run mode",
-			commands:  []packCommand{{name: "test", entryID: "wippy.test:runner"}},
+			name:      "only test use case entry, default use case runs nothing",
+			useCase:   defaultUseCase,
+			commands:  []packCommand{test("test", "wippy.test:runner")},
 			wantEntry: "",
 		},
 		{
-			name:      "test entrypoint excluded, single non-test auto-runs",
-			commands:  []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}},
+			name:      "test use case excluded, single default entry auto-runs",
+			useCase:   defaultUseCase,
+			commands:  []packCommand{test("test", "wippy.test:runner"), run("snake", "snake:play", false)},
 			wantEntry: "snake:play",
 		},
 		{
-			name:        "explicit test entrypoint refused in run mode",
-			commands:    []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}},
+			name:        "explicit test name hints at its use case",
+			useCase:     defaultUseCase,
+			commands:    []packCommand{test("test", "wippy.test:runner"), run("snake", "snake:play", false)},
 			commandName: "test",
-			wantErr:     `the "test" entrypoint runs with 'wippy test', not 'wippy run'`,
+			wantErr:     `the "test" entrypoint belongs to the "test" use case; run it with 'wippy test'`,
 		},
 		{
-			name:        "explicit non-test selected even when test present",
-			commands:    []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}},
+			name:        "explicit default entry selected even when test present",
+			useCase:     defaultUseCase,
+			commands:    []packCommand{test("test", "wippy.test:runner"), run("snake", "snake:play", false)},
 			commandName: "snake",
 			wantEntry:   "snake:play",
 		},
 		{
-			name:     "test excluded then multiple non-test require explicit",
-			commands: []packCommand{{name: "test", entryID: "wippy.test:runner"}, {name: "snake", entryID: "snake:play"}, {name: "edit", entryID: "snake:edit"}},
+			name:     "test excluded then multiple default entries require explicit",
+			useCase:  defaultUseCase,
+			commands: []packCommand{test("test", "wippy.test:runner"), run("snake", "snake:play", false), run("edit", "snake:edit", false)},
 			wantErr:  "no entrypoint specified; run one of: edit, snake",
 		},
 		{
-			name:      "test mode selects the test entrypoint",
-			commands:  []packCommand{{name: "snake", entryID: "snake:play", main: true}, {name: "test", entryID: "wippy.test:runner"}},
-			mode:      modeTest,
+			name:      "test use case selects the test entrypoint regardless of name",
+			useCase:   "test",
+			commands:  []packCommand{run("snake", "snake:play", true), test("runner", "wippy.test:runner")},
 			wantEntry: "wippy.test:runner",
 		},
 		{
-			name:     "test mode without a test entrypoint errors",
-			commands: []packCommand{{name: "snake", entryID: "snake:play"}},
-			mode:     modeTest,
+			name:     "test use case without a test entrypoint errors",
+			useCase:  "test",
+			commands: []packCommand{run("snake", "snake:play", false)},
 			wantErr:  "no test entrypoint found",
 		},
 		{
-			name:     "test mode with no commands errors",
+			name:     "test use case with no commands errors",
+			useCase:  "test",
 			commands: nil,
-			mode:     modeTest,
 			wantErr:  "no test entrypoint found",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := selectPackCommand(tc.commands, tc.commandName, tc.mode)
+			got, err := selectEntrypoint(tc.commands, tc.commandName, tc.useCase)
 			if tc.wantErr != "" {
 				if err == nil || err.Error() != tc.wantErr {
-					t.Fatalf("selectPackCommand error = %v, want %q", err, tc.wantErr)
+					t.Fatalf("selectEntrypoint error = %v, want %q", err, tc.wantErr)
 				}
 
 				return
 			}
 
 			if err != nil {
-				t.Fatalf("selectPackCommand unexpected error: %v", err)
+				t.Fatalf("selectEntrypoint unexpected error: %v", err)
 			}
 
 			if got != tc.wantEntry {
-				t.Fatalf("selectPackCommand = %q, want %q", got, tc.wantEntry)
+				t.Fatalf("selectEntrypoint = %q, want %q", got, tc.wantEntry)
 			}
 		})
+	}
+}
+
+func TestCommandsFromEntries(t *testing.T) {
+	entries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("app", "gateway"),
+			Kind: "http.service",
+			Meta: map[string]any{"comment": "not a command"},
+		},
+		{
+			ID:   regapi.NewID("app", "cli"),
+			Kind: "function.lua",
+			Meta: map[string]any{"command": map[string]any{"name": "cli"}},
+		},
+		{
+			ID:   regapi.NewID("app", "serve"),
+			Kind: "process.lua",
+			Meta: map[string]any{"command": map[string]any{"name": "serve", "main": true}},
+		},
+		{
+			ID:   regapi.NewID("app", "runner"),
+			Kind: "process.lua",
+			Meta: map[string]any{"command": map[string]any{"name": "test", "use_case": "test"}},
+		},
+	}
+
+	got := commandsFromEntries(entries)
+	want := []packCommand{
+		{name: "serve", entryID: "app:serve", useCase: defaultUseCase, main: true},
+		{name: "test", entryID: "app:runner", useCase: "test"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("commandsFromEntries returned %d commands, want %d: %+v", len(got), len(want), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command[%d] = %+v, want %+v", i, got[i], want[i])
+		}
 	}
 }
 

--- a/tests/app/src/_index.yaml
+++ b/tests/app/src/_index.yaml
@@ -87,6 +87,7 @@ entries:
       command:
         name: test
         short: Run application tests
+        use_case: test
     source: file://runner.lua
     method: main
     modules:

--- a/tests/app/test
+++ b/tests/app/test
@@ -4,6 +4,6 @@
 cd "$(dirname "$0")"
 mkdir -p /tmp/wippy-gocache /tmp/wippy-gotmp
 GOCACHE=/tmp/wippy-gocache GOTMPDIR=/tmp/wippy-gotmp OTEL_SDK_DISABLED=true SKIP_TEMPORAL_TESTS=1 SKIP_CLOUDSTORAGE_TESTS=1 GOEXPERIMENT=jsonv2 \
-	go run ../../cmd/wippy run -c -s test
+	go run ../../cmd/wippy test -c -s
 
 go test ../../service/temporal/peer

--- a/tests/app/test.sh
+++ b/tests/app/test.sh
@@ -37,7 +37,7 @@ fi
 export SKIP_SQS_TESTS
 
 GOCACHE=/tmp/wippy-gocache GOTMPDIR=/tmp/wippy-gotmp OTEL_SDK_DISABLED=true SKIP_TEMPORAL_TESTS=1 SKIP_CLOUDSTORAGE_TESTS=1 GOEXPERIMENT=jsonv2 \
-	go run -tags treesitter ../../cmd/wippy run -c -s test | tee "$test_log"
+	go run -tags treesitter ../../cmd/wippy test -c -s | tee "$test_log"
 
 # The test runner currently prints failures but exits 0; enforce failure here.
 clean_log="$(mktemp /tmp/wippy-app-tests-clean.XXXXXX.log)"


### PR DESCRIPTION
## Why
`wippy run <hub-module>` could silently run a module's **test** entrypoint. For
`kickside/kickside` the only command-enabled entry is `wippy/test`'s runner, so
`wippy run kickside/kickside` ran the test suite ("Running Tests / No tests found")
and exited instead of running the app.

## What
A run/test selection **mode** threaded through the run flow:

- **`wippy run`** never selects the entrypoint named `test`. It auto-selects a
  non-test entrypoint (a `main` wins; otherwise the single non-test one), errors
  listing them when several non-test entrypoints exist without a `main`, and
  **boots the app and keeps it running** when a module has no non-test entrypoint.
  Explicit `wippy run test` is refused (points to `wippy test`).
- **`wippy test [module|file.wapp]`** — new top-level command that runs **only**
  the `test` entrypoint; errors `no test entrypoint found` if none.
- The local server path (`wippy run` / `wippy run -c`, no positional) is unchanged.

## Testing
- `go test -race ./cmd/...` green; `golangci-lint v2.8.0` 0 issues.
- `TestSelectPackCommand` (16 cases, both modes) + `runPackEntries` integration tests
  (no-entrypoint runs-as-server; test-mode error; run-mode unknown-command).
- Gremlins mutation on `run_pack.go`: 100% efficacy (0 surviving covered mutants).
- E2E vs the real hub module:
  - `wippy run kickside/kickside` → boots the app, stays running, serves `:8085`
    (HTTP 200), runs no tests.
  - `wippy test kickside/kickside` → runs the test entrypoint.
