### PR TITLE
fix(hub): refresh expired presigned download URL and retry

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -686,20 +686,14 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 	}
 
 	url := mod.URL
+	urlIsFresh := false
 	if url == "" {
-		downloadURLCtx, cancel := withOptionalTimeout(ctx, h.downloadTimeout)
-		defer cancel()
-
-		info, err := h.hub.GetDownloadURL(downloadURLCtx, &DownloadParams{
-			Org:       mod.Org,
-			Module:    mod.Name,
-			Version:   mod.Version,
-			VersionID: mod.VersionID,
-		})
-		if err != nil {
-			return "", NewDependencyDownloadError(modKey(mod), err)
+		info, infoErr := h.freshDownloadInfo(ctx, mod)
+		if infoErr != nil {
+			return "", NewDependencyDownloadError(modKey(mod), infoErr)
 		}
 		url = info.URL
+		urlIsFresh = true
 		if expectedDigest == "" {
 			expectedDigest = info.Digest
 		}
@@ -714,8 +708,25 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 	downloadCtx, cancel := withOptionalTimeout(ctx, h.downloadTimeout)
 	defer cancel()
 
-	if err := h.hub.DownloadToFile(downloadCtx, url, wappPath); err != nil {
-		return "", NewDependencyDownloadError(modKey(mod), err)
+	downloadErr := h.hub.DownloadToFile(downloadCtx, url, wappPath)
+	if downloadErr != nil && !urlIsFresh {
+		// mod.URL is a presigned URL captured at resolve time; on a long-lived
+		// process it can expire (15-min TTL) before download. Fetch a fresh URL
+		// and retry once before giving up.
+		if info, infoErr := h.freshDownloadInfo(ctx, mod); infoErr == nil && info != nil && info.URL != "" {
+			if expectedDigest == "" {
+				expectedDigest = info.Digest
+			}
+			if expectedSize == 0 {
+				expectedSize = info.Size
+			}
+			retryCtx, retryCancel := withOptionalTimeout(ctx, h.downloadTimeout)
+			defer retryCancel()
+			downloadErr = h.hub.DownloadToFile(retryCtx, info.URL, wappPath)
+		}
+	}
+	if downloadErr != nil {
+		return "", NewDependencyDownloadError(modKey(mod), downloadErr)
 	}
 	if err := verifyDownloadedArtifact(wappPath, expectedDigest, expectedSize); err != nil {
 		_ = os.Remove(wappPath)
@@ -730,6 +741,21 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 	}
 
 	return wappPath, nil
+}
+
+// freshDownloadInfo fetches a current presigned download URL for a module.
+// Used both when the resolved manifest carries no URL and to refresh a URL
+// that expired before the artifact could be downloaded.
+func (h *DependencyHandler) freshDownloadInfo(ctx context.Context, mod ResolvedModule) (*DownloadInfo, error) {
+	downloadURLCtx, cancel := withOptionalTimeout(ctx, h.downloadTimeout)
+	defer cancel()
+
+	return h.hub.GetDownloadURL(downloadURLCtx, &DownloadParams{
+		Org:       mod.Org,
+		Module:    mod.Name,
+		Version:   mod.Version,
+		VersionID: mod.VersionID,
+	})
 }
 
 func (h *DependencyHandler) extractWappModule(wappPath, dirPath string) error {

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -195,6 +195,56 @@ func TestDependencyHandler_RejectsDownloadedArtifactWithDigestMismatch(t *testin
 	assert.Equal(t, "acme/http@v1.0.0", apiErr.Details().GetString("module", ""))
 }
 
+func TestDependencyHandler_RetriesDownloadWithFreshURLWhenPresignedExpired(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, "vendor")
+	moduleData := buildWappBytes(t, []wapp.Entry{
+		{ID: wapp.NewID("mod", "svc"), Kind: "service", Data: map[string]any{"ok": true}},
+	})
+	sum := sha256.Sum256(moduleData)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	var freshFetched atomic.Int32
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+				return &ModuleManifest{
+					Org: org, Name: module, Version: "v1.0.0",
+					URL:    "https://stale.invalid/expired.wapp",
+					Digest: digest,
+				}, nil
+			},
+			getDownload: func(_ context.Context, _ *DownloadParams) (*DownloadInfo, error) {
+				freshFetched.Add(1)
+				return &DownloadInfo{URL: "https://fresh.invalid/valid.wapp", Digest: digest}, nil
+			},
+			downloadFile: func(_ context.Context, url, destPath string) error {
+				if url == "https://stale.invalid/expired.wapp" {
+					return fmt.Errorf("download failed with status 403: Request has expired")
+				}
+				if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(destPath, moduleData, 0600)
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	depEntry := regapi.Entry{
+		ID:   regapi.NewID("app", "dep"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/http","version":"v1.0.0"}`, payload.JSON),
+	}
+
+	_, err = handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryCreate, Entry: depEntry}, nil)
+	require.NoError(t, err, "an expired presigned download URL must be refreshed and retried")
+	assert.GreaterOrEqual(t, freshFetched.Load(), int32(1), "a fresh download URL should be fetched for the retry")
+}
+
 func TestDependencyHandler_RedownloadsCorruptCachedArtifact(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Why
A module's presigned S3 download URL (15-min TTL) was captured at resolve time and reused; on a long-lived process an install/update whose download ran after the TTL failed with `download failed with status 403: Request has expired`, and a fresh URL was never fetched (mod.URL was non-empty). Surfaced while testing module version undo/redo through the kickside Hub UI.

Follow-up to #362/#363 (same branch, pushed after they merged).

## What
On a download failure where the URL came from the resolved manifest, fetch a fresh presigned URL via GetDownloadURL and retry once before failing (extracted as freshDownloadInfo, reused by the no-URL path).

## Testing
- TDD: TestDependencyHandler_RetriesDownloadWithFreshURLWhenPresignedExpired (stale URL fails → fresh URL retried → success); go test ./boot/deps/hub + build + golangci-lint clean.
- End-to-end: in the kickside Modules tab, redo (update v0.1.0→v0.2.0 after a downgrade) on a long-running instance now succeeds ("Module updated") instead of 403.