### PR TITLE
fix(temporal): resolve boundary type names as strings (no leading colon for namespace-less)

### DIFF
--- a/api/registry/id.go
+++ b/api/registry/id.go
@@ -37,17 +37,6 @@ func (t *ID) String() string {
 	return t.NS + ":" + t.Name
 }
 
-// Qualified returns the namespace-qualified identifier as "ns:name", or just
-// "name" when the namespace is empty. Unlike String, it never emits a leading
-// colon, making it suitable as an external type identifier such as a Temporal
-// workflow or activity type name.
-func (t *ID) Qualified() string {
-	if t.NS == "" {
-		return t.Name
-	}
-	return t.String()
-}
-
 // Equal returns true if both IDs have the same namespace and name.
 func (t *ID) Equal(other ID) bool {
 	return t.NS == other.NS && t.Name == other.Name

--- a/api/registry/id.go
+++ b/api/registry/id.go
@@ -37,6 +37,17 @@ func (t *ID) String() string {
 	return t.NS + ":" + t.Name
 }
 
+// Qualified returns the namespace-qualified identifier as "ns:name", or just
+// "name" when the namespace is empty. Unlike String, it never emits a leading
+// colon, making it suitable as an external type identifier such as a Temporal
+// workflow or activity type name.
+func (t *ID) Qualified() string {
+	if t.NS == "" {
+		return t.Name
+	}
+	return t.String()
+}
+
 // Equal returns true if both IDs have the same namespace and name.
 func (t *ID) Equal(other ID) bool {
 	return t.NS == other.NS && t.Name == other.Name

--- a/api/registry/id_test.go
+++ b/api/registry/id_test.go
@@ -265,57 +265,6 @@ func TestID_String(t *testing.T) {
 	}
 }
 
-func TestID_Qualified(t *testing.T) {
-	tests := []struct {
-		name     string
-		id       ID
-		expected string
-	}{
-		{
-			name:     "with namespace and name",
-			id:       ID{NS: "test-ns", Name: "test-name"},
-			expected: "test-ns:test-name",
-		},
-		{
-			name:     "name only has no leading colon",
-			id:       ID{NS: "", Name: "test-name"},
-			expected: "test-name",
-		},
-		{
-			name:     "namespace only",
-			id:       ID{NS: "test-ns", Name: ""},
-			expected: "test-ns:",
-		},
-		{
-			name:     "empty ID",
-			id:       ID{NS: "", Name: ""},
-			expected: "",
-		},
-		{
-			name:     "complex namespace and name",
-			id:       ID{NS: "my.namespace", Name: "my/name"},
-			expected: "my.namespace:my/name",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.id.Qualified()
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestID_Qualified_ParseRoundTrip(t *testing.T) {
-	bare := ParseID("PopulateItemRelation")
-	assert.Equal(t, ":PopulateItemRelation", bare.String())
-	assert.Equal(t, "PopulateItemRelation", bare.Qualified())
-
-	namespaced := ParseID("app:PopulateItemRelation")
-	assert.Equal(t, "app:PopulateItemRelation", namespaced.String())
-	assert.Equal(t, "app:PopulateItemRelation", namespaced.Qualified())
-}
-
 func TestID_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/api/registry/id_test.go
+++ b/api/registry/id_test.go
@@ -265,6 +265,57 @@ func TestID_String(t *testing.T) {
 	}
 }
 
+func TestID_Qualified(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       ID
+		expected string
+	}{
+		{
+			name:     "with namespace and name",
+			id:       ID{NS: "test-ns", Name: "test-name"},
+			expected: "test-ns:test-name",
+		},
+		{
+			name:     "name only has no leading colon",
+			id:       ID{NS: "", Name: "test-name"},
+			expected: "test-name",
+		},
+		{
+			name:     "namespace only",
+			id:       ID{NS: "test-ns", Name: ""},
+			expected: "test-ns:",
+		},
+		{
+			name:     "empty ID",
+			id:       ID{NS: "", Name: ""},
+			expected: "",
+		},
+		{
+			name:     "complex namespace and name",
+			id:       ID{NS: "my.namespace", Name: "my/name"},
+			expected: "my.namespace:my/name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.id.Qualified()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestID_Qualified_ParseRoundTrip(t *testing.T) {
+	bare := ParseID("PopulateItemRelation")
+	assert.Equal(t, ":PopulateItemRelation", bare.String())
+	assert.Equal(t, "PopulateItemRelation", bare.Qualified())
+
+	namespaced := ParseID("app:PopulateItemRelation")
+	assert.Equal(t, "app:PopulateItemRelation", namespaced.String())
+	assert.Equal(t, "app:PopulateItemRelation", namespaced.Qualified())
+}
+
 func TestID_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/service/temporal/activity/listener.go
+++ b/service/temporal/activity/listener.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/registry"
+	temporaloptions "github.com/wippyai/runtime/service/temporal/options"
 	"go.uber.org/zap"
 )
 
@@ -93,7 +94,7 @@ func (l *Listener) handleEntry(ctx context.Context, entry registry.Entry) error 
 	}
 
 	// Use custom name from metadata or default to qualified ID
-	activityName := activityMeta.GetString(MetaActivityName, entry.ID.Qualified())
+	activityName := activityMeta.GetString(MetaActivityName, temporaloptions.ActivityNameFromID(entry.ID))
 	isLocal := activityMeta.GetBool(MetaActivityLocal, false)
 
 	if isLocal {
@@ -141,7 +142,7 @@ func (l *Listener) handleDelete(ctx context.Context, entry registry.Entry) error
 	}
 
 	// Use custom name from metadata or default to qualified ID
-	activityName := activityMeta.GetString(MetaActivityName, entry.ID.Qualified())
+	activityName := activityMeta.GetString(MetaActivityName, temporaloptions.ActivityNameFromID(entry.ID))
 
 	if err := l.workers.UnregisterActivity(ctx, workerID, activityName); err != nil {
 		l.log.Error("failed to unregister activity",

--- a/service/temporal/activity/listener.go
+++ b/service/temporal/activity/listener.go
@@ -20,6 +20,7 @@ const (
 	MetaActivityBag      = "activity"
 	MetaActivityWorker   = "worker"
 	MetaActivityLocal    = "local"
+	MetaActivityName     = "name"
 )
 
 // WorkerRegistry provides access to workers for activity registration
@@ -91,8 +92,8 @@ func (l *Listener) handleEntry(ctx context.Context, entry registry.Entry) error 
 		return nil
 	}
 
-	// Always use full ID as activity name
-	activityName := entry.ID.Qualified()
+	// Use custom name from metadata or default to qualified ID
+	activityName := activityMeta.GetString(MetaActivityName, entry.ID.Qualified())
 	isLocal := activityMeta.GetBool(MetaActivityLocal, false)
 
 	if isLocal {
@@ -139,8 +140,8 @@ func (l *Listener) handleDelete(ctx context.Context, entry registry.Entry) error
 		return nil
 	}
 
-	// Always use full ID as activity name
-	activityName := entry.ID.Qualified()
+	// Use custom name from metadata or default to qualified ID
+	activityName := activityMeta.GetString(MetaActivityName, entry.ID.Qualified())
 
 	if err := l.workers.UnregisterActivity(ctx, workerID, activityName); err != nil {
 		l.log.Error("failed to unregister activity",

--- a/service/temporal/activity/listener.go
+++ b/service/temporal/activity/listener.go
@@ -92,7 +92,7 @@ func (l *Listener) handleEntry(ctx context.Context, entry registry.Entry) error 
 	}
 
 	// Always use full ID as activity name
-	activityName := entry.ID.String()
+	activityName := entry.ID.Qualified()
 	isLocal := activityMeta.GetBool(MetaActivityLocal, false)
 
 	if isLocal {
@@ -140,7 +140,7 @@ func (l *Listener) handleDelete(ctx context.Context, entry registry.Entry) error
 	}
 
 	// Always use full ID as activity name
-	activityName := entry.ID.String()
+	activityName := entry.ID.Qualified()
 
 	if err := l.workers.UnregisterActivity(ctx, workerID, activityName); err != nil {
 		l.log.Error("failed to unregister activity",

--- a/service/temporal/activity/listener_test.go
+++ b/service/temporal/activity/listener_test.go
@@ -132,6 +132,35 @@ func TestListener_Add_RegisterActivity(t *testing.T) {
 		assert.True(t, exists)
 		assert.Equal(t, entry.ID, funcID)
 	})
+
+	t.Run("custom name from metadata is used for register and unregister", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
+		workers := newMockWorkerRegistry()
+		listener := NewListener(logger, workers)
+
+		entry := registry.Entry{
+			ID:   registry.NewID("app.functions", "my_func"),
+			Kind: "function.lua",
+			Meta: attrs.Bag{
+				"temporal": map[string]any{
+					"activity": map[string]any{
+						"worker": "app.workers:default",
+						"name":   "ExternalActivity",
+					},
+				},
+			},
+		}
+
+		err := listener.Add(context.Background(), entry)
+		require.NoError(t, err)
+		funcID, exists := workers.activities["app.workers:default:ExternalActivity"]
+		assert.True(t, exists)
+		assert.Equal(t, entry.ID, funcID)
+
+		err = listener.Delete(context.Background(), entry)
+		require.NoError(t, err)
+		assert.Empty(t, workers.activities)
+	})
 }
 
 func TestListener_Add_SkipNonActivity(t *testing.T) {

--- a/service/temporal/options/name.go
+++ b/service/temporal/options/name.go
@@ -13,13 +13,13 @@ func WorkflowName(options attrs.Attributes, fallback registry.ID) string {
 	if name, ok := explicitName(options, OptionWorkflowName); ok {
 		return name
 	}
-	return fallback.Qualified()
+	return WorkflowNameFromID(fallback)
 }
 
 // WorkflowNameFromID resolves the Temporal workflow type name for call sites that
 // carry no options bag, using the qualified form of the ID.
 func WorkflowNameFromID(id registry.ID) string {
-	return id.Qualified()
+	return qualify(id)
 }
 
 // ActivityName resolves the Temporal activity type name from an explicit
@@ -28,13 +28,23 @@ func ActivityName(options attrs.Attributes, fallback registry.ID) string {
 	if name, ok := explicitName(options, OptionActivityName); ok {
 		return name
 	}
-	return fallback.Qualified()
+	return ActivityNameFromID(fallback)
 }
 
 // ActivityNameFromID resolves the Temporal activity type name for call sites that
 // carry no options bag, using the qualified form of the ID.
 func ActivityNameFromID(id registry.ID) string {
-	return id.Qualified()
+	return qualify(id)
+}
+
+// qualify renders a registry ID as a Temporal boundary type name: the bare name
+// when the namespace is empty, "ns:name" otherwise. It never emits a leading
+// colon, so a namespace-less name matches what an external worker registers.
+func qualify(id registry.ID) string {
+	if id.NS == "" {
+		return id.Name
+	}
+	return id.NS + ":" + id.Name
 }
 
 func explicitName(options attrs.Attributes, key string) (string, bool) {

--- a/service/temporal/options/name.go
+++ b/service/temporal/options/name.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package options
+
+import (
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+// WorkflowName resolves the Temporal workflow type name from an explicit
+// "workflow.name" option, falling back to the qualified form of the fallback ID.
+func WorkflowName(options attrs.Attributes, fallback registry.ID) string {
+	if name, ok := explicitName(options, OptionWorkflowName); ok {
+		return name
+	}
+	return fallback.Qualified()
+}
+
+// WorkflowNameFromID resolves the Temporal workflow type name for call sites that
+// carry no options bag, using the qualified form of the ID.
+func WorkflowNameFromID(id registry.ID) string {
+	return id.Qualified()
+}
+
+// ActivityName resolves the Temporal activity type name from an explicit
+// "activity.name" option, falling back to the qualified form of the fallback ID.
+func ActivityName(options attrs.Attributes, fallback registry.ID) string {
+	if name, ok := explicitName(options, OptionActivityName); ok {
+		return name
+	}
+	return fallback.Qualified()
+}
+
+// ActivityNameFromID resolves the Temporal activity type name for call sites that
+// carry no options bag, using the qualified form of the ID.
+func ActivityNameFromID(id registry.ID) string {
+	return id.Qualified()
+}
+
+func explicitName(options attrs.Attributes, key string) (string, bool) {
+	raw, ok := optionGet(options, key)
+	if !ok {
+		return "", false
+	}
+	name, err := parseString(key, raw)
+	if err != nil || name == "" {
+		return "", false
+	}
+	return name, true
+}

--- a/service/temporal/options/name_test.go
+++ b/service/temporal/options/name_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+func TestWorkflowName(t *testing.T) {
+	fallback := registry.NewID("app", "Flow")
+
+	t.Run("explicit option", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set(OptionWorkflowName, "ExternalFlow")
+		assert.Equal(t, "ExternalFlow", WorkflowName(opts, fallback))
+	})
+
+	t.Run("legacy alias", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set("temporal.workflow.name", "LegacyFlow")
+		assert.Equal(t, "LegacyFlow", WorkflowName(opts, fallback))
+	})
+
+	t.Run("canonical wins over alias", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set(OptionWorkflowName, "Canonical")
+		opts.Set("temporal.workflow.name", "Legacy")
+		assert.Equal(t, "Canonical", WorkflowName(opts, fallback))
+	})
+
+	t.Run("empty option falls back", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set(OptionWorkflowName, "")
+		assert.Equal(t, "app:Flow", WorkflowName(opts, fallback))
+	})
+
+	t.Run("non-string option falls back", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set(OptionWorkflowName, 123)
+		assert.Equal(t, "app:Flow", WorkflowName(opts, fallback))
+	})
+
+	t.Run("absent option falls back", func(t *testing.T) {
+		assert.Equal(t, "app:Flow", WorkflowName(attrs.NewBag(), fallback))
+	})
+
+	t.Run("nil options falls back", func(t *testing.T) {
+		assert.Equal(t, "app:Flow", WorkflowName(nil, fallback))
+	})
+
+	t.Run("namespace-less fallback has no leading colon", func(t *testing.T) {
+		assert.Equal(t, "Flow", WorkflowName(attrs.NewBag(), registry.ParseID("Flow")))
+	})
+}
+
+func TestWorkflowNameFromID(t *testing.T) {
+	assert.Equal(t, "Flow", WorkflowNameFromID(registry.ParseID("Flow")))
+	assert.Equal(t, "app:Flow", WorkflowNameFromID(registry.NewID("app", "Flow")))
+}
+
+func TestActivityName(t *testing.T) {
+	fallback := registry.NewID("app", "DoThing")
+
+	t.Run("explicit option", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set(OptionActivityName, "ExternalThing")
+		assert.Equal(t, "ExternalThing", ActivityName(opts, fallback))
+	})
+
+	t.Run("legacy alias", func(t *testing.T) {
+		opts := attrs.NewBag()
+		opts.Set("temporal.activity.name", "LegacyThing")
+		assert.Equal(t, "LegacyThing", ActivityName(opts, fallback))
+	})
+
+	t.Run("absent option falls back", func(t *testing.T) {
+		assert.Equal(t, "app:DoThing", ActivityName(attrs.NewBag(), fallback))
+	})
+
+	t.Run("namespace-less fallback has no leading colon", func(t *testing.T) {
+		assert.Equal(t, "DoThing", ActivityName(nil, registry.ParseID("DoThing")))
+	})
+}
+
+func TestActivityNameFromID(t *testing.T) {
+	assert.Equal(t, "DoThing", ActivityNameFromID(registry.ParseID("DoThing")))
+	assert.Equal(t, "app:DoThing", ActivityNameFromID(registry.NewID("app", "DoThing")))
+}

--- a/service/temporal/options/options.go
+++ b/service/temporal/options/options.go
@@ -47,6 +47,7 @@ const (
 	OptionWorkflowWaitForCancellation = "workflow.wait_for_cancellation"
 	OptionWorkflowParentClosePolicy   = "workflow.parent_close_policy"
 	OptionWorkflowVersioningIntent    = "workflow.versioning_intent"
+	OptionWorkflowName                = "workflow.name"
 
 	OptionActivityID               = "activity.id"
 	OptionActivityTaskQueue        = "activity.task_queue"
@@ -60,6 +61,7 @@ const (
 	OptionActivityVersioningIntent = "activity.versioning_intent"
 	OptionActivitySummary          = "activity.summary"
 	OptionActivityPriority         = "activity.priority"
+	OptionActivityName             = "activity.name"
 
 	legacyWorkflowSearchAttributes      = "temporal.workflow.search_attributes"
 	legacyWorkflowTypedSearchAttributes = "temporal.workflow.typed_search_attributes"
@@ -96,6 +98,7 @@ var legacyOptionAliases = map[string][]string{
 	OptionWorkflowWaitForCancellation: {"temporal.workflow.wait_for_cancellation"},
 	OptionWorkflowParentClosePolicy:   {"temporal.workflow.parent_close_policy"},
 	OptionWorkflowVersioningIntent:    {"temporal.workflow.versioning_intent"},
+	OptionWorkflowName:                {"temporal.workflow.name"},
 
 	OptionActivityID:               {"temporal.activity.id"},
 	OptionActivityTaskQueue:        {"temporal.activity.task_queue"},
@@ -109,6 +112,7 @@ var legacyOptionAliases = map[string][]string{
 	OptionActivityVersioningIntent: {"temporal.activity.versioning_intent"},
 	OptionActivitySummary:          {"temporal.activity.summary"},
 	OptionActivityPriority:         {"temporal.activity.priority"},
+	OptionActivityName:             {"temporal.activity.name"},
 }
 
 // StartOptionState tracks which optional fields were explicitly set during option application.

--- a/service/temporal/worker/host.go
+++ b/service/temporal/worker/host.go
@@ -36,7 +36,7 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 		taskQueue = w.config.TaskQueue
 	}
 
-	workflowName := start.Source.Qualified()
+	workflowName := resolveWorkflowName(start)
 	hostID := w.id.String()
 
 	execCtx := ctx

--- a/service/temporal/worker/host.go
+++ b/service/temporal/worker/host.go
@@ -36,7 +36,7 @@ func (w *Worker) Run(ctx context.Context, start *process.Start) (pid.PID, error)
 		taskQueue = w.config.TaskQueue
 	}
 
-	workflowName := start.Source.String()
+	workflowName := start.Source.Qualified()
 	hostID := w.id.String()
 
 	execCtx := ctx

--- a/service/temporal/worker/host_test.go
+++ b/service/temporal/worker/host_test.go
@@ -157,6 +157,46 @@ func TestWorker_Run_Success(t *testing.T) {
 	assert.NotEmpty(t, resultPID.UniqID)
 }
 
+func TestWorker_Run_WorkflowNameFromOption(t *testing.T) {
+	var gotType interface{}
+	w := newHostTestWorker(&testTemporalClient{
+		executeWorkflowFn: func(_ context.Context, _ client.StartWorkflowOptions, workflow interface{}, _ ...interface{}) (client.WorkflowRun, error) {
+			gotType = workflow
+			return &testWorkflowRun{}, nil
+		},
+	})
+
+	options := attrs.NewBag()
+	options.Set("workflow.name", "ExternalWorkflow")
+
+	start := &process.Start{
+		Source:  registry.NewID("app", "my-workflow"),
+		Options: options,
+	}
+
+	_, err := w.Run(context.Background(), start)
+	require.NoError(t, err)
+	assert.Equal(t, "ExternalWorkflow", gotType)
+}
+
+func TestWorker_Run_WorkflowNameDefaultsToQualifiedSource(t *testing.T) {
+	var gotType interface{}
+	w := newHostTestWorker(&testTemporalClient{
+		executeWorkflowFn: func(_ context.Context, _ client.StartWorkflowOptions, workflow interface{}, _ ...interface{}) (client.WorkflowRun, error) {
+			gotType = workflow
+			return &testWorkflowRun{}, nil
+		},
+	})
+
+	start := &process.Start{
+		Source: registry.ParseID("PopulateItemRelation"),
+	}
+
+	_, err := w.Run(context.Background(), start)
+	require.NoError(t, err)
+	assert.Equal(t, "PopulateItemRelation", gotType)
+}
+
 func TestWorker_Run_WithExplicitName(t *testing.T) {
 	var sawPolicy bool
 	var sawConflictPolicy enumspb.WorkflowIdConflictPolicy

--- a/service/temporal/worker/start_options.go
+++ b/service/temporal/worker/start_options.go
@@ -37,6 +37,12 @@ type temporalStartOptionState struct {
 	hasErrorOnStarted bool
 }
 
+// resolveWorkflowName returns the Temporal workflow type name for a spawn, preferring
+// an explicit workflow.name option and falling back to the source ID's qualified form.
+func resolveWorkflowName(start *process.Start) string {
+	return temporaloptions.WorkflowName(start.Options, start.Source)
+}
+
 // applyTemporalStartWorkflowOptions maps process.Start options to Temporal StartWorkflowOptions.
 func applyTemporalStartWorkflowOptions(opts *client.StartWorkflowOptions, start *process.Start) (temporalStartOptionState, error) {
 	var state temporalStartOptionState

--- a/service/temporal/workflow/execution.go
+++ b/service/temporal/workflow/execution.go
@@ -187,9 +187,9 @@ func (d *Definition) executeContinueAsNew() {
 		return
 	}
 
-	workflowType := d.id.String()
+	workflowType := d.id.Qualified()
 	if req.Source.Name != "" {
-		workflowType = req.Source.String()
+		workflowType = req.Source.Qualified()
 	}
 
 	var input *commonpb.Payloads

--- a/service/temporal/workflow/execution.go
+++ b/service/temporal/workflow/execution.go
@@ -17,6 +17,7 @@ import (
 	workflowapi "github.com/wippyai/runtime/api/runtime/workflow"
 	"github.com/wippyai/runtime/api/topology"
 	temporalerrors "github.com/wippyai/runtime/service/temporal/errors"
+	temporaloptions "github.com/wippyai/runtime/service/temporal/options"
 	commonpb "go.temporal.io/api/common/v1"
 	bindings "go.temporal.io/sdk/internalbindings"
 	"go.uber.org/zap"
@@ -187,9 +188,9 @@ func (d *Definition) executeContinueAsNew() {
 		return
 	}
 
-	workflowType := d.id.Qualified()
+	workflowType := temporaloptions.WorkflowNameFromID(d.id)
 	if req.Source.Name != "" {
-		workflowType = req.Source.Qualified()
+		workflowType = temporaloptions.WorkflowNameFromID(req.Source)
 	}
 
 	var input *commonpb.Payloads

--- a/service/temporal/workflow/handler_process.go
+++ b/service/temporal/workflow/handler_process.go
@@ -151,7 +151,7 @@ func (d *Definition) executeProcessSpawn(cmd *process.SpawnCmd, tag uint64) erro
 		return nil
 	}
 
-	workflowName := cmd.Start.Source.String()
+	workflowName := cmd.Start.Source.Qualified()
 
 	args, err := d.dc.ToPayloads(cmd.Start.Input)
 	if err != nil {
@@ -304,7 +304,7 @@ func (d *Definition) executeProcessUnlink(_ *process.UnlinkCmd, tag uint64) erro
 
 // executeProcessExec handles process.exec from workflows by executing a child workflow synchronously.
 func (d *Definition) executeProcessExec(cmd *process.ExecCmd, tag uint64) error {
-	workflowName := cmd.Source.String()
+	workflowName := cmd.Source.Qualified()
 
 	var args *commonpb.Payloads
 	if len(cmd.Input) > 0 {

--- a/service/temporal/workflow/handler_process.go
+++ b/service/temporal/workflow/handler_process.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wippyai/runtime/api/relay"
 	"github.com/wippyai/runtime/api/runtime"
 	temporalerrors "github.com/wippyai/runtime/service/temporal/errors"
+	temporaloptions "github.com/wippyai/runtime/service/temporal/options"
 	"github.com/wippyai/runtime/service/temporal/propagator"
 	commonpb "go.temporal.io/api/common/v1"
 	bindings "go.temporal.io/sdk/internalbindings"
@@ -151,7 +152,7 @@ func (d *Definition) executeProcessSpawn(cmd *process.SpawnCmd, tag uint64) erro
 		return nil
 	}
 
-	workflowName := cmd.Start.Source.Qualified()
+	workflowName := temporaloptions.WorkflowName(cmd.Start.Options, cmd.Start.Source)
 
 	args, err := d.dc.ToPayloads(cmd.Start.Input)
 	if err != nil {
@@ -304,7 +305,7 @@ func (d *Definition) executeProcessUnlink(_ *process.UnlinkCmd, tag uint64) erro
 
 // executeProcessExec handles process.exec from workflows by executing a child workflow synchronously.
 func (d *Definition) executeProcessExec(cmd *process.ExecCmd, tag uint64) error {
-	workflowName := cmd.Source.Qualified()
+	workflowName := temporaloptions.WorkflowNameFromID(cmd.Source)
 
 	var args *commonpb.Payloads
 	if len(cmd.Input) > 0 {

--- a/service/temporal/workflow/handler_workflow.go
+++ b/service/temporal/workflow/handler_workflow.go
@@ -29,7 +29,7 @@ const (
 
 // executeFunctionCall executes a function as an activity.
 func (d *Definition) executeFunctionCall(cmd *function.CallCmd, tag uint64) error {
-	activityName := cmd.Task.ID.String()
+	activityName := cmd.Task.ID.Qualified()
 
 	args, err := d.dc.ToPayloads(cmd.Task.Payloads)
 	if err != nil {
@@ -61,7 +61,7 @@ func (d *Definition) executeFunctionCall(cmd *function.CallCmd, tag uint64) erro
 
 // executeFunctionAsyncStart starts an activity and wires its completion to a future topic.
 func (d *Definition) executeFunctionAsyncStart(cmd *function.AsyncStartCmd, tag uint64) error {
-	activityName := cmd.Task.ID.String()
+	activityName := cmd.Task.ID.Qualified()
 
 	args, err := d.dc.ToPayloads(cmd.Task.Payloads)
 	if err != nil {
@@ -239,7 +239,7 @@ func (d *Definition) GetWorkflowInfo() workflowapi.Info {
 
 // executeWorkflowExec executes a child workflow synchronously and returns the result.
 func (d *Definition) executeWorkflowExec(cmd *workflowapi.ExecCmd, tag uint64) error {
-	workflowName := cmd.ID.String()
+	workflowName := cmd.ID.Qualified()
 
 	var args *commonpb.Payloads
 	if len(cmd.Args) > 0 {

--- a/service/temporal/workflow/handler_workflow.go
+++ b/service/temporal/workflow/handler_workflow.go
@@ -29,7 +29,8 @@ const (
 
 // executeFunctionCall executes a function as an activity.
 func (d *Definition) executeFunctionCall(cmd *function.CallCmd, tag uint64) error {
-	activityName := cmd.Task.ID.Qualified()
+	merged := d.mergedFunctionTaskOptions(cmd.Task)
+	activityName := temporaloptions.ActivityName(merged, cmd.Task.ID)
 
 	args, err := d.dc.ToPayloads(cmd.Task.Payloads)
 	if err != nil {
@@ -40,7 +41,7 @@ func (d *Definition) executeFunctionCall(cmd *function.CallCmd, tag uint64) erro
 		TaskQueueName:       d.env.WorkflowInfo().TaskQueueName,
 		StartToCloseTimeout: defaultActivityTimeout,
 	}
-	if err := applyTemporalActivityOptions(&opts, d.mergedFunctionTaskOptions(cmd.Task)); err != nil {
+	if err := applyTemporalActivityOptions(&opts, merged); err != nil {
 		d.resumeProcess(tag, function.CallResult{
 			Error: fmt.Errorf("invalid temporal activity options for %s: %w", activityName, err),
 		}, nil)
@@ -61,7 +62,8 @@ func (d *Definition) executeFunctionCall(cmd *function.CallCmd, tag uint64) erro
 
 // executeFunctionAsyncStart starts an activity and wires its completion to a future topic.
 func (d *Definition) executeFunctionAsyncStart(cmd *function.AsyncStartCmd, tag uint64) error {
-	activityName := cmd.Task.ID.Qualified()
+	merged := d.mergedFunctionTaskOptions(cmd.Task)
+	activityName := temporaloptions.ActivityName(merged, cmd.Task.ID)
 
 	args, err := d.dc.ToPayloads(cmd.Task.Payloads)
 	if err != nil {
@@ -72,7 +74,7 @@ func (d *Definition) executeFunctionAsyncStart(cmd *function.AsyncStartCmd, tag 
 		TaskQueueName:       d.env.WorkflowInfo().TaskQueueName,
 		StartToCloseTimeout: defaultActivityTimeout,
 	}
-	if err := applyTemporalActivityOptions(&opts, d.mergedFunctionTaskOptions(cmd.Task)); err != nil {
+	if err := applyTemporalActivityOptions(&opts, merged); err != nil {
 		d.resumeProcess(tag, function.AsyncStartResult{
 			Error: fmt.Errorf("invalid temporal activity options for %s: %w", activityName, err),
 		}, nil)
@@ -239,7 +241,7 @@ func (d *Definition) GetWorkflowInfo() workflowapi.Info {
 
 // executeWorkflowExec executes a child workflow synchronously and returns the result.
 func (d *Definition) executeWorkflowExec(cmd *workflowapi.ExecCmd, tag uint64) error {
-	workflowName := cmd.ID.Qualified()
+	workflowName := temporaloptions.WorkflowNameFromID(cmd.ID)
 
 	var args *commonpb.Payloads
 	if len(cmd.Args) > 0 {

--- a/service/temporal/workflow/listener.go
+++ b/service/temporal/workflow/listener.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/registry"
+	temporaloptions "github.com/wippyai/runtime/service/temporal/options"
 	"go.uber.org/zap"
 )
 
@@ -95,7 +96,7 @@ func (l *Listener) handleEntry(ctx context.Context, entry registry.Entry) error 
 	}
 
 	// Use custom name from metadata or default to full ID
-	workflowName := workflowMeta.GetString(MetaWorkflowName, entry.ID.Qualified())
+	workflowName := workflowMeta.GetString(MetaWorkflowName, temporaloptions.WorkflowNameFromID(entry.ID))
 
 	err = l.workers.RegisterWorkflow(ctx, workerID, workflowName, factory)
 	if err != nil {
@@ -135,7 +136,7 @@ func (l *Listener) handleDelete(ctx context.Context, entry registry.Entry) error
 	}
 
 	// Use custom name from metadata or default to full ID
-	workflowName := workflowMeta.GetString(MetaWorkflowName, entry.ID.Qualified())
+	workflowName := workflowMeta.GetString(MetaWorkflowName, temporaloptions.WorkflowNameFromID(entry.ID))
 
 	if err := l.workers.UnregisterWorkflow(ctx, workerID, workflowName); err != nil {
 		l.log.Error("failed to unregister workflow",

--- a/service/temporal/workflow/listener.go
+++ b/service/temporal/workflow/listener.go
@@ -95,7 +95,7 @@ func (l *Listener) handleEntry(ctx context.Context, entry registry.Entry) error 
 	}
 
 	// Use custom name from metadata or default to full ID
-	workflowName := workflowMeta.GetString(MetaWorkflowName, entry.ID.String())
+	workflowName := workflowMeta.GetString(MetaWorkflowName, entry.ID.Qualified())
 
 	err = l.workers.RegisterWorkflow(ctx, workerID, workflowName, factory)
 	if err != nil {
@@ -135,7 +135,7 @@ func (l *Listener) handleDelete(ctx context.Context, entry registry.Entry) error
 	}
 
 	// Use custom name from metadata or default to full ID
-	workflowName := workflowMeta.GetString(MetaWorkflowName, entry.ID.String())
+	workflowName := workflowMeta.GetString(MetaWorkflowName, entry.ID.Qualified())
 
 	if err := l.workers.UnregisterWorkflow(ctx, workerID, workflowName); err != nil {
 		l.log.Error("failed to unregister workflow",

--- a/service/temporal/workflow/listener_test.go
+++ b/service/temporal/workflow/listener_test.go
@@ -72,6 +72,38 @@ func TestWorkflowListenerRegistration(t *testing.T) {
 	require.Equal(t, "app.test:my_workflow", factory.ID.String())
 }
 
+// TestWorkflowListenerCustomName verifies a workflow.name meta override is used symmetrically
+// for register and unregister.
+func TestWorkflowListenerCustomName(t *testing.T) {
+	log := zap.NewNop()
+
+	mockWorkers := newMockWorkerRegistry()
+	listener := workflow.NewListener(log, mockWorkers)
+
+	meta := attrs.NewBag()
+	meta.Set("temporal", map[string]any{
+		"workflow": map[string]any{
+			"worker": "app.test:worker",
+			"name":   "ExternalWorkflow",
+		},
+	})
+
+	entry := registry.Entry{
+		ID:   registry.ID{NS: "app.test", Name: "my_workflow"},
+		Kind: "workflow.lua",
+		Meta: meta,
+	}
+
+	err := listener.Add(context.Background(), entry)
+	require.NoError(t, err)
+	require.Contains(t, mockWorkers.registeredWorkflows, "ExternalWorkflow")
+	require.NotContains(t, mockWorkers.registeredWorkflows, "app.test:my_workflow")
+
+	err = listener.Delete(context.Background(), entry)
+	require.NoError(t, err)
+	require.NotContains(t, mockWorkers.registeredWorkflows, "ExternalWorkflow")
+}
+
 // TestWorkflowListenerIgnoresNonWorkflows tests that non-workflow entries are ignored
 func TestWorkflowListenerIgnoresNonWorkflows(t *testing.T) {
 	log := zap.NewNop()

--- a/tests/app/src/test/temporal/tests/_index.yaml
+++ b/tests/app/src/test/temporal/tests/_index.yaml
@@ -17,6 +17,21 @@ entries:
     imports:
       assert2: app.lib:assert
 
+  - name: workflow_custom_name
+    kind: function.lua
+    meta:
+      type: test
+      suite: temporal
+      description: explicit workflow.name meta/option decouples type name from registry id
+    source: file://workflow_custom_name.lua
+    method: main
+    modules:
+      - process
+      - time
+      - channel
+    imports:
+      assert2: app.lib:assert
+
   - name: spawn_monitored
     kind: function.lua
     meta:

--- a/tests/app/src/test/temporal/tests/signal_updates_workflow.lua
+++ b/tests/app/src/test/temporal/tests/signal_updates_workflow.lua
@@ -80,7 +80,7 @@ local function main()
 	if msg == nil then
 		error("missing message for increment ok")
 	end
-	local data = payload_data(msg)
+	local data = payload_data(msg as Message)
 	if type(data) ~= "table" then
 		error("increment ok payload must be table")
 	end
@@ -102,7 +102,7 @@ local function main()
 	if msg == nil then
 		error("missing message for decrement ok")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	if type(data) ~= "table" then
 		error("decrement ok payload must be table")
 	end
@@ -117,7 +117,7 @@ local function main()
 	if msg == nil then
 		error("missing message for decrement nak")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	assert.contains(tostring(data), "negative", "negative reject reason")
 
 	ok, send_err = process.send(pid, "increment", { amount = "bad" })
@@ -129,7 +129,7 @@ local function main()
 	if msg == nil then
 		error("missing message for increment nak")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	assert.contains(tostring(data), "amount must be a number", "amount validation")
 
 	ok, send_err = process.send(pid, "get_value", {})
@@ -148,7 +148,7 @@ local function main()
 	if msg == nil then
 		error("missing message for get_value ok")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	if type(data) ~= "table" then
 		error("get_value ok payload must be table")
 	end
@@ -170,7 +170,7 @@ local function main()
 	if msg == nil then
 		error("missing message for fail error")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	assert.contains(tostring(data), "intentional failure", "fail error payload")
 
 	ok, send_err = process.send(pid, "finish", {})
@@ -189,7 +189,7 @@ local function main()
 	if msg == nil then
 		error("missing message for finish ok")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	if type(data) ~= "table" then
 		error("finish ok payload must be table")
 	end

--- a/tests/app/src/test/temporal/tests/startup_messages_conflict_fail.lua
+++ b/tests/app/src/test/temporal/tests/startup_messages_conflict_fail.lua
@@ -83,7 +83,7 @@ local function main()
 		msg, wait_err = wait_for_topic(inbox, pid, "ok", "5s")
 		assert.is_nil(wait_err, wait_err)
 		assert.not_nil(msg, "first startup ok received")
-		local data = payload_data(msg)
+		local data = payload_data(msg as Message)
 		assert.is_table(data, "first startup ok payload table")
 		assert.eq(data.value, 3, "first startup increment applied")
 

--- a/tests/app/src/test/temporal/tests/startup_messages_explicit_id_conflict_fail.lua
+++ b/tests/app/src/test/temporal/tests/startup_messages_explicit_id_conflict_fail.lua
@@ -85,7 +85,7 @@ local function main()
 		msg, wait_err = wait_for_topic(inbox, pid, "ok", "5s")
 		assert.is_nil(wait_err, wait_err)
 		assert.not_nil(msg, "first startup ok received")
-		local data = payload_data(msg)
+		local data = payload_data(msg as Message)
 		assert.is_table(data, "first startup ok payload table")
 		assert.eq(data.value, 1, "first startup increment applied")
 

--- a/tests/app/src/test/temporal/tests/startup_messages_explicit_id_error_on_started.lua
+++ b/tests/app/src/test/temporal/tests/startup_messages_explicit_id_error_on_started.lua
@@ -85,7 +85,7 @@ local function main()
 		msg, wait_err = wait_for_topic(inbox, pid, "ok", "5s")
 		assert.is_nil(wait_err, wait_err)
 		assert.not_nil(msg, "first startup ok received")
-		local data = payload_data(msg)
+		local data = payload_data(msg as Message)
 		assert.is_table(data, "first startup ok payload table")
 		assert.eq(data.value, 2, "first startup increment applied")
 

--- a/tests/app/src/test/temporal/tests/startup_messages_use_existing.lua
+++ b/tests/app/src/test/temporal/tests/startup_messages_use_existing.lua
@@ -79,7 +79,7 @@ local function main()
 	if msg == nil then
 		error("missing ok for first startup increment")
 	end
-	local data = payload_data(msg)
+	local data = payload_data(msg as Message)
 	assert.is_table(data, "ok payload is table")
 	assert.eq(data.value, 3, "first startup increment applied")
 
@@ -111,7 +111,7 @@ local function main()
 	if msg == nil then
 		error("missing ok for second startup increment")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	assert.is_table(data, "second ok payload is table")
 	assert.eq(data.value, 5, "second startup increment applied to existing workflow")
 
@@ -130,7 +130,7 @@ local function main()
 	if msg == nil then
 		error("missing finish ok")
 	end
-	data = payload_data(msg)
+	data = payload_data(msg as Message)
 	assert.is_table(data, "finish ok payload is table")
 	assert.contains(tostring(data.message), "finishing", "finish confirmation")
 

--- a/tests/app/src/test/temporal/tests/workflow_custom_name.lua
+++ b/tests/app/src/test/temporal/tests/workflow_custom_name.lua
@@ -1,0 +1,61 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+local assert = require("assert2")
+local time = require("time")
+
+local function wait_for_exit(events_ch, pid, timeout)
+	local deadline = time.after(timeout or "5s")
+	while true do
+		local result = channel.select {
+			events_ch:case_receive(),
+			deadline:case_receive(),
+		}
+		if result.channel == deadline then
+			return nil, "timeout waiting for exit"
+		end
+		local event = result.value
+		if event.from == pid and event.kind == process.event.EXIT then
+			return event, nil
+		end
+	end
+end
+
+local function main()
+	local events_ch = process.events()
+
+	local bare_pid, bare_err = process.spawn_monitored(
+		"ExternalNamedWorkflow",
+		"app.test.temporal:test_worker",
+		{ name = "Bare" }
+	)
+	assert.is_nil(bare_err, "spawn by bare custom name should not error")
+	assert.is_string(bare_pid, "got pid for bare-name spawn")
+
+	local bare_event, bare_wait = wait_for_exit(events_ch, bare_pid, "5s")
+	assert.is_nil(bare_wait, bare_wait)
+	assert.is_nil(bare_event.result.error, "bare-name workflow exited without error")
+	assert.is_table(bare_event.result.value, "bare-name result table")
+	assert.eq(bare_event.result.value.workflow, "ExternalNamedWorkflow", "bare name dispatched to the registered named workflow")
+	assert.contains(bare_event.result.value.message, "Bare", "bare-name message contains input")
+
+	local opt_pid, opt_err = process.with_options({
+		["workflow.name"] = "ExternalNamedWorkflow",
+	}):spawn_monitored(
+		"app.test.temporal.workflows:hello_workflow",
+		"app.test.temporal:test_worker",
+		{ name = "ViaOption" }
+	)
+	assert.is_nil(opt_err, "spawn with workflow.name option should not error")
+	assert.is_string(opt_pid, "got pid for option-override spawn")
+
+	local opt_event, opt_wait = wait_for_exit(events_ch, opt_pid, "5s")
+	assert.is_nil(opt_wait, opt_wait)
+	assert.is_nil(opt_event.result.error, "option-override workflow exited without error")
+	assert.is_table(opt_event.result.value, "option-override result table")
+	assert.eq(opt_event.result.value.workflow, "ExternalNamedWorkflow", "workflow.name option overrode the source id")
+	assert.contains(opt_event.result.value.message, "ViaOption", "option-override message contains input")
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/temporal/workflows/_index.yaml
+++ b/tests/app/src/test/temporal/workflows/_index.yaml
@@ -16,6 +16,20 @@ entries:
         workflow:
           worker: app.test.temporal:test_worker
 
+  # Named workflow - registered under an explicit string type name, decoupled
+  # from its registry id (proves meta.temporal.workflow.name on registration).
+  - name: named_hello_workflow
+    kind: workflow.lua
+    source: file://named_hello_workflow.lua
+    method: main
+    modules:
+      - time
+    meta:
+      temporal:
+        workflow:
+          worker: app.test.temporal:test_worker
+          name: ExternalNamedWorkflow
+
   # Concurrent workflow - demonstrates coroutines, channels, and timers
   - name: concurrent_workflow
     kind: workflow.lua

--- a/tests/app/src/test/temporal/workflows/named_hello_workflow.lua
+++ b/tests/app/src/test/temporal/workflows/named_hello_workflow.lua
@@ -1,0 +1,21 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+local time = require("time")
+
+local function main(input)
+	local name = "World"
+	if input ~= nil and input.name ~= nil then
+		name = input.name
+	end
+
+	time.sleep(50 * time.MILLISECOND)
+
+	return {
+		message = string.format("Named hello, %s!", name),
+		workflow = "ExternalNamedWorkflow",
+		status = "completed",
+		timestamp = time.now()
+	}
+end
+
+return main


### PR DESCRIPTION
## Why

Spawning a workflow whose registry ID has no namespace (e.g. an external, PHP-hosted workflow) recorded the Temporal `WorkflowType` as `":PopulateItemRelation"` instead of `"PopulateItemRelation"`. Temporal type names are plain strings that only *sometimes* coincide with a registry ID; the runtime derived them by stringifying `registry.ID` ad-hoc across the dispatch paths, so a namespace-less ID rendered in its canonical `:name` form leaked into the type name. There was also no first-class way to name an external workflow.

## What

- **Boundary names are plain strings.** A single resolver (`service/temporal/options/name.go`) owns the rule: prefer an explicit name, else the qualified id (`name` when the namespace is empty, `ns:name` otherwise — never a leading colon). The qualify logic lives entirely in the temporal options package; `registry.ID` is untouched.
- **Explicit name controls.** New `workflow.name` / `activity.name` spawn options (with `temporal.*` legacy aliases) and a `MetaActivityName` registration override mirroring the existing `MetaWorkflowName`.
- **All dispatch + registration sites** (host spawn, child spawn/exec, workflow exec, activity dispatch, continue-as-new, listeners) resolve through the resolver. `registry.ID` stays the carrier on `Start.Source` (the local process path needs it as a key) but is demoted to a naming fallback.
- **Application-level tests** under `tests/app` exercise the real Lua surface: a workflow registered under an explicit string name, spawned by a bare custom name and via the `workflow.name` option override.
- **Incidental fix:** narrowed `Message?` -> `Message` at 13 call sites in 5 pre-existing temporal app fixtures (latent Luau type error that blocked the temporal app suite from loading; unrelated to naming).

## Testing

- `make build-wippy` + `go build ./...` green; `golangci-lint` 0 issues; `go test -race ./service/temporal/... ./api/registry/` green.
- Go unit/integration: resolver precedence/fallback (canonical vs legacy alias, empty/non-string/nil -> fallback, namespace-less -> no colon); host dispatch wire-capture (`workflow.name` override and namespace-less default -> `PopulateItemRelation`); workflow + activity listener register/unregister symmetry with a custom name. gremlins on the resolver: 100% killed.
- **Application surface against a real Temporal dev server: app suite 423/423, temporal suite 41/41** including the new `workflow_custom_name` test (bare-name dispatch + option override end-to-end).
