### PR TITLE
fix(lua): guard cyclic table conversion

### DIFF
--- a/runtime/lua/engine/value/util.go
+++ b/runtime/lua/engine/value/util.go
@@ -252,8 +252,14 @@ func GetFunc(l *lua.LState, value lua.LValue, field string) (*lua.LFunction, boo
 	return nil, false
 }
 
+const cyclicTableSentinel = "<cyclic table>"
+
 // ToGoAny converts a lua.LValue to its Go equivalent.
 func ToGoAny(v lua.LValue) any {
+	return toGoAny(v, make(map[*lua.LTable]struct{}))
+}
+
+func toGoAny(v lua.LValue, stack map[*lua.LTable]struct{}) any {
 	if v == nil {
 		return nil
 	}
@@ -271,11 +277,14 @@ func ToGoAny(v lua.LValue) any {
 		return string(v.(lua.LString))
 	case lua.LTTable:
 		tbl := v.(*lua.LTable)
+		if _, ok := stack[tbl]; ok {
+			return cyclicTableSentinel
+		}
 		maxn := tbl.MaxN()
 		if maxn == 0 {
-			return TableToMap(tbl)
+			return tableToMap(tbl, stack)
 		}
-		return TableToSlice(tbl, maxn)
+		return tableToSlice(tbl, maxn, stack)
 	case lua.LTFunction, lua.LTUserData, lua.LTThread, lua.LTChannel:
 		fallthrough
 	default:
@@ -285,18 +294,32 @@ func ToGoAny(v lua.LValue) any {
 
 // TableToMap converts a Lua table to a Go map.
 func TableToMap(tbl *lua.LTable) map[string]any {
+	return tableToMap(tbl, make(map[*lua.LTable]struct{}))
+}
+
+func tableToMap(tbl *lua.LTable, stack map[*lua.LTable]struct{}) map[string]any {
 	result := make(map[string]any, tbl.Len())
+	stack[tbl] = struct{}{}
+	defer delete(stack, tbl)
+
 	tbl.ForEach(func(key, value lua.LValue) {
-		result[key.String()] = ToGoAny(value)
+		result[key.String()] = toGoAny(value, stack)
 	})
 	return result
 }
 
 // TableToSlice converts a Lua table to a Go slice.
 func TableToSlice(tbl *lua.LTable, maxn int) []any {
+	return tableToSlice(tbl, maxn, make(map[*lua.LTable]struct{}))
+}
+
+func tableToSlice(tbl *lua.LTable, maxn int, stack map[*lua.LTable]struct{}) []any {
 	result := make([]any, 0, maxn)
+	stack[tbl] = struct{}{}
+	defer delete(stack, tbl)
+
 	for i := 1; i <= maxn; i++ {
-		result = append(result, ToGoAny(tbl.RawGetInt(i)))
+		result = append(result, toGoAny(tbl.RawGetInt(i), stack))
 	}
 	return result
 }

--- a/runtime/lua/engine/value/util_test.go
+++ b/runtime/lua/engine/value/util_test.go
@@ -580,6 +580,44 @@ func TestToGoAny(t *testing.T) {
 		assert.Equal(t, float64(42), m["key2"])
 	})
 
+	t.Run("cyclic map table uses sentinel", func(t *testing.T) {
+		L := lua.NewState()
+		defer L.Close()
+
+		tbl := L.CreateTable(0, 2)
+		nested := L.CreateTable(0, 1)
+		tbl.RawSetString("name", lua.LString("root"))
+		tbl.RawSetString("self", tbl)
+		nested.RawSetString("parent", tbl)
+		tbl.RawSetString("nested", nested)
+
+		result := ToGoAny(tbl)
+		m, ok := result.(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "root", m["name"])
+		assert.Equal(t, cyclicTableSentinel, m["self"])
+
+		nestedMap, ok := m["nested"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, cyclicTableSentinel, nestedMap["parent"])
+	})
+
+	t.Run("cyclic array table uses sentinel", func(t *testing.T) {
+		L := lua.NewState()
+		defer L.Close()
+
+		tbl := L.CreateTable(2, 0)
+		tbl.RawSetInt(1, lua.LString("first"))
+		tbl.RawSetInt(2, tbl)
+
+		result := ToGoAny(tbl)
+		arr, ok := result.([]any)
+		assert.True(t, ok)
+		assert.Len(t, arr, 2)
+		assert.Equal(t, "first", arr[0])
+		assert.Equal(t, cyclicTableSentinel, arr[1])
+	})
+
 	t.Run("function returns string representation", func(t *testing.T) {
 		L := lua.NewState()
 		defer L.Close()

--- a/test.sh
+++ b/test.sh
@@ -33,6 +33,7 @@ go test \
 	./service/env/... \
 	./service/sql/... \
 	./service/cdc/postgres \
+	./runtime/lua/engine/value \
 	./runtime/lua/modules/cdc \
 	./boot/components/dispatchers
 

--- a/tests/app/src/test/process/_index.yaml
+++ b/tests/app/src/test/process/_index.yaml
@@ -525,6 +525,17 @@ entries:
     imports:
       assert2: app.lib:assert
 
+  - name: context_cyclic_table
+    kind: function.lua
+    meta:
+      type: test
+      suite: process
+      description: Cyclic tables in process context do not recurse forever
+    source: file://context_cyclic_table.lua
+    method: main
+    imports:
+      assert2: app.lib:assert
+
   - name: ctx_actor
     kind: function.lua
     meta:

--- a/tests/app/src/test/process/context_cyclic_table.lua
+++ b/tests/app/src/test/process/context_cyclic_table.lua
@@ -1,0 +1,24 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: Lua->Go conversion handles cyclic tables at process context boundaries.
+local assert = require("assert2")
+
+local function main()
+	local root = {
+		name = "root",
+		nested = {
+			value = 42
+		}
+	}
+	root.self = root
+	root.nested.parent = root
+
+	local spawner = process.with_context({
+		cyclic = root
+	})
+	assert.not_nil(spawner, "with_context returns spawner for cyclic table")
+
+	return true
+end
+
+return { main = main }


### PR DESCRIPTION
## Summary
- Prevent Lua table conversion from recursing forever on cyclic tables by tracking the active conversion stack.
- Preserve existing acyclic table conversion behavior; cyclic references become a bounded sentinel string.
- Add unit coverage for cyclic map and array tables.
- Add an app-level process context regression so tests/app/test.sh covers the runtime boundary that previously hit TableToMap -> ToGoAny recursion.

## Validation
- go test ./runtime/lua/engine/value -count=1
- tests/app runner passed in the existing runtime checkout with optional external suites skipped: 385 tests

Note: running the app test runner from a clean origin/main worktree currently stops before tests on an unrelated eval config decode issue: app.test.eval:runner_allow_classes has security as an array while main expects security.Config.