### PR TITLE
fix(contract): inherit ambient security on open

### DIFF
--- a/runtime/lua/modules/contract/integration_test.go
+++ b/runtime/lua/modules/contract/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/attrs"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	apicontract "github.com/wippyai/runtime/api/contract"
 	"github.com/wippyai/runtime/api/dispatcher"
@@ -39,6 +40,7 @@ import (
 	sysrelay "github.com/wippyai/runtime/system/relay"
 	"github.com/wippyai/runtime/system/scheduler"
 	"github.com/wippyai/runtime/system/scheduler/actor"
+	securitysys "github.com/wippyai/runtime/system/security"
 	"go.uber.org/zap"
 )
 
@@ -1195,6 +1197,34 @@ func actorReportFunc(ctx context.Context, _ runtime.Task) (*runtime.Result, erro
 	return &runtime.Result{Value: payload.New("actor:" + actor.ID)}, nil
 }
 
+type ambientScopePolicy struct {
+	id registry.ID
+}
+
+func (p ambientScopePolicy) ID() registry.ID { return p.id }
+
+func (p ambientScopePolicy) Evaluate(security.Actor, string, string, attrs.Bag) security.Result {
+	return security.Allow
+}
+
+func actorScopeReportFunc(policyID registry.ID) function.Func {
+	return func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+		actorID := "none"
+		if actor, ok := security.GetActor(ctx); ok {
+			actorID = actor.ID
+		}
+		scopeStatus := "none"
+		if scope, ok := security.GetScope(ctx); ok && scope != nil {
+			if scope.Contains(policyID) {
+				scopeStatus = policyID.String()
+			} else {
+				scopeStatus = "present"
+			}
+		}
+		return &runtime.Result{Value: payload.New("actor:" + actorID + "|scope:" + scopeStatus)}, nil
+	}
+}
+
 // TestIntegration_ActorPropagation asserts that an actor framed on a contract via
 // with_actor() reaches the bound function's execution context. The bound function
 // reads the actor from its ctx and returns its id; the script frames a specific
@@ -1429,6 +1459,98 @@ func TestIntegration_ContractInheritsAmbientActor(t *testing.T) {
 	require.Nil(t, result.Error)
 	require.NotNil(t, result.Value)
 	assert.Equal(t, "actor:ambient-user", string(result.Value.Data().(lua.LString)))
+}
+
+func TestIntegration_DirectOpenInheritsAmbientActorAndScope(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	policyID := registry.NewID("test", "ambient-direct")
+	funcID := registry.NewID("test", "direct_ambient_report")
+	tc.registerFunction(t, funcID, actorScopeReportFunc(policyID))
+
+	contractID := registry.NewID("test", "direct_ambient_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "report"}},
+	})
+
+	bindingID := registry.NewID("test", "direct_ambient_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"report": funcID}},
+		},
+	})
+
+	script := `
+		local instance, err = contract.open("test:direct_ambient_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local result, err = instance:report()
+		if err then
+			return nil, tostring(err)
+		end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	require.NoError(t, security.SetActor(frameCtx, security.Actor{ID: "ambient-direct-user"}))
+	require.NoError(t, security.SetScope(frameCtx, securitysys.NewScope([]security.Policy{
+		ambientScopePolicy{id: policyID},
+	})))
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:ambient-direct-user|scope:"+policyID.String(), string(result.Value.Data().(lua.LString)))
+}
+
+func TestIntegration_ContractOpenInheritsAmbientActorAndScope(t *testing.T) {
+	tc := setupIntegrationTest(t, 4)
+	defer tc.Close(t)
+
+	policyID := registry.NewID("test", "ambient-wrapper")
+	funcID := registry.NewID("test", "wrapper_ambient_report")
+	tc.registerFunction(t, funcID, actorScopeReportFunc(policyID))
+
+	contractID := registry.NewID("test", "wrapper_ambient_service")
+	tc.registerContract(t, contractID, &apicontract.Definition{
+		Methods: []apicontract.MethodDef{{Name: "report"}},
+	})
+
+	bindingID := registry.NewID("test", "wrapper_ambient_impl")
+	tc.registerBinding(t, bindingID, &apicontract.Binding{
+		Contracts: []apicontract.BoundContract{
+			{Contract: contractID, Methods: map[string]registry.ID{"report": funcID}},
+		},
+	})
+
+	script := `
+		local instance, err = contract.get("test:wrapper_ambient_service"):open("test:wrapper_ambient_impl")
+		if err then
+			return nil, tostring(err)
+		end
+		local result, err = instance:report()
+		if err then
+			return nil, tostring(err)
+		end
+		return result
+	`
+
+	frameCtx, _ := ctxapi.OpenFrameContext(tc.ctx)
+	require.NoError(t, security.SetActor(frameCtx, security.Actor{ID: "ambient-wrapper-user"}))
+	require.NoError(t, security.SetScope(frameCtx, securitysys.NewScope([]security.Policy{
+		ambientScopePolicy{id: policyID},
+	})))
+	proc := newLuaProcessWithSecurity(t, script)
+
+	result, err := tc.scheduler.Execute(frameCtx, uniqueTestPID(), proc, "", nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Error)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "actor:ambient-wrapper-user|scope:"+policyID.String(), string(result.Value.Data().(lua.LString)))
 }
 
 // TestIntegration_ActorPropagation_AsyncCall asserts the framed actor also reaches

--- a/runtime/lua/modules/contract/module.go
+++ b/runtime/lua/modules/contract/module.go
@@ -3,6 +3,7 @@
 package contract
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -102,6 +103,24 @@ type InstanceWrapper struct {
 	instance   contract.Instance
 	options    attrs.Bag
 	hasOptions bool
+}
+
+func applyOpenSecurityContext(ctx context.Context, yield *OpenYield, actor secapi.Actor, hasActor bool, scope secapi.Scope, hasScope bool) {
+	if hasActor {
+		yield.Actor = actor
+		yield.HasActor = true
+	} else if ambientActor, ok := secapi.GetActor(ctx); ok {
+		yield.Actor = ambientActor
+		yield.HasActor = true
+	}
+
+	if hasScope {
+		yield.SecurityScope = scope
+		yield.HasScope = true
+	} else if ambientScope, ok := secapi.GetScope(ctx); ok {
+		yield.SecurityScope = ambientScope
+		yield.HasScope = true
+	}
 }
 
 // parseBindingID parses a binding ID with optional query parameters.
@@ -242,6 +261,7 @@ func openBinding(l *lua.LState) int {
 	yield.Scope = scope
 	yield.options = options
 	yield.hasOptions = hasOptions
+	applyOpenSecurityContext(l.Context(), yield, secapi.Actor{}, false, nil, false)
 
 	l.Push(yield)
 	return -1
@@ -464,12 +484,9 @@ func contractOpen(l *lua.LState) int {
 	yield.BindingID = registry.ParseID(bindingID)
 	yield.Scope = scope
 	yield.Values = wrapper.values
-	yield.Actor = wrapper.actor
-	yield.HasActor = wrapper.hasActor
-	yield.SecurityScope = wrapper.scope
-	yield.HasScope = wrapper.hasScope
 	yield.options = wrapper.options
 	yield.hasOptions = wrapper.hasOptions
+	applyOpenSecurityContext(l.Context(), yield, wrapper.actor, wrapper.hasActor, wrapper.scope, wrapper.hasScope)
 
 	l.Push(yield)
 	return -1

--- a/runtime/lua/modules/contract/module_test.go
+++ b/runtime/lua/modules/contract/module_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/contract"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/runtime"
+	secapi "github.com/wippyai/runtime/api/security"
 )
 
 type mockInstanceForTest struct {
@@ -25,6 +27,30 @@ func (m *mockInstanceForTest) ID() registry.ID                 { return m.id }
 func (m *mockInstanceForTest) Implements() []contract.Contract { return m.contracts }
 func (m *mockInstanceForTest) Call(_ context.Context, _ string, _ payload.Payloads, _ runtime.Options) (*runtime.Result, error) {
 	return nil, nil
+}
+
+type mockSecurityScopeForContractTest struct {
+	id registry.ID
+}
+
+func (m *mockSecurityScopeForContractTest) With(secapi.Policy) secapi.Scope {
+	return m
+}
+
+func (m *mockSecurityScopeForContractTest) Without(registry.ID) secapi.Scope {
+	return m
+}
+
+func (m *mockSecurityScopeForContractTest) Evaluate(secapi.Actor, string, string, attrs.Bag) secapi.Result {
+	return secapi.Allow
+}
+
+func (m *mockSecurityScopeForContractTest) Contains(policyID registry.ID) bool {
+	return policyID == m.id
+}
+
+func (m *mockSecurityScopeForContractTest) Policies() []secapi.Policy {
+	return nil
 }
 
 func TestModule_Info(t *testing.T) {
@@ -78,6 +104,50 @@ func TestOpenYield_ToCommand(t *testing.T) {
 	assert.Equal(t, "ns", openCmd.BindingID.NS)
 	assert.Equal(t, "binding", openCmd.BindingID.Name)
 	assert.Equal(t, "bar", openCmd.Scope["foo"])
+}
+
+func TestApplyOpenSecurityContext_InheritsAmbientSecurity(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	defer ctxapi.ReleaseFrameContext(fc)
+
+	actor := secapi.Actor{ID: "caller"}
+	scope := &mockSecurityScopeForContractTest{id: registry.NewID("test", "ambient")}
+	require.NoError(t, secapi.SetActor(ctx, actor))
+	require.NoError(t, secapi.SetScope(ctx, scope))
+
+	y := AcquireOpenYield()
+	defer ReleaseOpenYield(y)
+
+	applyOpenSecurityContext(ctx, y, secapi.Actor{}, false, nil, false)
+
+	require.True(t, y.HasActor)
+	assert.Equal(t, actor, y.Actor)
+	require.True(t, y.HasScope)
+	assert.Same(t, scope, y.SecurityScope)
+}
+
+func TestApplyOpenSecurityContext_ExplicitSecurityOverridesAmbient(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	ctx, fc := ctxapi.OpenFrameContext(ctx)
+	defer ctxapi.ReleaseFrameContext(fc)
+
+	ambientActor := secapi.Actor{ID: "ambient"}
+	ambientScope := &mockSecurityScopeForContractTest{id: registry.NewID("test", "ambient")}
+	require.NoError(t, secapi.SetActor(ctx, ambientActor))
+	require.NoError(t, secapi.SetScope(ctx, ambientScope))
+
+	explicitActor := secapi.Actor{ID: "explicit"}
+	explicitScope := &mockSecurityScopeForContractTest{id: registry.NewID("test", "explicit")}
+	y := AcquireOpenYield()
+	defer ReleaseOpenYield(y)
+
+	applyOpenSecurityContext(ctx, y, explicitActor, true, explicitScope, true)
+
+	require.True(t, y.HasActor)
+	assert.Equal(t, explicitActor, y.Actor)
+	require.True(t, y.HasScope)
+	assert.Same(t, explicitScope, y.SecurityScope)
 }
 
 func TestOpenYield_CmdID(t *testing.T) {


### PR DESCRIPTION
## Summary
- inherit ambient actor/scope when opening contracts without explicit with_actor/with_scope
- apply the same fallback to both contract.open(binding) and contract.get(...):open(binding)
- keep explicit wrapper actor/scope taking precedence over ambient context

## Tests
- go test ./runtime/lua/modules/contract ./system/contract
- ./test.sh
