### PR TITLE
Fix strict-security env and function runtime grants

### DIFF
--- a/api/runtime/lua/config.go
+++ b/api/runtime/lua/config.go
@@ -6,6 +6,7 @@ package lua
 import (
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/security"
 )
 
 // Registry kind constants for different Lua component types.
@@ -58,12 +59,13 @@ type (
 	// It includes the source code, execution method, required libraries and modules,
 	// and VM pool settings.
 	FunctionConfig struct {
-		Imports map[string]registry.ID `json:"imports,omitempty"`
-		Meta    attrs.Bag              `json:"meta,omitempty"`
-		Source  string                 `json:"source"`
-		Method  string                 `json:"method"`
-		Modules []string               `json:"modules,omitempty"`
-		Pool    PoolConfig             `json:"pool,omitempty"`
+		Imports  map[string]registry.ID `json:"imports,omitempty"`
+		Meta     attrs.Bag              `json:"meta,omitempty"`
+		Source   string                 `json:"source"`
+		Method   string                 `json:"method"`
+		Modules  []string               `json:"modules,omitempty"`
+		Pool     PoolConfig             `json:"pool,omitempty"`
+		Security *security.Config       `json:"security,omitempty" yaml:"security,omitempty"`
 	}
 
 	// LibraryConfig defines the configuration for a Lua library component.
@@ -106,14 +108,15 @@ type (
 	// BytecodeFunctionConfig defines configuration for a precompiled Lua function.
 	// The bytecode is loaded from a filesystem and verified by hash before use.
 	BytecodeFunctionConfig struct {
-		Imports map[string]registry.ID `json:"imports,omitempty"`
-		Meta    attrs.Bag              `json:"meta,omitempty"`
-		FS      string                 `json:"fs"`
-		Path    string                 `json:"path"`
-		Hash    string                 `json:"hash"`
-		Method  string                 `json:"method"`
-		Modules []string               `json:"modules,omitempty"`
-		Pool    PoolConfig             `json:"pool,omitempty"`
+		Imports  map[string]registry.ID `json:"imports,omitempty"`
+		Meta     attrs.Bag              `json:"meta,omitempty"`
+		FS       string                 `json:"fs"`
+		Path     string                 `json:"path"`
+		Hash     string                 `json:"hash"`
+		Method   string                 `json:"method"`
+		Modules  []string               `json:"modules,omitempty"`
+		Pool     PoolConfig             `json:"pool,omitempty"`
+		Security *security.Config       `json:"security,omitempty" yaml:"security,omitempty"`
 	}
 
 	// BytecodeLibraryConfig defines configuration for a precompiled Lua library.

--- a/api/runtime/lua/config.go
+++ b/api/runtime/lua/config.go
@@ -61,11 +61,11 @@ type (
 	FunctionConfig struct {
 		Imports  map[string]registry.ID `json:"imports,omitempty"`
 		Meta     attrs.Bag              `json:"meta,omitempty"`
+		Security *security.Config       `json:"security,omitempty" yaml:"security,omitempty"`
 		Source   string                 `json:"source"`
 		Method   string                 `json:"method"`
 		Modules  []string               `json:"modules,omitempty"`
 		Pool     PoolConfig             `json:"pool,omitempty"`
-		Security *security.Config       `json:"security,omitempty" yaml:"security,omitempty"`
 	}
 
 	// LibraryConfig defines the configuration for a Lua library component.
@@ -110,13 +110,13 @@ type (
 	BytecodeFunctionConfig struct {
 		Imports  map[string]registry.ID `json:"imports,omitempty"`
 		Meta     attrs.Bag              `json:"meta,omitempty"`
+		Security *security.Config       `json:"security,omitempty" yaml:"security,omitempty"`
 		FS       string                 `json:"fs"`
 		Path     string                 `json:"path"`
 		Hash     string                 `json:"hash"`
 		Method   string                 `json:"method"`
 		Modules  []string               `json:"modules,omitempty"`
 		Pool     PoolConfig             `json:"pool,omitempty"`
-		Security *security.Config       `json:"security,omitempty" yaml:"security,omitempty"`
 	}
 
 	// BytecodeLibraryConfig defines configuration for a precompiled Lua library.

--- a/runtime/lua/component/function/lifecycle.go
+++ b/runtime/lua/component/function/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	runtimelua "github.com/wippyai/runtime/runtime/lua"
 	"github.com/wippyai/runtime/runtime/lua/code"
 	"github.com/wippyai/runtime/runtime/lua/component"
+	securitysys "github.com/wippyai/runtime/system/security"
 	"go.uber.org/zap"
 )
 
@@ -120,6 +121,8 @@ func (m *Manager) Execute(ctx context.Context, task runtime.Task) (*runtime.Resu
 		}
 	}
 
+	ctx = securitysys.WithSecurityConfig(ctx, entry.security)
+
 	result, err := entry.pool.Call(ctx, entry.method, task.Payloads)
 	return result, err
 }
@@ -144,10 +147,11 @@ func (m *Manager) addSource(ctx context.Context, entry registry.Entry) error {
 
 	opts, _ := cfg.Meta.GetBag("options")
 	configEntry := &configEntry{
-		method:  cfg.Method,
-		pool:    cfg.Pool,
-		source:  cfg,
-		options: opts,
+		method:   cfg.Method,
+		pool:     cfg.Pool,
+		source:   cfg,
+		options:  opts,
+		security: cfg.Security,
 	}
 
 	if err := m.createPool(entry.ID, configEntry); err != nil {
@@ -199,6 +203,7 @@ func (m *Manager) addBytecode(ctx context.Context, entry registry.Entry) error {
 		pool:     cfg.Pool,
 		bytecode: cfg,
 		options:  opts,
+		security: cfg.Security,
 	}
 
 	if err := m.createPool(entry.ID, configEntry); err != nil {
@@ -243,10 +248,11 @@ func (m *Manager) updateSource(ctx context.Context, entry registry.Entry) error 
 
 	opts, _ := cfg.Meta.GetBag("options")
 	configEntry := &configEntry{
-		method:  cfg.Method,
-		pool:    cfg.Pool,
-		source:  cfg,
-		options: opts,
+		method:   cfg.Method,
+		pool:     cfg.Pool,
+		source:   cfg,
+		options:  opts,
+		security: cfg.Security,
 	}
 
 	if err := m.replacePool(entry.ID, configEntry); err != nil {
@@ -291,6 +297,7 @@ func (m *Manager) updateBytecode(ctx context.Context, entry registry.Entry) erro
 		pool:     cfg.Pool,
 		bytecode: cfg,
 		options:  opts,
+		security: cfg.Security,
 	}
 
 	if err := m.replacePool(entry.ID, configEntry); err != nil {

--- a/runtime/lua/component/function/manager.go
+++ b/runtime/lua/component/function/manager.go
@@ -40,11 +40,11 @@ type configEntry struct {
 type poolEntry struct {
 	drained  chan struct{}
 	pool     funcpool.Pool
+	security *security.Config
 	method   string
 	hostID   string
-	security *security.Config
-	mu       sync.Mutex
 	active   int
+	mu       sync.Mutex
 	stopOnce sync.Once
 	retired  bool
 }

--- a/runtime/lua/component/function/manager.go
+++ b/runtime/lua/component/function/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wippyai/runtime/api/relay"
 	"github.com/wippyai/runtime/api/runtime"
 	api "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/api/security"
 	"github.com/wippyai/runtime/api/topology"
 	"github.com/wippyai/runtime/runtime/lua/code"
 	"github.com/wippyai/runtime/runtime/lua/engine"
@@ -26,6 +27,7 @@ import (
 // configEntry holds config for either source or bytecode function.
 type configEntry struct {
 	options  runtime.Options
+	security *security.Config
 	source   *api.FunctionConfig
 	bytecode *api.BytecodeFunctionConfig
 	method   string
@@ -40,6 +42,7 @@ type poolEntry struct {
 	pool     funcpool.Pool
 	method   string
 	hostID   string
+	security *security.Config
 	mu       sync.Mutex
 	active   int
 	stopOnce sync.Once

--- a/runtime/lua/component/function/manager_test.go
+++ b/runtime/lua/component/function/manager_test.go
@@ -936,8 +936,8 @@ func (p *pidCapturePool) Send(*relay.Package) error {
 }
 
 type securityCapturePool struct {
-	actor security.Actor
 	scope security.Scope
+	actor security.Actor
 }
 
 func (p *securityCapturePool) Call(ctx context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {

--- a/runtime/lua/component/function/manager_test.go
+++ b/runtime/lua/component/function/manager_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/payload"
@@ -19,10 +20,12 @@ import (
 	"github.com/wippyai/runtime/api/relay"
 	"github.com/wippyai/runtime/api/runtime"
 	api "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/api/security"
 	"github.com/wippyai/runtime/runtime/lua/code"
 	systempayload "github.com/wippyai/runtime/system/payload"
 	"github.com/wippyai/runtime/system/payload/json"
 	systemrelay "github.com/wippyai/runtime/system/relay"
+	systemsecurity "github.com/wippyai/runtime/system/security"
 	"go.uber.org/zap"
 )
 
@@ -109,7 +112,7 @@ func TestManager_StartStartsPreexistingPools(t *testing.T) {
 	pool := &trackingPool{}
 	id := registry.NewID("test", "preexisting")
 	manager.mu.Lock()
-	manager.pools[id] = newPoolEntry(pool, "main", "test:preexisting#lua.test")
+	manager.pools[id] = newPoolEntry(pool, "main", "test:preexisting#lua.test", nil)
 	manager.mu.Unlock()
 
 	require.NoError(t, manager.Start(context.Background()))
@@ -136,7 +139,7 @@ func TestManager_StartRegistersPreexistingPoolHost(t *testing.T) {
 	hostID := "test:preexisting_host#lua.test"
 	pool := &trackingPool{}
 	manager.mu.Lock()
-	manager.pools[id] = newPoolEntry(pool, "main", hostID)
+	manager.pools[id] = newPoolEntry(pool, "main", hostID, nil)
 	manager.mu.Unlock()
 
 	ctx := relay.WithNode(ctxapi.NewRootContext(), node)
@@ -414,7 +417,7 @@ func TestManager_ExecuteUsesPoolGenerationHost(t *testing.T) {
 	hostID := "test:generation_func#lua.1"
 	pool := &pidCapturePool{}
 	manager.mu.Lock()
-	manager.pools[id] = newPoolEntry(pool, "main", hostID)
+	manager.pools[id] = newPoolEntry(pool, "main", hostID, nil)
 	manager.mu.Unlock()
 
 	ctx, fc := ctxapi.OpenFrameContext(context.Background())
@@ -436,8 +439,44 @@ func TestManager_ExecuteUsesPoolGenerationHost(t *testing.T) {
 	assert.Equal(t, "call-1", framePID.UniqID)
 }
 
+func TestManager_ExecuteAppliesFunctionSecurity(t *testing.T) {
+	log := zap.NewNop()
+	codeManager := &code.Manager{}
+	bus := newMockEventBus()
+	disp := &mockDispatcher{}
+	fsReg := newMockFSRegistry()
+	factory := newMockCompiledFactory()
+	manager := NewManager(log, codeManager, bus, disp, fsReg, factory)
+
+	policyID := registry.NewID("test", "db_access")
+	groupID := registry.NewID("test", "auth")
+	policy := newSecurityPolicy(policyID, security.Allow)
+	reg := newSecurityRegistry(map[registry.ID]security.Policy{policyID: policy}, map[registry.ID][]security.Policy{groupID: {policy}})
+
+	id := registry.NewID("test", "secured_func")
+	pool := &securityCapturePool{}
+	manager.mu.Lock()
+	manager.pools[id] = newPoolEntry(pool, "main", "test:secured_func#lua.1", &security.Config{
+		Actor:        security.Actor{ID: "userspace.user:auth"},
+		PolicyGroups: []registry.ID{groupID},
+	})
+	manager.mu.Unlock()
+
+	ctx, fc := ctxapi.OpenFrameContext(security.WithRegistry(ctxapi.NewRootContext(), reg))
+	defer func() { _ = fc.Close() }()
+	require.NoError(t, runtime.SetFramePID(ctx, (&pid.PID{Host: id.String(), UniqID: "call-1"}).Precomputed()))
+
+	result, err := manager.Execute(ctx, runtime.Task{ID: id})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "userspace.user:auth", pool.actor.ID)
+	require.NotNil(t, pool.scope)
+	assert.Equal(t, security.Allow, pool.scope.Evaluate(pool.actor, "db.get", "app:db", nil))
+}
+
 func TestPoolEntryRetireWaitsForActiveExecution(t *testing.T) {
-	entry := newPoolEntry(&trackingPool{}, "main", "test:retire#lua.1")
+	entry := newPoolEntry(&trackingPool{}, "main", "test:retire#lua.1", nil)
 	require.True(t, entry.acquire())
 
 	stopped := make(chan struct{})
@@ -474,7 +513,7 @@ func TestManager_RetiredPoolHostDrainsBeforeUnregister(t *testing.T) {
 	manager.node = node
 	hostID := "test:retired#lua.1"
 	pool := &trackingPool{}
-	entry := newPoolEntry(pool, "main", hostID)
+	entry := newPoolEntry(pool, "main", hostID, nil)
 	require.NoError(t, node.RegisterHost(hostID, pool))
 	require.True(t, entry.acquire())
 
@@ -894,4 +933,82 @@ func (p *pidCapturePool) Start() {}
 func (p *pidCapturePool) Stop()  {}
 func (p *pidCapturePool) Send(*relay.Package) error {
 	return nil
+}
+
+type securityCapturePool struct {
+	actor security.Actor
+	scope security.Scope
+}
+
+func (p *securityCapturePool) Call(ctx context.Context, _ string, _ payload.Payloads) (*runtime.Result, error) {
+	p.actor, _ = security.GetActor(ctx)
+	p.scope, _ = security.GetScope(ctx)
+	return &runtime.Result{Value: payload.New("ok")}, nil
+}
+
+func (p *securityCapturePool) Start() {}
+func (p *securityCapturePool) Stop()  {}
+func (p *securityCapturePool) Send(*relay.Package) error {
+	return nil
+}
+
+type testSecurityPolicy struct {
+	id       registry.ID
+	decision security.Result
+}
+
+func newSecurityPolicy(id registry.ID, decision security.Result) *testSecurityPolicy {
+	return &testSecurityPolicy{id: id, decision: decision}
+}
+
+func (p *testSecurityPolicy) ID() registry.ID {
+	return p.id
+}
+
+func (p *testSecurityPolicy) Evaluate(security.Actor, string, string, attrs.Bag) security.Result {
+	return p.decision
+}
+
+type testSecurityRegistry struct {
+	policies map[registry.ID]security.Policy
+	groups   map[registry.ID][]security.Policy
+}
+
+func newSecurityRegistry(
+	policies map[registry.ID]security.Policy,
+	groups map[registry.ID][]security.Policy,
+) *testSecurityRegistry {
+	return &testSecurityRegistry{policies: policies, groups: groups}
+}
+
+func (r *testSecurityRegistry) GetPolicy(id registry.ID) (security.Policy, error) {
+	policy, ok := r.policies[id]
+	if !ok {
+		return nil, security.ErrPolicyNotFound
+	}
+	return policy, nil
+}
+
+func (r *testSecurityRegistry) GetPolicyGroup(id registry.ID) (security.Scope, error) {
+	policies, ok := r.groups[id]
+	if !ok {
+		return nil, security.ErrGroupNotFound
+	}
+	return systemsecurity.NewScope(policies), nil
+}
+
+func (r *testSecurityRegistry) ListGroups() []registry.ID {
+	ids := make([]registry.ID, 0, len(r.groups))
+	for id := range r.groups {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (r *testSecurityRegistry) ListPolicies() []registry.ID {
+	ids := make([]registry.ID, 0, len(r.policies))
+	for id := range r.policies {
+		ids = append(ids, id)
+	}
+	return ids
 }

--- a/runtime/lua/component/function/pool.go
+++ b/runtime/lua/component/function/pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/runtime"
 	api "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/api/security"
 	"github.com/wippyai/runtime/api/supervisor"
 	runtimelua "github.com/wippyai/runtime/runtime/lua"
 	"github.com/wippyai/runtime/runtime/lua/engine"
@@ -26,12 +27,13 @@ import (
 	"go.uber.org/zap"
 )
 
-func newPoolEntry(pool funcpool.Pool, method, hostID string) *poolEntry {
+func newPoolEntry(pool funcpool.Pool, method, hostID string, securityConfig *security.Config) *poolEntry {
 	return &poolEntry{
-		pool:    pool,
-		method:  method,
-		hostID:  hostID,
-		drained: make(chan struct{}),
+		pool:     pool,
+		method:   method,
+		hostID:   hostID,
+		security: securityConfig,
+		drained:  make(chan struct{}),
 	}
 }
 
@@ -100,7 +102,7 @@ func (m *Manager) createPool(id registry.ID, cfg *configEntry) error {
 	}
 
 	m.mu.Lock()
-	m.pools[id] = newPoolEntry(pool, cfg.method, hostID)
+	m.pools[id] = newPoolEntry(pool, cfg.method, hostID, cfg.security)
 	m.mu.Unlock()
 
 	return nil
@@ -151,7 +153,7 @@ func (m *Manager) replacePool(id registry.ID, cfg *configEntry) error {
 		}
 	}
 
-	newEntry := newPoolEntry(pool, cfg.method, hostID)
+	newEntry := newPoolEntry(pool, cfg.method, hostID, cfg.security)
 	m.mu.Lock()
 	oldEntry, exists := m.pools[id]
 	m.pools[id] = newEntry

--- a/service/env/composite/manager.go
+++ b/service/env/composite/manager.go
@@ -73,6 +73,11 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 	m.storages[entry.ID] = storage
 	m.mu.Unlock()
 
+	// Register directly in the central registry for synchronous access.
+	if reg := env.GetRegistry(ctx); reg != nil {
+		reg.RegisterStorage(entry.ID, storage)
+	}
+
 	m.bus.Send(ctx, event.Event{
 		System: env.System,
 		Kind:   env.StorageRegister,

--- a/service/env/composite/manager_test.go
+++ b/service/env/composite/manager_test.go
@@ -20,9 +20,13 @@ import (
 
 type mockBus struct {
 	events []event.Event
+	onSend func(context.Context, event.Event)
 }
 
-func (m *mockBus) Send(_ context.Context, e event.Event) {
+func (m *mockBus) Send(ctx context.Context, e event.Event) {
+	if m.onSend != nil {
+		m.onSend(ctx, e)
+	}
 	m.events = append(m.events, e)
 }
 
@@ -165,9 +169,18 @@ func TestManager_Add(t *testing.T) {
 			Meta: attrs.NewBag(),
 			Data: payload.New(nil),
 		}
+		registeredSynchronously := false
+		bus.onSend = func(ctx context.Context, e event.Event) {
+			require.Equal(t, env.StorageRegister, e.Kind)
+			registeredStorage, err := mockReg.GetStorage(ctx, entry.ID)
+			require.NoError(t, err)
+			require.Same(t, e.Data, registeredStorage)
+			registeredSynchronously = true
+		}
 
 		err := mgr.Add(ctx, entry)
 		require.NoError(t, err)
+		require.True(t, registeredSynchronously)
 
 		require.Len(t, bus.events, 1)
 		assert.Equal(t, env.StorageRegister, bus.events[0].Kind)

--- a/service/env/composite/manager_test.go
+++ b/service/env/composite/manager_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 type mockBus struct {
-	events []event.Event
 	onSend func(context.Context, event.Event)
+	events []event.Event
 }
 
 func (m *mockBus) Send(ctx context.Context, e event.Event) {

--- a/system/security/context.go
+++ b/system/security/context.go
@@ -50,7 +50,7 @@ func WithSecurityConfig(ctx context.Context, config *security.Config) context.Co
 	}
 
 	if len(allPolicies) > 0 {
-		var scope security.Scope = NewScope(allPolicies)
+		scope := NewScope(allPolicies)
 		if existing, ok := security.GetScope(ctx); ok && existing != nil {
 			scope = existing
 			for _, policy := range allPolicies {

--- a/system/security/context.go
+++ b/system/security/context.go
@@ -8,14 +8,24 @@ import (
 	"github.com/wippyai/runtime/api/security"
 )
 
+func actorConfigured(actor security.Actor) bool {
+	return actor.ID != "" || len(actor.Meta) > 0
+}
+
 // WithSecurityConfig configures the security context based on the provided configuration.
 func WithSecurityConfig(ctx context.Context, config *security.Config) context.Context {
 	if config == nil {
 		return ctx
 	}
 
-	if err := security.SetActor(ctx, config.Actor); err != nil {
-		return ctx
+	if actorConfigured(config.Actor) {
+		if err := security.SetActor(ctx, config.Actor); err != nil {
+			return ctx
+		}
+	} else if _, ok := security.GetActor(ctx); !ok {
+		if err := security.SetActor(ctx, config.Actor); err != nil {
+			return ctx
+		}
 	}
 
 	reg, ok := security.GetRegistry(ctx)
@@ -40,7 +50,13 @@ func WithSecurityConfig(ctx context.Context, config *security.Config) context.Co
 	}
 
 	if len(allPolicies) > 0 {
-		scope := NewScope(allPolicies)
+		var scope security.Scope = NewScope(allPolicies)
+		if existing, ok := security.GetScope(ctx); ok && existing != nil {
+			scope = existing
+			for _, policy := range allPolicies {
+				scope = scope.With(policy)
+			}
+		}
 		if err := security.SetScope(ctx, scope); err != nil {
 			return ctx
 		}

--- a/system/security/context_test.go
+++ b/system/security/context_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/security"
 	"github.com/wippyai/runtime/system/eventbus"
@@ -50,4 +52,49 @@ func TestWithSecurityConfig(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = security.GetScope(result)
 	assert.False(t, ok)
+}
+
+func TestWithSecurityConfig_PreservesExistingActorWhenConfigHasNoActor(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	t.Cleanup(func() { ctxapi.ReleaseFrameContext(fc) })
+
+	require.NoError(t, security.SetActor(ctx, security.Actor{ID: "caller"}))
+
+	result := WithSecurityConfig(ctx, &security.Config{
+		PolicyGroups: []registry.ID{registry.NewID("test", "group1")},
+	})
+
+	actor, ok := security.GetActor(result)
+	require.True(t, ok)
+	assert.Equal(t, "caller", actor.ID)
+}
+
+func TestWithSecurityConfig_MergesPoliciesIntoExistingScope(t *testing.T) {
+	reg := NewPolicyRegistry(eventbus.NewBus(), nil)
+	existingPolicy := newMockPolicy("existing", security.Allow)
+	addedPolicy := newMockPolicy("added", security.Deny)
+	addedPolicyID := addedPolicy.ID()
+
+	reg.handleEvent(event.Event{
+		Kind: security.PolicyRegister,
+		Path: addedPolicyID.String(),
+		Data: &security.PolicyEntry{Policy: addedPolicy},
+	})
+
+	ctx := security.WithRegistry(ctxapi.NewRootContext(), reg)
+	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	t.Cleanup(func() { ctxapi.ReleaseFrameContext(fc) })
+
+	require.NoError(t, security.SetActor(ctx, security.Actor{ID: "caller"}))
+	require.NoError(t, security.SetScope(ctx, NewScope([]security.Policy{existingPolicy})))
+
+	result := WithSecurityConfig(ctx, &security.Config{
+		Policies: []registry.ID{addedPolicyID},
+	})
+
+	scope, ok := security.GetScope(result)
+	require.True(t, ok)
+	assert.True(t, scope.Contains(existingPolicy.ID()))
+	assert.True(t, scope.Contains(addedPolicyID))
 }


### PR DESCRIPTION
## Summary
- Register `env.storage.router` directly with the central env registry before publishing the `StorageRegister` event.
- Decode and apply `security:` declared on Lua function and bytecode-function configs at execution time.
- Preserve ambient actors and merge declared function policies into the existing scope instead of replacing caller context.

## Why
Kickside exposed two runtime-level contract gaps during strict-security boot:

1. Router-backed env variables can be materialized in the same boot pass as the router storage. Before this change, the composite manager only published an async registration event, so dependent `env.variable` entries could observe `storage not found` and fail permanently depending on event ordering.
2. Packages such as `wippy.facade`, `wippy.views`, and app public-login handlers already declare runtime policies on `function.lua` entries. Upstream runtime decoded no `security` field for Lua funcs, so those handlers ran without their declared policies. The result was empty facade config, `public.js` failures, and login-path failures under the strict model.

Together these make package-declared runtime security deterministic without app-level hardcoded grants.

## Compatibility
- Existing `StorageRegister` event is still emitted unchanged.
- The manager-local router storage cache is unchanged.
- `env.storage.router` now matches the synchronous registration behavior of file, memory, os, and static env storage managers.
- Function `security:` is additive for existing apps: entries without it behave as before.
- Policy-only function configs preserve the ambient actor and merge into existing scope, so user-owned calls do not lose caller identity.

## Tests
- `go test ./service/env/... ./system/env/...`
- `go test ./runtime/lua/component/function ./system/security`
- `go test ./api/env ./api/runtime/lua ./runtime/lua/component/function ./service/env/... ./system/env/... ./system/security ./boot/components/env/...`
- `go test ./runtime/lua/modules/process ./system/contract`
- `go test ./...`
- `make build-wippy-local`

Kickside smoke was validated with the PR-built binary:
- `GET /api/public/facade/config` returned populated facade/env values.
- `GET /api/public/env/public.js` returned populated JS env.
- `GET /` returned `200`.
- `GET /app/login.html` returned `200`.
- Bad login returned `401 Invalid credentials` instead of the previous nil-db `500`.
