### PR TITLE
feat(lint): flag undeclared require() and centralize the ambient module set

### DIFF
--- a/cmd/wippy/cmd/lint.go
+++ b/cmd/wippy/cmd/lint.go
@@ -18,6 +18,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
+	"github.com/wippyai/go-lua/compiler/ast"
 	"github.com/wippyai/go-lua/compiler/parse"
 	"github.com/wippyai/go-lua/types/diag"
 	"github.com/wippyai/go-lua/types/io"
@@ -31,6 +32,8 @@ import (
 	"github.com/wippyai/runtime/runtime/lua/code"
 	"github.com/wippyai/runtime/runtime/lua/code/lint"
 	_ "github.com/wippyai/runtime/runtime/lua/code/lint/rules" // register lint rules
+	"github.com/wippyai/runtime/runtime/lua/component"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 	transcoder "github.com/wippyai/runtime/system/payload"
 	"github.com/wippyai/runtime/system/registry/topology"
 	"go.uber.org/zap"
@@ -422,6 +425,19 @@ func createLinter(ctx context.Context, enableRules bool) (*lint.Linter, lintCach
 		lcache.builtinModules = append(lcache.builtinModules, mod.Name)
 		builtinManifests[mod.Name] = manifest
 	}
+
+	// requireBuiltins is the set of modules a scoped require resolves without an
+	// explicit import/module declaration. It mirrors the runtime ambient base
+	// (engine core modules and standard libs) plus the modules every executable
+	// Lua kind injects, so an undeclared require that would fail at runtime is
+	// flagged at lint time. Every other registered module must be declared.
+	lcache.requireBuiltins = make(map[string]struct{})
+	for _, name := range engine.AmbientBaseModuleNames() {
+		lcache.requireBuiltins[name] = struct{}{}
+	}
+	for _, name := range component.ExecutableAmbientModuleNames() {
+		lcache.requireBuiltins[name] = struct{}{}
+	}
 	lcache.builtinHash = code.BuiltinManifestHash(builtinManifests)
 
 	return lint.New(typeChecker, registry), lcache
@@ -659,6 +675,11 @@ func lintOneEntry(entry regapi.Entry, data entryData, linter *lint.Linter, manif
 	lintResult := linter.CheckParsedWithTypecheck(stmts, entryID, imports, enableTypecheck)
 	linter.ClearCache()
 
+	requireDiags := lintRequireDeclarations(stmts, entryID, data, lcache.requireBuiltins)
+	if len(requireDiags) > 0 {
+		lintResult.Diagnostics = append(requireDiags, lintResult.Diagnostics...)
+	}
+
 	if cachedDiagnostics != nil {
 		lintResult.Manifest = cachedManifest
 		lintResult.Diagnostics = append(cachedDiagnostics, lintResult.Diagnostics...)
@@ -726,6 +747,136 @@ func mergeEntryResult(result *LintResult, er *entryResult, manifestMap map[regap
 		result.ErrorCount += er.errors
 		result.WarningCount += er.warnings
 		result.HintCount += er.hints
+	}
+}
+
+func lintRequireDeclarations(stmts []ast.Stmt, entryID string, data entryData, builtinModules map[string]struct{}) []diag.Diagnostic {
+	declared := make(map[string]struct{}, len(data.Imports))
+	for alias := range data.Imports {
+		if alias != "" {
+			declared[alias] = struct{}{}
+		}
+	}
+
+	collector := diag.NewCollector(entryID)
+	walkRequireStmts(stmts, func(call *ast.FuncCallExpr, moduleName string) {
+		if _, ok := declared[moduleName]; ok {
+			return
+		}
+		if _, ok := builtinModules[moduleName]; ok {
+			return
+		}
+		collector.Add(call, diag.ErrNoHandler,
+			"require(%q) is not declared in _index.yaml imports or modules", moduleName)
+	})
+	return collector.All()
+}
+
+func walkRequireStmts(stmts []ast.Stmt, visit func(*ast.FuncCallExpr, string)) {
+	for _, stmt := range stmts {
+		walkRequireStmt(stmt, visit)
+	}
+}
+
+func walkRequireStmt(stmt ast.Stmt, visit func(*ast.FuncCallExpr, string)) {
+	if stmt == nil {
+		return
+	}
+
+	switch s := stmt.(type) {
+	case *ast.AssignStmt:
+		for _, expr := range s.Lhs {
+			walkRequireExpr(expr, visit)
+		}
+		for _, expr := range s.Rhs {
+			walkRequireExpr(expr, visit)
+		}
+	case *ast.LocalAssignStmt:
+		for _, expr := range s.Exprs {
+			walkRequireExpr(expr, visit)
+		}
+	case *ast.FuncCallStmt:
+		walkRequireExpr(s.Expr, visit)
+	case *ast.DoBlockStmt:
+		walkRequireStmts(s.Stmts, visit)
+	case *ast.WhileStmt:
+		walkRequireExpr(s.Condition, visit)
+		walkRequireStmts(s.Stmts, visit)
+	case *ast.RepeatStmt:
+		walkRequireStmts(s.Stmts, visit)
+		walkRequireExpr(s.Condition, visit)
+	case *ast.IfStmt:
+		walkRequireExpr(s.Condition, visit)
+		walkRequireStmts(s.Then, visit)
+		walkRequireStmts(s.Else, visit)
+	case *ast.NumberForStmt:
+		walkRequireExpr(s.Init, visit)
+		walkRequireExpr(s.Limit, visit)
+		walkRequireExpr(s.Step, visit)
+		walkRequireStmts(s.Stmts, visit)
+	case *ast.GenericForStmt:
+		for _, expr := range s.Exprs {
+			walkRequireExpr(expr, visit)
+		}
+		walkRequireStmts(s.Stmts, visit)
+	case *ast.FuncDefStmt:
+		if s.Func != nil {
+			walkRequireStmts(s.Func.Stmts, visit)
+		}
+	case *ast.ReturnStmt:
+		for _, expr := range s.Exprs {
+			walkRequireExpr(expr, visit)
+		}
+	}
+}
+
+func walkRequireExpr(expr ast.Expr, visit func(*ast.FuncCallExpr, string)) {
+	if expr == nil {
+		return
+	}
+
+	switch e := expr.(type) {
+	case *ast.FuncCallExpr:
+		if ident, ok := e.Func.(*ast.IdentExpr); ok && ident.Value == "require" && e.Receiver == nil && e.Method == "" && len(e.Args) > 0 {
+			if mod, ok := e.Args[0].(*ast.StringExpr); ok && mod.Value != "" {
+				visit(e, mod.Value)
+			}
+		}
+		walkRequireExpr(e.Func, visit)
+		walkRequireExpr(e.Receiver, visit)
+		for _, arg := range e.Args {
+			walkRequireExpr(arg, visit)
+		}
+	case *ast.AttrGetExpr:
+		walkRequireExpr(e.Object, visit)
+		walkRequireExpr(e.Key, visit)
+	case *ast.TableExpr:
+		for _, field := range e.Fields {
+			walkRequireExpr(field.Key, visit)
+			walkRequireExpr(field.Value, visit)
+		}
+	case *ast.FunctionExpr:
+		walkRequireStmts(e.Stmts, visit)
+	case *ast.LogicalOpExpr:
+		walkRequireExpr(e.Lhs, visit)
+		walkRequireExpr(e.Rhs, visit)
+	case *ast.RelationalOpExpr:
+		walkRequireExpr(e.Lhs, visit)
+		walkRequireExpr(e.Rhs, visit)
+	case *ast.ArithmeticOpExpr:
+		walkRequireExpr(e.Lhs, visit)
+		walkRequireExpr(e.Rhs, visit)
+	case *ast.StringConcatOpExpr:
+		walkRequireExpr(e.Lhs, visit)
+		walkRequireExpr(e.Rhs, visit)
+	case *ast.UnaryMinusOpExpr:
+		walkRequireExpr(e.Expr, visit)
+	case *ast.UnaryNotOpExpr:
+		walkRequireExpr(e.Expr, visit)
+	case *ast.UnaryLenOpExpr:
+		walkRequireExpr(e.Expr, visit)
+	case *ast.UnaryBNotOpExpr:
+		walkRequireExpr(e.Expr, visit)
 	}
 }
 

--- a/cmd/wippy/cmd/lint_cache.go
+++ b/cmd/wippy/cmd/lint_cache.go
@@ -18,11 +18,12 @@ import (
 )
 
 type lintCache struct {
-	store          cache.Store
-	cfg            cache.Config
-	builtinHash    string
-	typecheckHash  string
-	builtinModules []string
+	store           cache.Store
+	requireBuiltins map[string]struct{}
+	builtinHash     string
+	typecheckHash   string
+	cfg             cache.Config
+	builtinModules  []string
 }
 
 type lintFingerprints struct {

--- a/cmd/wippy/cmd/lint_test.go
+++ b/cmd/wippy/cmd/lint_test.go
@@ -4,13 +4,23 @@ package cmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/wippyai/go-lua/compiler/parse"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/runtime/lua/component"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 	transcoder "github.com/wippyai/runtime/system/payload"
 	payloadjson "github.com/wippyai/runtime/system/payload/json"
 )
+
+// ambientRequireBuiltins assembles the require allowlist the same way
+// createLinter does, so these tests track the runtime ambient set.
+func ambientRequireBuiltins() []string {
+	return append(engine.AmbientBaseModuleNames(), component.ExecutableAmbientModuleNames()...)
+}
 
 func makeLuaEntry(id registry.ID, imports map[string]registry.ID) registry.Entry {
 	cfg := struct {
@@ -54,5 +64,110 @@ func TestExpandLuaEntriesByImports_IncludesDeps(t *testing.T) {
 	}
 	if !seen[rootID] || !seen[depID] {
 		t.Fatalf("expected expanded entries to include root and dep; got %v", seen)
+	}
+}
+
+func runRequireDeclarations(t *testing.T, source string, imports map[string]registry.ID, builtins []string) []string {
+	t.Helper()
+	stmts, err := parse.ParseString(source, "ns.test:entry")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if imports == nil {
+		imports = map[string]registry.ID{}
+	}
+	builtinSet := make(map[string]struct{}, len(builtins))
+	for _, b := range builtins {
+		builtinSet[b] = struct{}{}
+	}
+	diags := lintRequireDeclarations(stmts, "ns.test:entry", entryData{Imports: imports}, builtinSet)
+	msgs := make([]string, 0, len(diags))
+	for _, d := range diags {
+		msgs = append(msgs, d.Message)
+	}
+	return msgs
+}
+
+func TestLintRequireDeclarations_DeclaredImportIsClean(t *testing.T) {
+	msgs := runRequireDeclarations(t,
+		`local dep = require("dep"); return dep`,
+		map[string]registry.ID{"dep": registry.NewID("ns.dep", "dep")}, nil)
+	if len(msgs) != 0 {
+		t.Fatalf("expected no diagnostics for declared import, got %v", msgs)
+	}
+}
+
+func TestLintRequireDeclarations_BuiltinModuleIsClean(t *testing.T) {
+	msgs := runRequireDeclarations(t,
+		`local j = require("json"); return j`,
+		nil, []string{"json"})
+	if len(msgs) != 0 {
+		t.Fatalf("expected no diagnostics for builtin module, got %v", msgs)
+	}
+}
+
+func TestLintRequireDeclarations_UndeclaredModuleReported(t *testing.T) {
+	msgs := runRequireDeclarations(t,
+		`local x = require("mystery"); return x`,
+		nil, nil)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %v", msgs)
+	}
+	if !strings.Contains(msgs[0], `require("mystery")`) {
+		t.Fatalf("diagnostic should name the offending module, got %q", msgs[0])
+	}
+}
+
+func TestLintRequireDeclarations_DynamicRequireIgnored(t *testing.T) {
+	msgs := runRequireDeclarations(t,
+		`local name = "dep"; local x = require(name); return x`,
+		nil, nil)
+	if len(msgs) != 0 {
+		t.Fatalf("dynamic require(var) must not be flagged statically, got %v", msgs)
+	}
+}
+
+func TestLintRequireDeclarations_DetectedInsideFunctionBody(t *testing.T) {
+	msgs := runRequireDeclarations(t,
+		`return function() return require("mystery").run() end`,
+		nil, nil)
+	if len(msgs) != 1 {
+		t.Fatalf("expected require nested in a function body to be detected, got %v", msgs)
+	}
+}
+
+func TestLintRequireDeclarations_AmbientModulesNeedNoDeclaration(t *testing.T) {
+	builtins := ambientRequireBuiltins()
+	if len(builtins) == 0 {
+		t.Fatal("ambient require builtins are empty")
+	}
+	for _, name := range builtins {
+		msgs := runRequireDeclarations(t, `local m = require("`+name+`"); return m`, nil, builtins)
+		if len(msgs) != 0 {
+			t.Fatalf("ambient module %q must not require a declaration, got %v", name, msgs)
+		}
+	}
+}
+
+func TestLintRequireDeclarations_NonAmbientRegisteredModuleMustBeDeclared(t *testing.T) {
+	builtins := ambientRequireBuiltins()
+	for _, name := range builtins {
+		if name == "json" {
+			t.Fatalf("test assumes json is not ambient, but it is in %v", builtins)
+		}
+	}
+
+	// json is a registered module with type info but is not ambient at runtime;
+	// an undeclared require must be flagged at lint time.
+	flagged := runRequireDeclarations(t, `local j = require("json"); return j`, nil, builtins)
+	if len(flagged) != 1 {
+		t.Fatalf("undeclared require(\"json\") must be flagged, got %v", flagged)
+	}
+
+	// Declaring it clears the diagnostic.
+	clean := runRequireDeclarations(t, `local j = require("json"); return j`,
+		map[string]registry.ID{"json": registry.NewID("wippy.json", "json")}, builtins)
+	if len(clean) != 0 {
+		t.Fatalf("declared json import must clear the diagnostic, got %v", clean)
 	}
 }

--- a/runtime/lua/component/ambient.go
+++ b/runtime/lua/component/ambient.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package component
+
+import (
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	processmod "github.com/wippyai/runtime/runtime/lua/modules/process"
+)
+
+// ExecutableAmbientModules are the modules injected into every executable Lua
+// kind (function, process, workflow) on top of the engine base, and therefore
+// require-able without an explicit import declaration. It is the single source
+// the kind factories and lint share so the two cannot drift.
+func ExecutableAmbientModules() []*luaapi.ModuleDef {
+	return []*luaapi.ModuleDef{processmod.Module}
+}
+
+// ExecutableAmbientModuleNames returns the names of ExecutableAmbientModules.
+func ExecutableAmbientModuleNames() []string {
+	mods := ExecutableAmbientModules()
+	names := make([]string, 0, len(mods))
+	for _, m := range mods {
+		names = append(names, m.Name)
+	}
+	return names
+}

--- a/runtime/lua/component/ambient_test.go
+++ b/runtime/lua/component/ambient_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package component
+
+import (
+	"testing"
+
+	processmod "github.com/wippyai/runtime/runtime/lua/modules/process"
+)
+
+func TestExecutableAmbientModules_IncludesProcess(t *testing.T) {
+	found := false
+	for _, m := range ExecutableAmbientModules() {
+		if m == processmod.Module {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("ExecutableAmbientModules must include the process module")
+	}
+}
+
+func TestExecutableAmbientModuleNames_MatchModules(t *testing.T) {
+	mods := ExecutableAmbientModules()
+	names := ExecutableAmbientModuleNames()
+	if len(names) != len(mods) {
+		t.Fatalf("name count %d does not match module count %d", len(names), len(mods))
+	}
+	for i, m := range mods {
+		if names[i] != m.Name {
+			t.Fatalf("name %d = %q, want module name %q", i, names[i], m.Name)
+		}
+	}
+}

--- a/runtime/lua/component/function/pool.go
+++ b/runtime/lua/component/function/pool.go
@@ -17,8 +17,8 @@ import (
 	"github.com/wippyai/runtime/api/security"
 	"github.com/wippyai/runtime/api/supervisor"
 	runtimelua "github.com/wippyai/runtime/runtime/lua"
+	"github.com/wippyai/runtime/runtime/lua/component"
 	"github.com/wippyai/runtime/runtime/lua/engine"
-	processmod "github.com/wippyai/runtime/runtime/lua/modules/process"
 	funcpool "github.com/wippyai/runtime/system/scheduler/pool"
 	"github.com/wippyai/runtime/system/scheduler/pool/adaptive"
 	"github.com/wippyai/runtime/system/scheduler/pool/inline"
@@ -109,7 +109,7 @@ func (m *Manager) createPool(id registry.ID, cfg *configEntry) error {
 }
 
 func (m *Manager) buildPool(id registry.ID, cfg *configEntry) (funcpool.Pool, error) {
-	factoryFn, err := m.factory.CreateFactory(id, engine.WithModule(processmod.Module))
+	factoryFn, err := m.factory.CreateFactory(id, engine.WithModules(component.ExecutableAmbientModules()...))
 	if err != nil {
 		return nil, err // Already has compile context from code.Manager
 	}

--- a/runtime/lua/component/process/manager.go
+++ b/runtime/lua/component/process/manager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/wippyai/runtime/runtime/lua/code"
 	"github.com/wippyai/runtime/runtime/lua/component"
 	"github.com/wippyai/runtime/runtime/lua/engine"
-	processmod "github.com/wippyai/runtime/runtime/lua/modules/process"
 	"go.uber.org/zap"
 )
 
@@ -253,7 +252,7 @@ func (m *Manager) updateBytecode(ctx context.Context, entry registry.Entry) erro
 // registerFactory registers a process factory with the factory registry and waits for confirmation.
 func (m *Manager) registerFactory(ctx context.Context, id registry.ID, method string) error {
 	// Create factory using ProcessFactory
-	factoryFn, err := m.factory.CreateFactory(id, engine.WithModule(processmod.Module))
+	factoryFn, err := m.factory.CreateFactory(id, engine.WithModules(component.ExecutableAmbientModules()...))
 	if err != nil {
 		return err // Already has compile context from code.Manager
 	}

--- a/runtime/lua/component/workflow/manager.go
+++ b/runtime/lua/component/workflow/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/wippyai/runtime/runtime/lua/code"
 	"github.com/wippyai/runtime/runtime/lua/component"
 	"github.com/wippyai/runtime/runtime/lua/engine"
-	processmod "github.com/wippyai/runtime/runtime/lua/modules/process"
 	"go.uber.org/zap"
 )
 
@@ -272,7 +271,7 @@ func (m *Manager) registerFactory(ctx context.Context, id registry.ID, method st
 	// Modules must have ClassDeterministic or ClassWorkflow to be allowed.
 	factoryFn, err := m.factory.CreateFactory(id,
 		engine.WithAllowedClasses(api.ClassDeterministic, api.ClassWorkflow),
-		engine.WithModule(processmod.Module),
+		engine.WithModules(component.ExecutableAmbientModules()...),
 	)
 	if err != nil {
 		return err // Already has compile context from code.Manager

--- a/runtime/lua/engine/ambient_test.go
+++ b/runtime/lua/engine/ambient_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package engine
+
+import (
+	"testing"
+
+	lua "github.com/wippyai/go-lua"
+)
+
+// TestAmbientBaseModuleNames_AllResolveAsGlobals guards against drift between
+// AmbientBaseModuleNames and what the runtime actually installs: every advertised
+// ambient name must be reachable as a global after the same base setup CreateState
+// performs (OpenBase, BindCachedLibs, LoadCoreModules). The scoped require base
+// fallback resolves names through these globals.
+func TestAmbientBaseModuleNames_AllResolveAsGlobals(t *testing.T) {
+	l := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer l.Close()
+
+	lua.OpenBase(l)
+	BindCachedLibs(l)
+	if err := LoadCoreModules(l); err != nil {
+		t.Fatalf("LoadCoreModules: %v", err)
+	}
+
+	names := AmbientBaseModuleNames()
+	if len(names) == 0 {
+		t.Fatal("AmbientBaseModuleNames returned no names")
+	}
+	for _, name := range names {
+		if l.GetGlobal(name) == lua.LNil {
+			t.Fatalf("ambient base name %q is not installed as a runtime global", name)
+		}
+	}
+}

--- a/runtime/lua/engine/cached_libs.go
+++ b/runtime/lua/engine/cached_libs.go
@@ -18,7 +18,16 @@ var (
 	cachedCoroutineLib *lua.LTable
 	cachedStringLib    *lua.LTable
 	cachedErrorsLib    *lua.LTable
+
+	// cachedLibs is the ordered set of standard libraries bound as globals by
+	// BindCachedLibs. It is the single source for both binding and StdLibNames.
+	cachedLibs []cachedLib
 )
+
+type cachedLib struct {
+	tbl  *lua.LTable
+	name string
+}
 
 func initCachedLibs() {
 	initOnce.Do(func() {
@@ -48,6 +57,15 @@ func initCachedLibs() {
 		lua.OpenErrors(tmp)
 		cachedErrorsLib = tmp.GetGlobal(lua.ErrorsLibName).(*lua.LTable)
 		cachedErrorsLib.Immutable = true
+
+		cachedLibs = []cachedLib{
+			{name: lua.TabLibName, tbl: cachedTableLib},
+			{name: lua.MathLibName, tbl: cachedMathLib},
+			{name: "os", tbl: cachedOsLib},
+			{name: lua.CoroutineLibName, tbl: cachedCoroutineLib},
+			{name: lua.StringLibName, tbl: cachedStringLib},
+			{name: lua.ErrorsLibName, tbl: cachedErrorsLib},
+		}
 	})
 }
 
@@ -55,16 +73,25 @@ func initCachedLibs() {
 func BindCachedLibs(L *lua.LState) {
 	initCachedLibs()
 
-	L.SetGlobal(lua.TabLibName, cachedTableLib)
-	L.SetGlobal(lua.MathLibName, cachedMathLib)
-	L.SetGlobal("os", cachedOsLib)
-	L.SetGlobal(lua.CoroutineLibName, cachedCoroutineLib)
-	L.SetGlobal(lua.StringLibName, cachedStringLib)
-	L.SetGlobal(lua.ErrorsLibName, cachedErrorsLib)
+	for _, lib := range cachedLibs {
+		L.SetGlobal(lib.name, lib.tbl)
+	}
 
 	// Register error metatable (needed per-LState for builtinMts)
 	lua.RegisterErrorMetatable(L)
 
 	// String lib as metatable for string values (enables "hello":upper())
 	L.SetMetatable(lua.LString(""), cachedStringLib)
+}
+
+// StdLibNames returns the names of the standard libraries BindCachedLibs
+// installs as globals.
+func StdLibNames() []string {
+	initCachedLibs()
+
+	names := make([]string, len(cachedLibs))
+	for i, lib := range cachedLibs {
+		names[i] = lib.name
+	}
+	return names
 }

--- a/runtime/lua/engine/core_modules.go
+++ b/runtime/lua/engine/core_modules.go
@@ -98,12 +98,21 @@ func printFunc(l *lua.LState) int {
 	return 0
 }
 
+// coreModules are loaded as ambient globals into every Lua state by
+// LoadCoreModules and are therefore require-able without an import declaration.
+// ostime.Module is named "os" and supplies the standard os library.
+var coreModules = []*luaapi.ModuleDef{
+	payload.Module,
+	ostime.Module,
+	PrintModule,
+	ChannelModule,
+}
+
 // LoadCoreModules loads all core modules into the LState.
 func LoadCoreModules(l *lua.LState) error {
-	LoadModuleDef(l, payload.Module)
-	LoadModuleDef(l, ostime.Module)
-	LoadModuleDef(l, PrintModule)
-	LoadModuleDef(l, ChannelModule)
+	for _, m := range coreModules {
+		LoadModuleDef(l, m)
+	}
 	loadPubSubGlobals(l)
 	return nil
 }
@@ -118,4 +127,16 @@ func loadPubSubGlobals(l *lua.LState) {
 // CoreBinders returns the core module loader as a single binder.
 func CoreBinders() []ModuleBinder {
 	return []ModuleBinder{LoadCoreModules}
+}
+
+// AmbientBaseModuleNames returns the names of modules and standard libraries
+// that every Lua chunk can require without an explicit import declaration. It is
+// derived from coreModules (loaded by LoadCoreModules) and StdLibNames (installed
+// by BindCachedLibs), so it cannot drift from what the runtime actually installs.
+func AmbientBaseModuleNames() []string {
+	names := make([]string, 0, len(coreModules))
+	for _, m := range coreModules {
+		names = append(names, m.Name)
+	}
+	return append(names, StdLibNames()...)
 }

--- a/runtime/lua/engine/factory_test.go
+++ b/runtime/lua/engine/factory_test.go
@@ -724,7 +724,7 @@ func TestFactory_ModuleAliasing_GoModule(t *testing.T) {
 	state := luaProc.State()
 
 	// Imports are scoped to the chunk environment, not the shared _G.
-	aliasedMod := state.Env.RawGetString("aliased_module")
+	aliasedMod := state.GetField(state.Env, "aliased_module")
 	if aliasedMod == lua.LNil {
 		t.Fatal("aliased_module not found in chunk env")
 	}
@@ -790,7 +790,7 @@ func TestFactory_ModuleAliasing_LuaLibrary(t *testing.T) {
 	state := luaProc.State()
 
 	// Imports are scoped to the chunk environment, not the shared _G.
-	utilsMod := state.Env.RawGetString("utils")
+	utilsMod := state.GetField(state.Env, "utils")
 	if utilsMod == lua.LNil {
 		t.Fatal("utils not found in chunk env")
 	}
@@ -884,7 +884,7 @@ func TestFactory_ModuleAliasing_MultipleAliases(t *testing.T) {
 	state := luaProc.State()
 
 	// Verify first alias
-	firstMod := state.Env.RawGetString("first")
+	firstMod := state.GetField(state.Env, "first")
 	if firstMod == lua.LNil {
 		t.Fatal("first not found in chunk env")
 	}
@@ -897,7 +897,7 @@ func TestFactory_ModuleAliasing_MultipleAliases(t *testing.T) {
 	}
 
 	// Verify second alias
-	secondMod := state.Env.RawGetString("second")
+	secondMod := state.GetField(state.Env, "second")
 	if secondMod == lua.LNil {
 		t.Fatal("second not found in chunk env")
 	}
@@ -979,7 +979,7 @@ func TestFactory_ModuleAliasing_SameModuleDifferentAliases(t *testing.T) {
 	state1 := proc1.(*Process).State()
 
 	// Verify alpha is set but not shared_mod
-	alphaMod := state1.Env.RawGetString("alpha")
+	alphaMod := state1.GetField(state1.Env, "alpha")
 	if alphaMod == lua.LNil {
 		t.Fatal("alpha not found in proc1 chunk env")
 	}
@@ -1007,7 +1007,7 @@ func TestFactory_ModuleAliasing_SameModuleDifferentAliases(t *testing.T) {
 	state2 := proc2.(*Process).State()
 
 	// Verify beta is set but not shared_mod
-	betaMod := state2.Env.RawGetString("beta")
+	betaMod := state2.GetField(state2.Env, "beta")
 	if betaMod == lua.LNil {
 		t.Fatal("beta not found in proc2 chunk env")
 	}

--- a/runtime/lua/engine/process_factory.go
+++ b/runtime/lua/engine/process_factory.go
@@ -100,6 +100,13 @@ func WithModule(mod *luaapi.ModuleDef) FactoryOption {
 	}
 }
 
+// WithModules adds several extra modules to load.
+func WithModules(mods ...*luaapi.ModuleDef) FactoryOption {
+	return func(c *processConfig) {
+		c.extraModules = append(c.extraModules, mods...)
+	}
+}
+
 // WithFilter sets a custom filter function.
 // Return (true, nil) to include, (false, nil) to exclude, (false, err) to fail.
 func WithFilter(fn func(name string, classes []string) (bool, error)) FactoryOption {
@@ -268,17 +275,19 @@ func (f *ProcessFactory) isolationBinder(
 }
 
 // buildChunkEnv creates a scoped global environment for one code chunk. The
-// environment exposes only the chunk's declared imports (both as globals and
+// environment exposes only the chunk's declared imports (as global lookups and
 // through a scoped require) and falls back to the shared safe base for standard
-// globals via its metatable. Undeclared modules resolve to nil and require
-// fails closed.
+// globals via its metatable.
+//
+// A runtime-installed DSL global may temporarily shadow an import alias when
+// that global did not exist in the base environment at chunk creation time. This
+// preserves the old shared-_G migration DSL behavior without leaking declared
+// imports into _G. Undeclared modules resolve to nil and require fails closed.
 func buildChunkEnv(l *lua.LState, base *lua.LTable, imports []code.Import, valueByNode map[registry.ID]lua.LValue) *lua.LTable {
 	env := l.NewTable()
-	mt := l.NewTable()
-	mt.RawSetString("__index", base)
-	l.SetMetatable(env, mt)
 
 	resolved := make(map[string]lua.LValue, len(imports))
+	baseHadAlias := make(map[string]bool, len(imports))
 	for _, imp := range imports {
 		v, ok := valueByNode[imp.ID]
 		if !ok {
@@ -288,9 +297,33 @@ func buildChunkEnv(l *lua.LState, base *lua.LTable, imports []code.Import, value
 		if alias == "" {
 			alias = imp.ID.Name
 		}
-		env.RawSetString(alias, v)
 		resolved[alias] = v
+		baseHadAlias[alias] = base.RawGetString(alias) != lua.LNil
 	}
+
+	mt := l.NewTable()
+	mt.RawSetString("__index", l.NewFunction(func(s *lua.LState) int {
+		name := s.CheckString(2)
+		baseValue := base.RawGetString(name)
+		if baseValue != lua.LNil && !baseHadAlias[name] {
+			// Dynamic globals installed after chunk creation, such as the
+			// migration DSL's migration/up/down helpers, must be visible to
+			// closures running in this chunk environment.
+			s.Push(baseValue)
+			return 1
+		}
+		if v, ok := resolved[name]; ok {
+			s.Push(v)
+			return 1
+		}
+		if baseValue != lua.LNil {
+			s.Push(baseValue)
+			return 1
+		}
+		s.Push(lua.LNil)
+		return 1
+	}))
+	l.SetMetatable(env, mt)
 
 	env.RawSetString("require", l.NewFunction(func(s *lua.LState) int {
 		name := s.CheckString(1)

--- a/runtime/lua/engine/process_isolation_test.go
+++ b/runtime/lua/engine/process_isolation_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/registry"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	"github.com/wippyai/runtime/runtime/lua/code"
@@ -78,7 +80,7 @@ func TestFactory_ImportIsolation_LibDepDoesNotLeak(t *testing.T) {
 	env := state.Env
 
 	// The library resolved its declared module: proves libs keep working.
-	libVal := env.RawGetString("lib")
+	libVal := state.GetField(env, "lib")
 	libTbl, ok := libVal.(*lua.LTable)
 	if !ok {
 		t.Fatalf("entry env missing 'lib' table, got %T", libVal)
@@ -160,7 +162,7 @@ func TestFactory_ImportIsolation_OverlayLibrary(t *testing.T) {
 	env := state.Env
 
 	// The runner can call the overlay's privileged API and get its result.
-	overlayVal := env.RawGetString("overlay")
+	overlayVal := state.GetField(env, "overlay")
 	overlayTbl, ok := overlayVal.(*lua.LTable)
 	if !ok {
 		t.Fatalf("runner env missing 'overlay' table, got %T", overlayVal)
@@ -183,5 +185,134 @@ func TestFactory_ImportIsolation_OverlayLibrary(t *testing.T) {
 	}
 	if v := state.GetGlobal("funcs"); v != lua.LNil {
 		t.Fatalf("LEAK: 'funcs' is a real global: %v", v)
+	}
+}
+
+func TestFactory_ImportIsolation_ExplicitGlobalExportIsVisibleWithoutImportLeak(t *testing.T) {
+	cm := setupFactoryCodeManager(t)
+
+	if err := cm.AddNode(context.Background(), code.Node{
+		ID:     registry.NewID("", "funcs"),
+		Kind:   luaapi.ModuleKind,
+		Module: isolationSecretModule,
+	}, nil); err != nil {
+		t.Fatalf("AddNode funcs failed: %v", err)
+	}
+
+	exporterID := registry.NewID("app", "global_exporter")
+	if err := cm.AddNode(context.Background(), code.Node{
+		ID:     exporterID,
+		Kind:   luaapi.Library,
+		Source: `_G.public_export = "visible"; local f = require("funcs"); return { marker = f.marker }`,
+	}, []code.Import{{ID: registry.NewID("", "funcs"), Alias: "funcs"}}); err != nil {
+		t.Fatalf("AddNode exporter failed: %v", err)
+	}
+
+	consumerID := registry.NewID("app", "global_consumer")
+	if err := cm.AddNode(context.Background(), code.Node{
+		ID:     consumerID,
+		Kind:   luaapi.Function,
+		Source: `return function() return public_export end`,
+		Method: "main",
+	}, []code.Import{{ID: exporterID, Alias: "exporter"}}); err != nil {
+		t.Fatalf("AddNode consumer failed: %v", err)
+	}
+
+	pf := NewProcessFactory(cm)
+	factoryFn, err := pf.CreateFactory(consumerID)
+	if err != nil {
+		t.Fatalf("CreateFactory failed: %v", err)
+	}
+	procRaw, err := factoryFn()
+	if err != nil {
+		t.Fatalf("factory() failed: %v", err)
+	}
+	defer procRaw.Close()
+
+	luaProc := procRaw.(*Process)
+	state := luaProc.State()
+
+	if got := state.GetGlobal("public_export"); got.String() != "visible" {
+		t.Fatalf("explicit global export not visible in _G, got %v", got)
+	}
+	if got := state.GetField(state.Env, "public_export"); got.String() != "visible" {
+		t.Fatalf("explicit global export not visible through chunk env, got %v", got)
+	}
+	if v := luaProc.State().GetGlobal("funcs"); v != lua.LNil {
+		t.Fatalf("LEAK: imported capability module became a real global: %v", v)
+	}
+	if v := state.GetField(state.Env, "funcs"); v != lua.LNil {
+		t.Fatalf("LEAK: imported capability module visible to consumer env: %v", v)
+	}
+}
+
+func TestFactory_ImportIsolation_DynamicDSLGlobalOverridesImportAlias(t *testing.T) {
+	cm := setupFactoryCodeManager(t)
+
+	migrationID := registry.NewID("wippy", "migration")
+	if err := cm.AddNode(context.Background(), code.Node{
+		ID:   migrationID,
+		Kind: luaapi.Library,
+		Source: `
+			return {
+				define = function(fn)
+					_G.migration = function(name)
+						return "dsl:" .. name
+					end
+					local ok, result = pcall(fn)
+					_G.migration = nil
+					if not ok then error(result) end
+					return result
+				end
+			}
+		`,
+	}, nil); err != nil {
+		t.Fatalf("AddNode migration library failed: %v", err)
+	}
+
+	fnID := registry.NewID("app", "migration_consumer")
+	if err := cm.AddNode(context.Background(), code.Node{
+		ID:     fnID,
+		Kind:   luaapi.Function,
+		Source: `return function() return require("migration").define(function() return migration("ok") end) end`,
+		Method: "main",
+	}, []code.Import{{ID: migrationID, Alias: "migration"}}); err != nil {
+		t.Fatalf("AddNode migration consumer failed: %v", err)
+	}
+
+	pf := NewProcessFactory(cm)
+	factoryFn, err := pf.CreateFactory(fnID)
+	if err != nil {
+		t.Fatalf("CreateFactory failed: %v", err)
+	}
+	procRaw, err := factoryFn()
+	if err != nil {
+		t.Fatalf("factory() failed: %v", err)
+	}
+	defer procRaw.Close()
+
+	ctx, _ := ctxapi.OpenFrameContext(context.Background())
+	if err := procRaw.Init(ctx, "main", nil); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	var output process.StepOutput
+	if err := procRaw.Step(nil, &output); err != nil {
+		t.Fatalf("Step failed: %v", err)
+	}
+	if output.Status() != process.StepDone {
+		t.Fatalf("expected StepDone, got %v", output.Status())
+	}
+	if output.Result() == nil {
+		t.Fatal("expected non-nil result")
+	}
+	got, ok := output.Result().Data().(lua.LString)
+	if !ok || got.String() != "dsl:ok" {
+		t.Fatalf("expected dynamic DSL global to shadow migration import alias, got %#v", output.Result().Data())
+	}
+
+	luaProc := procRaw.(*Process)
+	if v := luaProc.State().GetGlobal("migration"); v != lua.LNil {
+		t.Fatalf("migration DSL leaked into _G after define cleanup: %v", v)
 	}
 }


### PR DESCRIPTION
## Problem

Under per-chunk import scoping (#388), a scoped `require("x")` resolves only the chunk's declared imports plus a small ambient base (core modules, std libs, the `process` module). An undeclared registry module — e.g. `require("json")` without `json` in the entry's `_index.yaml` — therefore fails **closed at runtime** (`module 'json' not found`), with no warning at lint time.

Lint did not catch it: its require allowlist was built from *every* registered module (`GetModuleDefs()`), so any module with type info looked ambient.

## Change

**`feat(lint)`** — a literal `require("x")` is now an error when `x` is neither a declared import/module in the entry's `_index.yaml` nor an ambient module. Lint walks the parsed AST for literal require strings; dynamic `require(var)` stays runtime-checked. `requireBuiltins` is built from the real ambient set, so the lint allowlist matches what the runtime actually resolves without a declaration.

**`fix(lua)`** — the ambient set is now single-sourced so runtime and lint cannot drift:
- `engine.coreModules` drives both `LoadCoreModules` and `AmbientBaseModuleNames`.
- `engine.cachedLibs` drives both `BindCachedLibs` and `StdLibNames`.
- `component.ExecutableAmbientModules` is the one source for the `process` module injected into every executable Lua kind; the function, process and workflow factories consume it via `engine.WithModules`.

Also hardens `buildChunkEnv`: globals resolve through a metatable `__index` function instead of pointing `__index` at the shared base, so a runtime-installed DSL global (the migration `up`/`down`/`migration` helpers) is visible to closures in that chunk while declared imports still never leak into `_G`.

## Tests

- engine: every advertised ambient name resolves as a real runtime global (drift guard).
- component: `ExecutableAmbientModules` includes the process module; names track modules.
- lint: ambient names need no declaration; undeclared `json` is flagged; declaring it clears the diagnostic; dynamic require ignored; nested-in-function detected.

## Validation

Ran over a large app (1350 entries): 35 findings, all genuine undeclared registry modules (`time`, `thread_ingest`, `env`, `security`, `json`, `access_policy`, `consts`, `uuid`, `tools`, `funcs`, `expr`, `component`) — zero ambient-name false positives. Verified per-entry precision: the same module is flagged where undeclared and clean where declared.