### PR TITLE
fix(scheduler): preserve process PID across process.upgrade

### DIFF
--- a/system/scheduler/actor/edge_cases_test.go
+++ b/system/scheduler/actor/edge_cases_test.go
@@ -329,6 +329,71 @@ func TestUpgradeSuccess_ForksSealedFrameForReplacementProcess(t *testing.T) {
 	}
 }
 
+// pidAssertingProcess fails Init unless the upgrade frame carries the expected PID.
+type pidAssertingProcess struct {
+	wantPID pidapi.PID
+}
+
+func (p *pidAssertingProcess) Init(ctx context.Context, _ string, _ payload.Payloads) error {
+	got, ok := runtime.GetFramePID(ctx)
+	if !ok {
+		return errors.New("frame pid missing after upgrade")
+	}
+	if got.String() != p.wantPID.String() {
+		return fmt.Errorf("frame pid = %v, want %v", got, p.wantPID)
+	}
+	return nil
+}
+func (p *pidAssertingProcess) Step(_ []process.Event, out *process.StepOutput) error {
+	out.Done(nil)
+	return nil
+}
+func (p *pidAssertingProcess) Send(*relay.Package) error { return nil }
+func (p *pidAssertingProcess) Close()                    {}
+
+// TestUpgradeSuccess_PreservesFramePIDAcrossSealedFork guards the regression where
+// process.pid() returned nil in the upgraded instance: the upgrade path forks a fresh
+// frame off the sealed parent, which must re-assert FramePID so the new code keeps its PID.
+func TestUpgradeSuccess_PreservesFramePIDAcrossSealedFork(t *testing.T) {
+	reg := scheduler.NewRegistry()
+	te := newTestExecutorWithRegistry(1, reg)
+	te.Start()
+	defer te.Stop()
+
+	selfPID := pidapi.PID{UniqID: "upgrade-pid-preserve"}
+
+	root := ctxapi.WithAppContext(context.Background(), ctxapi.NewAppContext())
+	ctx, fc := ctxapi.OpenFrameContext(root)
+	defer ctxapi.ReleaseFrameContext(fc)
+	if err := runtime.SetFramePID(ctx, selfPID); err != nil {
+		t.Fatalf("set frame pid: %v", err)
+	}
+	fc.Seal()
+
+	process.WithFactory(ctx, &mockFactory{
+		createFunc: func(_ registry.ID) (process.Process, *process.Meta, error) {
+			return &pidAssertingProcess{wantPID: selfPID}, &process.Meta{Method: "run"}, nil
+		},
+	})
+
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	proc := &UpgradeProcess{
+		upgradeReq: &process.UpgradeRequest{
+			Source: registry.ID{Name: "test"},
+		},
+	}
+
+	result, err := te.Execute(runCtx, selfPID, proc, "", nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("upgrade dropped FramePID across sealed-frame fork: %v", result.Error)
+	}
+}
+
 // TestUpgradeSuccess_Stress guards against missed wakeup regressions by repeatedly
 // executing upgrade flow on a single-worker scheduler.
 func TestUpgradeSuccess_Stress(t *testing.T) {

--- a/system/scheduler/actor/worker.go
+++ b/system/scheduler/actor/worker.go
@@ -363,7 +363,19 @@ func (w *Worker) executeOne(proc *Processor) {
 		if meta != nil && meta.Method != "" {
 			method = meta.Method
 		}
+		selfPID, hasSelfPID := runtime.GetFramePID(proc.ctx)
 		upgradeCtx, _ := ctxapi.OpenFrameContext(proc.ctx)
+		if hasSelfPID {
+			if err := runtime.SetFramePID(upgradeCtx, selfPID); err != nil {
+				proc.Process.Close()
+				if !proc.casState(StateRunning, StateComplete) {
+					return
+				}
+				proc.queue.Close()
+				w.scheduler.complete(proc, nil, fmt.Errorf("upgrade: preserve pid failed: %w", err))
+				return
+			}
+		}
 		if err := newProc.Init(upgradeCtx, method, req.Input); err != nil {
 			proc.Process.Close()
 			if !proc.casState(StateRunning, StateComplete) {


### PR DESCRIPTION
## Why

After `process.upgrade`, `process.pid()` returned `nil` in the upgraded process instance, which also broke self re-registration and any PID-dependent logic. Discovered while building a live service-upgrade flow.

Root cause: the upgrade path opens a fresh frame context off the parent frame, which is sealed by the time the upgrade fires (`runtime/lua/engine/process.go`). `OpenFrameContext` therefore forks a new frame, and `FramePIDKey` is not an inheriting key, so the PID is dropped. Normal process start injects the PID via `service/host/host.go`.

## What

In the `StepUpgrade` handler (`system/scheduler/actor/worker.go`), capture the frame PID from the current context before opening the upgrade frame and re-assert it on the new frame, aborting the upgrade if it cannot be set (consistent with the surrounding error handling). The fix is intentionally local rather than marking `FramePIDKey` inheritable, which would leak a parent's PID into child frames across `process.spawn`.

## Testing

- New regression test `TestUpgradeSuccess_PreservesFramePIDAcrossSealedFork` (`system/scheduler/actor/edge_cases_test.go`): seals the frame (mirroring the real flow) and asserts the replacement process sees the original PID. Verified it **fails without the fix** (`frame pid missing after upgrade`) and passes with it.
- Full `system/scheduler/actor` package green under `-race`.
- Whole-module `go build` and `golangci-lint run ./...` clean.
- End-to-end: a long-running `process.service` upgraded live via `process.upgrade` now keeps the same PID; `process.pid()` returns the real PID after the swap, state is preserved, and no queued messages are lost.
