### PR TITLE
fix(hub): version-scope the locked-digest integrity check

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -521,7 +521,7 @@ func (p *replacementManifestProvider) GetManifest(ctx context.Context, org, modu
 				Org:     org,
 				Name:    module,
 				Version: version,
-				Digest:  p.lockedDigests[name],
+				Digest:  p.lockedDigests[name+"@"+version],
 			}, nil
 		}
 	}
@@ -984,10 +984,14 @@ func (h *DependencyHandler) lockedModuleDigests() map[string]string {
 	}
 	digests := make(map[string]string, len(modules))
 	for _, mod := range modules {
-		if mod.Hash == "" || mod.Name == "" {
+		if mod.Hash == "" || mod.Name == "" || mod.Version == "" {
 			continue
 		}
-		digests[mod.Name] = mod.Hash
+		// Key by name@version so the integrity check only fires when resolving
+		// the exact version the lock pins. A version-agnostic key would compare
+		// a new version's digest against the locked old version's and wrongly
+		// block updates.
+		digests[mod.Name+"@"+mod.Version] = mod.Hash
 	}
 	if len(digests) == 0 {
 		return nil

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -1087,6 +1087,41 @@ func TestDependencyHandler_ResolveModules_PinsInstalledTransitiveVersions(t *tes
 	assert.NotContains(t, manifestRequests, "wippy/facade@0.6.0")
 }
 
+func TestDependencyHandler_ResolveModules_LockedDigestDoesNotBlockUpdate(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+  src: ./src
+modules:
+  - name: acme/http
+    version: 1.0.0
+    hash: sha256:v1digest
+`), 0600))
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
+				return &ModuleManifest{Org: org, Name: module, Version: version, Digest: "sha256:v2digest"}, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	modules, err := handler.resolveModules(ctx,
+		[]DependencyDefinition{{Component: "acme/http", Version: "2.0.0"}},
+		map[string]string{},
+	)
+
+	require.NoError(t, err, "a digest locked for v1 must not block resolving/updating to v2")
+	require.Len(t, modules, 1)
+	assert.Equal(t, "2.0.0", modules[0].Version)
+}
+
 func TestDependencyHandler_ResolveModules_ToleratesReplacedModuleAbsentFromHub(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -158,7 +158,7 @@ func (r *resolver) fetchManifest(ctx context.Context, org, name, version string)
 		return nil, fmt.Errorf("hub returned no manifest for %s/%s@%s", org, name, version)
 	}
 
-	expected := r.lockedDigests[org+"/"+name]
+	expected := r.lockedDigests[org+"/"+name+"@"+version]
 	if expected == "" || manifest.Digest == expected {
 		return manifest, nil
 	}

--- a/boot/deps/hub/resolve_test.go
+++ b/boot/deps/hub/resolve_test.go
@@ -463,7 +463,7 @@ func TestResolve_LockedDigestMatch(t *testing.T) {
 	result, err := Resolve(context.Background(), p, []DependencySpec{
 		{Org: "acme", Name: "http", Constraint: "1.0.0"},
 	}, &ResolveOptions{
-		LockedDigests: map[string]string{"acme/http": "sha256:1.0.0"},
+		LockedDigests: map[string]string{"acme/http@1.0.0": "sha256:1.0.0"},
 	})
 
 	require.NoError(t, err)
@@ -479,7 +479,7 @@ func TestResolve_LockedDigestMismatchBareProvider(t *testing.T) {
 	result, err := Resolve(context.Background(), p, []DependencySpec{
 		{Org: "acme", Name: "http", Constraint: "1.0.0"},
 	}, &ResolveOptions{
-		LockedDigests: map[string]string{"acme/http": "sha256:expected"},
+		LockedDigests: map[string]string{"acme/http@1.0.0": "sha256:expected"},
 	})
 
 	require.NoError(t, err)
@@ -502,7 +502,7 @@ func TestResolve_LockedDigestCacheHeals(t *testing.T) {
 	result, err := Resolve(context.Background(), cache, []DependencySpec{
 		{Org: "acme", Name: "http", Constraint: "1.0.0"},
 	}, &ResolveOptions{
-		LockedDigests: map[string]string{"acme/http": "sha256:1.0.0"},
+		LockedDigests: map[string]string{"acme/http@1.0.0": "sha256:1.0.0"},
 	})
 
 	require.NoError(t, err)
@@ -524,7 +524,7 @@ func TestResolve_LockedDigestCacheDriftErrors(t *testing.T) {
 	result, err := Resolve(context.Background(), cache, []DependencySpec{
 		{Org: "acme", Name: "http", Constraint: "1.0.0"},
 	}, &ResolveOptions{
-		LockedDigests: map[string]string{"acme/http": "sha256:expected"},
+		LockedDigests: map[string]string{"acme/http@1.0.0": "sha256:expected"},
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Why
`lockedModuleDigests` keyed digests by module **name only**, so the manifest digest integrity check in `resolve.go` compared a NEW version's digest against the OLD (locked) version's digest and failed with "manifest digest mismatch". This blocked live **updating** any locked hub module to a new version — the dynamic update path behind the keeper Hub UI.

Follow-up to #362 (which surfaced this once errors became legible); pushed after #362 merged, hence a separate PR.

## What
Key locked digests by `name@version` and look them up by the version being resolved, so the integrity check fires only for the exact pinned version (tamper detection intact) and no longer blocks version updates. The replacement manifest provider matches the same versioned key.

## Testing
- TDD: `TestDependencyHandler_ResolveModules_LockedDigestDoesNotBlockUpdate` (red→green); existing locked-digest tests updated to name@version and still green; `go test ./boot/deps/hub` + build + golangci-lint clean.
- End-to-end: in the kickside browser Modules tab, updating sandbox/wasmfs v0.1.0→v0.2.0 now succeeds (previously failed with the digest mismatch); the fs.embed pack swaps (7.6 KB → 3.5 MB).