### PR TITLE
fix(deps): bump wasm-runtime to ship reactor start-shim fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4
 	github.com/wippyai/wapp v0.1.2
-	github.com/wippyai/wasm-runtime v0.0.0-20260621204001-8eab7f42df1b
+	github.com/wippyai/wasm-runtime v0.0.0-20260623160937-4f371ee0f68a
 	github.com/xuri/excelize/v2 v2.10.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/wippyai/tree-sitter-sql v0.0.4 h1:0hJyjkV6/lhoGA5FJAaf96od2xyo+OJINSE
 github.com/wippyai/tree-sitter-sql v0.0.4/go.mod h1:QN9CfIO55fwQNVNk1p/7pjxrLk7iKxrQs42Zh6lrr84=
 github.com/wippyai/wapp v0.1.2 h1:fCoxKr9s3gk+pWx4XcnIQmOVgPiuimXf3QcE9mHbdmw=
 github.com/wippyai/wapp v0.1.2/go.mod h1:ndCkYR80+osLGbd7AFWlP+3DxwooR+R6cxQYPZhksg4=
-github.com/wippyai/wasm-runtime v0.0.0-20260621204001-8eab7f42df1b h1:/BeP9g3dy0dfVPCrWPUbUC3USj/2U25Pltz7xGr+C5M=
-github.com/wippyai/wasm-runtime v0.0.0-20260621204001-8eab7f42df1b/go.mod h1:1AVYdZibORqlBez081Seakxv2u9IR+KIMrvlBKsk2bQ=
+github.com/wippyai/wasm-runtime v0.0.0-20260623160937-4f371ee0f68a h1:hNZ5ujZpmQgWlvk9mCaN1Dzvdq2wokrGUVJ8w4OG+Zc=
+github.com/wippyai/wasm-runtime v0.0.0-20260623160937-4f371ee0f68a/go.mod h1:1AVYdZibORqlBez081Seakxv2u9IR+KIMrvlBKsk2bQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
## Why
C/C++ `wasm32-wasip2` reactor components (e.g. the `html2pdf` module) failed to instantiate because the linker could not wire the wit-component start-shim's empty-named import. [wasm-runtime#6](https://github.com/wippyai/wasm-runtime/pull/6) fixes the linker; the runtime must pin the merged commit to ship the fix.

## What
Bump `github.com/wippyai/wasm-runtime` to `v0.0.0-20260623160937-4f371ee0f68a` (merge commit `4f371ee0`) and drop the local `replace` directive used for pre-merge development.

## Testing
- `go build ./...` clean; `make build-wippy` produces the binary (CGO, `fts5 sqlite_vec treesitter`).
- All wasm/linker test packages pass with build tags.
- `go mod verify` clean; `go vet ./runtime/wasm/...` clean.