### PR TITLE
fix(hub): reliable live changeset expansion (surface cause, resolve replacements locally, honor excludes)

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wippyai/runtime/boot/build"
 	"github.com/wippyai/runtime/boot/build/stages"
 	"github.com/wippyai/runtime/boot/deps/auth"
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/graph"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	"github.com/wippyai/runtime/boot/deps/wappextract"
@@ -584,7 +585,40 @@ func (h *DependencyHandler) loadEntriesForModule(ctx context.Context, transcoder
 		return nil, err
 	}
 	registerResolvedModuleSourceRoot(ctx, mod.Org+"/"+mod.Name, modulePath)
-	return loadRawEntriesFromPaths(ctx, []string{modulePath}, h.logger, transcoder)
+	entries, err := loadRawEntriesFromPaths(ctx, []string{modulePath}, h.logger, transcoder)
+	if err != nil {
+		return nil, err
+	}
+	return h.applyModuleConfigFilters(ctx, modulePath, entries)
+}
+
+// applyModuleConfigFilters drops entries the module's wippy.yaml excludes
+// (exclude / exclude_meta) when the module is loaded from a directory tree —
+// e.g. a lock replacement pointed at the module's source. Without it a host app
+// picks up the module's own fixtures (test/_index.yaml under namespace "app"),
+// which then collide with the host's real entries during linking. .wapp packs
+// are skipped: they were already filtered at publish time.
+func (h *DependencyHandler) applyModuleConfigFilters(ctx context.Context, modulePath string, entries []regapi.Entry) ([]regapi.Entry, error) {
+	if filepath.Ext(modulePath) == ".wapp" {
+		return entries, nil
+	}
+	cfg, err := depconfig.Load(modulePath)
+	if err != nil {
+		return entries, nil
+	}
+	entryExcludes := cfg.EntryExcludes()
+	if len(entryExcludes) == 0 && len(cfg.ExcludeMeta) == 0 {
+		return entries, nil
+	}
+	filtered := append([]regapi.Entry(nil), entries...)
+	stage := stages.DisableWithOptions(stages.DisableOptions{
+		Entries:     entryExcludes,
+		MetaFilters: cfg.ExcludeMeta,
+	})
+	if err := stage.Execute(ctx, &filtered); err != nil {
+		return nil, NewDependencyLoadError(modulePath, err)
+	}
+	return filtered, nil
 }
 
 func registerResolvedModuleSourceRoot(ctx context.Context, moduleName, modulePath string) {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -32,6 +32,7 @@ import (
 	entrypkg "github.com/wippyai/runtime/internal/entry"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -462,9 +463,16 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 	if h.manifestCache != nil {
 		provider = h.manifestCache
 	}
+	lockedDigests := h.lockedModuleDigests()
+	provider = &replacementManifestProvider{
+		base:           provider,
+		handler:        h,
+		lockedVersions: lockedVersions,
+		lockedDigests:  lockedDigests,
+	}
 	result, err := Resolve(resolveCtx, provider, roots, &ResolveOptions{
 		LockedVersions: lockedVersions,
-		LockedDigests:  h.lockedModuleDigests(),
+		LockedDigests:  lockedDigests,
 	})
 	if err != nil {
 		if h.logger != nil {
@@ -480,6 +488,53 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 	}
 
 	return result.Modules, nil
+}
+
+// replacementManifestProvider resolves locally-replaced modules from their lock
+// replacement instead of the Hub. A replaced module's source of truth is local,
+// so it must never be re-fetched from the Hub during live changeset expansion —
+// otherwise installing any module fails when an already-installed, locally-sourced
+// module is absent from the Hub. Non-replaced modules delegate to the base provider.
+type replacementManifestProvider struct {
+	base           ManifestProvider
+	handler        *DependencyHandler
+	lockedVersions map[string]string
+	lockedDigests  map[string]string
+}
+
+func (p *replacementManifestProvider) replacedVersion(name, constraint string) string {
+	if version := p.lockedVersions[name]; version != "" {
+		return version
+	}
+	if version := p.handler.replacementModuleVersion(name); version != "" {
+		return version
+	}
+	return strings.TrimPrefix(constraint, "@")
+}
+
+func (p *replacementManifestProvider) GetManifest(ctx context.Context, org, module, constraint string) (*ModuleManifest, error) {
+	name := org + "/" + module
+	if _, ok := p.handler.replacementPath(name); ok {
+		if version := p.replacedVersion(name, constraint); version != "" {
+			return &ModuleManifest{
+				Org:     org,
+				Name:    module,
+				Version: version,
+				Digest:  p.lockedDigests[name],
+			}, nil
+		}
+	}
+	return p.base.GetManifest(ctx, org, module, constraint)
+}
+
+func (p *replacementManifestProvider) ListAllVersions(ctx context.Context, org, module string) ([]VersionInfo, error) {
+	name := org + "/" + module
+	if _, ok := p.handler.replacementPath(name); ok {
+		if version := p.replacedVersion(name, ""); version != "" {
+			return []VersionInfo{{Version: version}}, nil
+		}
+	}
+	return p.base.ListAllVersions(ctx, org, module)
 }
 
 // touchedModuleNames returns the resolved modules this operation actually
@@ -721,6 +776,44 @@ func (h *DependencyHandler) replacementPath(moduleName string) (string, bool) {
 		path = filepath.Join(filepath.Dir(lockObj.Path()), path)
 	}
 	return path, true
+}
+
+// replacementModuleVersion reads the authoritative version of a locally-replaced
+// module from its wippy.yaml, used when resolving the module from its local source
+// instead of the Hub.
+func (h *DependencyHandler) replacementModuleVersion(moduleName string) string {
+	path, ok := h.replacementPath(moduleName)
+	if !ok {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(path, "wippy.yaml"))
+	if err != nil {
+		return ""
+	}
+	var manifest struct {
+		Version string `yaml:"version"`
+	}
+	if err := yaml.Unmarshal(data, &manifest); err == nil {
+		if version := strings.TrimSpace(manifest.Version); version != "" {
+			return version
+		}
+	}
+	// version is a top-level scalar; read it directly so an unrelated YAML
+	// quirk elsewhere in the manifest cannot leave a locally replaced module
+	// unresolvable and wrongly send it to the Hub.
+	return topLevelYAMLScalar(data, "version")
+}
+
+func topLevelYAMLScalar(data []byte, key string) string {
+	prefix := key + ":"
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		return strings.Trim(value, `"'`)
+	}
+	return ""
 }
 
 func (h *DependencyHandler) shouldUnpackModules() bool {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -467,9 +467,15 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 		LockedDigests:  h.lockedModuleDigests(),
 	})
 	if err != nil {
+		if h.logger != nil {
+			h.logger.Error("dependency resolution failed", zap.Error(err))
+		}
 		return nil, NewDependencyResolutionError(err)
 	}
 	if len(result.Errors) > 0 {
+		if h.logger != nil {
+			h.logger.Error("dependency resolution failed", zap.String("errors", formatResolutionErrors(result.Errors)))
+		}
 		return nil, NewDependencyResolutionErrors(result.Errors)
 	}
 
@@ -1238,16 +1244,22 @@ func NewDependencyResolutionErrors(errs []ResolutionError) apierror.Error {
 		}
 	}
 
+	summary := formatResolutionErrors(errs)
 	bag := map[string]any{
 		"count":   len(errs),
-		"summary": formatResolutionErrors(errs),
+		"summary": summary,
 		"errors":  details,
 	}
 	if unauthenticated {
 		bag["hint"] = registryAuthHint
 	}
 
-	return apierror.New(apierror.Conflict, "dependency resolution failed").
+	message := "dependency resolution failed"
+	if summary != "" {
+		message += ": " + summary
+	}
+
+	return apierror.New(apierror.Conflict, message).
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(bag))
 }

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -490,6 +490,16 @@ func TestNewDependencyResolutionErrors_NoHintWithoutAuthCause(t *testing.T) {
 	assert.Empty(t, apiErr.Details().GetString("hint", ""))
 }
 
+func TestNewDependencyResolutionErrors_MessageIncludesCause(t *testing.T) {
+	errs := []ResolutionError{
+		{Org: "kickside", Name: "research", Constraint: "0.1.0", Message: "module not found", Err: errors.New("module not found")},
+	}
+
+	apiErr := NewDependencyResolutionErrors(errs)
+	assert.Contains(t, apiErr.Error(), "kickside/research@0.1.0")
+	assert.Contains(t, apiErr.Error(), "module not found")
+}
+
 // --- verifyDownloadedArtifact ---
 
 func TestVerifyDownloadedArtifact_NonExistentFile(t *testing.T) {

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -1087,6 +1087,155 @@ func TestDependencyHandler_ResolveModules_PinsInstalledTransitiveVersions(t *tes
 	assert.NotContains(t, manifestRequests, "wippy/facade@0.6.0")
 }
 
+func TestDependencyHandler_ResolveModules_ToleratesReplacedModuleAbsentFromHub(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+  src: ./src
+modules:
+  - name: acme/app
+    version: 1.0.0
+  - name: local/mod
+    version: 0.1.0
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`), 0600))
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
+				if org+"/"+module == "local/mod" {
+					return nil, fmt.Errorf("module not found")
+				}
+				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	modules, err := handler.resolveModules(ctx,
+		[]DependencyDefinition{
+			{Component: "acme/app", Version: "1.0.0"},
+			{Component: "local/mod", Version: "0.1.0"},
+		},
+		map[string]string{"local/mod": "0.1.0"},
+	)
+
+	require.NoError(t, err, "a locally-replaced module absent from the Hub must not fail resolution")
+	require.Len(t, modules, 2)
+	var found bool
+	for _, m := range modules {
+		if m.Org == "local" && m.Name == "mod" {
+			found = true
+			assert.Equal(t, "0.1.0", m.Version)
+		}
+	}
+	assert.True(t, found, "replaced module should resolve from its local source")
+}
+
+func TestDependencyHandler_ResolveModules_ReplacedModuleRangeConstraintFromLocalManifest(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	localMod := filepath.Join(tmpDir, "local-mod")
+	require.NoError(t, os.MkdirAll(localMod, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localMod, "wippy.yaml"), []byte("organization: local\nmodule: mod\nversion: 0.2.0\n"), 0600))
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+  src: ./src
+modules:
+  - name: acme/app
+    version: 1.0.0
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`), 0600))
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
+				if org+"/"+module == "local/mod" {
+					return nil, fmt.Errorf("module not found")
+				}
+				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+			},
+			listVersions: func(_ context.Context, org, module string) ([]VersionInfo, error) {
+				return nil, fmt.Errorf("module not found")
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	modules, err := handler.resolveModules(ctx,
+		[]DependencyDefinition{{Component: "local/mod", Version: ">=v0.1.0"}},
+		map[string]string{},
+	)
+
+	require.NoError(t, err, "a replaced module with a range constraint and no locked version must resolve from its local wippy.yaml")
+	require.Len(t, modules, 1)
+	assert.Equal(t, "local", modules[0].Org)
+	assert.Equal(t, "mod", modules[0].Name)
+	assert.Equal(t, "0.2.0", modules[0].Version)
+}
+
+func TestDependencyHandler_ResolveModules_ReplacedModuleVersionFromManifestWithUnrelatedYAMLQuirk(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	localMod := filepath.Join(tmpDir, "local-mod")
+	require.NoError(t, os.MkdirAll(localMod, 0755))
+	// description contains ": " which makes the full YAML document invalid,
+	// yet the top-level version scalar is well-formed.
+	require.NoError(t, os.WriteFile(filepath.Join(localMod, "wippy.yaml"),
+		[]byte("organization: local\nmodule: mod\nversion: 0.3.0\ndescription: Self-contained: builds and ships\n"), 0600))
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+  src: ./src
+modules:
+  - name: acme/app
+    version: 1.0.0
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`), 0600))
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
+				if org+"/"+module == "local/mod" {
+					return nil, fmt.Errorf("module not found")
+				}
+				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+			},
+			listVersions: func(_ context.Context, _, _ string) ([]VersionInfo, error) {
+				return nil, fmt.Errorf("module not found")
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	modules, err := handler.resolveModules(ctx,
+		[]DependencyDefinition{{Component: "local/mod", Version: ">=v0.1.0"}},
+		map[string]string{},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, modules, 1)
+	assert.Equal(t, "0.3.0", modules[0].Version)
+}
+
 func TestDependencyHandler_CollectDesiredDependencies_DoesNotPinUpdatedDependency(t *testing.T) {
 	ctx := newTestContext()
 	transcoder := payload.GetTranscoder(ctx)

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -1236,6 +1236,59 @@ replacements:
 	assert.Equal(t, "0.3.0", modules[0].Version)
 }
 
+func TestDependencyHandler_LoadEntriesForModule_AppliesExcludeMetaForDirectorySource(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	localMod := filepath.Join(tmpDir, "local-mod")
+	require.NoError(t, os.MkdirAll(localMod, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localMod, "wippy.yaml"),
+		[]byte("organization: local\nmodule: mod\nversion: 0.1.0\nexclude_meta:\n  type:\n    - test\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(localMod, "_index.json"), []byte(`{
+  "namespace": "local.mod",
+  "entries": [
+    { "name": "keep", "kind": "fs.directory", "path": "./keep" },
+    { "name": "drop", "kind": "fs.directory", "meta": { "type": "test" }, "path": "./drop" }
+  ]
+}`), 0600))
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+  src: ./src
+modules:
+  - name: local/mod
+    version: 0.1.0
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`), 0600))
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       &fakeHub{},
+		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	transcoder := payload.GetTranscoder(ctx)
+	require.NotNil(t, transcoder)
+
+	entries, err := handler.loadEntriesForModule(ctx, transcoder, ResolvedModule{Org: "local", Name: "mod", Version: "0.1.0"})
+	require.NoError(t, err)
+
+	var hasKeep, hasDrop bool
+	for _, e := range entries {
+		if e.ID == regapi.NewID("local.mod", "keep") {
+			hasKeep = true
+		}
+		if e.ID == regapi.NewID("local.mod", "drop") {
+			hasDrop = true
+		}
+	}
+	assert.True(t, hasKeep, "non-test entry must load")
+	assert.False(t, hasDrop, "test entry must be excluded per the module's exclude_meta")
+}
+
 func TestDependencyHandler_CollectDesiredDependencies_DoesNotPinUpdatedDependency(t *testing.T) {
 	ctx := newTestContext()
 	transcoder := payload.GetTranscoder(ctx)


### PR DESCRIPTION
## Why
Live changeset expansion (the runtime path behind the keeper Hub install UI) failed installing modules in three independent ways: the real per-module failure cause was hidden behind a generic "dependency resolution failed"; already-installed, locally-replaced modules were wrongly re-resolved from the Hub (so any install failed when such a module was absent from the Hub); and module entries loaded from a directory/replacement source were not filtered by the module's own `exclude`/`exclude_meta`, so test fixtures leaked into the host registry and collided during linking.

## What
- Surface the cause: `NewDependencyResolutionErrors` folds the per-module summary into the error message so it reaches logs, the keeper API and the UI; `resolveModules` logs `result.Errors`.
- Resolve locally-replaced modules from their local source (lock version / local wippy.yaml) instead of the Hub, in both `GetManifest` and `ListAllVersions`; non-replaced modules still resolve from the Hub, so a genuinely broken dependency still surfaces.
- Apply the module's `exclude`/`exclude_meta` when loading entries from a directory source (mirrors `cmd/internal/entries/loader.go`), skipping already-filtered `.wapp` packs.

## Testing
- TDD per fix; `go test` for `boot/deps/hub` plus `boot/...` and `system/registry/...` green; `go vet` clean; `golangci-lint` 0 issues; `make build-wippy` ok.
- End-to-end: install + uninstall of a WASM-uses-FS module through the kickside browser Modules tab both succeed on the rebuilt binary.