### PR TITLE
fix(pack): resolve embedded fs directories from the module root

### DIFF
--- a/api/service/fs/directory/resolve.go
+++ b/api/service/fs/directory/resolve.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package directory
+
+import (
+	"context"
+	"path"
+	"path/filepath"
+
+	"github.com/wippyai/runtime/api/modules"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+// ResolveDirectory resolves an fs.directory entry's configured path to a load path.
+func ResolveDirectory(ctx context.Context, entry registry.Entry, cfg *Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.Directory == "" || IsConfiguredPathAbsolute(cfg.Directory) {
+		return cfg.Directory
+	}
+	if cfg.Base == BaseProject {
+		return cfg.Directory
+	}
+
+	moduleName := ""
+	if entry.Meta != nil {
+		moduleName = entry.Meta.GetString("module", "")
+	}
+	if moduleName == "" {
+		return cfg.Directory
+	}
+
+	root, ok := modules.SourceRoot(ctx, moduleName)
+	if !ok {
+		return cfg.Directory
+	}
+
+	return filepath.Join(root, cfg.Directory)
+}
+
+// IsConfiguredPathAbsolute reports whether a configured directory path is absolute,
+// in host or slash form.
+func IsConfiguredPathAbsolute(dir string) bool {
+	return filepath.IsAbs(dir) || path.IsAbs(filepath.ToSlash(dir))
+}

--- a/api/service/fs/directory/resolve_test.go
+++ b/api/service/fs/directory/resolve_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package directory
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/modules"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+func moduleEntry(module string) registry.Entry {
+	e := registry.Entry{ID: registry.NewID("acme.ui", "ui_fs")}
+	if module != "" {
+		e.Meta = attrs.NewBagFrom(map[string]any{"module": module})
+	}
+	return e
+}
+
+func TestResolveDirectory(t *testing.T) {
+	abs := filepath.Join(string(filepath.Separator), "abs", "path")
+
+	t.Run("nil config", func(t *testing.T) {
+		if got := ResolveDirectory(ctxapi.NewRootContext(), moduleEntry("acme/ui"), nil); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		if got := ResolveDirectory(ctxapi.NewRootContext(), moduleEntry("acme/ui"), &Config{}); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("absolute path unchanged", func(t *testing.T) {
+		if got := ResolveDirectory(ctxapi.NewRootContext(), moduleEntry("acme/ui"), &Config{Directory: abs}); got != abs {
+			t.Fatalf("got %q, want %q", got, abs)
+		}
+	})
+
+	t.Run("project base stays working-dir relative", func(t *testing.T) {
+		ctx := ctxapi.NewRootContext()
+		modules.WithSourceRoots(ctx, modules.SourceRoots{"acme/ui": abs})
+		cfg := &Config{Directory: "./static", Base: BaseProject}
+		if got := ResolveDirectory(ctx, moduleEntry("acme/ui"), cfg); got != "./static" {
+			t.Fatalf("got %q, want ./static", got)
+		}
+	})
+
+	t.Run("no module meta stays unchanged", func(t *testing.T) {
+		ctx := ctxapi.NewRootContext()
+		modules.WithSourceRoots(ctx, modules.SourceRoots{"acme/ui": abs})
+		if got := ResolveDirectory(ctx, moduleEntry(""), &Config{Directory: "./static"}); got != "./static" {
+			t.Fatalf("got %q, want ./static", got)
+		}
+	})
+
+	t.Run("module meta without source root stays unchanged", func(t *testing.T) {
+		if got := ResolveDirectory(ctxapi.NewRootContext(), moduleEntry("acme/ui"), &Config{Directory: "./static"}); got != "./static" {
+			t.Fatalf("got %q, want ./static", got)
+		}
+	})
+
+	t.Run("module meta with source root joins", func(t *testing.T) {
+		ctx := ctxapi.NewRootContext()
+		modules.WithSourceRoots(ctx, modules.SourceRoots{"acme/ui": abs})
+		want := filepath.Join(abs, "static")
+		if got := ResolveDirectory(ctx, moduleEntry("acme/ui"), &Config{Directory: "./static"}); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/boot/build/stages/embed_fs.go
+++ b/boot/build/stages/embed_fs.go
@@ -4,7 +4,9 @@ package stages
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/wippyai/runtime/api/boot"
@@ -23,13 +25,18 @@ var (
 )
 
 type embedFSStage struct {
+	moduleRoot    string
 	embedPatterns []string
 }
 
-// EmbedFS creates a stage that collects fs.directory entries for embedding.
-// It transforms these entries to fs.embed and stores resource specs in context.
-func EmbedFS(embedPatterns ...string) boot.Stage {
+// EmbedFS creates a stage that collects fs.directory entries for embedding and
+// transforms them to fs.embed. moduleRoot is the root that module-relative
+// directories resolve against when no module source root is registered in
+// context (publish, which loads entries straight from a module checkout); pass
+// an empty string when the lock loader has already registered source roots.
+func EmbedFS(moduleRoot string, embedPatterns ...string) boot.Stage {
 	return &embedFSStage{
+		moduleRoot:    moduleRoot,
 		embedPatterns: embedPatterns,
 	}
 }
@@ -61,7 +68,7 @@ func (s *embedFSStage) Execute(ctx context.Context, entries *[]registry.Entry) e
 		}
 	}
 
-	res, err := collectResources(filteredEntries, log)
+	res, err := collectResources(ctx, s.moduleRoot, filteredEntries, log)
 	if err != nil {
 		return err
 	}
@@ -107,54 +114,65 @@ func filterEmbeddableEntries(entries []registry.Entry, embedPatterns []string) [
 	return embeddable
 }
 
-func collectResources(entries []registry.Entry, logger *zap.Logger) ([]wapp.ResourceSpec, error) {
+func collectResources(ctx context.Context, moduleRoot string, entries []registry.Entry, logger *zap.Logger) ([]wapp.ResourceSpec, error) {
 	specs := make([]wapp.ResourceSpec, 0, len(entries))
 	for _, entry := range entries {
 		if entry.Kind != dirapi.Kind {
 			continue
 		}
 
-		data := entry.Data.Data()
-		cfg, ok := data.(map[string]any)
-		if !ok {
-			logger.Warn("failed to decode directory config, skipping", zap.String("id", entry.ID.String()))
-			continue
+		cfg := directoryConfig(entry)
+		if cfg.Directory == "" {
+			return nil, fmt.Errorf("embed %s: directory path missing", entry.ID.String())
 		}
 
-		directory, ok := cfg["directory"].(string)
-		if !ok || directory == "" {
-			logger.Warn("directory path missing, skipping", zap.String("id", entry.ID.String()))
-			continue
-		}
+		dir := resolveEmbedDirectory(ctx, moduleRoot, entry, cfg)
 
-		info, err := os.Stat(directory)
+		info, err := os.Stat(dir)
 		if err != nil {
-			logger.Warn("directory not found, skipping",
-				zap.String("id", entry.ID.String()),
-				zap.String("directory", directory),
-				zap.Error(err))
-			continue
+			return nil, fmt.Errorf("embed %s: directory %q not found: %w", entry.ID.String(), dir, err)
 		}
-
 		if !info.IsDir() {
-			logger.Warn("path is not a directory, skipping",
-				zap.String("id", entry.ID.String()),
-				zap.String("directory", directory))
-			continue
+			return nil, fmt.Errorf("embed %s: path %q is not a directory", entry.ID.String(), dir)
 		}
 
-		spec := wapp.ResourceSpec{
+		specs = append(specs, wapp.ResourceSpec{
 			ID:   wapp.NewID(entry.ID.NS, entry.ID.Name),
-			FS:   os.DirFS(directory),
+			FS:   os.DirFS(dir),
 			Meta: wapp.Metadata(entry.Meta),
-		}
-		specs = append(specs, spec)
+		})
 
 		logger.Info("collected directory for embedding",
 			zap.String("id", entry.ID.String()),
-			zap.String("directory", directory))
+			zap.String("directory", dir))
 	}
 	return specs, nil
+}
+
+func directoryConfig(entry registry.Entry) *dirapi.Config {
+	cfg := &dirapi.Config{}
+	if entry.Data == nil {
+		return cfg
+	}
+	data, ok := entry.Data.Data().(map[string]any)
+	if !ok {
+		return cfg
+	}
+	if directory, ok := data["directory"].(string); ok {
+		cfg.Directory = directory
+	}
+	if base, ok := data["base"].(string); ok {
+		cfg.Base = base
+	}
+	return cfg
+}
+
+func resolveEmbedDirectory(ctx context.Context, moduleRoot string, entry registry.Entry, cfg *dirapi.Config) string {
+	dir := dirapi.ResolveDirectory(ctx, entry, cfg)
+	if moduleRoot != "" && cfg.Base != dirapi.BaseProject && !dirapi.IsConfiguredPathAbsolute(cfg.Directory) {
+		return filepath.Join(moduleRoot, cfg.Directory)
+	}
+	return dir
 }
 
 func transformEntries(entries []registry.Entry, embeddableIDs []registry.ID) []registry.Entry {

--- a/boot/build/stages/embed_fs.go
+++ b/boot/build/stages/embed_fs.go
@@ -47,6 +47,7 @@ func (s *embedFSStage) Name() string {
 
 func (s *embedFSStage) Execute(ctx context.Context, entries *[]registry.Entry) error {
 	log := logs.GetLogger(ctx)
+	setResources(nil)
 
 	embeddableIDs := filterEmbeddableEntries(*entries, s.embedPatterns)
 	if len(embeddableIDs) == 0 {
@@ -73,9 +74,7 @@ func (s *embedFSStage) Execute(ctx context.Context, entries *[]registry.Entry) e
 		return err
 	}
 
-	resourcesMu.Lock()
-	resources = res
-	resourcesMu.Unlock()
+	setResources(res)
 
 	transformed := transformEntries(*entries, embeddableIDs)
 	*entries = transformed
@@ -92,6 +91,12 @@ func GetResources(_ context.Context) []wapp.ResourceSpec {
 	resourcesMu.RLock()
 	defer resourcesMu.RUnlock()
 	return resources
+}
+
+func setResources(res []wapp.ResourceSpec) {
+	resourcesMu.Lock()
+	defer resourcesMu.Unlock()
+	resources = res
 }
 
 func filterEmbeddableEntries(entries []registry.Entry, embedPatterns []string) []registry.ID {

--- a/boot/build/stages/embed_fs_test.go
+++ b/boot/build/stages/embed_fs_test.go
@@ -165,6 +165,38 @@ func TestEmbedFSErrorsOnNilEntryData(t *testing.T) {
 	}
 }
 
+func TestEmbedFSClearsResourcesWhenNoDirectories(t *testing.T) {
+	moduleRoot := t.TempDir()
+	staticDir := filepath.Join(moduleRoot, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("mkdir static dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<html>ui</html>"), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+
+	ctx := context.Background()
+	entries := []registry.Entry{{
+		ID:   registry.NewID("acme.ui", "ui_fs"),
+		Kind: dirapi.Kind,
+		Data: payload.New(map[string]any{"directory": "./static"}),
+	}}
+	if err := EmbedFS(moduleRoot, "ui_fs").Execute(ctx, &entries); err != nil {
+		t.Fatalf("first stage execute: %v", err)
+	}
+	if got := len(GetResources(ctx)); got != 1 {
+		t.Fatalf("resources after first run = %d, want 1", got)
+	}
+
+	entries = []registry.Entry{{ID: registry.NewID("acme.ui", "definition"), Kind: "ns.definition"}}
+	if err := EmbedFS(moduleRoot).Execute(ctx, &entries); err != nil {
+		t.Fatalf("second stage execute: %v", err)
+	}
+	if got := len(GetResources(ctx)); got != 0 {
+		t.Fatalf("resources after no-directory run = %d, want 0", got)
+	}
+}
+
 func TestFilterEmbeddableEntries(t *testing.T) {
 	dirA := registry.Entry{ID: registry.NewID("acme.app", "ui_fs"), Kind: dirapi.Kind}
 	dirB := registry.Entry{ID: registry.NewID("acme.app", "wasm_fs"), Kind: dirapi.Kind}

--- a/boot/build/stages/embed_fs_test.go
+++ b/boot/build/stages/embed_fs_test.go
@@ -3,6 +3,8 @@
 package stages
 
 import (
+	"bytes"
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 	dirapi "github.com/wippyai/runtime/api/service/fs/directory"
 	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
+	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
 
@@ -37,7 +40,7 @@ func TestEmbedFSCollectsModuleRelativeDirectory(t *testing.T) {
 		}),
 	}
 
-	resources, err := collectResources([]registry.Entry{entry}, zap.NewNop())
+	resources, err := collectResources(context.Background(), "", []registry.Entry{entry}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("collectResources failed: %v", err)
 	}
@@ -61,5 +64,229 @@ func TestEmbedFSCollectsModuleRelativeDirectory(t *testing.T) {
 	}
 	if transformed[0].Kind != embedapi.Kind {
 		t.Fatalf("transformed kind = %q, want %q", transformed[0].Kind, embedapi.Kind)
+	}
+}
+
+func TestEmbedFSResolvesModuleRootWithoutChdir(t *testing.T) {
+	moduleRoot := t.TempDir()
+	staticDir := filepath.Join(moduleRoot, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("mkdir static dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<html>ui</html>"), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+
+	t.Chdir(t.TempDir())
+
+	entry := registry.Entry{
+		ID:   registry.NewID("acme.ui", "ui_fs"),
+		Kind: dirapi.Kind,
+		Meta: attrs.NewBagFrom(map[string]any{"module": "acme/ui"}),
+		Data: payload.New(map[string]any{"directory": "./static"}),
+	}
+
+	resources, err := collectResources(context.Background(), moduleRoot, []registry.Entry{entry}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("collectResources failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(resources))
+	}
+	data, err := fs.ReadFile(resources[0].FS, "index.html")
+	if err != nil {
+		t.Fatalf("read embedded index.html: %v", err)
+	}
+	if string(data) != "<html>ui</html>" {
+		t.Fatalf("embedded index.html = %q", string(data))
+	}
+}
+
+func TestEmbedFSCollectsMultipleResources(t *testing.T) {
+	moduleRoot := t.TempDir()
+	for _, sub := range []string{"static", "wasm"} {
+		dir := filepath.Join(moduleRoot, sub)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, sub+".bin"), []byte(sub), 0o644); err != nil {
+			t.Fatalf("write %s: %v", sub, err)
+		}
+	}
+	t.Chdir(t.TempDir())
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("acme.app", "ui_fs"),
+			Kind: dirapi.Kind,
+			Meta: attrs.NewBagFrom(map[string]any{"module": "acme/app"}),
+			Data: payload.New(map[string]any{"directory": "./static"}),
+		},
+		{
+			ID:   registry.NewID("acme.app", "wasm_fs"),
+			Kind: dirapi.Kind,
+			Meta: attrs.NewBagFrom(map[string]any{"module": "acme/app"}),
+			Data: payload.New(map[string]any{"directory": "./wasm"}),
+		},
+	}
+
+	resources, err := collectResources(context.Background(), moduleRoot, entries, zap.NewNop())
+	if err != nil {
+		t.Fatalf("collectResources failed: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resource count = %d, want 2", len(resources))
+	}
+}
+
+func TestEmbedFSErrorsOnMissingDirectory(t *testing.T) {
+	moduleRoot := t.TempDir()
+	t.Chdir(t.TempDir())
+
+	entry := registry.Entry{
+		ID:   registry.NewID("acme.ui", "ui_fs"),
+		Kind: dirapi.Kind,
+		Meta: attrs.NewBagFrom(map[string]any{"module": "acme/ui"}),
+		Data: payload.New(map[string]any{"directory": "./does-not-exist"}),
+	}
+
+	_, err := collectResources(context.Background(), moduleRoot, []registry.Entry{entry}, zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for missing directory, got nil")
+	}
+}
+
+func TestEmbedFSErrorsOnNilEntryData(t *testing.T) {
+	entry := registry.Entry{ID: registry.NewID("acme.ui", "ui_fs"), Kind: dirapi.Kind}
+
+	_, err := collectResources(context.Background(), "", []registry.Entry{entry}, zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for entry with nil data, got nil")
+	}
+}
+
+func TestFilterEmbeddableEntries(t *testing.T) {
+	dirA := registry.Entry{ID: registry.NewID("acme.app", "ui_fs"), Kind: dirapi.Kind}
+	dirB := registry.Entry{ID: registry.NewID("acme.app", "wasm_fs"), Kind: dirapi.Kind}
+	notDir := registry.Entry{ID: registry.NewID("acme.app", "compute"), Kind: "function.wasm"}
+	all := []registry.Entry{dirA, dirB, notDir}
+
+	ids := func(entries []registry.ID) []string {
+		out := make([]string, len(entries))
+		for i, id := range entries {
+			out[i] = id.String()
+		}
+		return out
+	}
+
+	t.Run("no patterns embeds every directory", func(t *testing.T) {
+		got := ids(filterEmbeddableEntries(all, nil))
+		want := []string{"acme.app:ui_fs", "acme.app:wasm_fs"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("match by full id", func(t *testing.T) {
+		got := ids(filterEmbeddableEntries(all, []string{"acme.app:wasm_fs"}))
+		if len(got) != 1 || got[0] != "acme.app:wasm_fs" {
+			t.Fatalf("got %v, want [acme.app:wasm_fs]", got)
+		}
+	})
+
+	t.Run("match by name", func(t *testing.T) {
+		got := ids(filterEmbeddableEntries(all, []string{"ui_fs"}))
+		if len(got) != 1 || got[0] != "acme.app:ui_fs" {
+			t.Fatalf("got %v, want [acme.app:ui_fs]", got)
+		}
+	})
+
+	t.Run("non-matching pattern embeds nothing", func(t *testing.T) {
+		if got := filterEmbeddableEntries(all, []string{"nope"}); len(got) != 0 {
+			t.Fatalf("got %v, want empty", ids(got))
+		}
+	})
+
+	t.Run("non-directory kinds are never embeddable", func(t *testing.T) {
+		if got := filterEmbeddableEntries([]registry.Entry{notDir}, nil); len(got) != 0 {
+			t.Fatalf("got %v, want empty", ids(got))
+		}
+	})
+}
+
+func TestEmbedFSEndToEndPacksBothResources(t *testing.T) {
+	moduleRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(moduleRoot, "static"), 0o755); err != nil {
+		t.Fatalf("mkdir static: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleRoot, "static", "index.html"), []byte("<html>ui</html>"), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(moduleRoot, "wasm"), 0o755); err != nil {
+		t.Fatalf("mkdir wasm: %v", err)
+	}
+	wasmBytes := []byte("\x00asm\x01\x00\x00\x00")
+	if err := os.WriteFile(filepath.Join(moduleRoot, "wasm", "compute.wasm"), wasmBytes, 0o644); err != nil {
+		t.Fatalf("write compute.wasm: %v", err)
+	}
+	t.Chdir(t.TempDir())
+
+	entries := []registry.Entry{
+		{ID: registry.NewID("acme.app", "definition"), Kind: "ns.definition"},
+		{
+			ID:   registry.NewID("acme.app", "ui_fs"),
+			Kind: dirapi.Kind,
+			Data: payload.New(map[string]any{"directory": "./static"}),
+		},
+		{
+			ID:   registry.NewID("acme.app", "wasm_fs"),
+			Kind: dirapi.Kind,
+			Data: payload.New(map[string]any{"directory": "./wasm"}),
+		},
+	}
+
+	stage := EmbedFS(moduleRoot, "ui_fs", "wasm_fs")
+	if err := stage.Execute(context.Background(), &entries); err != nil {
+		t.Fatalf("stage execute: %v", err)
+	}
+
+	for _, e := range entries {
+		if (e.ID.Name == "ui_fs" || e.ID.Name == "wasm_fs") && e.Kind != embedapi.Kind {
+			t.Fatalf("entry %s kind = %q, want %q", e.ID.String(), e.Kind, embedapi.Kind)
+		}
+	}
+
+	specs := GetResources(context.Background())
+	if len(specs) != 2 {
+		t.Fatalf("collected resources = %d, want 2", len(specs))
+	}
+
+	var buf bytes.Buffer
+	if err := wapp.NewWriter().PackWithResources(wapp.Metadata{}, nil, specs, &buf); err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	reader, err := wapp.NewReader(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	if got := len(reader.ListResources()); got != 2 {
+		t.Fatalf("packed resources = %d, want 2", got)
+	}
+
+	uiFS, err := reader.GetFS(wapp.NewID("acme.app", "ui_fs"))
+	if err != nil {
+		t.Fatalf("get ui fs: %v", err)
+	}
+	if data, err := fs.ReadFile(uiFS, "index.html"); err != nil || string(data) != "<html>ui</html>" {
+		t.Fatalf("ui content = %q err=%v", string(data), err)
+	}
+
+	wasmFS, err := reader.GetFS(wapp.NewID("acme.app", "wasm_fs"))
+	if err != nil {
+		t.Fatalf("get wasm fs: %v", err)
+	}
+	if data, err := fs.ReadFile(wasmFS, "compute.wasm"); err != nil || !bytes.Equal(data, wasmBytes) {
+		t.Fatalf("wasm content mismatch err=%v", err)
 	}
 }

--- a/cmd/wippy/cmd/pack.go
+++ b/cmd/wippy/cmd/pack.go
@@ -481,7 +481,7 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 			percent: 0.55,
 			status:  fmt.Sprintf("Processing embed patterns: %s", strings.Join(embedPatterns, ", ")),
 		})
-		pipelineStages = append(pipelineStages, stages.EmbedFS(embedPatterns...))
+		pipelineStages = append(pipelineStages, stages.EmbedFS("", embedPatterns...))
 	}
 
 	pipeline := build.New(pipelineStages...)

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -465,7 +465,7 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		stages.Override(),
 	}
 	if len(embedPatterns) > 0 {
-		pipelineStages = append(pipelineStages, stages.EmbedFS(embedPatterns...))
+		pipelineStages = append(pipelineStages, stages.EmbedFS(srcDir, embedPatterns...))
 	}
 
 	pipeline := build.New(pipelineStages...)

--- a/service/fs/directory/manager.go
+++ b/service/fs/directory/manager.go
@@ -4,13 +4,10 @@ package directory
 
 import (
 	"context"
-	"path"
-	"path/filepath"
 	"sync"
 
 	"github.com/wippyai/runtime/api/event"
 	fsapi "github.com/wippyai/runtime/api/fs"
-	moduleapi "github.com/wippyai/runtime/api/modules"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	dirapi "github.com/wippyai/runtime/api/service/fs/directory"
@@ -177,34 +174,7 @@ func (m *Manager) registerFSLocked(ctx context.Context, entry registry.Entry, cf
 }
 
 func resolveDirectoryPath(ctx context.Context, entry registry.Entry, cfg *dirapi.Config) string {
-	if cfg == nil {
-		return ""
-	}
-	if cfg.Directory == "" || isAbsoluteConfiguredPath(cfg.Directory) {
-		return cfg.Directory
-	}
-	if cfg.Base == dirapi.BaseProject {
-		return cfg.Directory
-	}
-
-	moduleName := ""
-	if entry.Meta != nil {
-		moduleName = entry.Meta.GetString("module", "")
-	}
-	if moduleName == "" {
-		return cfg.Directory
-	}
-
-	root, ok := moduleapi.SourceRoot(ctx, moduleName)
-	if !ok {
-		return cfg.Directory
-	}
-
-	return filepath.Join(root, cfg.Directory)
-}
-
-func isAbsoluteConfiguredPath(dir string) bool {
-	return filepath.IsAbs(dir) || path.IsAbs(filepath.ToSlash(dir))
+	return dirapi.ResolveDirectory(ctx, entry, cfg)
 }
 
 // removeFS removes the filesystem from the fs system


### PR DESCRIPTION
## Why

Packing or publishing a module that ships embedded filesystems — e.g. a UI bundle **and** a WASM binary — could report success while embedding **zero** files. The embed stage resolved each `fs.directory` path against the process working directory instead of the module source root the runtime uses, then skipped a missing directory with only a warning while still rewriting the entry to `fs.embed`. The result was a `.wapp` whose `fs.embed` entries had no backing resource; installed modules served no UI and failed to load the WASM binary.

## What

- New `api/service/fs/directory.ResolveDirectory` centralizes directory resolution (absolute / `base: project` / module source root); the runtime directory manager and the embed build stage now share it, so they cannot drift.
- The embed stage resolves module-relative directories against the module root (the lock loader already registers per-module source roots; `publish` passes the module root explicitly) and now **returns an error** when an embeddable directory cannot be found, instead of silently producing a broken pack.

## Proof (CLI, ui+wasm module)

**Before — silent success, empty pack** (working dir does not contain the asset dirs):
```
$ wippy pack --embed ui_fs,wasm_fs out.wapp
✓ Pack created successfully    Size: 0.87 KB    exit 0
# inspecting the pack:
RESOURCES: 0
  - id=app:ui_fs    kind=fs.embed      # claims an embedded fs
  - id=app:wasm_fs  kind=fs.embed      # claims an embedded fs
# 0.87 KB — the 14 KB WASM is absent
```

**After — fails loudly, no broken pack:**
```
$ wippy pack --embed ui_fs,wasm_fs out.wapp
✗ Error: stage 'embed_fs' failed: embed app:ui_fs: directory "./static" not found
exit 1
```

**After — correct layout embeds both filesystems:**
```
$ wippy pack --embed ui_fs,wasm_fs out.wapp
✓ Pack created successfully    Size: 7.60 KB
  Embedded resources:
    • app:ui_fs   (1 files, 0.03 KB)
    • app:wasm_fs (1 files, 14.07 KB)   # WASM actually embedded
# inspecting the pack:
RESOURCES: 2
  - id=app:ui_fs    type=tree files=1 size=28
  - id=app:wasm_fs  type=tree files=1 size=14410
```

## Testing

- New unit + integration tests (incl. an end-to-end stage→`wapp.Writer`→read-back that embeds and reads both the UI and WASM filesystems). Reverting each fix facet makes the matching test fail.
- `golangci-lint` clean; `go vet` clean; full module build clean; full short race test suite green.
- Mutation testing (gremlins): 100% on both changed packages.
