### PR TITLE
fix(wasm): make Rust-std WASI components runnable (insecure-seed + warm instance reuse)

### DIFF
--- a/runtime/wasm/engine/process.go
+++ b/runtime/wasm/engine/process.go
@@ -54,6 +54,7 @@ type Process struct {
 	yieldSeq          uint64
 	waitingYield      bool
 	done              bool
+	started           bool
 }
 
 // NewProcess creates a scheduler process for WASM execution.
@@ -75,7 +76,7 @@ func NewProcess(
 
 // Init captures call parameters for this process execution.
 func (p *Process) Init(ctx context.Context, method string, input payload.Payloads) error {
-	p.endExecution()
+	p.softReset()
 	p.ctx = ctx
 	p.method = method
 	p.input = input
@@ -102,11 +103,12 @@ func (p *Process) Step(events []process.Event, out *process.StepOutput) error {
 		return err
 	}
 
-	if p.inst == nil {
+	if !p.started {
 		if err := p.startExecution(); err != nil {
 			p.endExecution()
 			return err
 		}
+		p.started = true
 	}
 
 	if p.session == nil {
@@ -139,7 +141,7 @@ func (p *Process) stepSync(out *process.StepOutput) error {
 
 	p.result = result
 	p.done = true
-	p.endExecution()
+	p.softReset()
 	out.Done(result)
 	return nil
 }
@@ -218,29 +220,30 @@ func (p *Process) startExecution() error {
 	p.asyncValues = wippyhost.NewAsyncValueStore()
 	execCtx = wippyhost.WithAsyncValueStore(execCtx, p.asyncValues)
 
-	inst, err := p.module.InstantiateWithAsyncify(execCtx)
-	if err != nil {
-		cancel()
-		return runtimewasm.NewInstantiateModuleError(err)
+	if p.inst == nil {
+		inst, err := p.module.InstantiateWithAsyncify(execCtx)
+		if err != nil {
+			cancel()
+			return runtimewasm.NewInstantiateModuleError(err)
+		}
+		p.inst = inst
 	}
 
 	args, err := p.prepareArgs(execCtx)
 	if err != nil {
-		_ = inst.Close(context.Background())
 		cancel()
 		return err
 	}
 
 	p.execCtx = execCtx
 	p.cancel = cancel
-	p.inst = inst
 	p.callArgs = args
 
-	if inst.Scheduler() == nil {
+	if p.inst.Scheduler() == nil {
 		return nil
 	}
 
-	session, err := inst.StartCall(execCtx, p.method, args...)
+	session, err := p.inst.StartCall(execCtx, p.method, args...)
 	if err != nil {
 		p.endExecution()
 		return runtimewasm.NewCallMethodError(p.method, err)
@@ -254,6 +257,16 @@ func (p *Process) endExecution() {
 		_ = p.inst.Close(context.Background())
 		p.inst = nil
 	}
+	p.softReset()
+}
+
+// softReset clears per-call state while keeping the instance warm for reuse.
+// A WASI component's synthetic import bridges are bound to the core instance
+// that first created them, so re-instantiating from the same module after a
+// WASI host call has been made corrupts subsequent instances. Reusing one warm
+// instance for sequential synchronous calls (the inline pool serializes them)
+// sidesteps that. Asynchronous calls still close the instance per call below.
+func (p *Process) softReset() {
 	if p.cancel != nil {
 		p.cancel()
 		p.cancel = nil
@@ -264,6 +277,7 @@ func (p *Process) endExecution() {
 	p.pendingYield = nil
 	p.pendingTag = 0
 	p.waitingYield = false
+	p.started = false
 	if p.asyncValues != nil {
 		p.asyncValues.Reset()
 		p.asyncValues = nil

--- a/runtime/wasm/host/wippy/hosts/random/random.go
+++ b/runtime/wasm/host/wippy/hosts/random/random.go
@@ -13,11 +13,11 @@ import (
 
 const (
 	// SecureNamespace is the WASI random/random namespace.
-	SecureNamespace = "wasi:random/random@0.2.0"
+	SecureNamespace = "wasi:random/random@0.2.8"
 	// InsecureNamespace is the WASI random/insecure namespace.
-	InsecureNamespace = "wasi:random/insecure@0.2.0"
+	InsecureNamespace = "wasi:random/insecure@0.2.8"
 	// InsecureSeedNamespace is the WASI random/insecure-seed namespace.
-	InsecureSeedNamespace = "wasi:random/insecure-seed@0.2.0"
+	InsecureSeedNamespace = "wasi:random/insecure-seed@0.2.8"
 )
 
 // MaxRandomBytes limits single-call allocation to prevent DoS (1MB).
@@ -131,8 +131,9 @@ func (h *InsecureSeedHost) Register() map[string]any {
 	}
 }
 
-// InsecureSeed returns a pair of uint64 values derived from current time.
-func (h *InsecureSeedHost) InsecureSeed(_ context.Context) (uint64, uint64) {
+// InsecureSeed returns the WIT tuple<u64, u64> seed as a single [2]uint64.
+// The result is one tuple, so the host returns one Go value, not two u64s.
+func (h *InsecureSeedHost) InsecureSeed(_ context.Context) [2]uint64 {
 	now := time.Now().UnixNano()
-	return uint64(now), uint64(now >> 32)
+	return [2]uint64{uint64(now), uint64(now >> 32)}
 }


### PR DESCRIPTION
## Why
Rust components compiled to `wasm32-wasip2` (anything using `std` `HashMap`) could not run on the runtime — the first conversion failed, or every call after the first trapped with `exit_code(1)`. Two independent bugs in the WASI / component layer.

## What
- **WASI `insecure-seed`** (`runtime/wasm/host/wippy/hosts/random/random.go`): return the seed as a single `[2]uint64` — the WIT result is one `tuple<u64,u64>`, not two `u64`s — and bump the `wasi:random` host namespaces to `@0.2.8` so the toolchain's `@0.2.6` import resolves (`Version.Compatible` requires host ≥ guest).
- **Component instance reuse** (`runtime/wasm/engine/process.go`): reuse one warm instance per inline pool worker for synchronous calls instead of instantiate-and-close per call. Re-instantiating a WASI-importing component corrupts later instances (synthetic import bridges stay bound to the first core instance), so previously only the first call per process succeeded.

Tradeoff: the warm instance's linear memory stays resident between calls per worker; reclaimed on `Close`.

## Testing (local)
- `go test ./runtime/wasm/...` — pass
- `golangci-lint` on changed packages — 0 issues
- `tests/app` integration suite — **360 passed / 22 failed, byte-identical to `main`** (the 22 are pre-existing env-dependent tests: Docker/HTTP/CORS/WASI-HTTP); 8/9 wasm Lua tests pass on both
- End-to-end: a Rust (`unpdf`/`undoc`) component converts PDF/DOCX/XLSX/PPTX across many sequential calls (previously trapped after the first).