### PR TITLE
fix(sql): apply env-backed database updates live

### DIFF
--- a/service/sql/conn.go
+++ b/service/sql/conn.go
@@ -23,12 +23,102 @@ import (
 // ConnPool represents a database connection pool that acts both as a service
 // and a resource provider
 type ConnPool struct {
-	db     *sql.DB
-	status chan any
-	config atomic.Pointer[any]
-	kind   registry.Kind
-	wg     sync.WaitGroup
-	closed atomic.Bool
+	db      *sql.DB
+	current *dbGeneration
+	status  chan any
+	config  atomic.Pointer[any]
+	kind    registry.Kind
+	mu      sync.RWMutex
+	wg      sync.WaitGroup
+	closed  atomic.Bool
+}
+
+type dbGeneration struct {
+	db       *sql.DB
+	closed   chan struct{}
+	closeErr error
+	closeMu  sync.Mutex
+	once     sync.Once
+	refs     atomic.Int32
+	closing  atomic.Bool
+}
+
+func newDBGeneration(db *sql.DB) *dbGeneration {
+	return &dbGeneration{
+		db:     db,
+		closed: make(chan struct{}),
+	}
+}
+
+func (g *dbGeneration) acquire() bool {
+	if g == nil || g.closing.Load() {
+		return false
+	}
+	g.refs.Add(1)
+	if g.closing.Load() {
+		g.release()
+		return false
+	}
+	return true
+}
+
+func (g *dbGeneration) release() {
+	if g == nil {
+		return
+	}
+	if g.refs.Add(-1) == 0 && g.closing.Load() {
+		g.closeNow()
+	}
+}
+
+func (g *dbGeneration) closeWhenIdle() {
+	if g == nil {
+		return
+	}
+	g.closing.Store(true)
+	if g.refs.Load() == 0 {
+		g.closeNow()
+	}
+}
+
+func (g *dbGeneration) closeNow() {
+	g.once.Do(func() {
+		g.closeMu.Lock()
+		g.closeErr = g.db.Close()
+		g.closeMu.Unlock()
+		close(g.closed)
+	})
+}
+
+func (g *dbGeneration) waitClosed(ctx context.Context) error {
+	if g == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-g.closed:
+		g.closeMu.Lock()
+		err := g.closeErr
+		g.closeMu.Unlock()
+		return err
+	}
+}
+
+func (p *ConnPool) currentGeneration() *dbGeneration {
+	p.mu.RLock()
+	gen := p.current
+	p.mu.RUnlock()
+	if gen != nil {
+		return gen
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.current == nil && p.db != nil {
+		p.current = newDBGeneration(p.db)
+	}
+	return p.current
 }
 
 // Start implements supervisor.Service
@@ -37,8 +127,13 @@ func (p *ConnPool) Start(ctx context.Context) (<-chan any, error) {
 		return nil, ErrPoolClosed
 	}
 
+	gen := p.currentGeneration()
+	if gen == nil {
+		return nil, ErrPoolClosed
+	}
+
 	// Test connection
-	if err := p.db.PingContext(ctx); err != nil {
+	if err := gen.db.PingContext(ctx); err != nil {
 		return nil, NewPingError(err)
 	}
 
@@ -69,7 +164,16 @@ func (p *ConnPool) Stop(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-done:
-		return p.db.Close()
+		p.mu.Lock()
+		if p.current == nil && p.db != nil {
+			p.current = newDBGeneration(p.db)
+		}
+		gen := p.current
+		p.current = nil
+		p.db = nil
+		p.mu.Unlock()
+		gen.closeWhenIdle()
+		return gen.waitClosed(ctx)
 	}
 }
 
@@ -89,9 +193,29 @@ func (p *ConnPool) UpdateConfig(cfg any) error {
 			return NewInvalidConfigError(err)
 		}
 
-		p.db.SetMaxOpenConns(c.Pool.MaxOpen)
-		p.db.SetMaxIdleConns(c.Pool.MaxIdle)
-		p.db.SetConnMaxLifetime(c.Pool.MaxLifetime)
+		newDB, err := openStandardDB(p.kind, c)
+		if err != nil {
+			return err
+		}
+
+		newGen := newDBGeneration(newDB)
+		p.mu.Lock()
+		if p.closed.Load() {
+			p.mu.Unlock()
+			_ = newDB.Close()
+			return ErrPoolClosed
+		}
+		oldGen := p.current
+		if oldGen == nil && p.db != nil {
+			oldGen = newDBGeneration(p.db)
+		}
+		p.current = newGen
+		p.db = newDB
+		p.mu.Unlock()
+
+		if oldGen != nil {
+			oldGen.closeWhenIdle()
+		}
 
 		var cfg any = c
 		p.config.Store(&cfg)
@@ -105,7 +229,11 @@ func (p *ConnPool) UpdateConfig(cfg any) error {
 			return NewInvalidConfigError(err)
 		}
 
-		p.db.SetConnMaxLifetime(c.Pool.MaxLifetime)
+		gen := p.currentGeneration()
+		if gen == nil {
+			return ErrPoolClosed
+		}
+		gen.db.SetConnMaxLifetime(c.Pool.MaxLifetime)
 
 		var cfg any = c
 		p.config.Store(&cfg)
@@ -136,7 +264,37 @@ func (p *ConnPool) Acquire(
 		return nil, ErrPoolClosed
 	}
 
-	return newDBConn(p, p.db, p.kind), nil
+	for {
+		gen := p.currentGeneration()
+		if gen == nil {
+			p.wg.Done()
+			return nil, ErrPoolClosed
+		}
+		if gen.acquire() {
+			return newDBConn(p, gen, p.kind), nil
+		}
+		if p.closed.Load() {
+			p.wg.Done()
+			return nil, ErrPoolClosed
+		}
+	}
+}
+
+func openStandardDB(kind registry.Kind, cfg *config.DBConfig) (*sql.DB, error) {
+	dsn, err := buildDSN(kind, cfg)
+	if err != nil {
+		return nil, NewInvalidDSNError(err)
+	}
+
+	db, err := sql.Open(getDriver(kind), dsn)
+	if err != nil {
+		return nil, NewConnectionPoolCreationError(err)
+	}
+
+	db.SetMaxOpenConns(cfg.Pool.MaxOpen)
+	db.SetMaxIdleConns(cfg.Pool.MaxIdle)
+	db.SetConnMaxLifetime(cfg.Pool.MaxLifetime)
+	return db, nil
 }
 
 // Helper to build DSN string for different database types
@@ -279,7 +437,7 @@ func buildOptionsString(options map[string]string) string {
 // DBConn represents a database connection resource
 type DBConn struct {
 	pool     *ConnPool
-	db       *sql.DB
+	gen      *dbGeneration
 	dbType   registry.Kind
 	released atomic.Bool
 }
@@ -291,10 +449,10 @@ type DBResource struct {
 }
 
 // newDBConn creates a new database resource
-func newDBConn(pool *ConnPool, db *sql.DB, dbType registry.Kind) *DBConn {
+func newDBConn(pool *ConnPool, gen *dbGeneration, dbType registry.Kind) *DBConn {
 	return &DBConn{
 		pool:   pool,
-		db:     db,
+		gen:    gen,
 		dbType: dbType,
 	}
 }
@@ -307,7 +465,7 @@ func (r *DBConn) Get() (any, error) {
 
 	// Return both the DB and its type
 	return DBResource{
-		DB:   r.db,
+		DB:   r.gen.db,
 		Type: r.dbType,
 	}, nil
 }
@@ -319,5 +477,6 @@ func (r *DBConn) Release() {
 		return
 	}
 
+	r.gen.release()
 	r.pool.wg.Done()
 }

--- a/service/sql/conn_test.go
+++ b/service/sql/conn_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/stretchr/testify/assert"
@@ -303,6 +304,63 @@ func TestConnPool_UpdateConfigAfterClose(t *testing.T) {
 	err = pool.UpdateConfig(newCfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "closed")
+}
+
+func TestConnPool_UpdateConfigKeepsCurrentDBOnInvalidStandardConfig(t *testing.T) {
+	pool := NewMockConnPool(apiconfig.Postgres)
+	ctx := context.Background()
+	defer func() { _ = pool.Stop(ctx) }()
+
+	oldDB := pool.currentGeneration().db
+
+	err := pool.UpdateConfig(&apiconfig.DBConfig{
+		Host:     "",
+		Port:     5432,
+		Database: "db",
+		Username: "user",
+		Password: "pass",
+		Pool:     apiconfig.PoolConfig{MaxLifetime: time.Hour},
+	})
+	require.Error(t, err)
+	assert.Same(t, oldDB, pool.currentGeneration().db)
+	require.NoError(t, oldDB.PingContext(ctx))
+}
+
+func TestConnPool_UpdateConfigSwapsStandardDBAndRetiresOldAfterRelease(t *testing.T) {
+	pool := NewMockConnPool(apiconfig.Postgres)
+	ctx := context.Background()
+
+	res, err := pool.Acquire(ctx, testID, resource.ModeNormal)
+	require.NoError(t, err)
+
+	oldResource, err := res.Get()
+	require.NoError(t, err)
+	oldDB := oldResource.(DBResource).DB
+
+	newCfg := &apiconfig.DBConfig{
+		Host:     "updated-host",
+		Port:     5432,
+		Database: "updated-db",
+		Username: "updated-user",
+		Password: "updated-pass",
+		Pool:     apiconfig.PoolConfig{MaxOpen: 7, MaxIdle: 3, MaxLifetime: time.Hour},
+	}
+
+	require.NoError(t, pool.UpdateConfig(newCfg))
+	require.NotSame(t, oldDB, pool.db)
+
+	stillBorrowed, err := res.Get()
+	require.NoError(t, err)
+	assert.Same(t, oldDB, stillBorrowed.(DBResource).DB)
+	require.NoError(t, oldDB.PingContext(ctx))
+
+	res.Release()
+
+	require.Eventually(t, func() bool {
+		return oldDB.PingContext(ctx) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, pool.Stop(ctx))
 }
 
 func TestBuildDSN(t *testing.T) {

--- a/service/sql/factory.go
+++ b/service/sql/factory.go
@@ -33,25 +33,16 @@ func (f *DefaultPoolFactory) CreateStandardPool(_ context.Context, kind registry
 		return nil, NewInvalidConfigError(err)
 	}
 
-	dsn, err := buildDSN(kind, cfg)
+	db, err := openStandardDB(kind, cfg)
 	if err != nil {
-		return nil, NewInvalidDSNError(err)
+		return nil, err
 	}
-
-	db, err := sql.Open(getDriver(kind), dsn)
-	if err != nil {
-		return nil, NewConnectionPoolCreationError(err)
-	}
-
-	// Configure pool settings
-	db.SetMaxOpenConns(cfg.Pool.MaxOpen)
-	db.SetMaxIdleConns(cfg.Pool.MaxIdle)
-	db.SetConnMaxLifetime(cfg.Pool.MaxLifetime)
 
 	pool := &ConnPool{
-		kind:   kind,
-		db:     db,
-		status: make(chan any, 1),
+		kind:    kind,
+		db:      db,
+		current: newDBGeneration(db),
+		status:  make(chan any, 1),
 	}
 
 	var cfgAny any = cfg
@@ -93,9 +84,10 @@ func (f *DefaultPoolFactory) CreateSQLitePool(ctx context.Context, cfg *config.S
 	db.SetConnMaxLifetime(cfg.Pool.MaxLifetime)
 
 	pool := &ConnPool{
-		kind:   config.SQLite,
-		db:     db,
-		status: make(chan any, 1),
+		kind:    config.SQLite,
+		db:      db,
+		current: newDBGeneration(db),
+		status:  make(chan any, 1),
 	}
 
 	var cfgAny any = cfg

--- a/service/sql/manager.go
+++ b/service/sql/manager.go
@@ -120,33 +120,8 @@ func (m *Manager) handleStandardDBAdd(ctx context.Context, entry registry.Entry)
 		return NewInvalidConfigError(err)
 	}
 
-	if v, rerr := m.resolveEnv(ctx, cfg.HostEnv, "host"); rerr != nil {
-		return rerr
-	} else if v != "" {
-		cfg.Host = v
-	}
-	if v, rerr := m.resolveEnv(ctx, cfg.PortEnv, "port"); rerr != nil {
-		return rerr
-	} else if v != "" {
-		cfg.Port, err = strconv.Atoi(v)
-		if err != nil {
-			return NewInvalidPortError(cfg.PortEnv, err)
-		}
-	}
-	if v, rerr := m.resolveEnv(ctx, cfg.DatabaseEnv, "database"); rerr != nil {
-		return rerr
-	} else if v != "" {
-		cfg.Database = v
-	}
-	if v, rerr := m.resolveEnv(ctx, cfg.UsernameEnv, "username"); rerr != nil {
-		return rerr
-	} else if v != "" {
-		cfg.Username = v
-	}
-	if v, rerr := m.resolveEnv(ctx, cfg.PasswordEnv, "password"); rerr != nil {
-		return rerr
-	} else if v != "" {
-		cfg.Password = v
+	if err := m.resolveDBConfigEnv(ctx, cfg); err != nil {
+		return err
 	}
 
 	pool, err := m.factory.CreateStandardPool(ctx, entry.Kind, cfg)
@@ -184,6 +159,10 @@ func (m *Manager) handleStandardDBUpdate(ctx context.Context, entry registry.Ent
 	cfg, err := entryutil.DecodeEntryConfig[config.DBConfig](ctx, m.dtt, entry)
 	if err != nil {
 		return NewInvalidConfigError(err)
+	}
+
+	if err := m.resolveDBConfigEnv(ctx, cfg); err != nil {
+		return err
 	}
 
 	if err := pool.UpdateConfig(cfg); err != nil {
@@ -293,6 +272,39 @@ func (m *Manager) unregisterService(ctx context.Context, entry registry.Entry) {
 
 	m.log.Info("removed database service",
 		zap.String("id", entry.ID.String()))
+}
+
+func (m *Manager) resolveDBConfigEnv(ctx context.Context, cfg *config.DBConfig) error {
+	var err error
+	if v, rerr := m.resolveEnv(ctx, cfg.HostEnv, "host"); rerr != nil {
+		return rerr
+	} else if v != "" {
+		cfg.Host = v
+	}
+	if v, rerr := m.resolveEnv(ctx, cfg.PortEnv, "port"); rerr != nil {
+		return rerr
+	} else if v != "" {
+		cfg.Port, err = strconv.Atoi(v)
+		if err != nil {
+			return NewInvalidPortError(cfg.PortEnv, err)
+		}
+	}
+	if v, rerr := m.resolveEnv(ctx, cfg.DatabaseEnv, "database"); rerr != nil {
+		return rerr
+	} else if v != "" {
+		cfg.Database = v
+	}
+	if v, rerr := m.resolveEnv(ctx, cfg.UsernameEnv, "username"); rerr != nil {
+		return rerr
+	} else if v != "" {
+		cfg.Username = v
+	}
+	if v, rerr := m.resolveEnv(ctx, cfg.PasswordEnv, "password"); rerr != nil {
+		return rerr
+	} else if v != "" {
+		cfg.Password = v
+	}
+	return nil
 }
 
 func (m *Manager) resolveEnv(ctx context.Context, envVar, field string) (string, error) {

--- a/service/sql/manager_test.go
+++ b/service/sql/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/stretchr/testify/assert"
@@ -746,6 +747,87 @@ func TestManager_AddWithEnvVars(t *testing.T) {
 	assert.Equal(t, "env-db", applied.Database)
 	assert.Equal(t, "env-user", applied.Username)
 	assert.Equal(t, "env-pass", applied.Password)
+}
+
+func TestManager_UpdateWithEnvVars(t *testing.T) {
+	manager, _, _ := newTestManager(t)
+	ctx := ctxapi.NewRootContext()
+	id := registry.NewID("test", "env-update-db")
+
+	require.NoError(t, manager.Add(ctx, registry.Entry{
+		ID:   id,
+		Kind: apiconfig.Postgres,
+		Data: payload.New(map[string]string{"test": "data"}),
+	}))
+
+	envRegistry := NewMockEnvRegistry()
+	require.NoError(t, envRegistry.Set(ctx, "DB_HOST", "updated-host"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_PORT", "6543"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_NAME", "updated-db"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_USER", "updated-user"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_PASS", "updated-pass"))
+	manager.env = envRegistry
+	manager.dtt = &EnvConfigTranscoder{}
+
+	require.NoError(t, manager.Update(ctx, registry.Entry{
+		ID:   id,
+		Kind: apiconfig.Postgres,
+		Data: payload.New(map[string]string{"updated": "config"}),
+	}))
+
+	applied := currentPoolDBConfig(t, manager.services[id])
+	assert.Equal(t, "updated-host", applied.Host)
+	assert.Equal(t, 6543, applied.Port)
+	assert.Equal(t, "updated-db", applied.Database)
+	assert.Equal(t, "updated-user", applied.Username)
+	assert.Equal(t, "updated-pass", applied.Password)
+	require.NoError(t, manager.services[id].Stop(ctx))
+}
+
+func TestManager_UpdateWithUnresolvableEnvDoesNotMutatePool(t *testing.T) {
+	manager, _, _ := newTestManager(t)
+	ctx := ctxapi.NewRootContext()
+	id := registry.NewID("test", "env-update-fail-db")
+
+	require.NoError(t, manager.Add(ctx, registry.Entry{
+		ID:   id,
+		Kind: apiconfig.Postgres,
+		Data: payload.New(map[string]string{"test": "data"}),
+	}))
+	before := currentPoolDBConfig(t, manager.services[id])
+
+	envRegistry := NewMockEnvRegistry()
+	require.NoError(t, envRegistry.Set(ctx, "DB_HOST", "updated-host"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_PORT", "6543"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_NAME", "updated-db"))
+	require.NoError(t, envRegistry.Set(ctx, "DB_PASS", "updated-pass"))
+	manager.env = envRegistry
+	manager.dtt = &UnresolvableEnvConfigTranscoder{}
+
+	err := manager.Update(ctx, registry.Entry{
+		ID:   id,
+		Kind: apiconfig.Postgres,
+		Data: payload.New(map[string]string{"updated": "config"}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be resolved")
+
+	after := currentPoolDBConfig(t, manager.services[id])
+	assert.Equal(t, before.Host, after.Host)
+	assert.Equal(t, before.Port, after.Port)
+	assert.Equal(t, before.Database, after.Database)
+	assert.Equal(t, before.Username, after.Username)
+	assert.Equal(t, before.Password, after.Password)
+	require.NoError(t, manager.services[id].Stop(ctx))
+}
+
+func currentPoolDBConfig(t *testing.T, pool *ConnPool) *apiconfig.DBConfig {
+	t.Helper()
+	raw := pool.config.Load()
+	require.NotNil(t, raw)
+	cfg, ok := (*raw).(*apiconfig.DBConfig)
+	require.True(t, ok)
+	return cfg
 }
 
 // EnvConfigTranscoder returns a config with env var fields set

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,15 @@ for arg in "$@"; do
 	esac
 done
 
-go test ./api/service/cdc ./service/cdc/postgres ./runtime/lua/modules/cdc ./boot/components/dispatchers
+go test \
+	./api/service/cdc \
+	./api/service/sql \
+	./system/env/... \
+	./service/env/... \
+	./service/sql/... \
+	./service/cdc/postgres \
+	./runtime/lua/modules/cdc \
+	./boot/components/dispatchers
 
 if [[ -n "${WIPPY_CDC_IT_REPL_DSN:-}" && -n "${WIPPY_CDC_IT_ADMIN_DSN:-}" ]]; then
 	go test -tags integration ./service/cdc/postgres


### PR DESCRIPTION
## Summary
- resolve SQL *_env fields during update as well as add
- swap standard SQL pools to a new DB handle on connection config updates
- keep existing borrowed DB handles alive until release, then retire them
- expand test.sh to cover env and SQL surfaces touched by #367

## Verification
- make lint
- ./test.sh
- go test -count=1 ./system/env/... ./service/env/... ./service/sql/... ./service/cdc/postgres/... ./api/service/sql ./api/service/cdc ./runtime/lua/modules/cdc ./boot/components/dispatchers
- go test -race -count=1 ./service/sql

Note: ./test.sh ran CDC integration compile checks only because WIPPY_CDC_IT_REPL_DSN/WIPPY_CDC_IT_ADMIN_DSN are unset.