### PR TITLE
feat(auth): runtime hub token override with no-restart Lua push

### DIFF
--- a/boot/deps/auth/runtime.go
+++ b/boot/deps/auth/runtime.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package auth
+
+import "sync"
+
+var (
+	runtimeMu     sync.RWMutex
+	runtimeTokens = map[string]string{}
+)
+
+func SetRuntimeToken(registry, token string) {
+	runtimeMu.Lock()
+	runtimeTokens[registry] = token
+	runtimeMu.Unlock()
+}
+
+func ClearRuntimeToken(registry string) {
+	runtimeMu.Lock()
+	delete(runtimeTokens, registry)
+	runtimeMu.Unlock()
+}
+
+func runtimeToken(registry string) string {
+	runtimeMu.RLock()
+	defer runtimeMu.RUnlock()
+
+	return runtimeTokens[registry]
+}

--- a/boot/deps/auth/runtime_test.go
+++ b/boot/deps/auth/runtime_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package auth
+
+import (
+	"sync"
+	"testing"
+
+	authapi "github.com/wippyai/runtime/api/auth"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeToken_OverridesFile(t *testing.T) {
+	store, _ := newTestStore(t)
+	reg := "https://override-file.example.com"
+
+	require.NoError(t, store.Set(&authapi.Credential{Token: "wpy_filetoken1234567890", Registry: reg}, false))
+
+	SetRuntimeToken(reg, "wpy_runtimetoken123456789")
+	t.Cleanup(func() { ClearRuntimeToken(reg) })
+
+	got, err := store.Get(reg)
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_runtimetoken123456789", got.Token)
+	assert.Equal(t, reg, got.Registry)
+}
+
+func TestRuntimeToken_BeatsEnv(t *testing.T) {
+	store, _ := newTestStore(t)
+	reg := "https://override-env.example.com"
+
+	t.Setenv(EnvToken, "wpy_envtoken123456789012")
+
+	SetRuntimeToken(reg, "wpy_runtimetoken123456789")
+	t.Cleanup(func() { ClearRuntimeToken(reg) })
+
+	got, err := store.Get(reg)
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_runtimetoken123456789", got.Token)
+}
+
+func TestRuntimeToken_PerRegistry(t *testing.T) {
+	store, _ := newTestStore(t)
+	regA := "https://a.example.com"
+	regB := "https://b.example.com"
+
+	SetRuntimeToken(regA, "wpy_tokenA12345678901234")
+	t.Cleanup(func() { ClearRuntimeToken(regA) })
+
+	got, err := store.Get(regA)
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_tokenA12345678901234", got.Token)
+
+	_, err = store.Get(regB)
+	assert.Equal(t, authapi.ErrNotAuthenticated, err)
+}
+
+func TestRuntimeToken_GetEmptyResolvesToDefaultKey(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	SetRuntimeToken(store.DefaultRegistry(), "wpy_defaulttoken12345678")
+	t.Cleanup(func() { ClearRuntimeToken(store.DefaultRegistry()) })
+
+	got, err := store.Get(DefaultRegistry)
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_defaulttoken12345678", got.Token)
+
+	got, err = store.Get("")
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_defaulttoken12345678", got.Token)
+}
+
+func TestRuntimeToken_Clear(t *testing.T) {
+	store, _ := newTestStore(t)
+	reg := "https://clear.example.com"
+
+	SetRuntimeToken(reg, "wpy_cleartoken1234567890")
+	got, err := store.Get(reg)
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_cleartoken1234567890", got.Token)
+
+	ClearRuntimeToken(reg)
+
+	_, err = store.Get(reg)
+	assert.Equal(t, authapi.ErrNotAuthenticated, err)
+}
+
+func TestRuntimeToken_Concurrent(t *testing.T) {
+	reg := "https://concurrent.example.com"
+	t.Cleanup(func() { ClearRuntimeToken(reg) })
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+			SetRuntimeToken(reg, "wpy_concurrenttoken12345")
+		}()
+
+		go func() {
+			defer wg.Done()
+			_ = runtimeToken(reg)
+		}()
+
+		go func() {
+			defer wg.Done()
+			ClearRuntimeToken(reg)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/boot/deps/auth/store.go
+++ b/boot/deps/auth/store.go
@@ -77,6 +77,13 @@ func (s *Store) Get(registry string) (*auth.Credential, error) {
 		registry = s.DefaultRegistry()
 	}
 
+	if token := runtimeToken(registry); token != "" {
+		return &auth.Credential{
+			Token:    token,
+			Registry: registry,
+		}, nil
+	}
+
 	// Environment override
 	if token := TokenFromEnv(); token != "" {
 		return &auth.Credential{

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1063,6 +1064,8 @@ var (
 	ErrDependencyNoContent            = apierror.New(apierror.NotFound, "no download URL available").WithRetryable(apierror.False)
 )
 
+const registryAuthHint = "registry authentication required: start the process with WIPPY_TOKEN set, push a token at runtime via hub.auth.set_token, or run `wippy auth login`"
+
 func NewDependencyEntryInvalidError(entryID, detail, component string) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid dependency entry").
 		WithDetails(attrs.NewBagFrom(map[string]any{
@@ -1095,21 +1098,30 @@ func NewDependencyResolutionError(cause error) apierror.Error {
 
 func NewDependencyResolutionErrors(errs []ResolutionError) apierror.Error {
 	details := make([]map[string]any, 0, len(errs))
+	unauthenticated := false
 	for _, e := range errs {
 		details = append(details, map[string]any{
 			"module":     e.Org + "/" + e.Name,
 			"constraint": e.Constraint,
 			"message":    e.Message,
 		})
+		if errors.Is(e.Err, ErrNotAuthenticated) {
+			unauthenticated = true
+		}
+	}
+
+	bag := map[string]any{
+		"count":   len(errs),
+		"summary": formatResolutionErrors(errs),
+		"errors":  details,
+	}
+	if unauthenticated {
+		bag["hint"] = registryAuthHint
 	}
 
 	return apierror.New(apierror.Conflict, "dependency resolution failed").
 		WithRetryable(apierror.False).
-		WithDetails(attrs.NewBagFrom(map[string]any{
-			"count":   len(errs),
-			"summary": formatResolutionErrors(errs),
-			"errors":  details,
-		}))
+		WithDetails(attrs.NewBagFrom(bag))
 }
 
 func NewDependencyDownloadError(module string, cause error) apierror.Error {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1064,7 +1064,7 @@ var (
 	ErrDependencyNoContent            = apierror.New(apierror.NotFound, "no download URL available").WithRetryable(apierror.False)
 )
 
-const registryAuthHint = "registry authentication required: start the process with WIPPY_TOKEN set, push a token at runtime via hub.auth.set_token, or run `wippy auth login`"
+const registryAuthHint = "registry authentication required: start the process with WIPPY_TOKEN set, push a token at runtime via hub.auth.authenticate, or run `wippy auth login`"
 
 func NewDependencyEntryInvalidError(entryID, detail, component string) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid dependency entry").

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -3,6 +3,8 @@
 package hub
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/attrs"
+	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 )
@@ -430,6 +433,37 @@ func TestFormatResolutionErrors_Multiple(t *testing.T) {
 	assert.Contains(t, result, "no match")
 	assert.Contains(t, result, "; ")
 	assert.Contains(t, result, "conflict")
+}
+
+// --- NewDependencyResolutionErrors auth hint ---
+
+func TestNewDependencyResolutionErrors_AuthHint(t *testing.T) {
+	errs := []ResolutionError{
+		{Org: "acme", Name: "http", Constraint: "^1.0.0", Message: ErrNotAuthenticated.Error(), Err: ErrNotAuthenticated},
+	}
+
+	apiErr := NewDependencyResolutionErrors(errs)
+	assert.Equal(t, apierror.Conflict, apiErr.Kind())
+	assert.Equal(t, registryAuthHint, apiErr.Details().GetString("hint", ""))
+}
+
+func TestNewDependencyResolutionErrors_AuthHintWrapped(t *testing.T) {
+	wrapped := fmt.Errorf("fetch manifest: %w", ErrNotAuthenticated)
+	errs := []ResolutionError{
+		{Org: "acme", Name: "http", Message: wrapped.Error(), Err: wrapped},
+	}
+
+	apiErr := NewDependencyResolutionErrors(errs)
+	assert.Equal(t, registryAuthHint, apiErr.Details().GetString("hint", ""))
+}
+
+func TestNewDependencyResolutionErrors_NoHintWithoutAuthCause(t *testing.T) {
+	errs := []ResolutionError{
+		{Org: "acme", Name: "http", Message: "no match", Err: errors.New("no match")},
+	}
+
+	apiErr := NewDependencyResolutionErrors(errs)
+	assert.Empty(t, apiErr.Details().GetString("hint", ""))
 }
 
 // --- verifyDownloadedArtifact ---

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -31,6 +31,7 @@ type DependencySpec struct {
 }
 
 type ResolutionError struct {
+	Err        error
 	Org        string
 	Name       string
 	Constraint string

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -112,6 +112,7 @@ func (r *resolver) resolveOne(ctx context.Context, org, name, constraint string,
 	version, err := r.resolveConstraint(ctx, org, name, constraint)
 	if err != nil {
 		r.errors = append(r.errors, ResolutionError{
+			Err:        err,
 			Org:        org,
 			Name:       name,
 			Constraint: constraint,
@@ -123,6 +124,7 @@ func (r *resolver) resolveOne(ctx context.Context, org, name, constraint string,
 	manifest, err := r.fetchManifest(ctx, org, name, version)
 	if err != nil {
 		r.errors = append(r.errors, ResolutionError{
+			Err:        err,
 			Org:        org,
 			Name:       name,
 			Constraint: constraint,

--- a/runtime/lua/modules/hub/module.go
+++ b/runtime/lua/modules/hub/module.go
@@ -82,7 +82,7 @@ func (h *hubModule) authStore() *bootauth.Store {
 }
 
 func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
-	mod := lua.CreateTable(0, 5)
+	mod := lua.CreateTable(0, 6)
 
 	modules := lua.CreateTable(0, 4)
 	modules.RawSetString("list", lua.LGoFunc(h.modulesList))
@@ -109,11 +109,17 @@ func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
 	files.RawSetString("list", lua.LGoFunc(h.filesList))
 	files.Immutable = true
 
+	auth := lua.CreateTable(0, 2)
+	auth.RawSetString("set_token", lua.LGoFunc(h.authSetToken))
+	auth.RawSetString("clear_token", lua.LGoFunc(h.authClearToken))
+	auth.Immutable = true
+
 	mod.RawSetString("modules", modules)
 	mod.RawSetString("versions", versions)
 	mod.RawSetString("dependencies", dependencies)
 	mod.RawSetString("dependents", dependents)
 	mod.RawSetString("files", files)
+	mod.RawSetString("auth", auth)
 	mod.Immutable = true
 
 	return mod, nil
@@ -676,6 +682,60 @@ func (h *hubModule) newHubClient(l *lua.LState, base baseOptions) (*boothub.Clie
 	}
 
 	return client, nil
+}
+
+func (h *hubModule) resolveRegistry(registry string) string {
+	registry = firstNonEmpty(registry, h.opts.BaseURL)
+	if registry == "" {
+		if store := h.authStore(); store != nil {
+			registry = store.DefaultRegistry()
+		}
+	}
+
+	return registry
+}
+
+func (h *hubModule) authSetToken(l *lua.LState) int {
+	token := strings.TrimSpace(l.OptString(1, ""))
+	registry := h.resolveRegistry(l.OptString(2, ""))
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.auth.set_token", registry, nil) {
+		return pushError(l, permissionDenied(l, "hub.auth.set_token", registry))
+	}
+
+	if formatErr := bootauth.ValidateTokenFormat(token); formatErr != nil {
+		return pushError(l, invalidArgument(l, formatErr.Error()))
+	}
+
+	bootauth.SetRuntimeToken(registry, token)
+
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+
+	return 2
+}
+
+func (h *hubModule) authClearToken(l *lua.LState) int {
+	registry := h.resolveRegistry(l.OptString(1, ""))
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.auth.clear_token", registry, nil) {
+		return pushError(l, permissionDenied(l, "hub.auth.clear_token", registry))
+	}
+
+	bootauth.ClearRuntimeToken(registry)
+
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+
+	return 2
 }
 
 func withTimeout(ctx context.Context, timeout time.Duration) (context.Context, func()) {

--- a/runtime/lua/modules/hub/module.go
+++ b/runtime/lua/modules/hub/module.go
@@ -111,8 +111,8 @@ func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
 	files.Immutable = true
 
 	auth := lua.CreateTable(0, 3)
-	auth.RawSetString("set_token", lua.LGoFunc(h.authSetToken))
-	auth.RawSetString("clear_token", lua.LGoFunc(h.authClearToken))
+	auth.RawSetString("authenticate", lua.LGoFunc(h.authAuthenticate))
+	auth.RawSetString("logout", lua.LGoFunc(h.authLogout))
 	auth.RawSetString("status", lua.LGoFunc(h.authStatus))
 	auth.Immutable = true
 
@@ -697,7 +697,7 @@ func (h *hubModule) resolveRegistry(registry string) string {
 	return registry
 }
 
-func (h *hubModule) authSetToken(l *lua.LState) int {
+func (h *hubModule) authAuthenticate(l *lua.LState) int {
 	token := strings.TrimSpace(l.OptString(1, ""))
 	registry := h.resolveRegistry(l.OptString(2, ""))
 
@@ -705,31 +705,44 @@ func (h *hubModule) authSetToken(l *lua.LState) int {
 	if err != nil {
 		return pushError(l, err)
 	}
-	if !security.IsAllowed(ctx, "hub.auth.set_token", registry, nil) {
-		return pushError(l, permissionDenied(l, "hub.auth.set_token", registry))
+	if !security.IsAllowed(ctx, "hub.auth.authenticate", registry, nil) {
+		return pushError(l, permissionDenied(l, "hub.auth.authenticate", registry))
 	}
 
 	if formatErr := bootauth.ValidateTokenFormat(token); formatErr != nil {
 		return pushError(l, invalidArgument(l, formatErr.Error()))
 	}
 
+	client, clientErr := bootauth.NewClient(registry)
+	if clientErr != nil {
+		return pushError(l, lua.WrapErrorWithLua(l, clientErr, "auth client init").WithKind(lua.Invalid).WithRetryable(false))
+	}
+
+	result, validateErr := client.Validate(ctx, token)
+	if validateErr != nil {
+		if errors.Is(validateErr, authapi.ErrTokenInvalid) ||
+			errors.Is(validateErr, authapi.ErrTokenExpired) ||
+			errors.Is(validateErr, authapi.ErrInsufficientScope) {
+			return pushAuthStatus(l, registry, false, nil, nil)
+		}
+
+		return pushError(l, hubCallError(l, validateErr))
+	}
+
 	bootauth.SetRuntimeToken(registry, token)
 
-	l.Push(lua.LTrue)
-	l.Push(lua.LNil)
-
-	return 2
+	return pushAuthStatus(l, registry, true, &authapi.Credential{Token: token, Registry: registry}, result)
 }
 
-func (h *hubModule) authClearToken(l *lua.LState) int {
+func (h *hubModule) authLogout(l *lua.LState) int {
 	registry := h.resolveRegistry(l.OptString(1, ""))
 
 	ctx, err := h.requireContext(l)
 	if err != nil {
 		return pushError(l, err)
 	}
-	if !security.IsAllowed(ctx, "hub.auth.clear_token", registry, nil) {
-		return pushError(l, permissionDenied(l, "hub.auth.clear_token", registry))
+	if !security.IsAllowed(ctx, "hub.auth.logout", registry, nil) {
+		return pushError(l, permissionDenied(l, "hub.auth.logout", registry))
 	}
 
 	bootauth.ClearRuntimeToken(registry)

--- a/runtime/lua/modules/hub/module.go
+++ b/runtime/lua/modules/hub/module.go
@@ -12,6 +12,7 @@ import (
 
 	"connectrpc.com/connect"
 	lua "github.com/wippyai/go-lua"
+	authapi "github.com/wippyai/runtime/api/auth"
 	modulev1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1"
 	modulev1connect "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1/modulev1connect"
 	versionv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/version/v1"
@@ -109,9 +110,10 @@ func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
 	files.RawSetString("list", lua.LGoFunc(h.filesList))
 	files.Immutable = true
 
-	auth := lua.CreateTable(0, 2)
+	auth := lua.CreateTable(0, 3)
 	auth.RawSetString("set_token", lua.LGoFunc(h.authSetToken))
 	auth.RawSetString("clear_token", lua.LGoFunc(h.authClearToken))
+	auth.RawSetString("status", lua.LGoFunc(h.authStatus))
 	auth.Immutable = true
 
 	mod.RawSetString("modules", modules)
@@ -736,6 +738,92 @@ func (h *hubModule) authClearToken(l *lua.LState) int {
 	l.Push(lua.LNil)
 
 	return 2
+}
+
+func (h *hubModule) authStatus(l *lua.LState) int {
+	registry := h.resolveRegistry(l.OptString(1, ""))
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.auth.status", registry, nil) {
+		return pushError(l, permissionDenied(l, "hub.auth.status", registry))
+	}
+
+	var cred *authapi.Credential
+	if store := h.authStore(); store != nil {
+		cred, _ = store.Get(registry)
+	}
+
+	if cred == nil || cred.Token == "" {
+		return pushAuthStatus(l, registry, false, nil, nil)
+	}
+
+	client, clientErr := bootauth.NewClient(registry)
+	if clientErr != nil {
+		return pushError(l, lua.WrapErrorWithLua(l, clientErr, "auth client init").WithKind(lua.Invalid).WithRetryable(false))
+	}
+
+	result, validateErr := client.Validate(ctx, cred.Token)
+	if validateErr != nil {
+		if errors.Is(validateErr, authapi.ErrTokenInvalid) ||
+			errors.Is(validateErr, authapi.ErrTokenExpired) ||
+			errors.Is(validateErr, authapi.ErrInsufficientScope) {
+			return pushAuthStatus(l, registry, false, cred, nil)
+		}
+
+		return pushError(l, hubCallError(l, validateErr))
+	}
+
+	return pushAuthStatus(l, registry, true, cred, result)
+}
+
+func pushAuthStatus(l *lua.LState, registry string, authenticated bool, cred *authapi.Credential, result *bootauth.ValidateResult) int {
+	status := lua.CreateTable(0, 7)
+	status.RawSetString("authenticated", lua.LBool(authenticated))
+	status.RawSetString("registry", lua.LString(registry))
+
+	if authenticated && cred != nil {
+		if cred.Username != "" {
+			status.RawSetString("username", lua.LString(cred.Username))
+		}
+		if cred.UserID != "" {
+			status.RawSetString("user_id", lua.LString(cred.UserID))
+		}
+		if cred.Scope != "" {
+			status.RawSetString("scope", lua.LString(string(cred.Scope)))
+		}
+		if !cred.ExpiresAt.IsZero() {
+			status.RawSetString("expires_at", lua.LString(cred.ExpiresAt.Format(time.RFC3339)))
+			status.RawSetString("expired", lua.LBool(cred.IsExpired()))
+		}
+	}
+
+	var orgs []bootauth.OrgInfo
+	if result != nil {
+		orgs = result.Orgs
+	}
+	status.RawSetString("orgs", orgsToTable(orgs))
+
+	l.Push(status)
+	l.Push(lua.LNil)
+
+	return 2
+}
+
+func orgsToTable(orgs []bootauth.OrgInfo) *lua.LTable {
+	items := lua.CreateTable(len(orgs), 0)
+	for i, o := range orgs {
+		entry := lua.CreateTable(0, 4)
+		entry.RawSetString("id", lua.LString(o.ID))
+		entry.RawSetString("name", lua.LString(o.Name))
+		entry.RawSetString("display_name", lua.LString(o.DisplayName))
+		entry.RawSetString("role", lua.LString(o.Role))
+		items.RawSetInt(i+1, entry)
+	}
+
+	return items
 }
 
 func withTimeout(ctx context.Context, timeout time.Duration) (context.Context, func()) {

--- a/runtime/lua/modules/hub/module_test.go
+++ b/runtime/lua/modules/hub/module_test.go
@@ -315,6 +315,113 @@ func TestHubModule_ModuleClientShortCircuitDoesNotInitializeStore(t *testing.T) 
 	assert.Nil(t, h.store)
 }
 
+func setupStrictContext() context.Context {
+	ctx := context.Background()
+	appCtx := ctxapi.NewAppContext()
+	ctx = ctxapi.WithAppContext(ctx, appCtx)
+	ctx = secapi.SetStrictMode(ctx, true)
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	return ctx
+}
+
+func TestAuthSetTokenSucceeds(t *testing.T) {
+	const reg = "https://reg-set.example.com"
+	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
+
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+
+	if err := l.DoString(`
+		local ok, err = hub.auth.set_token("wpy_validtoken1234567890", "https://reg-set.example.com")
+		if err then error(err) end
+		if ok ~= true then error("expected true") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	got, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(reg)
+	require.NoError(t, err)
+	assert.Equal(t, "wpy_validtoken1234567890", got.Token)
+}
+
+func TestAuthSetTokenInvalidFormat(t *testing.T) {
+	const reg = "https://reg-bad.example.com"
+	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
+
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+
+	if err := l.DoString(`
+		local ok, err = hub.auth.set_token("bad", "https://reg-bad.example.com")
+		if err == nil then error("expected error") end
+		if ok ~= nil then error("expected nil ok") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	_, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(reg)
+	require.Error(t, err)
+}
+
+func TestAuthSetTokenPermissionDenied(t *testing.T) {
+	const reg = "https://reg-denied.example.com"
+	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
+
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupStrictContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+
+	if err := l.DoString(`
+		local ok, err = hub.auth.set_token("wpy_validtoken1234567890", "https://reg-denied.example.com")
+		if err == nil then error("expected permission denied") end
+		if ok ~= nil then error("expected nil ok") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	_, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(reg)
+	require.Error(t, err)
+}
+
+func TestAuthClearToken(t *testing.T) {
+	const reg = "https://reg-clear.example.com"
+	bootauth.SetRuntimeToken(reg, "wpy_validtoken1234567890")
+	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
+
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+
+	if err := l.DoString(`
+		local ok, err = hub.auth.clear_token("https://reg-clear.example.com")
+		if err then error(err) end
+		if ok ~= true then error("expected true") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	_, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(reg)
+	require.Error(t, err)
+}
+
 func buildWappBytesForHubModuleTest(t *testing.T, entries []wapp.Entry) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/runtime/lua/modules/hub/module_test.go
+++ b/runtime/lua/modules/hub/module_test.go
@@ -327,9 +327,25 @@ func setupStrictContext() context.Context {
 	return ctx
 }
 
-func TestAuthSetTokenSucceeds(t *testing.T) {
-	const reg = "https://reg-set.example.com"
-	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
+func TestAuthAuthenticateSucceeds(t *testing.T) {
+	t.Setenv(bootauth.EnvToken, "")
+
+	const token = "wpy_validtoken1234567890"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/account/orgs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"org":{"id":"org-1","name":"acme","display_name":"Acme"},"role":"admin"}]`))
+	}))
+	defer srv.Close()
+	t.Cleanup(func() { bootauth.ClearRuntimeToken(srv.URL) })
 
 	mod := NewModule(Options{})
 	l := lua.NewState()
@@ -338,21 +354,57 @@ func TestAuthSetTokenSucceeds(t *testing.T) {
 
 	tbl, _ := mod.Build()
 	l.SetGlobal(mod.Name, tbl)
+	l.SetGlobal("REGISTRY", lua.LString(srv.URL))
+	l.SetGlobal("TOKEN", lua.LString(token))
 
 	if err := l.DoString(`
-		local ok, err = hub.auth.set_token("wpy_validtoken1234567890", "https://reg-set.example.com")
+		local st, err = hub.auth.authenticate(TOKEN, REGISTRY)
 		if err then error(err) end
-		if ok ~= true then error("expected true") end
+		if st.authenticated ~= true then error("expected authenticated") end
+		if #st.orgs ~= 1 then error("expected 1 org, got " .. tostring(#st.orgs)) end
+		if st.orgs[1].name ~= "acme" then error("org name mismatch") end
+		if st.orgs[1].role ~= "admin" then error("org role mismatch") end
 	`); err != nil {
 		t.Fatalf("lua error: %v", err)
 	}
 
-	got, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(reg)
+	got, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(srv.URL)
 	require.NoError(t, err)
-	assert.Equal(t, "wpy_validtoken1234567890", got.Token)
+	assert.Equal(t, token, got.Token)
 }
 
-func TestAuthSetTokenInvalidFormat(t *testing.T) {
+func TestAuthAuthenticateRejectedNotStored(t *testing.T) {
+	t.Setenv(bootauth.EnvToken, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	t.Cleanup(func() { bootauth.ClearRuntimeToken(srv.URL) })
+
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+	l.SetGlobal("REGISTRY", lua.LString(srv.URL))
+
+	if err := l.DoString(`
+		local st, err = hub.auth.authenticate("wpy_rejectedtoken123456", REGISTRY)
+		if err then error(err) end
+		if st.authenticated ~= false then error("expected not authenticated") end
+		if #st.orgs ~= 0 then error("expected no orgs") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	_, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(srv.URL)
+	require.Error(t, err)
+}
+
+func TestAuthAuthenticateInvalidFormat(t *testing.T) {
 	const reg = "https://reg-bad.example.com"
 	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
 
@@ -365,9 +417,9 @@ func TestAuthSetTokenInvalidFormat(t *testing.T) {
 	l.SetGlobal(mod.Name, tbl)
 
 	if err := l.DoString(`
-		local ok, err = hub.auth.set_token("bad", "https://reg-bad.example.com")
+		local st, err = hub.auth.authenticate("bad", "https://reg-bad.example.com")
 		if err == nil then error("expected error") end
-		if ok ~= nil then error("expected nil ok") end
+		if st ~= nil then error("expected nil status") end
 	`); err != nil {
 		t.Fatalf("lua error: %v", err)
 	}
@@ -376,7 +428,7 @@ func TestAuthSetTokenInvalidFormat(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestAuthSetTokenPermissionDenied(t *testing.T) {
+func TestAuthAuthenticatePermissionDenied(t *testing.T) {
 	const reg = "https://reg-denied.example.com"
 	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
 
@@ -389,9 +441,9 @@ func TestAuthSetTokenPermissionDenied(t *testing.T) {
 	l.SetGlobal(mod.Name, tbl)
 
 	if err := l.DoString(`
-		local ok, err = hub.auth.set_token("wpy_validtoken1234567890", "https://reg-denied.example.com")
+		local st, err = hub.auth.authenticate("wpy_validtoken1234567890", "https://reg-denied.example.com")
 		if err == nil then error("expected permission denied") end
-		if ok ~= nil then error("expected nil ok") end
+		if st ~= nil then error("expected nil status") end
 	`); err != nil {
 		t.Fatalf("lua error: %v", err)
 	}
@@ -400,7 +452,7 @@ func TestAuthSetTokenPermissionDenied(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestAuthClearToken(t *testing.T) {
+func TestAuthLogout(t *testing.T) {
 	const reg = "https://reg-clear.example.com"
 	bootauth.SetRuntimeToken(reg, "wpy_validtoken1234567890")
 	t.Cleanup(func() { bootauth.ClearRuntimeToken(reg) })
@@ -414,7 +466,7 @@ func TestAuthClearToken(t *testing.T) {
 	l.SetGlobal(mod.Name, tbl)
 
 	if err := l.DoString(`
-		local ok, err = hub.auth.clear_token("https://reg-clear.example.com")
+		local ok, err = hub.auth.logout("https://reg-clear.example.com")
 		if err then error(err) end
 		if ok ~= true then error("expected true") end
 	`); err != nil {

--- a/runtime/lua/modules/hub/module_test.go
+++ b/runtime/lua/modules/hub/module_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	lua "github.com/wippyai/go-lua"
+	authapi "github.com/wippyai/runtime/api/auth"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	modulev1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1"
 	modulev1connect "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1/modulev1connect"
@@ -420,6 +423,133 @@ func TestAuthClearToken(t *testing.T) {
 
 	_, err := bootauth.NewStore(bootauth.NewConfig(t.TempDir())).Get(reg)
 	require.Error(t, err)
+}
+
+func TestAuthStatusAuthenticated(t *testing.T) {
+	t.Setenv(bootauth.EnvToken, "")
+
+	const token = "wpy_statustoken123456789"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/account/orgs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"org":{"id":"org-1","name":"acme","display_name":"Acme"},"role":"admin"},{"org":{"id":"org-2","name":"beta","display_name":"Beta"},"role":"member"}]`))
+	}))
+	defer srv.Close()
+
+	store := bootauth.NewStore(bootauth.NewConfig(t.TempDir()))
+	require.NoError(t, store.Set(&authapi.Credential{
+		Token:    token,
+		Registry: srv.URL,
+		Username: "alice",
+		Scope:    authapi.ScopePublish,
+	}, false))
+
+	mod := NewModule(Options{AuthStore: store})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+	l.SetGlobal("REGISTRY", lua.LString(srv.URL))
+
+	if err := l.DoString(`
+		local st, err = hub.auth.status(REGISTRY)
+		if err then error(err) end
+		if st.authenticated ~= true then error("expected authenticated") end
+		if st.username ~= "alice" then error("username mismatch") end
+		if st.scope ~= "publish" then error("scope mismatch") end
+		if #st.orgs ~= 2 then error("expected 2 orgs, got " .. tostring(#st.orgs)) end
+		if st.orgs[1].name ~= "acme" then error("org1 name mismatch") end
+		if st.orgs[1].role ~= "admin" then error("org1 role mismatch") end
+		if st.orgs[2].display_name ~= "Beta" then error("org2 display_name mismatch") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+}
+
+func TestAuthStatusNotAuthenticated(t *testing.T) {
+	t.Setenv(bootauth.EnvToken, "")
+
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+
+	if err := l.DoString(`
+		local st, err = hub.auth.status("http://127.0.0.1:1/no-creds-here")
+		if err then error(err) end
+		if st.authenticated ~= false then error("expected not authenticated") end
+		if #st.orgs ~= 0 then error("expected no orgs") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+}
+
+func TestAuthStatusInvalidTokenSuppressesIdentity(t *testing.T) {
+	t.Setenv(bootauth.EnvToken, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	store := bootauth.NewStore(bootauth.NewConfig(t.TempDir()))
+	require.NoError(t, store.Set(&authapi.Credential{
+		Token:    "wpy_storedtoken123456789",
+		Registry: srv.URL,
+		Username: "alice",
+		Scope:    authapi.ScopePublish,
+	}, false))
+
+	mod := NewModule(Options{AuthStore: store})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+	l.SetGlobal("REGISTRY", lua.LString(srv.URL))
+
+	if err := l.DoString(`
+		local st, err = hub.auth.status(REGISTRY)
+		if err then error(err) end
+		if st.authenticated ~= false then error("expected not authenticated") end
+		if st.username ~= nil then error("expected username suppressed when not authenticated") end
+		if st.scope ~= nil then error("expected scope suppressed when not authenticated") end
+		if #st.orgs ~= 0 then error("expected no orgs") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+}
+
+func TestAuthStatusPermissionDenied(t *testing.T) {
+	mod := NewModule(Options{})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(setupStrictContext())
+
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+
+	if err := l.DoString(`
+		local st, err = hub.auth.status("https://reg-status-denied.example.com")
+		if err == nil then error("expected permission denied") end
+		if st ~= nil then error("expected nil status") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
 }
 
 func buildWappBytesForHubModuleTest(t *testing.T, entries []wapp.Entry) []byte {

--- a/runtime/lua/modules/hub/types.go
+++ b/runtime/lua/modules/hub/types.go
@@ -60,8 +60,8 @@ func ModuleTypes() *io.Manifest {
 		Build()
 
 	authIface := typ.NewInterface("hub.auth", []typ.Method{
-		{Name: "set_token", Type: typ.Func().Param("token", typ.String).OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
-		{Name: "clear_token", Type: typ.Func().OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "authenticate", Type: typ.Func().Param("token", typ.String).OptParam("registry", typ.String).Returns(authStatus, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "logout", Type: typ.Func().OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "status", Type: typ.Func().OptParam("registry", typ.String).Returns(authStatus, typ.NewOptional(typ.LuaError)).Build()},
 	})
 

--- a/runtime/lua/modules/hub/types.go
+++ b/runtime/lua/modules/hub/types.go
@@ -53,12 +53,18 @@ func ModuleTypes() *io.Manifest {
 		{Name: "list", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(listResponse, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
+	authIface := typ.NewInterface("hub.auth", []typ.Method{
+		{Name: "set_token", Type: typ.Func().Param("token", typ.String).OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "clear_token", Type: typ.Func().OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+	})
+
 	moduleType := typ.NewRecord().
 		Field("modules", modulesIface).
 		Field("versions", versionsIface).
 		Field("dependencies", dependenciesIface).
 		Field("dependents", dependentsIface).
 		Field("files", filesIface).
+		Field("auth", authIface).
 		Build()
 
 	m.SetExport(moduleType)

--- a/runtime/lua/modules/hub/types.go
+++ b/runtime/lua/modules/hub/types.go
@@ -53,9 +53,16 @@ func ModuleTypes() *io.Manifest {
 		{Name: "list", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(listResponse, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
+	authStatus := typ.NewRecord().
+		Field("authenticated", typ.Boolean).
+		Field("registry", typ.String).
+		Field("orgs", typ.Any).
+		Build()
+
 	authIface := typ.NewInterface("hub.auth", []typ.Method{
 		{Name: "set_token", Type: typ.Func().Param("token", typ.String).OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "clear_token", Type: typ.Func().OptParam("registry", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "status", Type: typ.Func().OptParam("registry", typ.String).Returns(authStatus, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
 	moduleType := typ.NewRecord().


### PR DESCRIPTION
## Why
Remote instances could only authenticate to the module registry/hub by running `wippy auth login` and restarting the process — the credential is read through `Store.Get` with no runtime path to set it. There was also no way for a UI to know auth state / org access.

## What
- **Process-global token override** consulted first by `Store.Get` (precedence override > env > file). Every hub consumer already reads through `Store.Get`, so a pushed token takes effect **live, no restart**, with no call-site changes.
- **`hub.auth.set_token` / `hub.auth.clear_token`** Lua bindings, permission-gated via `security.IsAllowed` and validated with `ValidateTokenFormat`.
- **`hub.auth.status([registry])`** for UI: live validate returning `{ authenticated, registry, orgs = [{id,name,display_name,role}] }`, plus `username`/`user_id`/`scope`/`expires_at`/`expired` **only when authenticated** (never leaked on a rejected token). Invalid/expired token → `authenticated=false`; transport failure → error.
- **Actionable 401 hint**: `ResolutionError` carries its cause; dependency resolution surfaces how to authenticate when it fails unauthenticated.

No Keycloak/OAuth: a `wpy_` token is sufficient for instance→registry auth. Registry resolution stays at the boundary (`Store.Get` / the Lua handler), never inside the override store.

Note: identity fields in `status` come from a login/file credential; the `WIPPY_TOKEN`/runtime-push path carries only the token, so on that path `status` returns `authenticated=true` with `orgs` but without the optional identity fields.

## Testing
- `go test -race` green: `boot/deps/auth`, `boot/deps/hub`, `runtime/lua/modules/hub` (override precedence/concurrency, the Lua bindings incl. permission-denied, `status` happy/not-authed/invalid-token-identity-suppression, and the 401 hint).
- `golangci-lint v2.8.0 ... ./...` → 0 issues.
- `make build-wippy` → binary runs.
- Mutation (`gremlins`, `boot/deps/auth`): all mutants in the new code killed.

Draft.