### PR TITLE
feat(eval): per-import privilege grants and LRU compile cache

### DIFF
--- a/boot/components/runtime/lua/eval.go
+++ b/boot/components/runtime/lua/eval.go
@@ -5,6 +5,7 @@ package lua
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/wippyai/runtime/api/boot"
 	dispatcherapi "github.com/wippyai/runtime/api/dispatcher"
@@ -13,6 +14,9 @@ import (
 	"github.com/wippyai/runtime/boot/components/dispatchers"
 	"github.com/wippyai/runtime/runtime/lua/evalhost"
 )
+
+// defaultEvalCacheSize bounds the eval compile cache when not configured.
+const defaultEvalCacheSize = 256
 
 const EvalHostName boot.Name = "runtime.lua.eval"
 
@@ -34,11 +38,26 @@ func Eval() boot.Component {
 				return ctx, ErrCodeManagerNotFound
 			}
 
+			// Resolve compile-cache settings (bounds recompilation of frequently
+			// evaluated source).
+			evalCacheSize := defaultEvalCacheSize
+			var evalCacheTTL time.Duration
+			if cfg := boot.GetConfig(ctx); cfg != nil {
+				if luaCfg := cfg.Sub("lua"); luaCfg != nil {
+					evalCacheSize = luaCfg.GetInt("eval.cache_size", evalCacheSize)
+					evalCacheTTL = luaCfg.GetDuration("eval.cache_ttl", evalCacheTTL)
+				}
+			}
+
 			// Create eval host with dynamic module provider
 			evalLogger := logger.Named("eval")
 			host := evalhost.NewHost(
 				evalLogger,
 				cm.GetModuleDefs,
+				evalhost.WithProgramCache(evalhost.HostConfig{
+					CacheSize: evalCacheSize,
+					CacheTTL:  evalCacheTTL,
+				}),
 			)
 
 			// Set up import loader to load library sources from code manager

--- a/runtime/lua/evalhost/cache_bench_test.go
+++ b/runtime/lua/evalhost/cache_bench_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package evalhost
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// makeEvalSources returns n distinct eval programs so each has its own compile
+// key.
+func makeEvalSources(n int) []RunCmd {
+	cmds := make([]RunCmd, n)
+	for i := range n {
+		cmds[i] = RunCmd{
+			Source:  fmt.Sprintf(`return { run = function() return %d * 2 + 1 end }`, i),
+			Method:  "run",
+			Modules: []string{"json"},
+		}
+	}
+	return cmds
+}
+
+// benchEvalRun runs full eval (compile + process + execute) cycling through 60
+// distinct programs. cacheSize 0 disables the compile cache.
+func benchEvalRun(b *testing.B, cacheSize int) {
+	var opts []HostOption
+	if cacheSize > 0 {
+		opts = append(opts, WithProgramCache(HostConfig{CacheSize: cacheSize}))
+	}
+	host := NewHost(zap.NewNop(), safeModulesProvider(), opts...)
+	cmds := makeEvalSources(60)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := host.Run(ctx, cmds[i%len(cmds)]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvalRun_60Codes_Cached(b *testing.B)   { benchEvalRun(b, 64) }
+func BenchmarkEvalRun_60Codes_Uncached(b *testing.B) { benchEvalRun(b, 0) }
+
+// benchEvalCompile isolates the compile path (no process/execute) to show the
+// raw compile-cache effect.
+func benchEvalCompile(b *testing.B, cacheSize int) {
+	var opts []HostOption
+	if cacheSize > 0 {
+		opts = append(opts, WithProgramCache(HostConfig{CacheSize: cacheSize}))
+	}
+	host := NewHost(zap.NewNop(), safeModulesProvider(), opts...)
+	runCmds := makeEvalSources(60)
+	cmds := make([]CompileCmd, len(runCmds))
+	for i, rc := range runCmds {
+		cmds[i] = CompileCmd{Source: rc.Source, Method: rc.Method, Modules: rc.Modules}
+	}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := host.Compile(ctx, cmds[i%len(cmds)]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEvalCompile_60Codes_Cached(b *testing.B)   { benchEvalCompile(b, 64) }
+func BenchmarkEvalCompile_60Codes_Uncached(b *testing.B) { benchEvalCompile(b, 0) }

--- a/runtime/lua/evalhost/cache_test.go
+++ b/runtime/lua/evalhost/cache_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package evalhost
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/registry"
+	"go.uber.org/zap"
+)
+
+func TestHost_CompileCache_ReusesProgram(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+
+	cmd := CompileCmd{
+		Source:  `return { f = function() return 1 end }`,
+		Method:  "f",
+		Modules: []string{"json"},
+	}
+
+	p1, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	p2, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	assert.Same(t, p1, p2, "identical source must be served from the compile cache")
+
+	// Different source recompiles to a distinct program.
+	p3, err := host.Compile(context.Background(), CompileCmd{
+		Source:  `return { f = function() return 2 end }`,
+		Method:  "f",
+		Modules: []string{"json"},
+	})
+	require.NoError(t, err)
+	assert.NotSame(t, p1, p3, "different source must not reuse a cached program")
+
+	// A different module set is a different compile key.
+	p4, err := host.Compile(context.Background(), CompileCmd{
+		Source:  cmd.Source,
+		Method:  cmd.Method,
+		Modules: []string{"json", "time"},
+	})
+	require.NoError(t, err)
+	assert.NotSame(t, p1, p4, "different modules must not reuse a cached program")
+}
+
+func TestHost_CompileCache_DisabledRecompiles(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider())
+
+	cmd := CompileCmd{
+		Source:  `return { f = function() return 1 end }`,
+		Method:  "f",
+		Modules: []string{"json"},
+	}
+
+	p1, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	p2, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	assert.NotSame(t, p1, p2, "with caching disabled every compile must produce a fresh program")
+}
+
+func TestHost_CompileCache_ZeroSizeDisabled(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 0}))
+	assert.Nil(t, host.programCache, "a zero cache size must leave caching disabled")
+}
+
+func TestHost_CompileCache_KeyDistinguishesMethod(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+	src := `return { a = function() return 1 end, b = function() return 2 end }`
+
+	pa, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "a", Modules: []string{"json"}})
+	require.NoError(t, err)
+	pb, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "b", Modules: []string{"json"}})
+	require.NoError(t, err)
+	assert.NotSame(t, pa, pb, "different method must be a different compile key")
+}
+
+func TestHost_CompileCache_KeyDistinguishesAllowClasses(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+	src := `return { f = function() return 1 end }`
+
+	p1, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "f", Modules: []string{"json"}})
+	require.NoError(t, err)
+	p2, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "f", Modules: []string{"json"}, AllowClasses: []string{"time"}})
+	require.NoError(t, err)
+	assert.NotSame(t, p1, p2, "different allow_classes must be a different compile key")
+}
+
+func TestHost_CompileCache_OrderIndependentKeys(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+	src := `return { f = function() return 1 end }`
+
+	p1, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "f", Modules: []string{"json", "time"}, AllowClasses: []string{"time", "encoding"}})
+	require.NoError(t, err)
+	p2, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "f", Modules: []string{"time", "json"}, AllowClasses: []string{"encoding", "time"}})
+	require.NoError(t, err)
+	assert.Same(t, p1, p2, "module/class ordering must not change the cache key")
+}
+
+func TestHost_CompileCache_KeySeparatorsAvoidCollision(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+	src := `return { f = function() return 1 end }`
+
+	// ["json","time"] must not key-collide with a single "jsontime" token.
+	p1, err := host.Compile(context.Background(), CompileCmd{Source: src, Method: "f", Modules: []string{"json", "time"}})
+	require.NoError(t, err)
+	k1 := programCacheKey(CompileCmd{Source: src, Method: "f", Modules: []string{"json", "time"}})
+	k2 := programCacheKey(CompileCmd{Source: src, Method: "f", Modules: []string{"jsontime"}})
+	assert.NotEqual(t, k1, k2, "concatenated tokens must not collide")
+	require.NotNil(t, p1)
+}
+
+func TestHost_CompileCache_CompileErrorNotCached(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+
+	bad := CompileCmd{Source: `return function( syntax error`, Method: "f", Modules: []string{"json"}}
+	_, err := host.Compile(context.Background(), bad)
+	require.Error(t, err)
+	assert.Equal(t, 0, host.programCache.Len(), "a failed compile must not be cached")
+
+	// The same bad source still errors (no poisoned nil entry), and a valid one caches.
+	_, err = host.Compile(context.Background(), bad)
+	require.Error(t, err)
+	good := CompileCmd{Source: `return { f = function() return 1 end }`, Method: "f", Modules: []string{"json"}}
+	_, err = host.Compile(context.Background(), good)
+	require.NoError(t, err)
+	assert.Equal(t, 1, host.programCache.Len())
+}
+
+func TestHost_CompileCache_AllFitNoEviction(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 64}))
+	cmds := makeEvalSources(60)
+
+	for _, rc := range cmds {
+		_, err := host.Compile(context.Background(), CompileCmd{Source: rc.Source, Method: rc.Method, Modules: rc.Modules})
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 60, host.programCache.Len(), "all distinct programs fit and are cached")
+
+	// Second pass: every program is a hit (same pointer).
+	first, err := host.Compile(context.Background(), CompileCmd{Source: cmds[0].Source, Method: cmds[0].Method, Modules: cmds[0].Modules})
+	require.NoError(t, err)
+	again, err := host.Compile(context.Background(), CompileCmd{Source: cmds[0].Source, Method: cmds[0].Method, Modules: cmds[0].Modules})
+	require.NoError(t, err)
+	assert.Same(t, first, again)
+}
+
+func TestHost_CompileCache_EvictionRecompiles(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 1}))
+	a := CompileCmd{Source: `return { f = function() return 1 end }`, Method: "f", Modules: []string{"json"}}
+	b := CompileCmd{Source: `return { f = function() return 2 end }`, Method: "f", Modules: []string{"json"}}
+
+	pa1, err := host.Compile(context.Background(), a)
+	require.NoError(t, err)
+	_, err = host.Compile(context.Background(), b) // evicts a
+	require.NoError(t, err)
+	pa2, err := host.Compile(context.Background(), a) // a was evicted, recompiles
+	require.NoError(t, err)
+
+	assert.NotSame(t, pa1, pa2, "an evicted entry must be recompiled")
+	assert.Equal(t, 1, host.programCache.Len(), "size bound is enforced")
+}
+
+func TestHost_CompileCache_TTLExpiry(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8, CacheTTL: 30 * time.Millisecond}))
+	cmd := CompileCmd{Source: `return { f = function() return 1 end }`, Method: "f", Modules: []string{"json"}}
+
+	p1, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	p2, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	assert.Same(t, p1, p2, "within TTL the program is reused")
+
+	time.Sleep(80 * time.Millisecond)
+	p3, err := host.Compile(context.Background(), cmd)
+	require.NoError(t, err)
+	assert.NotSame(t, p1, p3, "after TTL the program is recompiled")
+}
+
+func TestHost_CompileCache_ConcurrentSafe(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 16}))
+	cmds := makeEvalSources(8)
+
+	var wg sync.WaitGroup
+	for g := range 32 {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range 200 {
+				rc := cmds[(g+i)%len(cmds)]
+				if _, err := host.Compile(context.Background(), CompileCmd{Source: rc.Source, Method: rc.Method, Modules: rc.Modules}); err != nil {
+					t.Errorf("concurrent compile failed: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	assert.LessOrEqual(t, host.programCache.Len(), 16)
+}
+
+// TestHost_Run_CachedProgramReusedCorrectly proves the shared cached program
+// (one immutable proto) yields correct results across repeated runs.
+func TestHost_Run_CachedProgramReusedCorrectly(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+	cmd := RunCmd{Source: `return { run = function() return 20 + 3 end }`, Method: "run", Modules: []string{"json"}}
+
+	for range 3 {
+		res, err := host.Run(context.Background(), cmd)
+		require.NoError(t, err)
+		num, ok := res.(lua.LNumber)
+		require.True(t, ok, "result should be LNumber, got %T", res)
+		assert.Equal(t, lua.LNumber(23), num)
+	}
+}
+
+// TestHost_Run_ImportsNotInCacheKey proves that imports are bound per run: the
+// same source served from the compile cache still binds whichever import the
+// run specifies.
+func TestHost_Run_ImportsNotInCacheKey(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider(), WithProgramCache(HostConfig{CacheSize: 8}))
+
+	libA := registry.ParseID("test.lib:a")
+	libB := registry.ParseID("test.lib:b")
+	host.WithImportLoader(mockImportLoader(map[registry.ID]string{
+		libA: `return { version = "A" }`,
+		libB: `return { version = "B" }`,
+	}))
+
+	src := `return { run = function() return dep.version end }`
+
+	resA, err := host.Run(context.Background(), RunCmd{
+		Source: src, Method: "run", Modules: []string{"json"},
+		Imports: map[string]registry.ID{"dep": libA},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "A", resA.(lua.LString).String())
+
+	// Same source (compile cache hit) but a different import must bind libB.
+	resB, err := host.Run(context.Background(), RunCmd{
+		Source: src, Method: "run", Modules: []string{"json"},
+		Imports: map[string]registry.ID{"dep": libB},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "B", resB.(lua.LString).String())
+
+	// Only one compiled program exists despite the differing imports.
+	assert.Equal(t, 1, host.programCache.Len(), "imports must not be part of the compile key")
+}

--- a/runtime/lua/evalhost/command.go
+++ b/runtime/lua/evalhost/command.go
@@ -22,11 +22,12 @@ func init() {
 
 // CompileCmd compiles Lua source code into a reusable Program.
 type CompileCmd struct {
-	Source       string                 // Lua source code
-	Method       string                 // Method name to execute
-	Modules      []string               // Allowed modules whitelist
-	Imports      map[string]registry.ID // Registry entries to import (alias -> ID)
-	AllowClasses []string               // Additional classes to allow (e.g., "process")
+	Source        string                 // Lua source code
+	Method        string                 // Method name to execute
+	Modules       []string               // Allowed modules whitelist
+	Imports       map[string]registry.ID // Registry entries to import (alias -> ID)
+	ImportModules map[string][]string    // Per-import privileged modules (alias -> module names) usable only inside that import
+	AllowClasses  []string               // Additional classes to allow (e.g., "process")
 }
 
 func (c CompileCmd) CmdID() dispatcher.CommandID {
@@ -40,6 +41,7 @@ type RunCmd struct {
 	Args          payload.Payloads       // Arguments to pass to method
 	Modules       []string               // Allowed modules whitelist
 	Imports       map[string]registry.ID // Registry entries to import (alias -> ID)
+	ImportModules map[string][]string    // Per-import privileged modules (alias -> module names) usable only inside that import
 	Context       map[string]any         // Context values to set
 	AllowClasses  []string               // Additional classes to allow (e.g., "process")
 	CustomModules map[string]any         // Custom Lua tables to inject as modules

--- a/runtime/lua/evalhost/host.go
+++ b/runtime/lua/evalhost/host.go
@@ -4,9 +4,12 @@ package evalhost
 
 import (
 	"context"
-	"sync"
-
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/go-lua/compiler/parse"
@@ -15,6 +18,8 @@ import (
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/registry"
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	lru "github.com/wippyai/runtime/internal/cache"
 	"github.com/wippyai/runtime/runtime/lua/engine"
 	payloadconv "github.com/wippyai/runtime/runtime/lua/engine/payload"
 	"go.uber.org/zap"
@@ -94,14 +99,47 @@ type Host struct {
 	log          *zap.Logger
 	compiler     *Compiler
 	importLoader ImportLoader
+	programCache *lru.Cache[string, *Program]
+}
+
+// HostConfig configures optional Host behavior.
+type HostConfig struct {
+	// CacheSize bounds the number of compiled eval programs kept in the LRU
+	// compile cache. Zero disables caching (every run recompiles).
+	CacheSize int
+	// CacheTTL optionally expires cached programs after a duration. Zero keeps
+	// entries until evicted by the size bound.
+	CacheTTL time.Duration
+}
+
+// HostOption configures a Host.
+type HostOption func(*Host)
+
+// WithProgramCache enables the compiled-program LRU cache. A size of zero leaves
+// caching disabled.
+func WithProgramCache(cfg HostConfig) HostOption {
+	return func(h *Host) {
+		if cfg.CacheSize <= 0 {
+			return
+		}
+		opts := []lru.Option{lru.WithCapacity(cfg.CacheSize)}
+		if cfg.CacheTTL > 0 {
+			opts = append(opts, lru.WithTTL(cfg.CacheTTL))
+		}
+		h.programCache = lru.New[string, *Program](opts...)
+	}
 }
 
 // NewHost creates a new eval host with a module provider.
-func NewHost(log *zap.Logger, provider ModuleProvider) *Host {
-	return &Host{
+func NewHost(log *zap.Logger, provider ModuleProvider, opts ...HostOption) *Host {
+	h := &Host{
 		log:      log,
 		compiler: NewCompiler(provider),
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
 // WithImportLoader sets the import loader for loading library sources.
@@ -112,17 +150,65 @@ func (h *Host) WithImportLoader(loader ImportLoader) *Host {
 
 // Compile compiles Lua source into a reusable Program.
 func (h *Host) Compile(_ context.Context, cmd CompileCmd) (*Program, error) {
-	program, err := h.compiler.Compile(cmd)
+	program, err := h.compile(cmd)
 	if err != nil {
 		return nil, NewCompileError(err)
 	}
 	return program, nil
 }
 
+// compile returns a compiled Program for the command, served from the LRU
+// compile cache when enabled. The compiled bytecode depends only on the source,
+// method, allowed modules and allowed classes; imports are bound at run time, so
+// they are not part of the cache key.
+func (h *Host) compile(cmd CompileCmd) (*Program, error) {
+	if h.programCache == nil {
+		return h.compiler.Compile(cmd)
+	}
+
+	key := programCacheKey(cmd)
+	if program, ok := h.programCache.Get(key); ok {
+		return program, nil
+	}
+
+	program, err := h.compiler.Compile(cmd)
+	if err != nil {
+		return nil, err
+	}
+	_ = h.programCache.Set(key, program)
+	return program, nil
+}
+
+// programCacheKey derives a collision-resistant key from the inputs that affect
+// compiled bytecode.
+func programCacheKey(cmd CompileCmd) string {
+	hsh := sha256.New()
+	hsh.Write([]byte(cmd.Source))
+	hsh.Write([]byte{0})
+	hsh.Write([]byte(cmd.Method))
+	hsh.Write([]byte{0})
+
+	mods := append([]string(nil), cmd.Modules...)
+	sort.Strings(mods)
+	for _, m := range mods {
+		hsh.Write([]byte(m))
+		hsh.Write([]byte{0})
+	}
+	hsh.Write([]byte{1})
+
+	classes := append([]string(nil), cmd.AllowClasses...)
+	sort.Strings(classes)
+	for _, c := range classes {
+		hsh.Write([]byte(c))
+		hsh.Write([]byte{0})
+	}
+	return hex.EncodeToString(hsh.Sum(nil))
+}
+
 // Run compiles and executes Lua source in one step.
 func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
-	// Compile the source
-	program, err := h.compiler.Compile(CompileCmd{
+	// Compile the source (served from the LRU compile cache when enabled).
+	program, err := h.compile(CompileCmd{
 		Source:       cmd.Source,
 		Method:       cmd.Method,
 		Modules:      cmd.Modules,
@@ -134,7 +220,7 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 	}
 
 	// Create module binder that also injects imports and custom modules
-	binder := h.createModuleBinder(program.Modules(), cmd.Imports, cmd.CustomModules)
+	binder := h.createModuleBinder(program.Modules(), cmd.Imports, cmd.ImportModules, cmd.CustomModules)
 	factory := engine.NewFactoryFromProto(program.Proto(), binder)
 	proc, err := factory()
 	if err != nil {
@@ -162,8 +248,14 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 	// Get dispatcher for handling yields
 	disp := dispatcher.GetDispatcher(ctx)
 
-	// Auto-collect yields from imported modules
-	allowedYields := h.collectModuleYields(program.Modules())
+	// Auto-collect yields from the eval program's modules and from any
+	// privileged modules granted to imports, so granted capabilities that yield
+	// (e.g. funcs) remain usable inside the import.
+	yieldModules := append([]string(nil), program.Modules()...)
+	for _, mods := range cmd.ImportModules {
+		yieldModules = append(yieldModules, mods...)
+	}
+	allowedYields := h.collectModuleYields(yieldModules)
 
 	// Merge with any explicitly provided yields (for overrides)
 	for _, id := range cmd.AllowYields {
@@ -299,7 +391,7 @@ func (h *Host) collectModuleYields(modules []string) map[dispatcher.CommandID]bo
 }
 
 // createModuleBinder returns a ModuleBinder that loads modules, imports, and custom tables.
-func (h *Host) createModuleBinder(modules []string, imports map[string]registry.ID, customModules map[string]any) engine.ModuleBinder {
+func (h *Host) createModuleBinder(modules []string, imports map[string]registry.ID, importModules map[string][]string, customModules map[string]any) engine.ModuleBinder {
 	available := h.compiler.getModules()
 	return func(l *lua.LState) error {
 		// Load standard modules
@@ -319,8 +411,11 @@ func (h *Host) createModuleBinder(modules []string, imports map[string]registry.
 					return NewImportError(alias, id, err)
 				}
 
-				// Compile and execute the library source to get its return value
-				lv, err := h.loadLibrarySource(l, source, alias)
+				// An import granted privileged modules runs in its own
+				// environment so those modules stay reachable only inside the
+				// import's code, never the eval'd program's globals.
+				granted := importModules[alias]
+				lv, err := h.loadLibrarySource(l, source, alias, granted, available)
 				if err != nil {
 					return NewImportError(alias, id, err)
 				}
@@ -342,8 +437,12 @@ func (h *Host) createModuleBinder(modules []string, imports map[string]registry.
 	}
 }
 
-// loadLibrarySource compiles and executes a library source, returning the library's return value.
-func (h *Host) loadLibrarySource(l *lua.LState, source, name string) (lua.LValue, error) {
+// loadLibrarySource compiles and executes a library source, returning the
+// library's return value. When granted is non-empty the library runs under a
+// private environment that exposes those modules (and a scoped require for
+// them) so they remain reachable only inside the import, never in the eval'd
+// program's globals.
+func (h *Host) loadLibrarySource(l *lua.LState, source, name string, granted []string, available map[string]*luaapi.ModuleDef) (lua.LValue, error) {
 	chunk, err := parse.Parse(strings.NewReader(source), name)
 	if err != nil {
 		return nil, err
@@ -355,6 +454,15 @@ func (h *Host) loadLibrarySource(l *lua.LState, source, name string) (lua.LValue
 	}
 
 	fn := l.NewFunctionFromProto(proto)
+
+	if len(granted) > 0 {
+		env, err := privilegedImportEnv(l, granted, available)
+		if err != nil {
+			return nil, err
+		}
+		fn.Env = env
+	}
+
 	l.Push(fn)
 	if err := l.PCall(0, 1, nil); err != nil {
 		return nil, err
@@ -363,4 +471,45 @@ func (h *Host) loadLibrarySource(l *lua.LState, source, name string) (lua.LValue
 	result := l.Get(-1)
 	l.Pop(1)
 	return result, nil
+}
+
+// privilegedImportEnv builds a scoped global environment for a privileged
+// import. It exposes only the granted modules (as globals and via a scoped
+// require) and falls back to the eval program's base globals for everything
+// else. Granted modules are not written into the shared eval globals, so the
+// eval'd program cannot reach them.
+func privilegedImportEnv(l *lua.LState, granted []string, available map[string]*luaapi.ModuleDef) (*lua.LTable, error) {
+	base := l.Get(lua.GlobalsIndex).(*lua.LTable)
+
+	env := l.NewTable()
+	mt := l.NewTable()
+	mt.RawSetString("__index", base)
+	l.SetMetatable(env, mt)
+
+	resolved := make(map[string]lua.LValue, len(granted))
+	for _, name := range granted {
+		m, ok := available[name]
+		if !ok {
+			return nil, NewModuleNotAvailableError(name)
+		}
+		v := engine.ModuleValue(m)
+		env.RawSetString(name, v)
+		resolved[name] = v
+	}
+
+	env.RawSetString("require", l.NewFunction(func(s *lua.LState) int {
+		name := s.CheckString(1)
+		if v, ok := resolved[name]; ok {
+			s.Push(v)
+			return 1
+		}
+		if v := base.RawGetString(name); v != lua.LNil {
+			s.Push(v)
+			return 1
+		}
+		s.RaiseError("module '%s' not found", name)
+		return 0
+	}))
+
+	return env, nil
 }

--- a/runtime/lua/evalhost/privileged_import_test.go
+++ b/runtime/lua/evalhost/privileged_import_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package evalhost
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/registry"
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/runtime/lua/modules/json"
+	timemod "github.com/wippyai/runtime/runtime/lua/modules/time"
+	"go.uber.org/zap"
+)
+
+// phoneModule stands in for a privileged capability ("phone calls") that an
+// eval'd program must not reach directly, only through a granted import.
+// phone carries a forbidden class (network), so an eval'd program can never get
+// it by default — it is reachable only when explicitly granted to an import.
+var phoneModule = &luaapi.ModuleDef{
+	Name:        "phone",
+	Description: "Privileged capability for testing import grants",
+	Class:       []string{luaapi.ClassNetwork},
+	Build: func() (*lua.LTable, []luaapi.YieldType) {
+		t := lua.CreateTable(0, 1)
+		t.RawSetString("call", lua.LGoFunc(func(s *lua.LState) int {
+			s.Push(lua.LString("ringing"))
+			return 1
+		}))
+		return t, nil
+	},
+}
+
+func phoneModulesProvider() ModuleProvider {
+	return func() []*luaapi.ModuleDef {
+		return []*luaapi.ModuleDef{json.Module, timemod.Module, phoneModule}
+	}
+}
+
+// quoteLibrarySource is a privileged import: it uses the phone capability
+// internally and exposes only a narrow API.
+const quoteLibrarySource = `
+local phone = require("phone")
+local quote = {}
+function quote.place_call()
+    return phone.call()
+end
+function quote.sees_phone()
+    return type(phone)
+end
+return quote
+`
+
+// TestHost_Run_PrivilegedImport_GrantsModuleToImportOnly proves that a module
+// granted to an import is usable inside the import's code but unreachable from
+// the eval'd program that imported it.
+func TestHost_Run_PrivilegedImport_GrantsModuleToImportOnly(t *testing.T) {
+	host := NewHost(zap.NewNop(), phoneModulesProvider())
+	libID := registry.ParseID("test.lib:quote")
+	host.WithImportLoader(mockImportLoader(map[registry.ID]string{
+		libID: quoteLibrarySource,
+	}))
+
+	// The eval'd program declares no modules; it only imports the library,
+	// granting that library the phone capability.
+	runWith := func(t *testing.T, source, method string) (any, error) {
+		t.Helper()
+		return host.Run(context.Background(), RunCmd{
+			Source:  source,
+			Method:  method,
+			Modules: []string{},
+			Imports: map[string]registry.ID{"quote": libID},
+			ImportModules: map[string][]string{
+				"quote": {"phone"},
+			},
+		})
+	}
+
+	t.Run("import can use the granted capability", func(t *testing.T) {
+		result, err := runWith(t, `
+			return { run = function() return quote.place_call() end }
+		`, "run")
+		require.NoError(t, err)
+		lstr, ok := result.(lua.LString)
+		require.True(t, ok, "result should be LString, got %T", result)
+		assert.Equal(t, "ringing", string(lstr))
+	})
+
+	t.Run("import really sees the capability table", func(t *testing.T) {
+		result, err := runWith(t, `
+			return { run = function() return quote.sees_phone() end }
+		`, "run")
+		require.NoError(t, err)
+		lstr, ok := result.(lua.LString)
+		require.True(t, ok, "result should be LString, got %T", result)
+		assert.Equal(t, "table", string(lstr))
+	})
+
+	t.Run("eval'd program cannot see the capability as a global", func(t *testing.T) {
+		result, err := runWith(t, `
+			return { run = function() return type(phone) end }
+		`, "run")
+		require.NoError(t, err)
+		lstr, ok := result.(lua.LString)
+		require.True(t, ok, "result should be LString, got %T", result)
+		assert.Equal(t, "nil", string(lstr), "phone must not leak into the eval program globals")
+	})
+
+	t.Run("eval'd program cannot require the capability", func(t *testing.T) {
+		result, err := runWith(t, `
+			return { run = function()
+				local ok = pcall(require, "phone")
+				return ok
+			end }
+		`, "run")
+		require.NoError(t, err)
+		lbool, ok := result.(lua.LBool)
+		require.True(t, ok, "result should be LBool, got %T", result)
+		assert.Equal(t, lua.LBool(false), lbool, "require('phone') must fail in the eval program")
+	})
+}

--- a/runtime/lua/modules/eval/runner/module.go
+++ b/runtime/lua/modules/eval/runner/module.go
@@ -93,6 +93,71 @@ func checkImportPermissions(ctx context.Context, imports map[string]registry.ID)
 	return "", true
 }
 
+// checkImportModulePermissions verifies the caller may delegate each granted
+// module to an import. Granting a privileged module to an import uses the same
+// eval.module action as using the module directly, so a caller cannot hand an
+// import a capability it is not itself allowed to delegate.
+func checkImportModulePermissions(ctx context.Context, importModules map[string][]string) (string, bool) {
+	if len(importModules) == 0 {
+		return "", true
+	}
+
+	meta := attrs.NewBag()
+	if frameID, ok := runtime.GetFrameID(ctx); ok {
+		meta.Set("entry_id", frameID.String())
+	}
+
+	for alias, mods := range importModules {
+		meta.Set("alias", alias)
+		for _, module := range mods {
+			if !security.IsAllowed(ctx, "eval.module", module, meta) {
+				return module, false
+			}
+		}
+	}
+	return "", true
+}
+
+// parseImports reads the imports table. Each value is either a plain registry ID
+// string, or a table { id = "...", modules = { ... } } granting the imported
+// library a set of privileged modules usable only inside that import's code.
+func parseImports(t *lua.LTable) (map[string]registry.ID, map[string][]string) {
+	imports := make(map[string]registry.ID)
+	var importModules map[string][]string
+
+	t.ForEach(func(k, v lua.LValue) {
+		alias, ok := k.(lua.LString)
+		if !ok {
+			return
+		}
+		switch val := v.(type) {
+		case lua.LString:
+			imports[string(alias)] = registry.ParseID(string(val))
+		case *lua.LTable:
+			if idVal, ok := val.RawGetString("id").(lua.LString); ok {
+				imports[string(alias)] = registry.ParseID(string(idVal))
+			}
+			modsVal, ok := val.RawGetString("modules").(*lua.LTable)
+			if !ok {
+				return
+			}
+			var list []string
+			modsVal.ForEach(func(_, mv lua.LValue) {
+				if ms, ok := mv.(lua.LString); ok {
+					list = append(list, string(ms))
+				}
+			})
+			if len(list) > 0 {
+				if importModules == nil {
+					importModules = make(map[string][]string)
+				}
+				importModules[string(alias)] = list
+			}
+		}
+	})
+	return imports, importModules
+}
+
 // checkClassPermissions checks if each class is allowed to be enabled
 func checkClassPermissions(ctx context.Context, classes []string) (string, bool) {
 	if len(classes) == 0 {
@@ -133,6 +198,7 @@ func compileFunc(l *lua.LState) int {
 
 	var modules []string
 	var imports map[string]registry.ID
+	var importModules map[string][]string
 	if l.GetTop() >= 3 && l.Get(3).Type() == lua.LTTable {
 		opts := l.CheckTable(3)
 		if modulesVal := opts.RawGetString("modules"); modulesVal.Type() == lua.LTTable {
@@ -144,15 +210,7 @@ func compileFunc(l *lua.LState) int {
 			})
 		}
 		if importsVal := opts.RawGetString("imports"); importsVal.Type() == lua.LTTable {
-			imports = make(map[string]registry.ID)
-			importsTable := importsVal.(*lua.LTable)
-			importsTable.ForEach(func(k, v lua.LValue) {
-				if alias, ok := k.(lua.LString); ok {
-					if idStr, ok := v.(lua.LString); ok {
-						imports[string(alias)] = registry.ParseID(string(idStr))
-					}
-				}
-			})
+			imports, importModules = parseImports(importsVal.(*lua.LTable))
 		}
 	}
 
@@ -170,11 +228,19 @@ func compileFunc(l *lua.LState) int {
 		return 2
 	}
 
+	if denied, ok := checkImportModulePermissions(ctx, importModules); !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "permission denied: eval.module "+denied).
+			WithKind(lua.PermissionDenied).WithRetryable(false))
+		return 2
+	}
+
 	yield := AcquireCompileYield()
 	yield.Source = source
 	yield.Method = method
 	yield.Modules = modules
 	yield.Imports = imports
+	yield.ImportModules = importModules
 
 	l.Push(yield)
 	return -1
@@ -224,15 +290,9 @@ func runFunc(l *lua.LState) int {
 	}
 
 	var imports map[string]registry.ID
+	var importModules map[string][]string
 	if v := config.RawGetString("imports"); v.Type() == lua.LTTable {
-		imports = make(map[string]registry.ID)
-		v.(*lua.LTable).ForEach(func(k, iv lua.LValue) {
-			if alias, ok := k.(lua.LString); ok {
-				if idStr, ok := iv.(lua.LString); ok {
-					imports[string(alias)] = registry.ParseID(string(idStr))
-				}
-			}
-		})
+		imports, importModules = parseImports(v.(*lua.LTable))
 	}
 
 	if denied, ok := checkModulePermissions(ctx, modules); !ok {
@@ -245,6 +305,13 @@ func runFunc(l *lua.LState) int {
 	if denied, ok := checkImportPermissions(ctx, imports); !ok {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, "permission denied: eval.import "+denied).
+			WithKind(lua.PermissionDenied).WithRetryable(false))
+		return 2
+	}
+
+	if denied, ok := checkImportModulePermissions(ctx, importModules); !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "permission denied: eval.module "+denied).
 			WithKind(lua.PermissionDenied).WithRetryable(false))
 		return 2
 	}
@@ -299,6 +366,7 @@ func runFunc(l *lua.LState) int {
 	yield.Args = args
 	yield.Modules = modules
 	yield.Imports = imports
+	yield.ImportModules = importModules
 	yield.Context = contextVals
 	yield.AllowClasses = allowClasses
 	yield.CustomModules = customModules

--- a/runtime/lua/modules/eval/runner/yields.go
+++ b/runtime/lua/modules/eval/runner/yields.go
@@ -16,11 +16,12 @@ import (
 
 // CompileYield is yielded by runner.compile to compile Lua source.
 type CompileYield struct {
-	Source       string
-	Method       string
-	Modules      []string
-	Imports      map[string]registry.ID
-	AllowClasses []string
+	Source        string
+	Method        string
+	Modules       []string
+	Imports       map[string]registry.ID
+	ImportModules map[string][]string
+	AllowClasses  []string
 }
 
 var compileYieldPool = sync.Pool{
@@ -36,6 +37,7 @@ func ReleaseCompileYield(y *CompileYield) {
 	y.Method = ""
 	y.Modules = nil
 	y.Imports = nil
+	y.ImportModules = nil
 	y.AllowClasses = nil
 	compileYieldPool.Put(y)
 }
@@ -46,11 +48,12 @@ func (y *CompileYield) Type() lua.LValueType        { return lua.LTUserData }
 func (y *CompileYield) CmdID() dispatcher.CommandID { return evalhost.Compile }
 func (y *CompileYield) ToCommand() dispatcher.Command {
 	return evalhost.CompileCmd{
-		Source:       y.Source,
-		Method:       y.Method,
-		Modules:      y.Modules,
-		Imports:      y.Imports,
-		AllowClasses: y.AllowClasses,
+		Source:        y.Source,
+		Method:        y.Method,
+		Modules:       y.Modules,
+		Imports:       y.Imports,
+		ImportModules: y.ImportModules,
+		AllowClasses:  y.AllowClasses,
 	}
 }
 
@@ -86,6 +89,7 @@ type RunYield struct {
 	Args          payload.Payloads
 	Modules       []string
 	Imports       map[string]registry.ID
+	ImportModules map[string][]string
 	Context       map[string]any
 	AllowClasses  []string
 	CustomModules map[string]any
@@ -106,6 +110,7 @@ func ReleaseRunYield(y *RunYield) {
 	y.Args = nil
 	y.Modules = nil
 	y.Imports = nil
+	y.ImportModules = nil
 	y.Context = nil
 	y.AllowClasses = nil
 	y.CustomModules = nil
@@ -124,6 +129,7 @@ func (y *RunYield) ToCommand() dispatcher.Command {
 		Args:          y.Args,
 		Modules:       y.Modules,
 		Imports:       y.Imports,
+		ImportModules: y.ImportModules,
 		Context:       y.Context,
 		AllowClasses:  y.AllowClasses,
 		CustomModules: y.CustomModules,

--- a/tests/app/src/test/eval_privilege/_index.yaml
+++ b/tests/app/src/test/eval_privilege/_index.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MPL-2.0
+
+version: "1.0"
+namespace: app.test.eval_privilege
+
+entries:
+  - name: pricing
+    kind: library.lua
+    meta:
+      comment: Privileged DSL helper that uses funcs; granted to eval imports
+    source: file://pricing.lua
+    modules:
+      - funcs
+
+  - name: import_privilege
+    kind: function.lua
+    meta:
+      type: test
+      suite: eval_privilege
+      description: Eval grants funcs to an import; the DSL on top cannot reach funcs
+    source: file://import_privilege.lua
+    method: main
+    modules:
+      - eval_runner
+    imports:
+      assert: app.lib:assert

--- a/tests/app/src/test/eval_privilege/import_privilege.lua
+++ b/tests/app/src/test/eval_privilege/import_privilege.lua
@@ -1,0 +1,43 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Proves eval per-import privilege end-to-end: the pricing import is granted
+-- funcs and uses it (funcs.call), while the eval'd DSL on top cannot reach funcs
+-- by any path. The runner itself runs under the user actor (root), so funcs is
+-- allowed by policy; isolation, not policy, is what keeps it out of the DSL.
+local assert = require("assert")
+
+local function main()
+	local runner = require("eval_runner")
+
+	local res, err = runner.run({
+		-- The DSL lists its own modules explicitly (no funcs), so it gets none
+		-- of the funcs capability except through the privileged import.
+		source = [[
+			local pricing = require("pricing")
+			return {
+				build = function()
+					return {
+						quoted = pricing.quote("synthetic"),
+						leaked = type(funcs) ~= "nil",
+						can_require = (pcall(require, "funcs")),
+					}
+				end
+			}
+		]],
+		method = "build",
+		modules = { "json" },
+		imports = {
+			pricing = { id = "app.test.eval_privilege:pricing", modules = { "funcs" } },
+		},
+	})
+
+	assert.is_nil(err, "eval run should succeed: " .. tostring(err))
+	assert.not_nil(res, "eval returns a result")
+	assert.eq(res.quoted, "synthetic", "import used funcs.call to produce the quote")
+	assert.eq(res.leaked, false, "funcs must NOT be visible to the DSL")
+	assert.eq(res.can_require, false, "DSL must NOT be able to require funcs")
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/eval_privilege/pricing.lua
+++ b/tests/app/src/test/eval_privilege/pricing.lua
@@ -1,0 +1,17 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Privileged DSL helper. It uses funcs internally; eval'd DSL code may call its
+-- API but must never reach funcs itself.
+local funcs = require("funcs")
+
+local pricing = {}
+
+function pricing.quote(input)
+	local res, err = funcs.call("app.test.funcs:echo", input)
+	if err then
+		error("pricing.quote: funcs.call failed: " .. tostring(err))
+	end
+	return res.echo
+end
+
+return pricing


### PR DESCRIPTION
Stacked on #388 (lua import isolation). Until #388 merges, this PR's diff also shows that commit; it drops out once #388 lands on main.

## Per-import privilege (safe DSLs)
An eval import can be granted privileged modules it may use internally, while the eval'd program on top cannot reach them:

```lua
runner.run({
  source  = dsl_source,        -- untrusted; generates the synthetic quote
  method  = "generate",
  modules = { "json" },        -- the DSL's own modules (NOT funcs)
  imports = {
    pricing = { id = "app.lib:pricing", modules = { "funcs" } }, -- granted only here
  },
})
```

- The import runs under its own environment (granted modules + scoped require); granted modules are never written into the eval program's `_G`, so the DSL sees `nil` / `require` fails.
- Grants are permission-checked with `eval.module` (can't delegate what you can't use).
- Granted modules' yields are allowed, so yielding capabilities (`funcs.call`) work inside the import.
- Plain `imports = { sdk = "id" }` string form is unchanged.

## LRU compile cache
The eval host recompiled (`parse` + full type-check + bytecode) on every `runner.run({source})`. Added an LRU compile cache (`internal/cache`) keyed by `source + method + modules + allowClasses` (imports are bound at run time and excluded). Configurable:

```yaml
lua:
  eval.cache_size: 256   # default 256; 0 disables
  eval.cache_ttl: 10m    # optional; default none (LRU-only)
```

**Benchmark — 100k runs, 60 distinct programs:** full run ~71× faster (45.6s → 0.64s), compile path ~845× faster on hit, ~51× fewer allocations.

## Tests
- `privileged_import_test.go` — import uses the granted capability; DSL can't see it or require it.
- `tests/app` `eval_privilege` suite — end-to-end: a privileged import does a real `funcs.call`, the DSL on top is blocked (passes via `wippy test`).
- `cache_test.go` — keying (method/modules/classes, order-independence, separator collisions), eviction, TTL expiry, compile-error-not-cached, shared-proto correctness, imports-not-in-key, concurrent access (`-race` clean).

All `runtime/lua/evalhost` + eval module tests pass; golangci-lint v2.8.0 = 0 issues.