### PR TITLE
feat(fs): support live embedded pack install/update lifecycle

### DIFF
--- a/api/service/fs/embed/registry.go
+++ b/api/service/fs/embed/registry.go
@@ -23,6 +23,16 @@ type Registry interface {
 	Close() error
 }
 
+// EntryResolver is an optional Registry capability that resolves a filesystem
+// for a specific registry entry, honoring the entry's module/version metadata.
+// It lets consumers pick the correct pack when more than one module version
+// exposes the same resource ID — for example, while a module update has both
+// the old and new packs staged. Implementations should fall back to GetFS for
+// entries without module metadata or whose owning pack is not registered.
+type EntryResolver interface {
+	GetFSForEntry(entry registry.Entry) (fs.ReadDirFS, error)
+}
+
 // WithRegistry stores the Registry in the context.
 func WithRegistry(ctx context.Context, reg Registry) context.Context {
 	ac := ctxapi.AppFromContext(ctx)

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -228,9 +228,19 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		})
 	}
 
+	var effects []regapi.Effect
+	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, snapshot)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	if packEffect != nil {
+		effects = append(effects, packEffect)
+	}
+
 	return regapi.DirectiveResult{
 		Applied:    true,
 		Additional: scoped,
+		Effects:    effects,
 	}, nil
 }
 

--- a/boot/deps/hub/embed_effect.go
+++ b/boot/deps/hub/embed_effect.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/wippyai/runtime/api/attrs"
+	apierror "github.com/wippyai/runtime/api/error"
+	regapi "github.com/wippyai/runtime/api/registry"
+	embedpkg "github.com/wippyai/runtime/service/fs/embed"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+// embedPackRegistry is the subset of the embed registry used to manage the
+// lifecycle of module-owned .wapp packs. It is satisfied by
+// *service/fs/embed.Registry and stubbed in tests.
+type embedPackRegistry interface {
+	RegisterPack(packPath, module, version string, reader *wapp.Reader, file *os.File) error
+	UnregisterPack(packPath string) error
+	UnregisterModule(module, version string) error
+}
+
+// stagedPack describes a new module pack to register during Prepare and to
+// roll back (unregister + close) if the apply fails.
+type stagedPack struct {
+	packPath string
+	module   string
+	version  string
+}
+
+// obsoletePack identifies a module pack to unregister (and close) on Commit
+// because the module was removed or replaced by a newer version.
+type obsoletePack struct {
+	module  string
+	version string
+}
+
+// embedPackEffect ties embedded-pack lifecycle to a module operation. Embedded
+// packs are module resources owned by dependency expansion, not by fs.embed
+// entries, so this effect runs alongside the registry changeset:
+//
+//   - Prepare registers newly resolved packs so the fs.embed entries created in
+//     the same changeset resolve during apply. New packs are keyed by their own
+//     .wapp path, so a version update stages the new pack without disturbing the
+//     pack still serving the old version.
+//   - Commit unregisters and closes packs made obsolete by the operation
+//     (removed modules on uninstall, prior versions on update). The new packs
+//     stay registered.
+//   - Rollback unregisters and closes the packs staged in Prepare, restoring the
+//     pre-operation set. Obsolete packs are left untouched because they are only
+//     dropped on a successful Commit.
+type embedPackEffect struct {
+	reg      embedPackRegistry
+	staged   []stagedPack
+	obsolete []obsoletePack
+	logger   *zap.Logger
+
+	prepared []string // pack paths registered by Prepare, for rollback
+}
+
+func (e *embedPackEffect) Prepare(_ context.Context) error {
+	for _, sp := range e.staged {
+		f, err := os.Open(sp.packPath)
+		if err != nil {
+			return newOpenPackError(sp.packPath, err)
+		}
+
+		reader, err := wapp.NewReader(f)
+		if err != nil {
+			f.Close()
+			return newReadPackError(sp.packPath, err)
+		}
+
+		if err := e.reg.RegisterPack(sp.packPath, sp.module, sp.version, reader, f); err != nil {
+			f.Close()
+			return newRegisterPackError(sp.packPath, err)
+		}
+		e.prepared = append(e.prepared, sp.packPath)
+
+		e.logger.Debug("staged embedded pack",
+			zap.String("path", sp.packPath),
+			zap.String("module", sp.module),
+			zap.String("version", sp.version))
+	}
+	return nil
+}
+
+func (e *embedPackEffect) Commit(_ context.Context) error {
+	for _, op := range e.obsolete {
+		if err := e.reg.UnregisterModule(op.module, op.version); err != nil {
+			// Logged, not fatal: the changeset already committed and the old
+			// pack is no longer referenced by any live entry. Failing here
+			// would only leak a file handle for the rest of the process life.
+			e.logger.Warn("failed to unregister obsolete embedded pack",
+				zap.String("module", op.module),
+				zap.String("version", op.version),
+				zap.Error(err))
+			continue
+		}
+		e.logger.Debug("released obsolete embedded pack",
+			zap.String("module", op.module),
+			zap.String("version", op.version))
+	}
+	return nil
+}
+
+func (e *embedPackEffect) Rollback(_ context.Context) error {
+	for _, packPath := range e.prepared {
+		if err := e.reg.UnregisterPack(packPath); err != nil {
+			e.logger.Warn("failed to unregister staged embedded pack during rollback",
+				zap.String("path", packPath),
+				zap.Error(err))
+		}
+	}
+	e.prepared = nil
+	return nil
+}
+
+// buildEmbedPackEffect computes the pack-lifecycle effect for a module
+// operation. resolved are the desired modules after the operation; snapshot is
+// the registry state before it. staged packs are the resolved modules backed by
+// a .wapp on disk; obsolete packs are modules present in the snapshot whose
+// version is no longer desired (removed) or has changed (updated).
+//
+// Returns nil when there is no embed registry in the context, or when neither
+// staged nor obsolete packs exist, so callers can append it unconditionally.
+func (h *DependencyHandler) buildEmbedPackEffect(
+	ctx context.Context,
+	resolved []ResolvedModule,
+	snapshot regapi.State,
+) (*embedPackEffect, error) {
+	reg := embedpkg.GetRegistryFromContext(ctx)
+	if reg == nil {
+		return nil, nil
+	}
+
+	desired := make(map[string]string, len(resolved))
+	staged := make([]stagedPack, 0, len(resolved))
+	for _, mod := range resolved {
+		name := mod.Org + "/" + mod.Name
+		desired[name] = mod.Version
+
+		path, isWapp, err := h.modulePackPath(ctx, mod)
+		if err != nil {
+			return nil, err
+		}
+		if !isWapp {
+			continue
+		}
+		staged = append(staged, stagedPack{
+			packPath: path,
+			module:   name,
+			version:  mod.Version,
+		})
+	}
+
+	obsolete := obsoletePacksFor(snapshot, desired)
+
+	if len(staged) == 0 && len(obsolete) == 0 {
+		return nil, nil
+	}
+
+	logger := h.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &embedPackEffect{
+		reg:      reg,
+		staged:   staged,
+		obsolete: obsolete,
+		logger:   logger.Named("embed_pack"),
+	}, nil
+}
+
+// obsoletePacksFor returns the snapshot modules whose version is not the desired
+// version (changed) or which are no longer desired at all (removed). A staged
+// pack for the new version is keyed by its own path, so unregistering the old
+// version by (module, version) never affects the new pack.
+func obsoletePacksFor(snapshot regapi.State, desired map[string]string) []obsoletePack {
+	current := snapshotModuleVersions(snapshot)
+	obsolete := make([]obsoletePack, 0)
+	for module, version := range current {
+		if version == "" {
+			continue
+		}
+		if want, ok := desired[module]; ok && want == version {
+			continue
+		}
+		obsolete = append(obsolete, obsoletePack{module: module, version: version})
+	}
+	return obsolete
+}
+
+// modulePackPath returns the on-disk path the module would be registered under
+// and whether that path is a .wapp pack. Replacement (local source) and
+// unpacked modules are directories and are reported as non-pack.
+func (h *DependencyHandler) modulePackPath(ctx context.Context, mod ResolvedModule) (string, bool, error) {
+	path, err := h.ensureModuleAvailable(ctx, mod)
+	if err != nil {
+		return "", false, err
+	}
+	return path, filepath.Ext(path) == ".wapp", nil
+}
+
+func newOpenPackError(path string, cause error) apierror.Error {
+	return apierror.New(apierror.Internal, "open embedded pack failed").
+		WithDetails(attrs.NewBagFrom(map[string]any{"path": path})).
+		WithCause(cause)
+}
+
+func newReadPackError(path string, cause error) apierror.Error {
+	return apierror.New(apierror.Internal, "read embedded pack failed").
+		WithDetails(attrs.NewBagFrom(map[string]any{"path": path})).
+		WithCause(cause)
+}
+
+func newRegisterPackError(path string, cause error) apierror.Error {
+	return apierror.New(apierror.Internal, "register embedded pack failed").
+		WithDetails(attrs.NewBagFrom(map[string]any{"path": path})).
+		WithCause(cause)
+}

--- a/boot/deps/hub/embed_effect.go
+++ b/boot/deps/hub/embed_effect.go
@@ -139,10 +139,15 @@ func (h *DependencyHandler) buildEmbedPackEffect(
 	}
 
 	desired := make(map[string]string, len(resolved))
+	installed := snapshotModuleVersions(snapshot)
 	staged := make([]stagedPack, 0, len(resolved))
 	for _, mod := range resolved {
 		name := mod.Org + "/" + mod.Name
 		desired[name] = mod.Version
+
+		if installed[name] == mod.Version {
+			continue
+		}
 
 		path, isWapp, err := h.modulePackPath(ctx, mod)
 		if err != nil {

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+// stubPackRegistry records pack lifecycle calls for assertions.
+type stubPackRegistry struct {
+	registered     map[string]*wapp.Reader
+	files          map[string]*os.File
+	unregistered   []string
+	modulesDropped []droppedModule
+
+	registerErr error
+}
+
+type droppedModule struct {
+	module  string
+	version string
+}
+
+func newStubPackRegistry() *stubPackRegistry {
+	return &stubPackRegistry{
+		registered: make(map[string]*wapp.Reader),
+		files:      make(map[string]*os.File),
+	}
+}
+
+func (s *stubPackRegistry) RegisterPack(packPath, _, _ string, reader *wapp.Reader, file *os.File) error {
+	if s.registerErr != nil {
+		return s.registerErr
+	}
+	s.registered[packPath] = reader
+	s.files[packPath] = file
+	return nil
+}
+
+func (s *stubPackRegistry) UnregisterPack(packPath string) error {
+	s.unregistered = append(s.unregistered, packPath)
+	if f := s.files[packPath]; f != nil {
+		_ = f.Close()
+	}
+	delete(s.registered, packPath)
+	delete(s.files, packPath)
+	return nil
+}
+
+func (s *stubPackRegistry) UnregisterModule(module, version string) error {
+	s.modulesDropped = append(s.modulesDropped, droppedModule{module: module, version: version})
+	return nil
+}
+
+// writeResourceWapp writes a .wapp containing one filesystem resource.
+func writeResourceWapp(t *testing.T, path, ns, name string, files map[string]string) {
+	t.Helper()
+
+	mapFS := fstest.MapFS{}
+	for p, content := range files {
+		mapFS[p] = &fstest.MapFile{Data: []byte(content), Mode: 0644}
+	}
+
+	var buf bytes.Buffer
+	writer := wapp.NewWriter()
+	require.NoError(t, writer.PackWithResources(
+		wapp.Metadata{},
+		nil,
+		[]wapp.ResourceSpec{{ID: wapp.NewID(ns, name), FS: mapFS}},
+		&buf,
+	))
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0600))
+}
+
+func newEffect(reg embedPackRegistry, staged []stagedPack, obsolete []obsoletePack) *embedPackEffect {
+	return &embedPackEffect{
+		reg:      reg,
+		staged:   staged,
+		obsolete: obsolete,
+		logger:   zap.NewNop(),
+	}
+}
+
+func TestEmbedPackEffect_PrepareCommit(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "org", "mod-v1.0.0.wapp")
+	writeResourceWapp(t, packPath, "ui", "app", map[string]string{"index.html": "<html>"})
+
+	reg := newStubPackRegistry()
+	eff := newEffect(reg, []stagedPack{{packPath: packPath, module: "org/mod", version: "1.0.0"}}, nil)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	assert.Contains(t, reg.registered, packPath)
+	require.Len(t, eff.prepared, 1)
+
+	require.NoError(t, eff.Commit(context.Background()))
+	// Commit must not unregister the staged pack on a fresh install.
+	assert.Empty(t, reg.unregistered)
+	assert.Empty(t, reg.modulesDropped)
+}
+
+func TestEmbedPackEffect_Rollback(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "org", "mod-v1.0.0.wapp")
+	writeResourceWapp(t, packPath, "ui", "app", map[string]string{"index.html": "<html>"})
+
+	reg := newStubPackRegistry()
+	eff := newEffect(reg, []stagedPack{{packPath: packPath, module: "org/mod", version: "1.0.0"}}, nil)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	require.NoError(t, eff.Rollback(context.Background()))
+
+	assert.Contains(t, reg.unregistered, packPath)
+	assert.NotContains(t, reg.registered, packPath)
+	assert.Nil(t, eff.prepared)
+}
+
+func TestEmbedPackEffect_Update(t *testing.T) {
+	dir := t.TempDir()
+	newPack := filepath.Join(dir, "org", "mod-v2.0.0.wapp")
+	writeResourceWapp(t, newPack, "ui", "app", map[string]string{"index.html": "<html>v2"})
+
+	reg := newStubPackRegistry()
+	eff := newEffect(reg,
+		[]stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}},
+		[]obsoletePack{{module: "org/mod", version: "1.0.0"}},
+	)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	assert.Contains(t, reg.registered, newPack)
+
+	require.NoError(t, eff.Commit(context.Background()))
+	// Old version dropped on commit; new pack remains registered.
+	require.Len(t, reg.modulesDropped, 1)
+	assert.Equal(t, droppedModule{module: "org/mod", version: "1.0.0"}, reg.modulesDropped[0])
+	assert.Contains(t, reg.registered, newPack)
+}
+
+func TestEmbedPackEffect_UpdateRollbackKeepsOld(t *testing.T) {
+	dir := t.TempDir()
+	newPack := filepath.Join(dir, "org", "mod-v2.0.0.wapp")
+	writeResourceWapp(t, newPack, "ui", "app", map[string]string{"index.html": "<html>v2"})
+
+	reg := newStubPackRegistry()
+	eff := newEffect(reg,
+		[]stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}},
+		[]obsoletePack{{module: "org/mod", version: "1.0.0"}},
+	)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	require.NoError(t, eff.Rollback(context.Background()))
+
+	// New pack removed; old version never dropped because Commit did not run.
+	assert.Contains(t, reg.unregistered, newPack)
+	assert.Empty(t, reg.modulesDropped)
+}
+
+func TestEmbedPackEffect_Uninstall(t *testing.T) {
+	reg := newStubPackRegistry()
+	eff := newEffect(reg, nil, []obsoletePack{{module: "org/mod", version: "1.0.0"}})
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	assert.Empty(t, reg.registered)
+
+	require.NoError(t, eff.Commit(context.Background()))
+	require.Len(t, reg.modulesDropped, 1)
+	assert.Equal(t, droppedModule{module: "org/mod", version: "1.0.0"}, reg.modulesDropped[0])
+}
+
+func TestEmbedPackEffect_PrepareMissingPackFails(t *testing.T) {
+	reg := newStubPackRegistry()
+	eff := newEffect(reg, []stagedPack{{packPath: "/does/not/exist.wapp", module: "org/mod", version: "1.0.0"}}, nil)
+
+	err := eff.Prepare(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open embedded pack failed")
+}
+
+func TestObsoletePacksFor(t *testing.T) {
+	snapshot := regapi.State{
+		moduleEntry("ui", "old-app", "org/mod", "1.0.0"),
+		moduleEntry("ui", "stable", "org/other", "3.0.0"),
+		moduleEntry("ui", "noversion", "org/nover", ""),
+	}
+
+	t.Run("update marks changed version obsolete", func(t *testing.T) {
+		desired := map[string]string{"org/mod": "2.0.0", "org/other": "3.0.0"}
+		obs := obsoletePacksFor(snapshot, desired)
+		require.Len(t, obs, 1)
+		assert.Equal(t, obsoletePack{module: "org/mod", version: "1.0.0"}, obs[0])
+	})
+
+	t.Run("removal marks dropped module obsolete", func(t *testing.T) {
+		desired := map[string]string{"org/other": "3.0.0"}
+		obs := obsoletePacksFor(snapshot, desired)
+		require.Len(t, obs, 1)
+		assert.Equal(t, obsoletePack{module: "org/mod", version: "1.0.0"}, obs[0])
+	})
+
+	t.Run("unchanged versions are not obsolete", func(t *testing.T) {
+		desired := map[string]string{"org/mod": "1.0.0", "org/other": "3.0.0"}
+		obs := obsoletePacksFor(snapshot, desired)
+		assert.Empty(t, obs)
+	})
+}
+
+func TestBuildEmbedPackEffect_NoRegistry(t *testing.T) {
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       &fakeHub{},
+		Logger:    zap.NewNop(),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	// No embed registry installed in context: effect is skipped.
+	eff, err := handler.buildEmbedPackEffect(newTestContext(), nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, eff)
+}
+
+func moduleEntry(ns, name, module, version string) regapi.Entry {
+	meta := attrs.NewBag()
+	meta.Set(metaModuleKey, module)
+	if version != "" {
+		meta.Set(metaModuleVersionKey, version)
+	}
+	return regapi.Entry{ID: regapi.NewID(ns, name), Meta: meta}
+}

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -66,6 +66,20 @@ func (s *stubPackRegistry) UnregisterModule(module, version string) error {
 	return nil
 }
 
+func (s *stubPackRegistry) Close() error {
+	var firstErr error
+	for packPath, f := range s.files {
+		if f != nil {
+			if err := f.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		delete(s.files, packPath)
+		delete(s.registered, packPath)
+	}
+	return firstErr
+}
+
 // writeResourceWapp writes a .wapp containing one filesystem resource.
 func writeResourceWapp(t *testing.T, path, ns, name string, files map[string]string) {
 	t.Helper()
@@ -103,6 +117,7 @@ func TestEmbedPackEffect_PrepareCommit(t *testing.T) {
 	writeResourceWapp(t, packPath, "ui", "app", map[string]string{"index.html": "<html>"})
 
 	reg := newStubPackRegistry()
+	defer func() { require.NoError(t, reg.Close()) }()
 	eff := newEffect(reg, []stagedPack{{packPath: packPath, module: "org/mod", version: "1.0.0"}}, nil)
 
 	require.NoError(t, eff.Prepare(context.Background()))
@@ -137,6 +152,7 @@ func TestEmbedPackEffect_Update(t *testing.T) {
 	writeResourceWapp(t, newPack, "ui", "app", map[string]string{"index.html": "<html>v2"})
 
 	reg := newStubPackRegistry()
+	defer func() { require.NoError(t, reg.Close()) }()
 	eff := newEffect(reg,
 		[]stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}},
 		[]obsoletePack{{module: "org/mod", version: "1.0.0"}},
@@ -258,6 +274,7 @@ func TestBuildEmbedPackEffect_SkipsUnchangedResolvedPack(t *testing.T) {
 
 func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
 	reg := embedpkg.NewRegistry()
+	defer func() { require.NoError(t, reg.Close()) }()
 	ctx := embedapi.WithRegistry(newTestContext(), reg)
 	vendorDir := t.TempDir()
 

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -5,6 +5,7 @@ package hub
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,12 +23,11 @@ import (
 
 // stubPackRegistry records pack lifecycle calls for assertions.
 type stubPackRegistry struct {
+	registerErr    error
 	registered     map[string]*wapp.Reader
 	files          map[string]*os.File
 	unregistered   []string
 	modulesDropped []droppedModule
-
-	registerErr error
 }
 
 type droppedModule struct {
@@ -256,6 +256,85 @@ func TestBuildEmbedPackEffect_SkipsUnchangedResolvedPack(t *testing.T) {
 	assert.Nil(t, eff)
 }
 
+func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
+	reg := embedpkg.NewRegistry()
+	ctx := embedapi.WithRegistry(newTestContext(), reg)
+	vendorDir := t.TempDir()
+
+	oldReader := createHubResourceReader(t, "ui", "app", map[string]string{"v.txt": "1"})
+	stableReader := createHubResourceReader(t, "ui", "stable", map[string]string{"v.txt": "stable"})
+	removedReader := createHubResourceReader(t, "ui", "removed", map[string]string{"v.txt": "removed"})
+	require.NoError(t, reg.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", oldReader, nil))
+	require.NoError(t, reg.RegisterPack("org/stable-v1.0.0.wapp", "org/stable", "1.0.0", stableReader, nil))
+	require.NoError(t, reg.RegisterPack("org/removed-v3.0.0.wapp", "org/removed", "3.0.0", removedReader, nil))
+
+	newPack := filepath.Join(vendorDir, "org", "mod-2.0.0.wapp")
+	writeResourceWapp(t, newPack, "ui", "app", map[string]string{"v.txt": "2"})
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+				t.Fatal("test pack already exists in the vendor cache")
+				return nil, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	resolved := []ResolvedModule{
+		{Org: "org", Name: "mod", Version: "2.0.0"},
+		{Org: "org", Name: "stable", Version: "1.0.0"},
+	}
+	snapshot := regapi.State{
+		moduleEntry("ui", "app", "org/mod", "1.0.0"),
+		moduleEntry("ui", "stable", "org/stable", "1.0.0"),
+		moduleEntry("ui", "removed", "org/removed", "3.0.0"),
+	}
+
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
+	require.NoError(t, err)
+	require.NotNil(t, eff)
+	assert.Equal(t, []stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}}, eff.staged)
+	assert.ElementsMatch(t, []obsoletePack{
+		{module: "org/mod", version: "1.0.0"},
+		{module: "org/removed", version: "3.0.0"},
+	}, eff.obsolete)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	assert.Equal(t, "1", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "1.0.0"), "v.txt"))
+	assert.Equal(t, "2", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "2.0.0"), "v.txt"))
+	assert.Equal(t, "stable", readHubResource(t, reg, moduleEntry("ui", "stable", "org/stable", "1.0.0"), "v.txt"))
+
+	require.NoError(t, eff.Commit(context.Background()))
+	assert.Equal(t, "2", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "2.0.0"), "v.txt"))
+	assert.Equal(t, "stable", readHubResource(t, reg, moduleEntry("ui", "stable", "org/stable", "1.0.0"), "v.txt"))
+	_, err = reg.GetFS(regapi.NewID("ui", "removed"))
+	require.Error(t, err)
+}
+
+func TestEmbedPackEffect_UpdateRollbackKeepsLiveOldVersion(t *testing.T) {
+	reg := embedpkg.NewRegistry()
+	oldReader := createHubResourceReader(t, "ui", "app", map[string]string{"v.txt": "1"})
+	require.NoError(t, reg.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", oldReader, nil))
+
+	dir := t.TempDir()
+	newPack := filepath.Join(dir, "org", "mod-v2.0.0.wapp")
+	writeResourceWapp(t, newPack, "ui", "app", map[string]string{"v.txt": "2"})
+
+	eff := newEffect(reg,
+		[]stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}},
+		[]obsoletePack{{module: "org/mod", version: "1.0.0"}},
+	)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	assert.Equal(t, "2", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "2.0.0"), "v.txt"))
+
+	require.NoError(t, eff.Rollback(context.Background()))
+	assert.Equal(t, "1", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "1.0.0"), "v.txt"))
+}
+
 func moduleEntry(ns, name, module, version string) regapi.Entry {
 	meta := attrs.NewBag()
 	meta.Set(metaModuleKey, module)
@@ -263,4 +342,28 @@ func moduleEntry(ns, name, module, version string) regapi.Entry {
 		meta.Set(metaModuleVersionKey, version)
 	}
 	return regapi.Entry{ID: regapi.NewID(ns, name), Meta: meta}
+}
+
+func createHubResourceReader(t *testing.T, ns, name string, files map[string]string) *wapp.Reader {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name+".wapp")
+	writeResourceWapp(t, path, ns, name, files)
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+
+	reader, err := wapp.NewReader(file)
+	require.NoError(t, err)
+	return reader
+}
+
+func readHubResource(t *testing.T, reg *embedpkg.Registry, entry regapi.Entry, name string) string {
+	t.Helper()
+
+	fsys, err := reg.GetFSForEntry(entry)
+	require.NoError(t, err)
+	data, err := fs.ReadFile(fsys, name)
+	require.NoError(t, err)
+	return string(data)
 }

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/attrs"
 	regapi "github.com/wippyai/runtime/api/registry"
+	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
+	embedpkg "github.com/wippyai/runtime/service/fs/embed"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
@@ -228,6 +230,28 @@ func TestBuildEmbedPackEffect_NoRegistry(t *testing.T) {
 
 	// No embed registry installed in context: effect is skipped.
 	eff, err := handler.buildEmbedPackEffect(newTestContext(), nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, eff)
+}
+
+func TestBuildEmbedPackEffect_SkipsUnchangedResolvedPack(t *testing.T) {
+	ctx := embedapi.WithRegistry(newTestContext(), embedpkg.NewRegistry())
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+				t.Fatal("unchanged module should not resolve a pack path")
+				return nil, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0"}}
+	snapshot := regapi.State{moduleEntry("ui", "app", "org/mod", "1.0.0")}
+
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
 	require.NoError(t, err)
 	assert.Nil(t, eff)
 }

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -72,7 +72,7 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 	logger.Info("loaded entries", zap.Int("count", len(entries)))
 
 	// Register .wapp files with embed registry for fs.embed support
-	if err := registerWappWithEmbedRegistry(ctx, flatPaths, logger); err != nil {
+	if err := registerWappWithEmbedRegistry(ctx, modulePaths, logger); err != nil {
 		return err
 	}
 
@@ -692,35 +692,41 @@ func ConvertToWappEntries(entries []regapi.Entry) []wapp.Entry {
 }
 
 // registerWappWithEmbedRegistry registers .wapp files with the embed registry for fs.embed support.
-// Files are kept open and tracked by the registry for cleanup on close.
-func registerWappWithEmbedRegistry(ctx context.Context, paths []string, logger *zap.Logger) error {
+// Files are kept open and owned by the registry, which closes them on unregister
+// or registry close. Packs are tagged with their owning module/version so live
+// module updates and uninstalls can target the exact pack via the same API the
+// hub dependency handler uses.
+func registerWappWithEmbedRegistry(ctx context.Context, modulePaths []lock.ModuleLoadPath, logger *zap.Logger) error {
 	embedReg := embedpkg.GetRegistryFromContext(ctx)
 	if embedReg == nil {
 		return nil // No embed registry, skip
 	}
 
-	for _, path := range paths {
-		if filepath.Ext(path) != ".wapp" {
+	for _, mp := range modulePaths {
+		if filepath.Ext(mp.Path) != ".wapp" {
 			continue
 		}
 
-		f, err := os.Open(path)
+		f, err := os.Open(mp.Path)
 		if err != nil {
-			return NewOpenWappError(path, err)
+			return NewOpenWappError(mp.Path, err)
 		}
 
 		reader, err := wapp.NewReader(f)
 		if err != nil {
 			f.Close()
-			return NewReadWappError(path, err)
+			return NewReadWappError(mp.Path, err)
 		}
 
-		if err := embedReg.Register(path, reader, f); err != nil {
+		if err := embedReg.RegisterPack(mp.Path, mp.Module, mp.Version, reader, f); err != nil {
 			f.Close()
 			return NewRegisterEmbedResourcesError(err)
 		}
 
-		logger.Debug("registered wapp with embed registry", zap.String("path", path))
+		logger.Debug("registered wapp with embed registry",
+			zap.String("path", mp.Path),
+			zap.String("module", mp.Module),
+			zap.String("version", mp.Version))
 	}
 
 	return nil

--- a/service/fs/embed/integration_test.go
+++ b/service/fs/embed/integration_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package embed
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/registry"
+	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
+	"github.com/wippyai/runtime/system/eventbus"
+	"go.uber.org/zap"
+)
+
+// TestLiveInstall_PackRegisteredResolvesForEntry reproduces the live hub-install
+// path: a module pack is registered into the concrete Registry, then the embed
+// Manager adds the module's fs.embed entry. The entry must resolve to the
+// registered pack's filesystem — before the fix this failed because live installs
+// never registered the pack reader.
+func TestLiveInstall_PackRegisteredResolvesForEntry(t *testing.T) {
+	reg := NewRegistry()
+	reader := createReaderWithResource(t, "ui", "app", map[string]string{"index.html": "<html>live</html>"})
+	require.NoError(t, reg.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", reader, nil))
+
+	manager := NewManager(eventbus.NewBus(), &mockDTT{}, reg, zap.NewNop())
+
+	entry := registry.Entry{
+		ID:   registry.NewID("ui", "app"),
+		Kind: embedapi.Kind,
+		Meta: moduleMeta("org/mod", "1.0.0"),
+		Data: payload.New(&embedapi.Config{}),
+	}
+
+	require.NoError(t, manager.Add(context.Background(), entry))
+
+	fsys, err := manager.resolveFS(entry)
+	require.NoError(t, err)
+	data, err := fs.ReadFile(fsys, "index.html")
+	require.NoError(t, err)
+	assert.Equal(t, "<html>live</html>", string(data))
+}
+
+// TestLiveUpdate_NewVersionResolvesWhileOldStaged proves version-aware resolution
+// during an update: both pack versions are registered simultaneously (as they are
+// between Prepare and Commit), and each entry resolves to its own version.
+func TestLiveUpdate_NewVersionResolvesWhileOldStaged(t *testing.T) {
+	reg := NewRegistry()
+	oldReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "1"})
+	newReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "2"})
+	require.NoError(t, reg.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", oldReader, nil))
+	require.NoError(t, reg.RegisterPack("org/mod-v2.0.0.wapp", "org/mod", "2.0.0", newReader, nil))
+
+	manager := NewManager(eventbus.NewBus(), &mockDTT{}, reg, zap.NewNop())
+
+	newEntry := registry.Entry{
+		ID:   registry.NewID("ui", "app"),
+		Kind: embedapi.Kind,
+		Meta: moduleMeta("org/mod", "2.0.0"),
+		Data: payload.New(&embedapi.Config{}),
+	}
+
+	fsys, err := manager.resolveFS(newEntry)
+	require.NoError(t, err)
+	data, err := fs.ReadFile(fsys, "v.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(data))
+
+	// After the old pack is dropped on commit, resolution still works.
+	require.NoError(t, reg.UnregisterModule("org/mod", "1.0.0"))
+	fsys, err = manager.resolveFS(newEntry)
+	require.NoError(t, err)
+	data, err = fs.ReadFile(fsys, "v.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(data))
+}
+
+// TestUninstall_PackUnregisteredNoLongerResolves confirms that once a module pack
+// is unregistered, its fs.embed entry no longer resolves.
+func TestUninstall_PackUnregisteredNoLongerResolves(t *testing.T) {
+	reg := NewRegistry()
+	reader := createReaderWithResource(t, "ui", "app", map[string]string{"index.html": "x"})
+	require.NoError(t, reg.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", reader, nil))
+
+	manager := NewManager(eventbus.NewBus(), &mockDTT{}, reg, zap.NewNop())
+	entry := registry.Entry{
+		ID:   registry.NewID("ui", "app"),
+		Kind: embedapi.Kind,
+		Meta: moduleMeta("org/mod", "1.0.0"),
+		Data: payload.New(&embedapi.Config{}),
+	}
+
+	_, err := manager.resolveFS(entry)
+	require.NoError(t, err)
+
+	require.NoError(t, reg.UnregisterModule("org/mod", "1.0.0"))
+	_, err = manager.resolveFS(entry)
+	require.Error(t, err)
+}
+
+func moduleMeta(module, version string) attrs.Bag {
+	meta := attrs.NewBag()
+	meta.Set(metaModuleKey, module)
+	meta.Set(metaModuleVersionKey, version)
+	return meta
+}

--- a/service/fs/embed/integration_test.go
+++ b/service/fs/embed/integration_test.go
@@ -4,6 +4,7 @@ package embed
 
 import (
 	"context"
+	"io"
 	"io/fs"
 	"testing"
 
@@ -56,6 +57,14 @@ func TestLiveUpdate_NewVersionResolvesWhileOldStaged(t *testing.T) {
 	require.NoError(t, reg.RegisterPack("org/mod-v2.0.0.wapp", "org/mod", "2.0.0", newReader, nil))
 
 	manager := NewManager(eventbus.NewBus(), &mockDTT{}, reg, zap.NewNop())
+	oldEntry := registry.Entry{
+		ID:   registry.NewID("ui", "app"),
+		Kind: embedapi.Kind,
+		Meta: moduleMeta("org/mod", "1.0.0"),
+		Data: payload.New(&embedapi.Config{}),
+	}
+	require.NoError(t, manager.Add(context.Background(), oldEntry))
+	assert.Equal(t, "1", readManagerFile(t, manager, oldEntry.ID, "v.txt"))
 
 	newEntry := registry.Entry{
 		ID:   registry.NewID("ui", "app"),
@@ -63,6 +72,9 @@ func TestLiveUpdate_NewVersionResolvesWhileOldStaged(t *testing.T) {
 		Meta: moduleMeta("org/mod", "2.0.0"),
 		Data: payload.New(&embedapi.Config{}),
 	}
+
+	require.NoError(t, manager.Update(context.Background(), newEntry))
+	assert.Equal(t, "2", readManagerFile(t, manager, newEntry.ID, "v.txt"))
 
 	fsys, err := manager.resolveFS(newEntry)
 	require.NoError(t, err)
@@ -107,4 +119,21 @@ func moduleMeta(module, version string) attrs.Bag {
 	meta.Set(metaModuleKey, module)
 	meta.Set(metaModuleVersionKey, version)
 	return meta
+}
+
+func readManagerFile(t *testing.T, manager *Manager, id registry.ID, name string) string {
+	t.Helper()
+
+	manager.mu.RLock()
+	fsys := manager.filesystems[id]
+	manager.mu.RUnlock()
+	require.NotNil(t, fsys)
+
+	file, err := fsys.Open(name)
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(file)
+	require.NoError(t, err)
+	return string(data)
 }

--- a/service/fs/embed/integration_test.go
+++ b/service/fs/embed/integration_test.go
@@ -91,6 +91,35 @@ func TestLiveUpdate_NewVersionResolvesWhileOldStaged(t *testing.T) {
 	assert.Equal(t, "2", string(data))
 }
 
+// TestLiveUpdate_MissingNewVersionDoesNotSwapToOld proves update is strict
+// about module version metadata. If the new pack was not staged, updating the
+// fs.embed entry must fail and leave the current live filesystem in place.
+func TestLiveUpdate_MissingNewVersionDoesNotSwapToOld(t *testing.T) {
+	reg := NewRegistry()
+	oldReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "1"})
+	require.NoError(t, reg.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", oldReader, nil))
+
+	manager := NewManager(eventbus.NewBus(), &mockDTT{}, reg, zap.NewNop())
+	oldEntry := registry.Entry{
+		ID:   registry.NewID("ui", "app"),
+		Kind: embedapi.Kind,
+		Meta: moduleMeta("org/mod", "1.0.0"),
+		Data: payload.New(&embedapi.Config{}),
+	}
+	require.NoError(t, manager.Add(context.Background(), oldEntry))
+	assert.Equal(t, "1", readManagerFile(t, manager, oldEntry.ID, "v.txt"))
+
+	newEntry := oldEntry
+	newEntry.Meta = moduleMeta("org/mod", "2.0.0")
+	err := manager.Update(context.Background(), newEntry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get embedded filesystem")
+	assert.Equal(t, "1", readManagerFile(t, manager, oldEntry.ID, "v.txt"))
+
+	_, err = manager.resolveFS(newEntry)
+	require.Error(t, err)
+}
+
 // TestUninstall_PackUnregisteredNoLongerResolves confirms that once a module pack
 // is unregistered, its fs.embed entry no longer resolves.
 func TestUninstall_PackUnregisteredNoLongerResolves(t *testing.T) {

--- a/service/fs/embed/manager.go
+++ b/service/fs/embed/manager.go
@@ -4,6 +4,7 @@ package embed
 
 import (
 	"context"
+	"io/fs"
 	"sync"
 
 	"github.com/wippyai/runtime/api/event"
@@ -59,7 +60,7 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 		return systemfs.NewFilesystemAlreadyExistsError(entry.ID.String())
 	}
 
-	if err := m.registerFS(ctx, entry.ID); err != nil {
+	if err := m.registerFS(ctx, entry); err != nil {
 		return err
 	}
 
@@ -82,7 +83,7 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 
 	// Remove old, register new
 	m.removeFS(ctx, entry.ID)
-	if err := m.registerFS(ctx, entry.ID); err != nil {
+	if err := m.registerFS(ctx, entry); err != nil {
 		return err
 	}
 
@@ -110,13 +111,15 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 	return nil
 }
 
-// registerFS retrieves the filesystem from embed registry and registers it.
-func (m *Manager) registerFS(ctx context.Context, id registry.ID) error {
-	// Get filesystem from embed registry
-	packFS, err := m.embedReg.GetFS(id)
+// registerFS retrieves the filesystem from the embed registry and registers it.
+// Resolution is entry-aware when the registry supports it, so updates select the
+// pack matching the entry's module/version rather than an arbitrary pack that
+// happens to expose the same resource ID.
+func (m *Manager) registerFS(ctx context.Context, entry registry.Entry) error {
+	packFS, err := m.resolveFS(entry)
 	if err != nil {
 		m.log.Error("failed to get embedded filesystem",
-			zap.String("id", id.String()),
+			zap.String("id", entry.ID.String()),
 			zap.Error(err))
 		return systemfs.NewGetEmbeddedFilesystemError(err)
 	}
@@ -125,17 +128,26 @@ func (m *Manager) registerFS(ctx context.Context, id registry.ID) error {
 	fs := fsapi.NewReadOnlyFS(packFS)
 
 	// Store in filesystems map
-	m.filesystems[id] = fs
+	m.filesystems[entry.ID] = fs
 
 	// Register with filesystem registry
 	m.bus.Send(ctx, event.Event{
 		System: fsapi.System,
 		Kind:   fsapi.FsRegister,
-		Path:   id.String(),
+		Path:   entry.ID.String(),
 		Data:   fs,
 	})
 
 	return nil
+}
+
+// resolveFS prefers an entry-aware lookup when the registry implements
+// embedapi.EntryResolver, otherwise falls back to ID-based lookup.
+func (m *Manager) resolveFS(entry registry.Entry) (fs.ReadDirFS, error) {
+	if resolver, ok := m.embedReg.(embedapi.EntryResolver); ok {
+		return resolver.GetFSForEntry(entry)
+	}
+	return m.embedReg.GetFS(entry.ID)
 }
 
 // removeFS removes the filesystem from the fs system.

--- a/service/fs/embed/manager.go
+++ b/service/fs/embed/manager.go
@@ -81,11 +81,12 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 		return systemfs.NewFilesystemNotFoundError(entry.ID.String())
 	}
 
-	// Remove old, register new
-	m.removeFS(ctx, entry.ID)
-	if err := m.registerFS(ctx, entry); err != nil {
+	nextFS, err := m.fsForEntry(entry)
+	if err != nil {
 		return err
 	}
+	m.removeFS(ctx, entry.ID)
+	m.storeFS(ctx, entry.ID, nextFS)
 
 	m.log.Info("embedded filesystem updated", zap.String("id", entry.ID.String()))
 	return nil
@@ -116,29 +117,35 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 // pack matching the entry's module/version rather than an arbitrary pack that
 // happens to expose the same resource ID.
 func (m *Manager) registerFS(ctx context.Context, entry registry.Entry) error {
+	fs, err := m.fsForEntry(entry)
+	if err != nil {
+		return err
+	}
+	m.storeFS(ctx, entry.ID, fs)
+	return nil
+}
+
+func (m *Manager) fsForEntry(entry registry.Entry) (fsapi.FS, error) {
 	packFS, err := m.resolveFS(entry)
 	if err != nil {
 		m.log.Error("failed to get embedded filesystem",
 			zap.String("id", entry.ID.String()),
 			zap.Error(err))
-		return systemfs.NewGetEmbeddedFilesystemError(err)
+		return nil, systemfs.NewGetEmbeddedFilesystemError(err)
 	}
+	return fsapi.NewReadOnlyFS(packFS), nil
+}
 
-	// Wrap in read-only adapter
-	fs := fsapi.NewReadOnlyFS(packFS)
-
-	// Store in filesystems map
-	m.filesystems[entry.ID] = fs
+func (m *Manager) storeFS(ctx context.Context, id registry.ID, fs fsapi.FS) {
+	m.filesystems[id] = fs
 
 	// Register with filesystem registry
 	m.bus.Send(ctx, event.Event{
 		System: fsapi.System,
 		Kind:   fsapi.FsRegister,
-		Path:   entry.ID.String(),
+		Path:   id.String(),
 		Data:   fs,
 	})
-
-	return nil
 }
 
 // resolveFS prefers an entry-aware lookup when the registry implements

--- a/service/fs/embed/manager_test.go
+++ b/service/fs/embed/manager_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	eventapi "github.com/wippyai/runtime/api/event"
+	fsapi "github.com/wippyai/runtime/api/fs"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
@@ -190,7 +192,7 @@ func TestManager_Update_NotFound(t *testing.T) {
 
 func TestManager_Update_ResolutionFailureKeepsExistingFS(t *testing.T) {
 	ctx := context.Background()
-	bus := eventbus.NewBus()
+	bus := &recordingBus{}
 	embedReg := &mockEntryResolverRegistry{
 		mockEmbedRegistry: mockEmbedRegistry{},
 		byEntry: map[string]fs.ReadDirFS{
@@ -207,6 +209,7 @@ func TestManager_Update_ResolutionFailureKeepsExistingFS(t *testing.T) {
 		Data: payload.New(&embedapi.Config{}),
 	}
 	require.NoError(t, manager.Add(ctx, entry))
+	bus.reset()
 
 	updateEntry := entry
 	updateEntry.Meta = map[string]any{"module": "org/mod", "module_version": "2.0.0"}
@@ -219,6 +222,7 @@ func TestManager_Update_ResolutionFailureKeepsExistingFS(t *testing.T) {
 	manager.mu.RUnlock()
 	assert.True(t, ok, "failed update must keep the current live filesystem")
 	assert.Equal(t, "test:fs|org/mod|2.0.0", embedReg.lastEntryKey)
+	assert.Empty(t, bus.events, "failed update must not send fs delete/register events")
 }
 
 func TestManager_Delete(t *testing.T) {
@@ -305,7 +309,7 @@ func TestManager_Add_UsesEntryResolver(t *testing.T) {
 
 func TestManager_Update_SelectsNewVersionViaResolver(t *testing.T) {
 	ctx := context.Background()
-	bus := eventbus.NewBus()
+	bus := &recordingBus{}
 	oldFS := &mockReadDirFS{}
 	newFS := &mockReadDirFS{}
 	embedReg := &mockEntryResolverRegistry{
@@ -328,6 +332,7 @@ func TestManager_Update_SelectsNewVersionViaResolver(t *testing.T) {
 		Data: payload.New(&embedapi.Config{}),
 	}
 	require.NoError(t, manager.Add(ctx, addEntry))
+	bus.reset()
 
 	updateEntry := addEntry
 	updateEntry.Meta = map[string]any{"module": "org/mod", "module_version": "2.0.0"}
@@ -339,9 +344,42 @@ func TestManager_Update_SelectsNewVersionViaResolver(t *testing.T) {
 	// The stored FS is wrapped; assert resolver was asked for the new version.
 	require.NotNil(t, stored)
 	assert.Equal(t, "test:fs|org/mod|2.0.0", embedReg.lastEntryKey)
+	require.Len(t, bus.events, 2)
+	assert.Equal(t, fsapi.FsDelete, bus.events[0].Kind)
+	assert.Equal(t, updateEntry.ID.String(), bus.events[0].Path)
+	assert.Equal(t, fsapi.FsRegister, bus.events[1].Kind)
+	assert.Equal(t, updateEntry.ID.String(), bus.events[1].Path)
+	assert.NotNil(t, bus.events[1].Data)
 }
 
 // Mock implementations
+
+type recordingBus struct {
+	events []eventapi.Event
+}
+
+func (b *recordingBus) Subscribe(context.Context, eventapi.System, chan<- eventapi.Event) (eventapi.SubscriberID, error) {
+	return "", nil
+}
+
+func (b *recordingBus) SubscribeP(
+	context.Context,
+	eventapi.System,
+	eventapi.Kind,
+	chan<- eventapi.Event,
+) (eventapi.SubscriberID, error) {
+	return "", nil
+}
+
+func (b *recordingBus) Unsubscribe(context.Context, eventapi.SubscriberID) {}
+
+func (b *recordingBus) Send(_ context.Context, evt eventapi.Event) {
+	b.events = append(b.events, evt)
+}
+
+func (b *recordingBus) reset() {
+	b.events = nil
+}
 
 type mockEmbedRegistry struct {
 	filesystems map[string]fs.ReadDirFS

--- a/service/fs/embed/manager_test.go
+++ b/service/fs/embed/manager_test.go
@@ -188,6 +188,39 @@ func TestManager_Update_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestManager_Update_ResolutionFailureKeepsExistingFS(t *testing.T) {
+	ctx := context.Background()
+	bus := eventbus.NewBus()
+	embedReg := &mockEntryResolverRegistry{
+		mockEmbedRegistry: mockEmbedRegistry{},
+		byEntry: map[string]fs.ReadDirFS{
+			"test:fs|org/mod|1.0.0": &mockReadDirFS{},
+		},
+	}
+	dtt := &mockDTT{}
+
+	manager := NewManager(bus, dtt, embedReg, zap.NewNop())
+	entry := registry.Entry{
+		ID:   registry.NewID("test", "fs"),
+		Kind: embedapi.Kind,
+		Meta: map[string]any{"module": "org/mod", "module_version": "1.0.0"},
+		Data: payload.New(&embedapi.Config{}),
+	}
+	require.NoError(t, manager.Add(ctx, entry))
+
+	updateEntry := entry
+	updateEntry.Meta = map[string]any{"module": "org/mod", "module_version": "2.0.0"}
+	err := manager.Update(ctx, updateEntry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get embedded filesystem")
+
+	manager.mu.RLock()
+	_, ok := manager.filesystems[entry.ID]
+	manager.mu.RUnlock()
+	assert.True(t, ok, "failed update must keep the current live filesystem")
+	assert.Equal(t, "test:fs|org/mod|2.0.0", embedReg.lastEntryKey)
+}
+
 func TestManager_Delete(t *testing.T) {
 	ctx := context.Background()
 	bus := eventbus.NewBus()
@@ -334,9 +367,9 @@ func (r *mockEmbedRegistry) Register(_ string, _ any) error {
 type mockEntryResolverRegistry struct {
 	mockEmbedRegistry
 	byEntry      map[string]fs.ReadDirFS
+	lastEntryKey string
 	entryCalls   int
 	idCalls      int
-	lastEntryKey string
 }
 
 func entryResolverKey(entry registry.Entry) string {

--- a/service/fs/embed/manager_test.go
+++ b/service/fs/embed/manager_test.go
@@ -241,6 +241,73 @@ func TestManager_Delete_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestManager_Add_UsesEntryResolver(t *testing.T) {
+	ctx := context.Background()
+	bus := eventbus.NewBus()
+	embedReg := &mockEntryResolverRegistry{
+		mockEmbedRegistry: mockEmbedRegistry{
+			filesystems: map[string]fs.ReadDirFS{
+				"test:fs": &mockReadDirFS{},
+			},
+		},
+		byEntry: map[string]fs.ReadDirFS{
+			"test:fs|org/mod|2.0.0": &mockReadDirFS{},
+		},
+	}
+	dtt := &mockDTT{}
+
+	manager := NewManager(bus, dtt, embedReg, zap.NewNop())
+
+	entry := registry.Entry{
+		ID:   registry.NewID("test", "fs"),
+		Kind: embedapi.Kind,
+		Meta: map[string]any{"module": "org/mod", "module_version": "2.0.0"},
+		Data: payload.New(&embedapi.Config{}),
+	}
+
+	require.NoError(t, manager.Add(ctx, entry))
+	assert.Equal(t, 1, embedReg.entryCalls)
+	assert.Equal(t, 0, embedReg.idCalls)
+}
+
+func TestManager_Update_SelectsNewVersionViaResolver(t *testing.T) {
+	ctx := context.Background()
+	bus := eventbus.NewBus()
+	oldFS := &mockReadDirFS{}
+	newFS := &mockReadDirFS{}
+	embedReg := &mockEntryResolverRegistry{
+		mockEmbedRegistry: mockEmbedRegistry{
+			filesystems: map[string]fs.ReadDirFS{"test:fs": oldFS},
+		},
+		byEntry: map[string]fs.ReadDirFS{
+			"test:fs|org/mod|1.0.0": oldFS,
+			"test:fs|org/mod|2.0.0": newFS,
+		},
+	}
+	dtt := &mockDTT{}
+
+	manager := NewManager(bus, dtt, embedReg, zap.NewNop())
+
+	addEntry := registry.Entry{
+		ID:   registry.NewID("test", "fs"),
+		Kind: embedapi.Kind,
+		Meta: map[string]any{"module": "org/mod", "module_version": "1.0.0"},
+		Data: payload.New(&embedapi.Config{}),
+	}
+	require.NoError(t, manager.Add(ctx, addEntry))
+
+	updateEntry := addEntry
+	updateEntry.Meta = map[string]any{"module": "org/mod", "module_version": "2.0.0"}
+	require.NoError(t, manager.Update(ctx, updateEntry))
+
+	manager.mu.RLock()
+	stored := manager.filesystems[updateEntry.ID]
+	manager.mu.RUnlock()
+	// The stored FS is wrapped; assert resolver was asked for the new version.
+	require.NotNil(t, stored)
+	assert.Equal(t, "test:fs|org/mod|2.0.0", embedReg.lastEntryKey)
+}
+
 // Mock implementations
 
 type mockEmbedRegistry struct {
@@ -260,6 +327,37 @@ func (r *mockEmbedRegistry) Close() error {
 
 func (r *mockEmbedRegistry) Register(_ string, _ any) error {
 	return nil
+}
+
+// mockEntryResolverRegistry implements embedapi.EntryResolver to verify the
+// manager prefers entry-aware resolution.
+type mockEntryResolverRegistry struct {
+	mockEmbedRegistry
+	byEntry      map[string]fs.ReadDirFS
+	entryCalls   int
+	idCalls      int
+	lastEntryKey string
+}
+
+func entryResolverKey(entry registry.Entry) string {
+	module, _ := entry.Meta["module"].(string)
+	version, _ := entry.Meta["module_version"].(string)
+	return entry.ID.String() + "|" + module + "|" + version
+}
+
+func (r *mockEntryResolverRegistry) GetFSForEntry(entry registry.Entry) (fs.ReadDirFS, error) {
+	r.entryCalls++
+	key := entryResolverKey(entry)
+	r.lastEntryKey = key
+	if fsys, ok := r.byEntry[key]; ok {
+		return fsys, nil
+	}
+	return r.mockEmbedRegistry.GetFS(entry.ID)
+}
+
+func (r *mockEntryResolverRegistry) GetFS(id registry.ID) (fs.ReadDirFS, error) {
+	r.idCalls++
+	return r.mockEmbedRegistry.GetFS(id)
 }
 
 type mockDTT struct {

--- a/service/fs/embed/registry.go
+++ b/service/fs/embed/registry.go
@@ -156,38 +156,44 @@ func (r *Registry) GetFS(id registry.ID) (fs.ReadDirFS, error) {
 // owns the entry's module and version (from meta.module / meta.module_version).
 // This is deterministic across updates: while a new pack is staged alongside the
 // old one, the entry's own metadata selects the correct version. Entries without
-// module metadata, or whose owning pack is not registered, fall back to GetFS.
+// module metadata fall back to GetFS. Versioned module entries require their
+// exact pack to be registered so updates never silently serve an older pack.
 func (r *Registry) GetFSForEntry(entry registry.Entry) (fs.ReadDirFS, error) {
 	module := entryMeta(entry, metaModuleKey)
 	version := entryMeta(entry, metaModuleVersionKey)
 
 	if module != "" {
-		r.mu.RLock()
-		var match *pack
-		for _, p := range r.packs {
-			if p.module != module {
-				continue
-			}
-			if version != "" && p.version != version {
-				continue
-			}
-			if !p.owns(entry.ID) {
-				continue
-			}
-			match = p
-			break
+		fsys, found, err := r.getFSForModuleEntry(entry, module, version)
+		if found {
+			return fsys, err
 		}
-		r.mu.RUnlock()
-
-		if match != nil {
-			fsys, err := match.reader.GetFS(wapp.NewID(entry.ID.NS, entry.ID.Name))
-			if err == nil {
-				return fsys, nil
-			}
+		if version != "" {
+			return nil, systemfs.NewFilesystemNotFoundWithCauseError(entry.ID.String(), fs.ErrNotExist)
 		}
 	}
 
 	return r.GetFS(entry.ID)
+}
+
+func (r *Registry) getFSForModuleEntry(entry registry.Entry, module, version string) (fs.ReadDirFS, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, p := range r.packs {
+		if p.module != module {
+			continue
+		}
+		if version != "" && p.version != version {
+			continue
+		}
+		if !p.owns(entry.ID) {
+			continue
+		}
+		fsys, err := p.reader.GetFS(wapp.NewID(entry.ID.NS, entry.ID.Name))
+		return fsys, true, err
+	}
+
+	return nil, false, nil
 }
 
 // Close implements embedapi.Registry.Close.

--- a/service/fs/embed/registry.go
+++ b/service/fs/embed/registry.go
@@ -19,12 +19,12 @@ import (
 // owns and the optional file handle that backs it. The handle is owned by the
 // registry and closed when the pack is unregistered or the registry is closed.
 type pack struct {
-	packPath  string
-	module    string
-	version   string
 	reader    *wapp.Reader
 	file      *os.File
 	resources map[registry.ID]struct{}
+	packPath  string
+	module    string
+	version   string
 }
 
 // owns reports whether the pack exposes the given resource ID.
@@ -80,7 +80,9 @@ func (r *Registry) RegisterPack(packPath, module, version string, reader *wapp.R
 	defer r.mu.Unlock()
 
 	if existing, ok := r.packs[packPath]; ok {
-		closeFile(existing.file)
+		if err := closeFile(existing.file); err != nil {
+			return err
+		}
 	}
 
 	r.packs[packPath] = &pack{

--- a/service/fs/embed/registry.go
+++ b/service/fs/embed/registry.go
@@ -15,24 +15,55 @@ import (
 	"github.com/wippyai/wapp"
 )
 
-// Registry implements embedapi.Registry by storing Readers.
+// pack holds a single registered .wapp reader together with the resources it
+// owns and the optional file handle that backs it. The handle is owned by the
+// registry and closed when the pack is unregistered or the registry is closed.
+type pack struct {
+	packPath  string
+	module    string
+	version   string
+	reader    *wapp.Reader
+	file      *os.File
+	resources map[registry.ID]struct{}
+}
+
+// owns reports whether the pack exposes the given resource ID.
+func (p *pack) owns(id registry.ID) bool {
+	_, ok := p.resources[id]
+	return ok
+}
+
+// Registry implements embedapi.Registry by storing per-pack readers.
+//
+// Packs are keyed by their pack path (the cached .wapp location at runtime, or
+// a synthetic key at boot). Each pack records its owning module and version so
+// a specific (module, version) pack can be located and replaced independently —
+// this lets module updates stage a new pack while the old one keeps serving
+// until commit, and lets uninstall close exactly the pack it removed.
 type Registry struct {
-	readers map[string]*wapp.Reader
-	files   []*os.File
-	mu      sync.RWMutex
+	packs map[string]*pack
+	mu    sync.RWMutex
 }
 
 // NewRegistry creates a new embed registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		readers: make(map[string]*wapp.Reader),
+		packs: make(map[string]*pack),
 	}
 }
 
-// Register adds a pack reader to the registry.
-// The pack path is used as a key for later lookup.
-// If a file handle is provided, it will be closed when the registry is closed.
+// Register adds a pack reader to the registry without module ownership.
+// Retained for callers that have no module identity. The pack path is used as
+// the lookup key; if a file handle is provided it is owned by the registry and
+// closed on unregister/close.
 func (r *Registry) Register(packPath string, reader *wapp.Reader, file *os.File) error {
+	return r.RegisterPack(packPath, "", "", reader, file)
+}
+
+// RegisterPack adds a pack reader tagged with its owning module and version.
+// Registering a pack path that already exists replaces the previous pack and
+// closes its file handle, so re-registration never leaks the prior handle.
+func (r *Registry) RegisterPack(packPath, module, version string, reader *wapp.Reader, file *os.File) error {
 	if packPath == "" {
 		return systemfs.NewEmptyPackPathError()
 	}
@@ -40,26 +71,77 @@ func (r *Registry) Register(packPath string, reader *wapp.Reader, file *os.File)
 		return systemfs.NewNilReaderError()
 	}
 
+	resources := make(map[registry.ID]struct{})
+	for _, res := range reader.ListResources() {
+		resources[registry.NewID(res.ID.Namespace, res.ID.Name)] = struct{}{}
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.readers[packPath] = reader
-	if file != nil {
-		r.files = append(r.files, file)
+
+	if existing, ok := r.packs[packPath]; ok {
+		closeFile(existing.file)
+	}
+
+	r.packs[packPath] = &pack{
+		packPath:  packPath,
+		module:    module,
+		version:   version,
+		reader:    reader,
+		file:      file,
+		resources: resources,
 	}
 	return nil
 }
 
+// UnregisterPack removes the pack registered under packPath and closes its file
+// handle. Unregistering an unknown pack path is a no-op.
+func (r *Registry) UnregisterPack(packPath string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, ok := r.packs[packPath]
+	if !ok {
+		return nil
+	}
+	delete(r.packs, packPath)
+	return closeFile(p.file)
+}
+
+// UnregisterModule removes every pack owned by the given module and version,
+// closing their file handles. Unregistering a module that is not present is a
+// no-op. Returns the first close error encountered, if any.
+func (r *Registry) UnregisterModule(module, version string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var firstErr error
+	for key, p := range r.packs {
+		if p.module != module || p.version != version {
+			continue
+		}
+		delete(r.packs, key)
+		if err := closeFile(p.file); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // GetFS implements embedapi.Registry.GetFS.
-// It searches all registered pack readers for a resource with the given ID.
+// It searches all registered packs for a resource with the given ID and returns
+// the first match. Use GetFSForEntry when a specific module version must be
+// selected (e.g. during an update where two versions expose the same ID).
 func (r *Registry) GetFS(id registry.ID) (fs.ReadDirFS, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	wappID := wapp.NewID(id.NS, id.Name)
-
-	// Search all pack readers for the resource
-	for _, reader := range r.readers {
-		fsys, err := reader.GetFS(wappID)
+	for _, p := range r.packs {
+		if !p.owns(id) {
+			continue
+		}
+		fsys, err := p.reader.GetFS(wappID)
 		if err == nil {
 			return fsys, nil
 		}
@@ -68,24 +150,85 @@ func (r *Registry) GetFS(id registry.ID) (fs.ReadDirFS, error) {
 	return nil, systemfs.NewFilesystemNotFoundWithCauseError(id.String(), fs.ErrNotExist)
 }
 
+// GetFSForEntry resolves the filesystem for an entry, preferring the pack that
+// owns the entry's module and version (from meta.module / meta.module_version).
+// This is deterministic across updates: while a new pack is staged alongside the
+// old one, the entry's own metadata selects the correct version. Entries without
+// module metadata, or whose owning pack is not registered, fall back to GetFS.
+func (r *Registry) GetFSForEntry(entry registry.Entry) (fs.ReadDirFS, error) {
+	module := entryMeta(entry, metaModuleKey)
+	version := entryMeta(entry, metaModuleVersionKey)
+
+	if module != "" {
+		r.mu.RLock()
+		var match *pack
+		for _, p := range r.packs {
+			if p.module != module {
+				continue
+			}
+			if version != "" && p.version != version {
+				continue
+			}
+			if !p.owns(entry.ID) {
+				continue
+			}
+			match = p
+			break
+		}
+		r.mu.RUnlock()
+
+		if match != nil {
+			fsys, err := match.reader.GetFS(wapp.NewID(entry.ID.NS, entry.ID.Name))
+			if err == nil {
+				return fsys, nil
+			}
+		}
+	}
+
+	return r.GetFS(entry.ID)
+}
+
 // Close implements embedapi.Registry.Close.
 func (r *Registry) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	var errs []error
-	for _, f := range r.files {
-		if err := f.Close(); err != nil {
+	for _, p := range r.packs {
+		if err := closeFile(p.file); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	r.files = nil
-	r.readers = make(map[string]*wapp.Reader)
+	r.packs = make(map[string]*pack)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to close %d file(s)", len(errs))
 	}
 	return nil
+}
+
+func closeFile(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	return f.Close()
+}
+
+const (
+	metaModuleKey        = "module"
+	metaModuleVersionKey = "module_version"
+)
+
+func entryMeta(entry registry.Entry, key string) string {
+	if entry.Meta == nil {
+		return ""
+	}
+	if v, ok := entry.Meta[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 // GetRegistryFromContext retrieves the concrete Registry from context.

--- a/service/fs/embed/registry_test.go
+++ b/service/fs/embed/registry_test.go
@@ -4,6 +4,7 @@ package embed
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/wapp"
 )
@@ -19,8 +21,8 @@ import (
 func TestRegistry_NewRegistry(t *testing.T) {
 	r := NewRegistry()
 	require.NotNil(t, r)
-	assert.NotNil(t, r.readers)
-	assert.Nil(t, r.files)
+	assert.NotNil(t, r.packs)
+	assert.Len(t, r.packs, 0)
 }
 
 func TestRegistry_Register(t *testing.T) {
@@ -48,8 +50,8 @@ func TestRegistry_Register(t *testing.T) {
 		require.NoError(t, err)
 
 		r.mu.RLock()
-		assert.Len(t, r.readers, 1)
-		assert.Len(t, r.files, 0)
+		assert.Len(t, r.packs, 1)
+		assert.Nil(t, r.packs["test/pack"].file)
 		r.mu.RUnlock()
 	})
 
@@ -62,31 +64,62 @@ func TestRegistry_Register(t *testing.T) {
 		require.NoError(t, err)
 
 		r.mu.RLock()
-		assert.Len(t, r.readers, 1)
-		assert.Len(t, r.files, 1)
+		assert.Len(t, r.packs, 1)
+		assert.NotNil(t, r.packs["test/pack"].file)
 		r.mu.RUnlock()
 	})
 
-	t.Run("overwrites existing reader", func(t *testing.T) {
+	t.Run("overwrites existing reader and closes old file", func(t *testing.T) {
 		r := NewRegistry()
-		reader1 := createTestReader(t)
+		reader1, file1 := createTestReaderWithFile(t)
 		reader2 := createTestReader(t)
 
-		err := r.Register("test/pack", reader1, nil)
-		require.NoError(t, err)
+		require.NoError(t, r.Register("test/pack", reader1, file1))
+		require.NoError(t, r.Register("test/pack", reader2, nil))
 
-		err = r.Register("test/pack", reader2, nil)
+		r.mu.RLock()
+		assert.Len(t, r.packs, 1)
+		assert.Equal(t, reader2, r.packs["test/pack"].reader)
+		r.mu.RUnlock()
+
+		// The replaced file handle must be closed.
+		_, err := file1.Read(make([]byte, 1))
+		require.Error(t, err)
+	})
+}
+
+func TestRegistry_RegisterPack(t *testing.T) {
+	t.Run("records module and version", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createTestReader(t)
+
+		err := r.RegisterPack("vendor/org/mod-v1.0.0.wapp", "org/mod", "1.0.0", reader, nil)
 		require.NoError(t, err)
 
 		r.mu.RLock()
-		assert.Len(t, r.readers, 1)
-		assert.Equal(t, reader2, r.readers["test/pack"])
+		p := r.packs["vendor/org/mod-v1.0.0.wapp"]
 		r.mu.RUnlock()
+		require.NotNil(t, p)
+		assert.Equal(t, "org/mod", p.module)
+		assert.Equal(t, "1.0.0", p.version)
+	})
+
+	t.Run("indexes pack resources", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createReaderWithResource(t, "ui", "assets", map[string]string{"index.html": "<html>"})
+
+		require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", reader, nil))
+
+		r.mu.RLock()
+		p := r.packs["p.wapp"]
+		r.mu.RUnlock()
+		assert.True(t, p.owns(registry.NewID("ui", "assets")))
+		assert.False(t, p.owns(registry.NewID("ui", "missing")))
 	})
 }
 
 func TestRegistry_GetFS(t *testing.T) {
-	t.Run("not found with no readers", func(t *testing.T) {
+	t.Run("not found with no packs", func(t *testing.T) {
 		r := NewRegistry()
 
 		_, err := r.GetFS(registry.NewID("test", "notfound"))
@@ -94,84 +127,192 @@ func TestRegistry_GetFS(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 
-	t.Run("not found with readers but no matching resource", func(t *testing.T) {
+	t.Run("not found with packs but no matching resource", func(t *testing.T) {
 		r := NewRegistry()
-		reader := createTestReader(t)
-		err := r.Register("test/pack", reader, nil)
-		require.NoError(t, err)
+		reader := createReaderWithResource(t, "ui", "assets", map[string]string{"a.txt": "a"})
+		require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", reader, nil))
 
-		_, err = r.GetFS(registry.NewID("nonexistent", "resource"))
+		_, err := r.GetFS(registry.NewID("nonexistent", "resource"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("returns matching filesystem", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createReaderWithResource(t, "ui", "assets", map[string]string{"index.html": "<html>hi</html>"})
+		require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", reader, nil))
+
+		fsys, err := r.GetFS(registry.NewID("ui", "assets"))
+		require.NoError(t, err)
+		data, err := fs.ReadFile(fsys, "index.html")
+		require.NoError(t, err)
+		assert.Equal(t, "<html>hi</html>", string(data))
+	})
+}
+
+func TestRegistry_GetFSForEntry(t *testing.T) {
+	makeEntry := func(ns, name, module, version string) registry.Entry {
+		meta := attrs.NewBag()
+		if module != "" {
+			meta.Set(metaModuleKey, module)
+		}
+		if version != "" {
+			meta.Set(metaModuleVersionKey, version)
+		}
+		return registry.Entry{ID: registry.NewID(ns, name), Meta: meta}
+	}
+
+	t.Run("selects pack matching entry module and version", func(t *testing.T) {
+		r := NewRegistry()
+		// Two pack versions expose the SAME resource ID with different content.
+		oldReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "old"})
+		newReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "new"})
+		require.NoError(t, r.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", oldReader, nil))
+		require.NoError(t, r.RegisterPack("org/mod-v2.0.0.wapp", "org/mod", "2.0.0", newReader, nil))
+
+		fsysNew, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", "2.0.0"))
+		require.NoError(t, err)
+		data, err := fs.ReadFile(fsysNew, "v.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "new", string(data))
+
+		fsysOld, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", "1.0.0"))
+		require.NoError(t, err)
+		data, err = fs.ReadFile(fsysOld, "v.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "old", string(data))
+	})
+
+	t.Run("matches by module when version omitted", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "only"})
+		require.NoError(t, r.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", reader, nil))
+
+		fsys, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", ""))
+		require.NoError(t, err)
+		data, err := fs.ReadFile(fsys, "v.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "only", string(data))
+	})
+
+	t.Run("falls back to GetFS without module metadata", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "legacy"})
+		require.NoError(t, r.RegisterPack("legacy.wapp", "", "", reader, nil))
+
+		fsys, err := r.GetFSForEntry(makeEntry("ui", "app", "", ""))
+		require.NoError(t, err)
+		data, err := fs.ReadFile(fsys, "v.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "legacy", string(data))
+	})
+
+	t.Run("falls back to GetFS when owning pack not registered", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "x"})
+		// Pack is registered under a different module than the entry claims.
+		require.NoError(t, r.RegisterPack("p.wapp", "org/other", "1.0.0", reader, nil))
+
+		fsys, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", "9.9.9"))
+		require.NoError(t, err)
+		data, err := fs.ReadFile(fsys, "v.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "x", string(data))
+	})
+}
+
+func TestRegistry_UnregisterPack(t *testing.T) {
+	t.Run("removes pack and closes file", func(t *testing.T) {
+		r := NewRegistry()
+		reader, file := createTestReaderWithFile(t)
+		require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", reader, file))
+
+		require.NoError(t, r.UnregisterPack("p.wapp"))
+
+		r.mu.RLock()
+		assert.Len(t, r.packs, 0)
+		r.mu.RUnlock()
+
+		_, err := file.Read(make([]byte, 1))
+		require.Error(t, err)
+	})
+
+	t.Run("unknown pack is a no-op", func(t *testing.T) {
+		r := NewRegistry()
+		require.NoError(t, r.UnregisterPack("missing.wapp"))
+	})
+}
+
+func TestRegistry_UnregisterModule(t *testing.T) {
+	t.Run("removes only matching module and version", func(t *testing.T) {
+		r := NewRegistry()
+		readerOld, fileOld := createTestReaderWithFile(t)
+		readerNew := createTestReader(t)
+		require.NoError(t, r.RegisterPack("mod-v1.wapp", "org/mod", "1.0.0", readerOld, fileOld))
+		require.NoError(t, r.RegisterPack("mod-v2.wapp", "org/mod", "2.0.0", readerNew, nil))
+
+		require.NoError(t, r.UnregisterModule("org/mod", "1.0.0"))
+
+		r.mu.RLock()
+		_, hasOld := r.packs["mod-v1.wapp"]
+		_, hasNew := r.packs["mod-v2.wapp"]
+		r.mu.RUnlock()
+		assert.False(t, hasOld)
+		assert.True(t, hasNew)
+
+		_, err := fileOld.Read(make([]byte, 1))
+		require.Error(t, err)
+	})
+
+	t.Run("absent module is a no-op", func(t *testing.T) {
+		r := NewRegistry()
+		require.NoError(t, r.UnregisterModule("org/absent", "1.0.0"))
 	})
 }
 
 func TestRegistry_Close(t *testing.T) {
-	t.Run("clears all readers", func(t *testing.T) {
+	t.Run("clears all packs", func(t *testing.T) {
 		r := NewRegistry()
-		reader := createTestReader(t)
-		err := r.Register("test/pack", reader, nil)
-		require.NoError(t, err)
+		require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", createTestReader(t), nil))
+
+		require.NoError(t, r.Close())
 
 		r.mu.RLock()
-		assert.Len(t, r.readers, 1)
-		r.mu.RUnlock()
-
-		err = r.Close()
-		require.NoError(t, err)
-
-		r.mu.RLock()
-		assert.Len(t, r.readers, 0)
+		assert.Len(t, r.packs, 0)
 		r.mu.RUnlock()
 	})
 
 	t.Run("closes tracked files", func(t *testing.T) {
 		r := NewRegistry()
 		reader, file := createTestReaderWithFile(t)
+		require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", reader, file))
 
-		err := r.Register("test/pack", reader, file)
-		require.NoError(t, err)
+		require.NoError(t, r.Close())
 
-		err = r.Close()
-		require.NoError(t, err)
-
-		// Verify file is closed by trying to read from it
-		_, err = file.Read(make([]byte, 1))
+		_, err := file.Read(make([]byte, 1))
 		require.Error(t, err)
 	})
 
 	t.Run("idempotent", func(t *testing.T) {
 		r := NewRegistry()
-
-		err := r.Close()
-		require.NoError(t, err)
-
-		err = r.Close()
-		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		require.NoError(t, r.Close())
 
 		r.mu.RLock()
-		assert.Len(t, r.readers, 0)
+		assert.Len(t, r.packs, 0)
 		r.mu.RUnlock()
 	})
+}
 
-	t.Run("clears files list", func(t *testing.T) {
-		r := NewRegistry()
-		reader, file := createTestReaderWithFile(t)
+func TestRegistry_NoDoubleClose(t *testing.T) {
+	// Unregister then Close must not double-close the file handle.
+	r := NewRegistry()
+	reader, file := createTestReaderWithFile(t)
+	require.NoError(t, r.RegisterPack("p.wapp", "org/mod", "1.0.0", reader, file))
 
-		err := r.Register("test/pack", reader, file)
-		require.NoError(t, err)
-
-		r.mu.RLock()
-		assert.Len(t, r.files, 1)
-		r.mu.RUnlock()
-
-		err = r.Close()
-		require.NoError(t, err)
-
-		r.mu.RLock()
-		assert.Len(t, r.files, 0)
-		r.mu.RUnlock()
-	})
+	require.NoError(t, r.UnregisterPack("p.wapp"))
+	// Close has no remaining handles; must not error from a second close.
+	require.NoError(t, r.Close())
 }
 
 func TestRegistry_ConcurrentAccess(t *testing.T) {
@@ -179,18 +320,16 @@ func TestRegistry_ConcurrentAccess(t *testing.T) {
 		r := NewRegistry()
 		var wg sync.WaitGroup
 
-		// Start multiple goroutines registering readers
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
 				reader := createTestReader(t)
 				packPath := filepath.Join("test", "pack", string(rune('a'+idx)))
-				_ = r.Register(packPath, reader, nil)
+				_ = r.RegisterPack(packPath, "org/mod", "1.0.0", reader, nil)
 			}(i)
 		}
 
-		// Start multiple goroutines querying
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
@@ -211,117 +350,54 @@ func TestRegistry_ConcurrentAccess(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				reader := createTestReader(t)
-				_ = r.Register("same/path", reader, nil)
+				_ = r.RegisterPack("same/path", "org/mod", "1.0.0", reader, nil)
 			}()
 		}
 
 		wg.Wait()
 
 		r.mu.RLock()
-		assert.Len(t, r.readers, 1)
+		assert.Len(t, r.packs, 1)
 		r.mu.RUnlock()
 	})
 
-	t.Run("concurrent close", func(t *testing.T) {
+	t.Run("concurrent unregister and close", func(t *testing.T) {
 		r := NewRegistry()
-		reader := createTestReader(t)
-		err := r.Register("test/pack", reader, nil)
-		require.NoError(t, err)
+		for i := 0; i < 20; i++ {
+			packPath := filepath.Join("p", string(rune('a'+i)))
+			require.NoError(t, r.RegisterPack(packPath, "org/mod", "1.0.0", createTestReader(t), nil))
+		}
 
 		var wg sync.WaitGroup
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 20; i++ {
 			wg.Add(1)
-			go func() {
+			go func(idx int) {
 				defer wg.Done()
-				_ = r.Close()
-			}()
+				_ = r.UnregisterPack(filepath.Join("p", string(rune('a'+idx))))
+			}(i)
 		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.Close()
+		}()
 
 		wg.Wait()
 	})
 }
 
-func TestRegistry_MultipleReaders(t *testing.T) {
-	t.Run("registers multiple readers", func(t *testing.T) {
-		r := NewRegistry()
-
-		for i := 0; i < 5; i++ {
-			reader := createTestReader(t)
-			packPath := filepath.Join("test", "pack", string(rune('a'+i))+".wapp")
-			err := r.Register(packPath, reader, nil)
-			require.NoError(t, err)
-		}
-
-		r.mu.RLock()
-		assert.Len(t, r.readers, 5)
-		r.mu.RUnlock()
-	})
-
-	t.Run("close clears all readers", func(t *testing.T) {
-		r := NewRegistry()
-
-		for i := 0; i < 5; i++ {
-			reader := createTestReader(t)
-			packPath := filepath.Join("test", "pack", string(rune('a'+i))+".wapp")
-			err := r.Register(packPath, reader, nil)
-			require.NoError(t, err)
-		}
-
-		err := r.Close()
-		require.NoError(t, err)
-
-		r.mu.RLock()
-		assert.Len(t, r.readers, 0)
-		r.mu.RUnlock()
-	})
-}
-
-// createTestReader creates a minimal wapp reader for testing.
+// createTestReader creates a minimal wapp reader with no resources.
 func createTestReader(t *testing.T) *wapp.Reader {
 	t.Helper()
-
-	// Create a minimal wapp in memory
-	fsys := fstest.MapFS{
-		"test.txt": &fstest.MapFile{Data: []byte("test"), Mode: 0644},
-	}
-
-	var buf bytes.Buffer
-	writer := wapp.NewWriter()
-	err := writer.PackEntries(wapp.Metadata{}, nil, &buf)
-	require.NoError(t, err)
-
-	// Write to temp file since wapp.Reader needs io.ReaderAt
-	tmpDir := t.TempDir()
-	wappPath := filepath.Join(tmpDir, "test.wapp")
-	err = os.WriteFile(wappPath, buf.Bytes(), 0644)
-	require.NoError(t, err)
-
-	file, err := os.Open(wappPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { file.Close() })
-
-	reader, err := wapp.NewReader(file)
-	require.NoError(t, err)
-
-	_ = fsys // unused but kept for clarity
-	return reader
+	return readerFromBytes(t, packEntriesOnly(t))
 }
 
-// createTestReaderWithFile creates a wapp reader and returns the file handle.
+// createTestReaderWithFile creates a minimal wapp reader and returns the open file handle.
 func createTestReaderWithFile(t *testing.T) (*wapp.Reader, *os.File) {
 	t.Helper()
 
-	// Create a minimal wapp in memory
-	var buf bytes.Buffer
-	writer := wapp.NewWriter()
-	err := writer.PackEntries(wapp.Metadata{}, nil, &buf)
-	require.NoError(t, err)
-
-	// Write to temp file since wapp.Reader needs io.ReaderAt
-	tmpDir := t.TempDir()
-	wappPath := filepath.Join(tmpDir, "test.wapp")
-	err = os.WriteFile(wappPath, buf.Bytes(), 0644)
-	require.NoError(t, err)
+	wappPath := filepath.Join(t.TempDir(), "test.wapp")
+	require.NoError(t, os.WriteFile(wappPath, packEntriesOnly(t), 0644))
 
 	file, err := os.Open(wappPath)
 	require.NoError(t, err)
@@ -330,4 +406,49 @@ func createTestReaderWithFile(t *testing.T) (*wapp.Reader, *os.File) {
 	require.NoError(t, err)
 
 	return reader, file
+}
+
+// createReaderWithResource builds a wapp containing a single filesystem resource.
+func createReaderWithResource(t *testing.T, ns, name string, files map[string]string) *wapp.Reader {
+	t.Helper()
+
+	mapFS := fstest.MapFS{}
+	for path, content := range files {
+		mapFS[path] = &fstest.MapFile{Data: []byte(content), Mode: 0644}
+	}
+
+	var buf bytes.Buffer
+	writer := wapp.NewWriter()
+	err := writer.PackWithResources(
+		wapp.Metadata{},
+		nil,
+		[]wapp.ResourceSpec{{ID: wapp.NewID(ns, name), FS: mapFS}},
+		&buf,
+	)
+	require.NoError(t, err)
+
+	return readerFromBytes(t, buf.Bytes())
+}
+
+func packEntriesOnly(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := wapp.NewWriter()
+	require.NoError(t, writer.PackEntries(wapp.Metadata{}, nil, &buf))
+	return buf.Bytes()
+}
+
+func readerFromBytes(t *testing.T, data []byte) *wapp.Reader {
+	t.Helper()
+
+	wappPath := filepath.Join(t.TempDir(), "pack.wapp")
+	require.NoError(t, os.WriteFile(wappPath, data, 0644))
+
+	file, err := os.Open(wappPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { file.Close() })
+
+	reader, err := wapp.NewReader(file)
+	require.NoError(t, err)
+	return reader
 }

--- a/service/fs/embed/registry_test.go
+++ b/service/fs/embed/registry_test.go
@@ -207,17 +207,28 @@ func TestRegistry_GetFSForEntry(t *testing.T) {
 		assert.Equal(t, "legacy", string(data))
 	})
 
-	t.Run("falls back to GetFS when owning pack not registered", func(t *testing.T) {
+	t.Run("does not fall back to another pack when versioned owner is missing", func(t *testing.T) {
 		r := NewRegistry()
-		reader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "x"})
-		// Pack is registered under a different module than the entry claims.
-		require.NoError(t, r.RegisterPack("p.wapp", "org/other", "1.0.0", reader, nil))
+		oldReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "old"})
+		otherReader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "other"})
+		require.NoError(t, r.RegisterPack("org/mod-v1.0.0.wapp", "org/mod", "1.0.0", oldReader, nil))
+		require.NoError(t, r.RegisterPack("org/other-v9.9.9.wapp", "org/other", "9.9.9", otherReader, nil))
 
-		fsys, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", "9.9.9"))
+		_, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", "2.0.0"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("falls back to GetFS when module version is omitted", func(t *testing.T) {
+		r := NewRegistry()
+		reader := createReaderWithResource(t, "ui", "app", map[string]string{"v.txt": "legacy"})
+		require.NoError(t, r.RegisterPack("legacy.wapp", "", "", reader, nil))
+
+		fsys, err := r.GetFSForEntry(makeEntry("ui", "app", "org/mod", ""))
 		require.NoError(t, err)
 		data, err := fs.ReadFile(fsys, "v.txt")
 		require.NoError(t, err)
-		assert.Equal(t, "x", string(data))
+		assert.Equal(t, "legacy", string(data))
 	})
 }
 


### PR DESCRIPTION
## Why
Live hub installs could add fs.embed entries before the corresponding .wapp reader was registered in the embedded filesystem registry. Updates also need deterministic version-aware resolution while old and new packs are both staged.

## What
- Track embedded packs per pack path with module/version ownership.
- Add entry-aware fs.embed resolution so Manager.Update selects the pack matching the entry metadata.
- Register new module packs in dependency expansion Prepare, unregister obsolete packs on Commit, and roll staged packs back on failure.
- Skip restaging unchanged module packs so live filesystems are not disturbed during unrelated dependency operations.
- Register lock-file .wapp loads with module/version metadata.

## Verification
- go test -race -short -tags "fts5 sqlite_vec treesitter" ./api/service/fs/embed ./boot/deps/hub ./cmd/internal/entries ./service/fs/embed
