### PR TITLE
fix(contract): propagate with_actor/with_scope to bound function

### DIFF
--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -1291,3 +1291,156 @@ func TestIntegration_ActorPropagation_PersistsAcrossCalls(t *testing.T) {
 	require.NotNil(t, result.Value)
 	assert.Equal(t, "actor:owner-42|actor:owner-42", string(result.Value.Data().(lua.LString)))
 }
+
+// TestIntegration_ScopePropagation asserts that a scope framed on a contract via
+// with_scope() reaches the bound function's execution context. The ambient context
+// carries no scope, so the bound function only sees one if framing propagated it.
+func TestIntegration_ScopePropagation(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	funcID := registry.NewID("test", "whichscope")
+	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		if _, ok := security.GetScope(ctx); ok {
+			return &runtime.Result{Value: payload.New("scope:yes")}, nil
+		}
+		return &runtime.Result{Value: payload.New("scope:no")}, nil
+	})
+
+	contractID := registry.NewID("test", "whichscope_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "run"}},
+	})
+
+	bindingID := registry.NewID("test", "whichscope_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"run": funcID}},
+		},
+	})
+
+	script := `
+		local scope = security.new_scope()
+		local instance, err = contract.get("test:whichscope_service"):with_scope(scope):open("test:whichscope_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local result, err = instance:run()
+		if err then
+			return nil, tostring(err)
+		end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "scope:yes", string(result.Value.Data().(lua.LString)))
+}
+
+// TestIntegration_ActorPropagation_OverridesAmbient asserts that with_actor() wins
+// over an actor already present in the caller's ambient context: framing replaces
+// the inherited actor rather than merely filling an empty slot.
+func TestIntegration_ActorPropagation_OverridesAmbient(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	funcID := registry.NewID("test", "whoami3")
+	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		actor, ok := security.GetActor(ctx)
+		if !ok {
+			return &runtime.Result{Value: payload.New("no-actor")}, nil
+		}
+		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
+	})
+
+	contractID := registry.NewID("test", "whoami3_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "whoami"}},
+	})
+
+	bindingID := registry.NewID("test", "whoami3_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"whoami": funcID}},
+		},
+	})
+
+	script := `
+		local actor = security.new_actor("framed-user", {})
+		local instance, err = contract.get("test:whoami3_service"):with_actor(actor):open("test:whoami3_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local result, err = instance:whoami()
+		if err then
+			return nil, tostring(err)
+		end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	require.NoError(t, security.SetActor(frameCtx, security.Actor{ID: "ambient-user"}))
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:framed-user", string(result.Value.Data().(lua.LString)))
+}
+
+// TestIntegration_ContractInheritsAmbientActor asserts that without with_actor()
+// the bound function still runs under the caller's ambient actor. This guards the
+// framing change against regressing the default inheritance path.
+func TestIntegration_ContractInheritsAmbientActor(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	funcID := registry.NewID("test", "whoami4")
+	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		actor, ok := security.GetActor(ctx)
+		if !ok {
+			return &runtime.Result{Value: payload.New("no-actor")}, nil
+		}
+		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
+	})
+
+	contractID := registry.NewID("test", "whoami4_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "whoami"}},
+	})
+
+	bindingID := registry.NewID("test", "whoami4_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"whoami": funcID}},
+		},
+	})
+
+	script := `
+		local instance, err = contract.get("test:whoami4_service"):open("test:whoami4_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local result, err = instance:whoami()
+		if err then
+			return nil, tostring(err)
+		end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	require.NoError(t, security.SetActor(frameCtx, security.Actor{ID: "ambient-user"}))
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:ambient-user", string(result.Value.Data().(lua.LString)))
+}

--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -1430,3 +1430,55 @@ func TestIntegration_ContractInheritsAmbientActor(t *testing.T) {
 	require.NotNil(t, result.Value)
 	assert.Equal(t, "actor:ambient-user", string(result.Value.Data().(lua.LString)))
 }
+
+// TestIntegration_ActorPropagation_AsyncCall asserts the framed actor also reaches
+// the bound function through the async call path (method_async + future), which
+// routes through the same instance as the sync path.
+func TestIntegration_ActorPropagation_AsyncCall(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	funcID := registry.NewID("test", "whoami_async_fn")
+	tc.registerFunction(t, funcID, actorReportFunc)
+
+	contractID := registry.NewID("test", "whoami_async_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "whoami"}},
+	})
+
+	bindingID := registry.NewID("test", "whoami_async_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"whoami": funcID}, Default: true},
+		},
+	})
+
+	script := `
+		local actor = security.new_actor("async-owner", {})
+		local instance, err = contract.get("test:whoami_async_service"):with_actor(actor):open("test:whoami_async_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local future, err = instance:whoami_async()
+		if err then
+			return nil, "async start failed: " .. tostring(err)
+		end
+		local p, ok = future:response():receive()
+		if not ok then
+			return nil, "future channel closed without result"
+		end
+		if p == nil then
+			return nil, "nil result"
+		end
+		return p:data()
+	`
+
+	frameCtx, runPID := asyncFrameCtx(t, tc)
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, runPID, proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error, "script error: %v", result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:async-owner", string(result.Value.Data().(lua.LString)))
+}

--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wippyai/runtime/internal/uniqid"
 	"github.com/wippyai/runtime/runtime/lua/engine"
 	contractmod "github.com/wippyai/runtime/runtime/lua/modules/contract"
+	securitymod "github.com/wippyai/runtime/runtime/lua/modules/security"
 	syscontract "github.com/wippyai/runtime/system/contract"
 	"github.com/wippyai/runtime/system/eventbus"
 	sysfunction "github.com/wippyai/runtime/system/function"
@@ -1157,4 +1158,136 @@ func TestIntegration_WithOptions_NoRetryWithoutOptions(t *testing.T) {
 	require.NotNil(t, result.Value)
 	assert.Equal(t, "failed:Unavailable", string(result.Value.Data().(lua.LString)))
 	assert.Equal(t, int64(1), callCount.Load())
+}
+
+// newLuaProcessWithSecurity builds a test process with the contract AND security
+// Lua modules bound, so scripts can construct an actor (security.new_actor) and
+// frame a contract with it (contract.get(...):with_actor(actor)).
+func newLuaProcessWithSecurity(t *testing.T, script string) *engine.Process {
+	t.Helper()
+	proto, _ := lua.CompileString(script, "test.lua")
+	proc, err := engine.NewProcess(
+		engine.WithProto(proto),
+		engine.WithModuleBinder(func(l *lua.LState) error {
+			engine.LoadModuleDef(l, engine.ChannelModule)
+			return nil
+		}),
+		engine.WithModuleBinder(bindContractModule),
+		engine.WithModuleBinder(func(l *lua.LState) error {
+			tbl, _ := securitymod.Module.Build()
+			l.SetGlobal(securitymod.Module.Name, tbl)
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewProcess failed: %v", err)
+	}
+	return proc
+}
+
+// TestIntegration_ActorPropagation asserts that an actor framed on a contract via
+// with_actor() reaches the bound function's execution context. The bound function
+// reads the actor from its ctx and returns its id; the script frames a specific
+// actor before opening, so the result must be that actor (not the ambient one).
+func TestIntegration_ActorPropagation(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	funcID := registry.NewID("test", "whoami")
+	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		actor, ok := security.GetActor(ctx)
+		if !ok {
+			return &runtime.Result{Value: payload.New("no-actor")}, nil
+		}
+		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
+	})
+
+	contractID := registry.NewID("test", "whoami_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "whoami"}},
+	})
+
+	bindingID := registry.NewID("test", "whoami_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"whoami": funcID}},
+		},
+	})
+
+	script := `
+		local actor = security.new_actor("framed-user", {})
+		local instance, err = contract.get("test:whoami_service"):with_actor(actor):open("test:whoami_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local result, err = instance:whoami()
+		if err then
+			return nil, tostring(err)
+		end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:framed-user", string(result.Value.Data().(lua.LString)))
+}
+
+// TestIntegration_ActorPropagation_PersistsAcrossCalls asserts the framed actor
+// is bound to the instance, so every subsequent method call runs under it — not
+// just the first.
+func TestIntegration_ActorPropagation_PersistsAcrossCalls(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	funcID := registry.NewID("test", "whoami2")
+	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		actor, ok := security.GetActor(ctx)
+		if !ok {
+			return &runtime.Result{Value: payload.New("no-actor")}, nil
+		}
+		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
+	})
+
+	contractID := registry.NewID("test", "whoami2_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "whoami"}},
+	})
+
+	bindingID := registry.NewID("test", "whoami2_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"whoami": funcID}},
+		},
+	})
+
+	script := `
+		local actor = security.new_actor("owner-42", {})
+		local instance, err = contract.get("test:whoami2_service"):with_actor(actor):open("test:whoami2_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local first, err = instance:whoami()
+		if err then
+			return nil, tostring(err)
+		end
+		local second, err = instance:whoami()
+		if err then
+			return nil, tostring(err)
+		end
+		return first .. "|" .. second
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:owner-42|actor:owner-42", string(result.Value.Data().(lua.LString)))
 }

--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -1185,6 +1185,16 @@ func newLuaProcessWithSecurity(t *testing.T, script string) *engine.Process {
 	return proc
 }
 
+// actorReportFunc reports the actor present in its execution context, used by the
+// framing tests to observe which actor the bound function runs under.
+func actorReportFunc(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+	actor, ok := security.GetActor(ctx)
+	if !ok {
+		return &runtime.Result{Value: payload.New("no-actor")}, nil
+	}
+	return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
+}
+
 // TestIntegration_ActorPropagation asserts that an actor framed on a contract via
 // with_actor() reaches the bound function's execution context. The bound function
 // reads the actor from its ctx and returns its id; the script frames a specific
@@ -1194,13 +1204,7 @@ func TestIntegration_ActorPropagation(t *testing.T) {
 	defer tc.Close(t)
 
 	funcID := registry.NewID("test", "whoami")
-	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
-		actor, ok := security.GetActor(ctx)
-		if !ok {
-			return &runtime.Result{Value: payload.New("no-actor")}, nil
-		}
-		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
-	})
+	tc.registerFunction(t, funcID, actorReportFunc)
 
 	contractID := registry.NewID("test", "whoami_service")
 	tc.registerContract(t, contractID, &apicontract.Definition{
@@ -1245,13 +1249,7 @@ func TestIntegration_ActorPropagation_PersistsAcrossCalls(t *testing.T) {
 	defer tc.Close(t)
 
 	funcID := registry.NewID("test", "whoami2")
-	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
-		actor, ok := security.GetActor(ctx)
-		if !ok {
-			return &runtime.Result{Value: payload.New("no-actor")}, nil
-		}
-		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
-	})
+	tc.registerFunction(t, funcID, actorReportFunc)
 
 	contractID := registry.NewID("test", "whoami2_service")
 	tc.registerContract(t, contractID, &apicontract.Definition{
@@ -1350,13 +1348,7 @@ func TestIntegration_ActorPropagation_OverridesAmbient(t *testing.T) {
 	defer tc.Close(t)
 
 	funcID := registry.NewID("test", "whoami3")
-	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
-		actor, ok := security.GetActor(ctx)
-		if !ok {
-			return &runtime.Result{Value: payload.New("no-actor")}, nil
-		}
-		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
-	})
+	tc.registerFunction(t, funcID, actorReportFunc)
 
 	contractID := registry.NewID("test", "whoami3_service")
 	tc.registerContract(t, contractID, &apicontract.Definition{
@@ -1402,13 +1394,7 @@ func TestIntegration_ContractInheritsAmbientActor(t *testing.T) {
 	defer tc.Close(t)
 
 	funcID := registry.NewID("test", "whoami4")
-	tc.registerFunction(t, funcID, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
-		actor, ok := security.GetActor(ctx)
-		if !ok {
-			return &runtime.Result{Value: payload.New("no-actor")}, nil
-		}
-		return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
-	})
+	tc.registerFunction(t, funcID, actorReportFunc)
 
 	contractID := registry.NewID("test", "whoami4_service")
 	tc.registerContract(t, contractID, &apicontract.Definition{

--- a/system/contract/dispatcher.go
+++ b/system/contract/dispatcher.go
@@ -69,6 +69,18 @@ func (d *Dispatcher) handleOpen(ctx context.Context, cmd dispatcher.Command, tag
 			receiver.CompleteYield(tag, contract.OpenResult{Error: err}, nil)
 			return
 		}
+		// Carry the open-time security framing (with_actor/with_scope) onto the
+		// instance so every method call runs the bound function under it.
+		if impl, ok := instance.(*instanceImpl); ok {
+			if openCmd.HasActor {
+				impl.actor = openCmd.Actor
+				impl.hasActor = true
+			}
+			if openCmd.HasScope {
+				impl.secScope = openCmd.SecurityScope
+				impl.hasScope = true
+			}
+		}
 		receiver.CompleteYield(tag, contract.OpenResult{Instance: instance}, nil)
 	}(callCtx, fc)
 

--- a/system/contract/dispatcher.go
+++ b/system/contract/dispatcher.go
@@ -71,14 +71,9 @@ func (d *Dispatcher) handleOpen(ctx context.Context, cmd dispatcher.Command, tag
 		}
 		// Carry the open-time security framing (with_actor/with_scope) onto the
 		// instance so every method call runs the bound function under it.
-		if impl, ok := instance.(*instanceImpl); ok {
-			if openCmd.HasActor {
-				impl.actor = openCmd.Actor
-				impl.hasActor = true
-			}
-			if openCmd.HasScope {
-				impl.secScope = openCmd.SecurityScope
-				impl.hasScope = true
+		if (openCmd.HasActor || openCmd.HasScope) && instance != nil {
+			if framer, ok := instance.(securityFramer); ok {
+				framer.frameSecurity(openCmd.Actor, openCmd.HasActor, openCmd.SecurityScope, openCmd.HasScope)
 			}
 		}
 		receiver.CompleteYield(tag, contract.OpenResult{Instance: instance}, nil)

--- a/system/contract/dispatcher.go
+++ b/system/contract/dispatcher.go
@@ -71,7 +71,7 @@ func (d *Dispatcher) handleOpen(ctx context.Context, cmd dispatcher.Command, tag
 		}
 		// Carry the open-time security framing (with_actor/with_scope) onto the
 		// instance so every method call runs the bound function under it.
-		if (openCmd.HasActor || openCmd.HasScope) && instance != nil {
+		if openCmd.HasActor || openCmd.HasScope {
 			if framer, ok := instance.(securityFramer); ok {
 				framer.frameSecurity(openCmd.Actor, openCmd.HasActor, openCmd.SecurityScope, openCmd.HasScope)
 			}

--- a/system/contract/instantiator.go
+++ b/system/contract/instantiator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/runtime"
+	secapi "github.com/wippyai/runtime/api/security"
 )
 
 // Instantiator implements contract.Instantiator interface for runtime execution.
@@ -60,6 +61,14 @@ type instanceImpl struct {
 	context   attrs.Bag
 	id        registry.ID
 	contracts []contract.Contract
+
+	// Security context the instance was opened with (via the contract wrapper's
+	// with_actor/with_scope). When set, every method call runs the bound function
+	// under this actor/scope rather than inheriting the caller's ambient one.
+	actor    secapi.Actor
+	hasActor bool
+	secScope secapi.Scope
+	hasScope bool
 }
 
 func (i *instanceImpl) Implements() []contract.Contract {
@@ -101,7 +110,12 @@ func (i *instanceImpl) Call(ctx context.Context, method string, args payload.Pay
 		Options:  options,
 	}
 
-	// Merge scope values into task.Context for downstream consumers.
+	// Build the context overrides applied to the bound function's FrameContext:
+	// scope values, plus the actor/scope the instance was opened with so the
+	// function runs under the framed security context (the same Task.Context pair
+	// mechanism funcs uses for its with_actor/with_scope).
+	var pairs []ctxapi.Pair
+
 	if len(i.context) > 0 {
 		// Get existing values from FrameContext or create new
 		values := ctxapi.GetValues(ctx)
@@ -117,8 +131,18 @@ func (i *instanceImpl) Call(ctx context.Context, method string, args payload.Pay
 			values.Set(k, v)
 		}
 
-		// Pass merged values via task.Context so they propagate through OpenFrameContext
-		task.Context = []ctxapi.Pair{ctxapi.ValuesPair(values)}
+		pairs = append(pairs, ctxapi.ValuesPair(values))
+	}
+
+	if i.hasActor {
+		pairs = append(pairs, secapi.ActorPair(i.actor))
+	}
+	if i.hasScope {
+		pairs = append(pairs, secapi.ScopePair(i.secScope))
+	}
+
+	if len(pairs) > 0 {
+		task.Context = pairs
 	}
 
 	// Call the function with context

--- a/system/contract/instantiator.go
+++ b/system/contract/instantiator.go
@@ -71,6 +71,19 @@ type instanceImpl struct {
 	hasScope bool
 }
 
+// securityFramer is implemented by contract instances that can run their bound
+// functions under an explicit open-time security context (the actor/scope set on
+// the contract wrapper via with_actor/with_scope). handleOpen frames the instance
+// through this capability rather than coupling to a concrete type.
+type securityFramer interface {
+	frameSecurity(actor secapi.Actor, hasActor bool, scope secapi.Scope, hasScope bool)
+}
+
+func (i *instanceImpl) frameSecurity(actor secapi.Actor, hasActor bool, scope secapi.Scope, hasScope bool) {
+	i.actor, i.hasActor = actor, hasActor
+	i.secScope, i.hasScope = scope, hasScope
+}
+
 func (i *instanceImpl) Implements() []contract.Contract {
 	return i.contracts
 }

--- a/system/contract/instantiator.go
+++ b/system/contract/instantiator.go
@@ -66,8 +66,8 @@ type instanceImpl struct {
 	// with_actor/with_scope). When set, every method call runs the bound function
 	// under this actor/scope rather than inheriting the caller's ambient one.
 	actor    secapi.Actor
-	hasActor bool
 	secScope secapi.Scope
+	hasActor bool
 	hasScope bool
 }
 

--- a/system/contract/instantiator.go
+++ b/system/contract/instantiator.go
@@ -57,18 +57,14 @@ func (i *Instantiator) Instantiate(ctx context.Context, bindingID registry.ID, s
 // instanceImpl implements contract.Instance interface.
 type instanceImpl struct {
 	funcReg   function.Registry
+	secScope  secapi.Scope
 	binding   *contract.Binding
 	context   attrs.Bag
 	id        registry.ID
+	actor     secapi.Actor
 	contracts []contract.Contract
-
-	// Security context the instance was opened with (via the contract wrapper's
-	// with_actor/with_scope). When set, every method call runs the bound function
-	// under this actor/scope rather than inheriting the caller's ambient one.
-	actor    secapi.Actor
-	secScope secapi.Scope
-	hasActor bool
-	hasScope bool
+	hasActor  bool
+	hasScope  bool
 }
 
 // securityFramer is implemented by contract instances that can run their bound

--- a/system/contract/instantiator_test.go
+++ b/system/contract/instantiator_test.go
@@ -20,9 +20,11 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 	relayapi "github.com/wippyai/runtime/api/relay"
 	"github.com/wippyai/runtime/api/runtime"
+	secapi "github.com/wippyai/runtime/api/security"
 	"github.com/wippyai/runtime/internal/uniqid"
 	functionSys "github.com/wippyai/runtime/system/function"
 	"github.com/wippyai/runtime/system/relay"
+	secsystem "github.com/wippyai/runtime/system/security"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -356,6 +358,131 @@ func TestInstanceImpl_Call_Integration(t *testing.T) {
 	_, err = instance.Call(ctx, "unknownMethod", payload.Payloads{}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "method 'unknownMethod' not bound")
+}
+
+// framePolicy is a minimal Policy used to prove a framed scope carries its
+// policies through to the bound function's execution context.
+type framePolicy struct {
+	id registry.ID
+}
+
+func (p framePolicy) ID() registry.ID { return p.id }
+
+func (p framePolicy) Evaluate(_ secapi.Actor, _, _ string, _ attrs.Bag) secapi.Result {
+	return secapi.Allow
+}
+
+// TestInstanceImpl_Call_FramesActorScopeAndPolicies asserts the security context
+// an instance is framed with (actor + scope, scope carrying its policies) reaches
+// the bound function's execution context on every call. This is the contract-level
+// counterpart to the Lua integration tests: it proves the propagation at the
+// instance boundary, including the scope's policy contents.
+func TestInstanceImpl_Call_FramesActorScopeAndPolicies(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	ctx = relayapi.WithNode(ctx, relay.NewNode("test"))
+
+	uniqGen := uniqid.NewGenerator()
+	pidGen := uniqid.NewPIDGenerator(uniqGen, "")
+	ctx = process.WithPIDGenerator(ctx, pidGen)
+
+	instantiator, bus, contractRegistry, functionRegistry := setupInstantiatorTest()
+
+	require.NoError(t, contractRegistry.Start(ctx))
+	require.NoError(t, functionRegistry.Start(ctx))
+	defer func() {
+		require.NoError(t, contractRegistry.Stop())
+		require.NoError(t, functionRegistry.Stop())
+	}()
+
+	var wg sync.WaitGroup
+
+	contractSub, err := eventbus.NewSubscriber(ctx, bus, contract.System, "contract.*", func(evt event.Event) {
+		if evt.Kind == contract.ContractAccept {
+			wg.Done()
+		}
+	})
+	require.NoError(t, err)
+	defer contractSub.Close()
+
+	functionSub, err := eventbus.NewSubscriber(ctx, bus, function.System, "function.*", func(evt event.Event) {
+		if evt.Kind == function.FunctionAccept {
+			wg.Done()
+		}
+	})
+	require.NoError(t, err)
+	defer functionSub.Close()
+
+	// The bound function reports the actor, scope presence, and the scope's policy
+	// IDs it observes in its own execution context.
+	funcID := registry.NewID("test", "report_security")
+	reportFunc := function.Func(func(fctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		actorID := "none"
+		if actor, ok := secapi.GetActor(fctx); ok {
+			actorID = actor.ID
+		}
+		policyIDs := "none"
+		if scope, ok := secapi.GetScope(fctx); ok {
+			policies := scope.Policies()
+			if len(policies) > 0 {
+				pid := policies[0].ID()
+				policyIDs = pid.String()
+			} else {
+				policyIDs = "empty"
+			}
+		}
+		return &runtime.Result{Value: payload.New("actor:" + actorID + "|policy:" + policyIDs)}, nil
+	})
+
+	wg.Add(1)
+	bus.Send(ctx, event.Event{
+		System: function.System,
+		Kind:   function.FunctionRegister,
+		Path:   funcID.String(),
+		Data:   &function.FuncEntry{Handler: reportFunc},
+	})
+	wg.Wait()
+
+	contractID := registry.NewID("test", "secured_contract")
+	wg.Add(1)
+	bus.Send(ctx, event.Event{
+		System: contract.System,
+		Kind:   contract.RegisterDefinition,
+		Path:   contractID.String(),
+		Data:   &contract.Definition{Methods: []contract.MethodDef{{Name: "report"}}},
+	})
+	wg.Wait()
+
+	bindingID := registry.NewID("test", "secured_binding")
+	wg.Add(1)
+	bus.Send(ctx, event.Event{
+		System: contract.System,
+		Kind:   contract.RegisterBinding,
+		Path:   bindingID.String(),
+		Data: &contract.Binding{
+			Contracts: []contract.BoundContract{
+				{Contract: contractID, Methods: map[string]registry.ID{"report": funcID}},
+			},
+		},
+	})
+	wg.Wait()
+
+	instance, err := instantiator.Instantiate(ctx, bindingID, attrs.Bag{})
+	require.NoError(t, err)
+
+	framer, ok := instance.(securityFramer)
+	require.True(t, ok, "built-in instance must support security framing")
+
+	policyID := registry.NewID("test", "allow-report")
+	scope := secsystem.NewScope([]secapi.Policy{framePolicy{id: policyID}})
+	framer.frameSecurity(secapi.Actor{ID: "framed-owner"}, true, scope, true)
+
+	// Every call runs under the framed actor and scope, including its policies.
+	for i := 0; i < 2; i++ {
+		result, err := instance.Call(ctx, "report", payload.Payloads{}, nil)
+		require.NoError(t, err)
+		require.Nil(t, result.Error)
+		assert.Equal(t, "actor:framed-owner|policy:"+policyID.String(), result.Value.Data().(string))
+	}
 }
 
 func TestInstanceImpl_Call_WithOptions(t *testing.T) {


### PR DESCRIPTION
## Problem

A contract framed with `:with_actor()` / `:with_scope()` **silently dropped the actor**. The Lua contract module sets `Actor`/`HasActor`/`SecurityScope`/`HasScope` on `OpenCmd`, but the dispatcher never applied them:

- `system/contract/dispatcher.go` `handleOpen` passed only `openCmd.Scope` (the binding value bag) to `Instantiate` and forked the **ambient** frame context.
- `instanceImpl.Call` built the `runtime.Task` with value pairs only, no security pairs.

Net effect: a bound function always ran under the **caller's ambient** `security.actor()`. Framing a specific owner (e.g. a background job registering a component on behalf of a user) was ignored, surfacing as `No authenticated actor found`. By contrast `funcs` works because it appends `secapi.ActorPair`/`ScopePair` to `Task.Context`.

## Fix

Mirror the funcs mechanism: carry the open-time actor/scope onto `instanceImpl` (set in `handleOpen` from `OpenCmd` — same package, no interface change), and append `ActorPair`/`ScopePair` to `task.Context` in `Call` **only when explicitly framed**. Non-framed calls keep inheriting the ambient context unchanged.

## Tests

- `TestIntegration_ActorPropagation` — opened `:with_actor("framed-user")`, the bound function must observe that actor (was `no-actor` before the fix).
- `TestIntegration_ActorPropagation_PersistsAcrossCalls` — the framed actor persists across multiple calls on the same instance.

`go build ./...`, `go vet`, and the `system/contract` / `runtime/lua/modules/contract` / `funcs` suites all pass.