### PR TITLE
fix(env,sql,cdc): prevent env name collision from corrupting SQL DSNs

### DIFF
--- a/service/cdc/postgres/config_decode_test.go
+++ b/service/cdc/postgres/config_decode_test.go
@@ -54,7 +54,8 @@ func TestConfigWireFormatMapsAndBuildsDSN(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 5*time.Second, standby)
 
-	repl, admin := buildDSNs(cfg)
+	repl, admin, err := buildDSNs(cfg)
+	require.NoError(t, err)
 	ru, err := url.Parse(repl)
 	require.NoError(t, err)
 	assert.Equal(t, "database", ru.Query().Get("replication"))

--- a/service/cdc/postgres/errors.go
+++ b/service/cdc/postgres/errors.go
@@ -46,6 +46,17 @@ func NewInvalidConfigError(err error) apierror.Error {
 	return apiErr
 }
 
+func NewUnresolvedEnvError(field, envVar string, err error) apierror.Error {
+	apiErr := apierror.New(apierror.Invalid, "configured env variable could not be resolved").
+		WithRetryable(apierror.False)
+	details := attrs.NewBagFrom(map[string]any{"field": field, "env_var": envVar})
+	if err != nil {
+		details.Set("cause", err.Error())
+		apiErr = apiErr.WithCause(err)
+	}
+	return apiErr.WithDetails(details)
+}
+
 func NewSourceCreationError(err error) apierror.Error {
 	apiErr := apierror.New(apierror.Internal, "failed to create cdc source").WithRetryable(apierror.False)
 	if err != nil {

--- a/service/cdc/postgres/manager.go
+++ b/service/cdc/postgres/manager.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -76,7 +77,10 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 
 	standby, _ := cfg.StandbyDuration()
 	status, _ := cfg.StatusDuration()
-	replDSN, adminDSN := buildDSNs(cfg)
+	replDSN, adminDSN, err := buildDSNs(cfg)
+	if err != nil {
+		return err
+	}
 	src := NewSource(SourceOptions{
 		ReplDSN:           replDSN,
 		AdminDSN:          adminDSN,
@@ -122,6 +126,11 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 		return NewInvalidConfigError(err)
 	}
 
+	replDSN, adminDSN, err := buildDSNs(cfg)
+	if err != nil {
+		return err
+	}
+
 	old := m.sources[entry.ID]
 	if old != nil {
 		old.closeSubscriptions()
@@ -131,7 +140,6 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 
 	standby, _ := cfg.StandbyDuration()
 	status, _ := cfg.StatusDuration()
-	replDSN, adminDSN := buildDSNs(cfg)
 	src := NewSource(SourceOptions{
 		ReplDSN:           replDSN,
 		AdminDSN:          adminDSN,
@@ -271,40 +279,69 @@ func (m *Manager) unregister(ctx context.Context, entry registry.Entry) {
 }
 
 func (m *Manager) resolveEnv(ctx context.Context, cfg *config.Config) error {
-	if v := m.lookup(ctx, cfg.HostEnv); v != "" {
+	if v, err := m.resolveField(ctx, cfg.HostEnv, "host"); err != nil {
+		return err
+	} else if v != "" {
 		cfg.Host = v
 	}
-	if v := m.lookup(ctx, cfg.PortEnv); v != "" {
-		p, err := strconv.Atoi(v)
-		if err != nil {
-			return NewInvalidConfigError(fmt.Errorf("port env %q is not numeric: %w", cfg.PortEnv, err))
+	if v, err := m.resolveField(ctx, cfg.PortEnv, "port"); err != nil {
+		return err
+	} else if v != "" {
+		p, perr := strconv.Atoi(v)
+		if perr != nil {
+			return NewInvalidConfigError(fmt.Errorf("port env %q is not numeric: %w", cfg.PortEnv, perr))
 		}
 		cfg.Port = p
 	}
-	if v := m.lookup(ctx, cfg.DatabaseEnv); v != "" {
+	if v, err := m.resolveField(ctx, cfg.DatabaseEnv, "database"); err != nil {
+		return err
+	} else if v != "" {
 		cfg.Database = v
 	}
-	if v := m.lookup(ctx, cfg.UsernameEnv); v != "" {
+	if v, err := m.resolveField(ctx, cfg.UsernameEnv, "username"); err != nil {
+		return err
+	} else if v != "" {
 		cfg.Username = v
 	}
-	if v := m.lookup(ctx, cfg.PasswordEnv); v != "" {
+	if v, err := m.resolveField(ctx, cfg.PasswordEnv, "password"); err != nil {
+		return err
+	} else if v != "" {
 		cfg.Password = v
 	}
 	return nil
 }
 
-func (m *Manager) lookup(ctx context.Context, name string) string {
-	if name == "" || m.env == nil {
-		return ""
+func (m *Manager) resolveField(ctx context.Context, envVar, field string) (string, error) {
+	if envVar == "" {
+		return "", nil
 	}
-	val, found, err := m.env.Lookup(ctx, name)
-	if err != nil || !found {
-		return ""
+	if m.env == nil {
+		return "", NewUnresolvedEnvError(field, envVar, errors.New("env registry not configured"))
 	}
-	return val
+	val, found, err := m.env.Lookup(ctx, envVar)
+	if err != nil {
+		return "", NewUnresolvedEnvError(field, envVar, err)
+	}
+	if !found {
+		return "", NewUnresolvedEnvError(field, envVar, envapi.ErrVariableNotFound)
+	}
+	return val, nil
 }
 
-func buildDSNs(cfg *config.Config) (replication, admin string) {
+func buildDSNs(cfg *config.Config) (replication, admin string, err error) {
+	if cfg.Host == "" {
+		return "", "", NewInvalidConfigError(errors.New("resolved host is empty"))
+	}
+	if cfg.Port <= 0 {
+		return "", "", NewInvalidConfigError(fmt.Errorf("resolved port is invalid: %d", cfg.Port))
+	}
+	if cfg.Username == "" {
+		return "", "", NewInvalidConfigError(errors.New("resolved username is empty"))
+	}
+	if cfg.Database == "" {
+		return "", "", NewInvalidConfigError(errors.New("resolved database is empty"))
+	}
+
 	host := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
 	base := url.URL{
 		Scheme: "postgres",
@@ -321,7 +358,7 @@ func buildDSNs(cfg *config.Config) (replication, admin string) {
 	q.Set("replication", "database")
 	replURL.RawQuery = q.Encode()
 
-	return replURL.String(), adminURL.String()
+	return replURL.String(), adminURL.String(), nil
 }
 
 func optionsQuery(options map[string]string) url.Values {

--- a/service/cdc/postgres/manager_test.go
+++ b/service/cdc/postgres/manager_test.go
@@ -11,9 +11,95 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	envapi "github.com/wippyai/runtime/api/env"
 	"github.com/wippyai/runtime/api/registry"
 	config "github.com/wippyai/runtime/api/service/cdc"
 )
+
+type mockEnvRegistry struct {
+	vars map[string]string
+}
+
+func (m *mockEnvRegistry) Get(_ context.Context, name string) (string, error) {
+	if v, ok := m.vars[name]; ok {
+		return v, nil
+	}
+	return "", envapi.ErrVariableNotFound
+}
+
+func (m *mockEnvRegistry) Lookup(_ context.Context, name string) (string, bool, error) {
+	v, ok := m.vars[name]
+	return v, ok, nil
+}
+
+func (m *mockEnvRegistry) Set(_ context.Context, name, value string) error {
+	m.vars[name] = value
+	return nil
+}
+
+func (m *mockEnvRegistry) All(_ context.Context) (map[string]string, error) {
+	return m.vars, nil
+}
+
+func (m *mockEnvRegistry) GetStorage(_ context.Context, _ registry.ID) (envapi.Storage, error) {
+	return nil, envapi.ErrStorageNotFound
+}
+
+func (m *mockEnvRegistry) RegisterStorage(_ registry.ID, _ envapi.Storage) {}
+
+func TestResolveEnv_FailsFastOnUnresolvable(t *testing.T) {
+	m := &Manager{env: &mockEnvRegistry{vars: map[string]string{"DB_HOST": "h"}}}
+	cfg := &config.Config{HostEnv: "DB_HOST", UsernameEnv: "MISSING_USER"}
+
+	err := m.resolveEnv(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be resolved")
+	assert.Contains(t, err.Error(), "environment variable not found")
+}
+
+func TestResolveEnv_AppliesResolvedValues(t *testing.T) {
+	m := &Manager{env: &mockEnvRegistry{vars: map[string]string{
+		"H": "resolved-host", "P": "6543", "D": "resolved-db", "U": "resolved-user", "PW": "resolved-pass",
+	}}}
+	cfg := &config.Config{HostEnv: "H", PortEnv: "P", DatabaseEnv: "D", UsernameEnv: "U", PasswordEnv: "PW"}
+
+	require.NoError(t, m.resolveEnv(context.Background(), cfg))
+	assert.Equal(t, "resolved-host", cfg.Host)
+	assert.Equal(t, 6543, cfg.Port)
+	assert.Equal(t, "resolved-db", cfg.Database)
+	assert.Equal(t, "resolved-user", cfg.Username)
+	assert.Equal(t, "resolved-pass", cfg.Password)
+}
+
+func TestBuildDSNs_RejectsEmptyRequiredField(t *testing.T) {
+	base := func() *config.Config {
+		return &config.Config{Host: "h", Port: 5432, Username: "u", Database: "d"}
+	}
+
+	c := base()
+	c.Host = ""
+	_, _, err := buildDSNs(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host")
+
+	c = base()
+	c.Port = 0
+	_, _, err = buildDSNs(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "port")
+
+	c = base()
+	c.Username = ""
+	_, _, err = buildDSNs(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username")
+
+	c = base()
+	c.Database = ""
+	_, _, err = buildDSNs(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database")
+}
 
 func TestBuildDSNs(t *testing.T) {
 	cfg := &config.Config{
@@ -23,7 +109,8 @@ func TestBuildDSNs(t *testing.T) {
 		Password: "p@ss/word",
 		Database: "appdb",
 	}
-	repl, admin := buildDSNs(cfg)
+	repl, admin, err := buildDSNs(cfg)
+	require.NoError(t, err)
 
 	ru, err := url.Parse(repl)
 	require.NoError(t, err)
@@ -145,7 +232,8 @@ func TestBuildDSNsCarriesOptions(t *testing.T) {
 		Database: "d",
 		Options:  map[string]string{"sslmode": "require"},
 	}
-	repl, admin := buildDSNs(cfg)
+	repl, admin, err := buildDSNs(cfg)
+	require.NoError(t, err)
 
 	ru, err := url.Parse(repl)
 	require.NoError(t, err)

--- a/service/sql/conn.go
+++ b/service/sql/conn.go
@@ -5,6 +5,8 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/url"
 	"sort"
 	"strconv"
@@ -141,19 +143,22 @@ func (p *ConnPool) Acquire(
 func buildDSN(kind registry.Kind, cfg *config.DBConfig) (string, error) {
 	switch kind {
 	case config.Postgres:
+		if err := validateDSNFields(cfg); err != nil {
+			return "", err
+		}
 		opts := buildPostgresOptionsString(cfg.Options)
 		var b strings.Builder
 		b.Grow(128)
 		b.WriteString("host=")
-		b.WriteString(cfg.Host)
+		b.WriteString(quotePostgresValue(cfg.Host))
 		b.WriteString(" port=")
 		b.WriteString(strconv.Itoa(cfg.Port))
 		b.WriteString(" user=")
-		b.WriteString(cfg.Username)
+		b.WriteString(quotePostgresValue(cfg.Username))
 		b.WriteString(" password=")
-		b.WriteString(cfg.Password)
+		b.WriteString(quotePostgresValue(cfg.Password))
 		b.WriteString(" dbname=")
-		b.WriteString(cfg.Database)
+		b.WriteString(quotePostgresValue(cfg.Database))
 		if opts != "" {
 			b.WriteString(" ")
 			b.WriteString(opts)
@@ -161,6 +166,9 @@ func buildDSN(kind registry.Kind, cfg *config.DBConfig) (string, error) {
 		return b.String(), nil
 
 	case config.MySQL:
+		if err := validateDSNFields(cfg); err != nil {
+			return "", err
+		}
 		opts := buildMySQLOptionsString(cfg.Options)
 		var b strings.Builder
 		b.Grow(128)
@@ -182,6 +190,35 @@ func buildDSN(kind registry.Kind, cfg *config.DBConfig) (string, error) {
 	default:
 		return "", NewUnsupportedDatabaseTypeError(kind)
 	}
+}
+
+func validateDSNFields(cfg *config.DBConfig) error {
+	switch {
+	case cfg.Host == "":
+		return NewInvalidDSNError(errors.New("host is empty"))
+	case cfg.Port <= 0:
+		return NewInvalidDSNError(fmt.Errorf("port is invalid: %d", cfg.Port))
+	case cfg.Username == "":
+		return NewInvalidDSNError(errors.New("username is empty"))
+	case cfg.Database == "":
+		return NewInvalidDSNError(errors.New("database is empty"))
+	}
+	return nil
+}
+
+func quotePostgresValue(value string) string {
+	var b strings.Builder
+	b.Grow(len(value) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c == '\\' || c == '\'' {
+			b.WriteByte('\\')
+		}
+		b.WriteByte(c)
+	}
+	b.WriteByte('\'')
+	return b.String()
 }
 
 func getDriver(kind registry.Kind) string {
@@ -215,7 +252,7 @@ func buildPostgresOptionsString(options map[string]string) string {
 		}
 		b.WriteString(k)
 		b.WriteString("=")
-		b.WriteString(options[k])
+		b.WriteString(quotePostgresValue(options[k]))
 	}
 
 	return b.String()

--- a/service/sql/conn_test.go
+++ b/service/sql/conn_test.go
@@ -358,7 +358,7 @@ func TestBuildOptionsString(t *testing.T) {
 
 	t.Run("single option", func(t *testing.T) {
 		result := buildOptionsString(map[string]string{"sslmode": "disable"})
-		assert.Equal(t, "sslmode=disable", result)
+		assert.Equal(t, "sslmode='disable'", result)
 	})
 
 	t.Run("postgres options are stable and space separated", func(t *testing.T) {
@@ -367,7 +367,7 @@ func TestBuildOptionsString(t *testing.T) {
 			"connect_timeout":  "10",
 			"application_name": "test",
 		})
-		assert.Equal(t, "application_name=test connect_timeout=10 sslmode=disable", result)
+		assert.Equal(t, "application_name='test' connect_timeout='10' sslmode='disable'", result)
 	})
 
 	t.Run("mysql options are stable query parameters", func(t *testing.T) {
@@ -378,6 +378,52 @@ func TestBuildOptionsString(t *testing.T) {
 		})
 		assert.Equal(t, "charset=utf8mb4&parseTime=true&timeout=2s", result)
 	})
+}
+
+func TestQuotePostgresValue(t *testing.T) {
+	assert.Equal(t, "'alice'", quotePostgresValue("alice"))
+	assert.Equal(t, "''", quotePostgresValue(""))
+	assert.Equal(t, "'se cret'", quotePostgresValue("se cret"))
+	assert.Equal(t, `'O\'Brien'`, quotePostgresValue("O'Brien"))
+	assert.Equal(t, `'a\\b'`, quotePostgresValue(`a\b`))
+}
+
+func TestValidateDSNFields(t *testing.T) {
+	base := func() *apiconfig.DBConfig {
+		return &apiconfig.DBConfig{Host: "h", Port: 5432, Username: "u", Database: "d"}
+	}
+
+	require.NoError(t, validateDSNFields(base()))
+
+	c := base()
+	c.Host = ""
+	assert.ErrorContains(t, validateDSNFields(c), "host is empty")
+
+	c = base()
+	c.Port = 0
+	assert.ErrorContains(t, validateDSNFields(c), "port is invalid")
+
+	c = base()
+	c.Username = ""
+	assert.ErrorContains(t, validateDSNFields(c), "username is empty")
+
+	c = base()
+	c.Database = ""
+	assert.ErrorContains(t, validateDSNFields(c), "database is empty")
+}
+
+func TestBuildDSN_EmptyUsernameDoesNotAbsorbNextToken(t *testing.T) {
+	cfg := &apiconfig.DBConfig{
+		Host:     "h",
+		Port:     5432,
+		Database: "d",
+		Username: "",
+		Password: "secret",
+	}
+
+	_, err := buildDSN(apiconfig.Postgres, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username is empty")
 }
 
 func TestGetDriver(t *testing.T) {

--- a/service/sql/errors.go
+++ b/service/sql/errors.go
@@ -108,6 +108,17 @@ func NewServiceNotFoundError(id registry.ID) apierror.Error {
 		WithDetails(attrs.NewBagFrom(map[string]any{"service_id": id.String()}))
 }
 
+func NewUnresolvedEnvError(field, envVar string, err error) apierror.Error {
+	apiErr := apierror.New(apierror.Invalid, "configured env variable could not be resolved").
+		WithRetryable(apierror.False)
+	details := attrs.NewBagFrom(map[string]any{"field": field, "env_var": envVar})
+	if err != nil {
+		details.Set("cause", err.Error())
+		apiErr = apiErr.WithCause(err)
+	}
+	return apiErr.WithDetails(details)
+}
+
 func NewInvalidPortError(envVar string, err error) apierror.Error {
 	apiErr := apierror.New(apierror.Invalid, "invalid port value from env").
 		WithRetryable(apierror.False)

--- a/service/sql/factory_test.go
+++ b/service/sql/factory_test.go
@@ -54,7 +54,7 @@ func TestDefaultPoolFactory_BuildDSN(t *testing.T) {
 					"sslmode": "disable",
 				},
 			},
-			expected: "host=localhost port=5432 user=user password=pass dbname=testdb sslmode=disable",
+			expected: "host='localhost' port=5432 user='user' password='pass' dbname='testdb' sslmode='disable'",
 			isError:  false,
 		},
 		{
@@ -71,7 +71,7 @@ func TestDefaultPoolFactory_BuildDSN(t *testing.T) {
 					"sslmode":         "disable",
 				},
 			},
-			expected: "host=localhost port=5432 user=user password=pass dbname=testdb connect_timeout=2 sslmode=disable",
+			expected: "host='localhost' port=5432 user='user' password='pass' dbname='testdb' connect_timeout='2' sslmode='disable'",
 			isError:  false,
 		},
 		{
@@ -112,6 +112,22 @@ func TestDefaultPoolFactory_BuildDSN(t *testing.T) {
 			name:     "Unsupported database type",
 			kind:     "db.unsupported",
 			cfg:      createTestDBConfig(),
+			expected: "",
+			isError:  true,
+		},
+		{
+			name: "PostgreSQL DSN with empty username is rejected",
+			kind: config.Postgres,
+			cfg: &config.DBConfig{
+				Host:     "localhost",
+				Port:     5432,
+				Database: "testdb",
+				Username: "",
+				Password: "secret",
+				Options: map[string]string{
+					"sslmode": "disable",
+				},
+			},
 			expected: "",
 			isError:  true,
 		},

--- a/service/sql/manager.go
+++ b/service/sql/manager.go
@@ -4,6 +4,7 @@ package sql
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"sync"
 
@@ -119,22 +120,32 @@ func (m *Manager) handleStandardDBAdd(ctx context.Context, entry registry.Entry)
 		return NewInvalidConfigError(err)
 	}
 
-	if v := m.resolveEnv(ctx, cfg.HostEnv, "host"); v != "" {
+	if v, rerr := m.resolveEnv(ctx, cfg.HostEnv, "host"); rerr != nil {
+		return rerr
+	} else if v != "" {
 		cfg.Host = v
 	}
-	if v := m.resolveEnv(ctx, cfg.PortEnv, "port"); v != "" {
+	if v, rerr := m.resolveEnv(ctx, cfg.PortEnv, "port"); rerr != nil {
+		return rerr
+	} else if v != "" {
 		cfg.Port, err = strconv.Atoi(v)
 		if err != nil {
 			return NewInvalidPortError(cfg.PortEnv, err)
 		}
 	}
-	if v := m.resolveEnv(ctx, cfg.DatabaseEnv, "database"); v != "" {
+	if v, rerr := m.resolveEnv(ctx, cfg.DatabaseEnv, "database"); rerr != nil {
+		return rerr
+	} else if v != "" {
 		cfg.Database = v
 	}
-	if v := m.resolveEnv(ctx, cfg.UsernameEnv, "username"); v != "" {
+	if v, rerr := m.resolveEnv(ctx, cfg.UsernameEnv, "username"); rerr != nil {
+		return rerr
+	} else if v != "" {
 		cfg.Username = v
 	}
-	if v := m.resolveEnv(ctx, cfg.PasswordEnv, "password"); v != "" {
+	if v, rerr := m.resolveEnv(ctx, cfg.PasswordEnv, "password"); rerr != nil {
+		return rerr
+	} else if v != "" {
 		cfg.Password = v
 	}
 
@@ -284,20 +295,19 @@ func (m *Manager) unregisterService(ctx context.Context, entry registry.Entry) {
 		zap.String("id", entry.ID.String()))
 }
 
-// resolveEnv looks up an environment variable and returns its value.
-// Returns empty string if envVar is empty, lookup fails, or var not found.
-func (m *Manager) resolveEnv(ctx context.Context, envVar, field string) string {
-	if envVar == "" || m.env == nil {
-		return ""
+func (m *Manager) resolveEnv(ctx context.Context, envVar, field string) (string, error) {
+	if envVar == "" {
+		return "", nil
+	}
+	if m.env == nil {
+		return "", NewUnresolvedEnvError(field, envVar, errors.New("env registry not configured"))
 	}
 	val, found, err := m.env.Lookup(ctx, envVar)
 	if err != nil {
-		m.log.Warn("failed to lookup env var", zap.String("field", field), zap.String("var", envVar), zap.Error(err))
-		return ""
+		return "", NewUnresolvedEnvError(field, envVar, err)
 	}
 	if !found {
-		m.log.Warn("env var not found", zap.String("field", field), zap.String("var", envVar))
-		return ""
+		return "", NewUnresolvedEnvError(field, envVar, envapi.ErrVariableNotFound)
 	}
-	return val
+	return val, nil
 }

--- a/service/sql/manager_test.go
+++ b/service/sql/manager_test.go
@@ -615,13 +615,14 @@ func TestManager_ResolveEnv(t *testing.T) {
 	manager.env = envRegistry
 
 	tests := []struct {
-		name     string
-		envVar   string
-		field    string
-		expected string
+		name      string
+		envVar    string
+		field     string
+		expected  string
+		expectErr bool
 	}{
 		{
-			name:     "Empty env var returns empty",
+			name:     "Empty env var returns empty without error",
 			envVar:   "",
 			field:    "host",
 			expected: "",
@@ -633,23 +634,88 @@ func TestManager_ResolveEnv(t *testing.T) {
 			expected: "test-host-value",
 		},
 		{
-			name:     "Not found env var returns empty",
-			envVar:   "NONEXISTENT_VAR",
-			field:    "database",
-			expected: "",
+			name:      "Configured but unresolvable env var fails fast",
+			envVar:    "NONEXISTENT_VAR",
+			field:     "database",
+			expectErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := manager.resolveEnv(ctx, tt.envVar, tt.field)
+			result, err := manager.resolveEnv(ctx, tt.envVar, tt.field)
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "could not be resolved")
+				assert.Contains(t, err.Error(), "environment variable not found")
+				assert.Empty(t, result)
+				return
+			}
+
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
+func TestManager_AddWithUnresolvableEnv(t *testing.T) {
+	manager, _, factory := newTestManager(t)
+	ctx := ctxapi.NewRootContext()
+
+	envRegistry := NewMockEnvRegistry()
+	require.NoError(t, envRegistry.Set(ctx, "DB_HOST", "env-host"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_PORT", "9999"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_NAME", "env-db"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_PASS", "env-pass"))
+	manager.env = envRegistry
+
+	manager.dtt = &UnresolvableEnvConfigTranscoder{}
+
+	entry := registry.Entry{
+		ID:   registry.NewID("test", "env-db"),
+		Kind: apiconfig.Postgres,
+		Data: payload.New(map[string]string{"test": "data"}),
+	}
+
+	err := manager.Add(ctx, entry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be resolved")
+	assert.Empty(t, factory.standardPoolCalls)
+}
+
+type UnresolvableEnvConfigTranscoder struct{}
+
+func (t *UnresolvableEnvConfigTranscoder) Marshal(v any) (payload.Payload, error) {
+	return payload.New(v), nil
+}
+
+func (t *UnresolvableEnvConfigTranscoder) Unmarshal(_ payload.Payload, v any) error {
+	switch target := v.(type) {
+	case *apiconfig.DBConfig:
+		*target = apiconfig.DBConfig{
+			HostEnv:     "DB_HOST",
+			PortEnv:     "DB_PORT",
+			DatabaseEnv: "DB_NAME",
+			UsernameEnv: "MISSING_USER",
+			PasswordEnv: "DB_PASS",
+			Pool: apiconfig.PoolConfig{
+				MaxOpen:     10,
+				MaxIdle:     5,
+				MaxLifetime: time.Hour,
+			},
+		}
+	default:
+		return fmt.Errorf("unsupported type: %T", v)
+	}
+	return nil
+}
+
+func (t *UnresolvableEnvConfigTranscoder) Transcode(p payload.Payload, format payload.Format) (payload.Payload, error) {
+	return payload.NewPayload(p.Data(), format), nil
+}
+
 func TestManager_AddWithEnvVars(t *testing.T) {
-	manager, _, _ := newTestManager(t)
+	manager, _, factory := newTestManager(t)
 	ctx := ctxapi.NewRootContext()
 
 	// Create env registry with test values
@@ -671,7 +737,15 @@ func TestManager_AddWithEnvVars(t *testing.T) {
 	}
 
 	err := manager.Add(ctx, entry)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	require.Len(t, factory.standardPoolCalls, 1)
+	applied := factory.standardPoolCalls[0].Cfg
+	assert.Equal(t, "env-host", applied.Host)
+	assert.Equal(t, 9999, applied.Port)
+	assert.Equal(t, "env-db", applied.Database)
+	assert.Equal(t, "env-user", applied.Username)
+	assert.Equal(t, "env-pass", applied.Password)
 }
 
 // EnvConfigTranscoder returns a config with env var fields set

--- a/system/env/registry.go
+++ b/system/env/registry.go
@@ -63,6 +63,32 @@ func (r *Registry) getEnvName(variable *env.Variable) string {
 	return variable.ID.String()
 }
 
+func (r *Registry) storeNameShortcut(envName string, id registry.ID, path event.Path) {
+	if existing, ok := r.loadNameShortcut(envName); ok && !existing.Equal(id) {
+		r.log.Warn("env variable name shortcut already claimed by another id; variable registered by id only",
+			zap.String("path", path), zap.String("base_name", envName),
+			zap.String("owner_id", existing.String()), zap.String("id", id.String()))
+		return
+	}
+
+	r.variablesByName.Store(envName, id)
+}
+
+func (r *Registry) deleteNameShortcut(envName string, id registry.ID) {
+	if existing, ok := r.loadNameShortcut(envName); ok && existing.Equal(id) {
+		r.variablesByName.Delete(envName)
+	}
+}
+
+func (r *Registry) loadNameShortcut(envName string) (registry.ID, bool) {
+	if storedID, exists := r.variablesByName.Load(envName); exists {
+		if id, ok := storedID.(registry.ID); ok {
+			return id, true
+		}
+	}
+	return registry.ID{}, false
+}
+
 func (r *Registry) nsFromCtx(ctx context.Context) string {
 	if ctx == nil {
 		return ""
@@ -148,14 +174,8 @@ func (r *Registry) registerVariable(e event.Event) {
 
 	envName := r.getEnvName(&variable)
 
-	if _, exists := r.variablesByName.Load(envName); exists {
-		r.log.Error("variable name already exists", zap.String("path", e.Path), zap.String("base_name", envName))
-		r.sendReject(e.Path, NewVariableNameExistsError(envName).Error())
-		return
-	}
-
 	r.variablesByID.Store(variable.ID, variable)
-	r.variablesByName.Store(envName, variable.ID)
+	r.storeNameShortcut(envName, variable.ID, e.Path)
 	r.sendAccept(e.Path)
 	r.log.Debug("variable registered", zap.String("id", variable.ID.String()), zap.String("name", variable.Name), zap.String("base_name", envName))
 }
@@ -182,26 +202,17 @@ func (r *Registry) updateVariable(e event.Event) {
 
 	envName := r.getEnvName(&variable)
 
-	if existingID, exists := r.variablesByName.Load(envName); exists {
-		if existingVarID, ok := existingID.(registry.ID); ok && !existingVarID.Equal(variable.ID) {
-			r.log.Error("variable name already exists", zap.String("path", e.Path), zap.String("base_name", envName))
-			r.sendReject(e.Path, NewVariableNameExistsError(envName).Error())
-			return
-		}
-	}
-
-	// Clean up old name mappings if variable exists
 	if storedVar, exists := r.variablesByID.Load(variable.ID); exists {
 		if oldVariable, ok := storedVar.(env.Variable); ok {
 			oldBaseName := r.getEnvName(&oldVariable)
 			if oldBaseName != envName {
-				r.variablesByName.Delete(oldBaseName)
+				r.deleteNameShortcut(oldBaseName, variable.ID)
 			}
 		}
 	}
 
 	r.variablesByID.Store(variable.ID, variable)
-	r.variablesByName.Store(envName, variable.ID)
+	r.storeNameShortcut(envName, variable.ID, e.Path)
 
 	r.sendAccept(e.Path)
 
@@ -212,8 +223,7 @@ func (r *Registry) deleteVariable(e event.Event) {
 	varID := registry.ParseID(e.Path)
 
 	if variable, ok := r.loadVariable(varID); ok {
-		envName := r.getEnvName(variable)
-		r.variablesByName.Delete(envName)
+		r.deleteNameShortcut(r.getEnvName(variable), varID)
 	}
 
 	r.variablesByID.Delete(varID)

--- a/system/env/registry_test.go
+++ b/system/env/registry_test.go
@@ -776,7 +776,6 @@ func TestRegistry_EventHandling_VariableRegister(t *testing.T) {
 		responses = nil
 		wg.Add(1)
 
-		// Register first variable
 		variable1 := env.Variable{
 			ID:        registry.ParseID("app:var1"),
 			Name:      "same_name",
@@ -785,10 +784,9 @@ func TestRegistry_EventHandling_VariableRegister(t *testing.T) {
 		reg.variablesByID.Store(variable1.ID, variable1)
 		reg.variablesByName.Store("same_name", variable1.ID)
 
-		// Try to register second variable with same name
 		variable2 := env.Variable{
 			ID:        registry.ParseID("app:var2"),
-			Name:      "same_name", // Same name as first variable
+			Name:      "same_name",
 			StorageID: registry.ParseID("app:storage"),
 		}
 		evt := event.Event{
@@ -800,7 +798,6 @@ func TestRegistry_EventHandling_VariableRegister(t *testing.T) {
 
 		bus.Send(ctx, evt)
 
-		// Wait for response
 		done := make(chan struct{})
 		go func() {
 			wg.Wait()
@@ -813,15 +810,17 @@ func TestRegistry_EventHandling_VariableRegister(t *testing.T) {
 			t.Fatal("timeout waiting for response")
 		}
 
-		// Verify second variable was not registered
-		_, exists := reg.variablesByID.Load(variable2.ID)
-		assert.False(t, exists)
+		stored, exists := reg.variablesByID.Load(variable2.ID)
+		assert.True(t, exists)
+		assert.Equal(t, variable2, stored)
 
-		// Verify reject event was sent
+		shortcut, ok := reg.variablesByName.Load("same_name")
+		require.True(t, ok)
+		assert.Equal(t, variable1.ID, shortcut)
+
 		mu.Lock()
 		require.Len(t, responses, 1)
-		assert.Equal(t, env.EnvReject, responses[0].Kind)
-		assert.Contains(t, responses[0].Data.(string), "variable name already exists")
+		assert.Equal(t, env.EnvAccept, responses[0].Kind)
 		mu.Unlock()
 	})
 }
@@ -1325,7 +1324,6 @@ func TestRegistry_UpdateVariable_NameConflict(t *testing.T) {
 	})
 	time.Sleep(10 * time.Millisecond)
 
-	// Try to update second variable to use first variable's name - should be rejected
 	bus.Send(ctx, event.Event{
 		System: env.System,
 		Kind:   env.VariableUpdate,
@@ -1338,10 +1336,16 @@ func TestRegistry_UpdateVariable_NameConflict(t *testing.T) {
 	})
 	time.Sleep(10 * time.Millisecond)
 
-	// Second variable should still be accessible by its original name
-	value, err := reg.Get(ctx, "other_name")
+	_, err := reg.Get(ctx, "other_name")
+	assert.ErrorIs(t, err, env.ErrVariableNotFound)
+
+	shortcut, ok := reg.variablesByName.Load("shared_name")
+	require.True(t, ok)
+	assert.Equal(t, registry.ParseID("app:var1"), shortcut)
+
+	value, err := reg.Get(ctx, "app:var2")
 	require.NoError(t, err)
-	assert.Equal(t, "value2", value)
+	assert.Equal(t, "value1", value)
 }
 
 func TestRegistry_GetStorage_InvalidType(t *testing.T) {
@@ -1379,6 +1383,106 @@ func TestRegistry_FindVariable_ByFullID(t *testing.T) {
 	value, err := reg.Get(ctx, "testns:myvar")
 	require.NoError(t, err)
 	assert.Equal(t, "value", value)
+}
+
+func TestRegistry_CrossNamespaceSameName_CoexistByID(t *testing.T) {
+	reg, bus, ctx := setupTestRegistry()
+	require.NoError(t, reg.Start(ctx))
+	defer safeStop(t, reg)
+
+	storageA := newMockStorage(map[string]string{"DB_USER": "alice"})
+	storageB := newMockStorage(map[string]string{"DB_USER": "bob"})
+	reg.storages.Store(registry.ParseID("a:storage"), storageA)
+	reg.storages.Store(registry.ParseID("b:storage"), storageB)
+
+	bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.VariableRegister,
+		Path:   "a:db_user",
+		Data: env.Variable{
+			ID:        registry.ParseID("a:db_user"),
+			Name:      "DB_USER",
+			StorageID: registry.ParseID("a:storage"),
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+
+	bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.VariableRegister,
+		Path:   "b:db_user",
+		Data: env.Variable{
+			ID:        registry.ParseID("b:db_user"),
+			Name:      "DB_USER",
+			StorageID: registry.ParseID("b:storage"),
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+
+	valueA, err := reg.Get(ctx, "a:db_user")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", valueA)
+
+	valueB, err := reg.Get(ctx, "b:db_user")
+	require.NoError(t, err)
+	assert.Equal(t, "bob", valueB)
+
+	shortcut, ok := reg.variablesByName.Load("DB_USER")
+	require.True(t, ok)
+	assert.Equal(t, registry.ParseID("a:db_user"), shortcut)
+}
+
+func TestRegistry_DeleteNonOwner_KeepsOwnerShortcut(t *testing.T) {
+	reg, bus, ctx := setupTestRegistry()
+	require.NoError(t, reg.Start(ctx))
+	defer safeStop(t, reg)
+
+	storageA := newMockStorage(map[string]string{"DB_USER": "alice"})
+	storageB := newMockStorage(map[string]string{"DB_USER": "bob"})
+	reg.storages.Store(registry.ParseID("a:storage"), storageA)
+	reg.storages.Store(registry.ParseID("b:storage"), storageB)
+
+	bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.VariableRegister,
+		Path:   "a:db_user",
+		Data: env.Variable{
+			ID:        registry.ParseID("a:db_user"),
+			Name:      "DB_USER",
+			StorageID: registry.ParseID("a:storage"),
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+
+	bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.VariableRegister,
+		Path:   "b:db_user",
+		Data: env.Variable{
+			ID:        registry.ParseID("b:db_user"),
+			Name:      "DB_USER",
+			StorageID: registry.ParseID("b:storage"),
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+
+	bus.Send(ctx, event.Event{
+		System: env.System,
+		Kind:   env.VariableDelete,
+		Path:   "b:db_user",
+	})
+	time.Sleep(10 * time.Millisecond)
+
+	shortcut, ok := reg.variablesByName.Load("DB_USER")
+	require.True(t, ok)
+	assert.Equal(t, registry.ParseID("a:db_user"), shortcut)
+
+	valueA, err := reg.Get(ctx, "a:db_user")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", valueA)
+
+	_, err = reg.Get(ctx, "b:db_user")
+	assert.ErrorIs(t, err, env.ErrVariableNotFound)
 }
 
 func TestRegistry_NsFromCtx_NilContext(t *testing.T) {


### PR DESCRIPTION
## Why

A single same-named `env.variable` in any namespace could take down **every** `db.sql.postgres` service non-deterministically, crash-looping with `pq: password authentication failed for user "password="` (or `"password=secret"`) — the fingerprint of an *empty resolved field*, not a real credential. Boot ordering decided which service lost the race, so the same config booted fine on some restarts and failed on others.

## What

Fixes a chain of three independent defects so each layer fails safely and loudly:

- **env registry (root cause)** — variables were keyed in a global flat namespace by short `Name`; a `Name` collision rejected the second registration before storing it by ID, so full-ID lookups failed. Now always store by ID; `variablesByName` is a first-wins shortcut, and the shortcut delete is ownership-guarded so a departing variable cannot remove another's shortcut.
- **sql/cdc managers** — a configured `*_env` that failed to resolve silently left the field blank. `resolveEnv` now fails fast with `NewUnresolvedEnvError` naming the field/var, distinguishing "not configured" (keep static) from "configured but unresolvable" (hard error).
- **sql DSN builder** — unquoted fields let an empty username produce `user= password=secret`, which lib/pq misparses by absorbing the next token. `buildDSN` now rejects empty required fields and quotes all Postgres keyword/value fields; CDC `buildDSNs` likewise rejects empty resolved fields and runs before the Update teardown.

## Testing

Validated locally on darwin/arm64 (no live Postgres; CDC `//go:build integration` tests not run):

- `make build-wippy` — green.
- `go test -race ./system/env/... ./service/sql/... ./service/cdc/postgres/...` — all pass.
- `golangci-lint run` on the three packages — 0 issues.
- Mutation testing (gremlins): every mutant in the changed functions killed (sql efficacy 86→95%, cdc 71→80%); surviving mutants are all in pre-existing untouched code or equivalent.
- Before/after proof: the new cross-namespace test fails on the original registry (`environment variable not found`) and passes on the fix; a standalone demo reproduces the exact corrupt DSN and error fingerprints.

New tests cover cross-namespace coexistence + full-ID lookup, ownership-guarded delete, fail-fast on unresolvable env, and DSN validation/quoting (including the empty-username "absorb next token" case).