### PR TITLE
Fix process-local registry resource lease leaks

### DIFF
--- a/api/runtime/resource/lease.go
+++ b/api/runtime/resource/lease.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/wippyai/runtime/api/registry"
+	apiresource "github.com/wippyai/runtime/api/resource"
+)
+
+// TypeRegistryLease is the resource table type ID for registry-backed leases.
+const TypeRegistryLease uint32 = 0x01
+
+type registryLeaseKey struct {
+	id   string
+	mode apiresource.AccessMode
+}
+
+type registryLeaseEntry struct {
+	key   registryLeaseKey
+	res   apiresource.Resource[any]
+	value any
+}
+
+func (e *registryLeaseEntry) Drop() {
+	if e.res != nil {
+		e.res.Release()
+		e.res = nil
+	}
+	e.value = nil
+}
+
+// Lease is a logical handle to a process-local registry resource lease.
+// Multiple Lease values can point at the same underlying table entry; releasing
+// one lease only returns that logical borrow.
+type Lease struct {
+	store    *Store
+	key      registryLeaseKey
+	handle   Handle
+	released atomic.Bool
+}
+
+var _ apiresource.Resource[any] = (*Lease)(nil)
+
+// AcquireRegistryResource acquires a registry resource using the process-local
+// resource store when available. For normal-mode resources this deduplicates
+// repeated acquisitions inside a process while still returning independent
+// logical handles to callers.
+func AcquireRegistryResource(ctx context.Context, reg apiresource.Registry, id registry.ID, mode apiresource.AccessMode) (apiresource.Resource[any], any, error) {
+	if s := GetStore(ctx); s != nil && mode == apiresource.ModeNormal {
+		return s.acquireRegistryResource(ctx, reg, id, mode)
+	}
+	return acquireDirectRegistryResource(ctx, reg, id, mode)
+}
+
+func acquireDirectRegistryResource(ctx context.Context, reg apiresource.Registry, id registry.ID, mode apiresource.AccessMode) (apiresource.Resource[any], any, error) {
+	if reg == nil {
+		return nil, nil, apiresource.ErrNotFound
+	}
+
+	res, err := reg.Acquire(ctx, id, mode)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	value, err := res.Get()
+	if err != nil {
+		res.Release()
+		return nil, nil, err
+	}
+
+	return res, value, nil
+}
+
+func (s *Store) acquireRegistryResource(ctx context.Context, reg apiresource.Registry, id registry.ID, mode apiresource.AccessMode) (*Lease, any, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
+	key := registryLeaseKey{id: id.String(), mode: mode}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, nil, apiresource.ErrReleased
+	}
+	if s.leases == nil {
+		s.leases = make(map[registryLeaseKey]Handle, 4)
+	}
+
+	if handle, ok := s.leases[key]; ok {
+		value, borrowed := s.borrowRegistryLeaseLocked(key, handle)
+		if borrowed {
+			s.mu.Unlock()
+			return &Lease{store: s, key: key, handle: handle}, value, nil
+		}
+		delete(s.leases, key)
+	}
+
+	res, value, err := acquireDirectRegistryResource(ctx, reg, id, mode)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, nil, err
+	}
+
+	entry := &registryLeaseEntry{key: key, res: res, value: value}
+	handle := s.table.Insert(TypeRegistryLease, entry)
+	if handle == 0 {
+		entry.Drop()
+		s.mu.Unlock()
+		return nil, nil, apiresource.ErrReleased
+	}
+	if !s.table.Borrow(handle) {
+		_, _ = s.table.Remove(handle)
+		s.mu.Unlock()
+		return nil, nil, apiresource.ErrReleased
+	}
+
+	s.leases[key] = handle
+	s.mu.Unlock()
+
+	return &Lease{store: s, key: key, handle: handle}, value, nil
+}
+
+func (s *Store) borrowRegistryLeaseLocked(key registryLeaseKey, handle Handle) (any, bool) {
+	raw, ok := s.table.GetTyped(handle, TypeRegistryLease)
+	if !ok {
+		return nil, false
+	}
+	entry, ok := raw.(*registryLeaseEntry)
+	if !ok || entry.key != key {
+		return nil, false
+	}
+	if !s.table.Borrow(handle) {
+		return nil, false
+	}
+	return entry.value, true
+}
+
+func (s *Store) releaseRegistryLease(key registryLeaseKey, handle Handle) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return
+	}
+	if !s.table.ReturnBorrow(handle) {
+		return
+	}
+	if _, removed := s.table.Remove(handle); removed {
+		if current, ok := s.leases[key]; ok && current == handle {
+			delete(s.leases, key)
+		}
+	}
+}
+
+// Get returns the underlying registry resource value while this logical lease is
+// still live.
+func (l *Lease) Get() (any, error) {
+	if l == nil || l.released.Load() || l.store == nil {
+		return nil, apiresource.ErrReleased
+	}
+
+	raw, ok := l.store.table.GetTyped(l.handle, TypeRegistryLease)
+	if !ok {
+		return nil, apiresource.ErrReleased
+	}
+	entry, ok := raw.(*registryLeaseEntry)
+	if !ok || entry.key != l.key {
+		return nil, fmt.Errorf("invalid registry lease entry")
+	}
+	return entry.value, nil
+}
+
+// Release returns this logical lease. The underlying resource is released only
+// after the last logical lease is released or when the process resource store
+// closes.
+func (l *Lease) Release() {
+	if l == nil || !l.released.CompareAndSwap(false, true) || l.store == nil {
+		return
+	}
+	l.store.releaseRegistryLease(l.key, l.handle)
+}

--- a/api/runtime/resource/lease.go
+++ b/api/runtime/resource/lease.go
@@ -20,9 +20,9 @@ type registryLeaseKey struct {
 }
 
 type registryLeaseEntry struct {
-	key   registryLeaseKey
 	res   apiresource.Resource[any]
 	value any
+	key   registryLeaseKey
 }
 
 func (e *registryLeaseEntry) Drop() {

--- a/api/runtime/resource/resource_test.go
+++ b/api/runtime/resource/resource_test.go
@@ -8,11 +8,14 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/registry"
+	apiresource "github.com/wippyai/runtime/api/resource"
 )
 
 func TestSetStore(t *testing.T) {
@@ -96,6 +99,136 @@ func TestStore_Table(t *testing.T) {
 	v, ok := table.Get(h)
 	assert.True(t, ok)
 	assert.Equal(t, "test", v)
+}
+
+type leaseTestRegistry struct {
+	value    any
+	acquires atomic.Int64
+	releases atomic.Int64
+}
+
+func (r *leaseTestRegistry) Acquire(_ context.Context, _ registry.ID, _ apiresource.AccessMode) (apiresource.Resource[any], error) {
+	r.acquires.Add(1)
+	return &leaseTestResource{value: r.value, releases: &r.releases}, nil
+}
+
+func (r *leaseTestRegistry) List() ([]registry.ID, error) {
+	return []registry.ID{registry.ParseID("test:resource")}, nil
+}
+
+func (r *leaseTestRegistry) Exists(registry.ID) bool {
+	return true
+}
+
+type leaseTestResource struct {
+	value    any
+	releases *atomic.Int64
+	released atomic.Bool
+}
+
+func (r *leaseTestResource) Get() (any, error) {
+	if r.released.Load() {
+		return nil, apiresource.ErrReleased
+	}
+	return r.value, nil
+}
+
+func (r *leaseTestResource) Release() {
+	if r.released.CompareAndSwap(false, true) {
+		r.releases.Add(1)
+	}
+}
+
+func TestAcquireRegistryResource_LeaseDedupeAndIndependentRelease(t *testing.T) {
+	ctx, fc := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(fc)
+
+	store := NewStore()
+	defer func() { _ = store.Close() }()
+	require.NoError(t, SetStore(ctx, store))
+
+	reg := &leaseTestRegistry{value: "shared"}
+	id := registry.ParseID("test:resource")
+
+	leaseA, valueA, err := AcquireRegistryResource(ctx, reg, id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	assert.Equal(t, "shared", valueA)
+
+	leaseB, valueB, err := AcquireRegistryResource(ctx, reg, id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	assert.Equal(t, "shared", valueB)
+	assert.Equal(t, int64(1), reg.acquires.Load())
+
+	leaseA.Release()
+	assert.Equal(t, int64(0), reg.releases.Load(), "first logical release must not release shared resource")
+
+	got, err := leaseB.Get()
+	require.NoError(t, err)
+	assert.Equal(t, "shared", got)
+
+	leaseB.Release()
+	assert.Equal(t, int64(1), reg.releases.Load(), "last logical release should release shared resource once")
+}
+
+func TestAcquireRegistryResource_LeaseReleasedOnStoreClose(t *testing.T) {
+	ctx, fc := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(fc)
+
+	store := NewStore()
+	require.NoError(t, SetStore(ctx, store))
+
+	reg := &leaseTestRegistry{value: "shared"}
+	id := registry.ParseID("test:resource")
+
+	leaseA, _, err := AcquireRegistryResource(ctx, reg, id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	leaseB, _, err := AcquireRegistryResource(ctx, reg, id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), reg.acquires.Load())
+
+	require.NoError(t, store.Close())
+	assert.Equal(t, int64(1), reg.releases.Load())
+
+	leaseA.Release()
+	leaseB.Release()
+	assert.Equal(t, int64(1), reg.releases.Load(), "logical release after store close must not double release")
+}
+
+func TestAcquireRegistryResource_FallsBackWithoutRuntimeStore(t *testing.T) {
+	reg := &leaseTestRegistry{value: "direct"}
+	id := registry.ParseID("test:resource")
+
+	leaseA, _, err := AcquireRegistryResource(context.Background(), reg, id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	leaseB, _, err := AcquireRegistryResource(context.Background(), reg, id, apiresource.ModeNormal)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), reg.acquires.Load())
+	leaseA.Release()
+	leaseB.Release()
+	assert.Equal(t, int64(2), reg.releases.Load())
+}
+
+func TestAcquireRegistryResource_DoesNotCacheExclusiveMode(t *testing.T) {
+	ctx, fc := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(fc)
+
+	store := NewStore()
+	defer func() { _ = store.Close() }()
+	require.NoError(t, SetStore(ctx, store))
+
+	reg := &leaseTestRegistry{value: "exclusive"}
+	id := registry.ParseID("test:resource")
+
+	leaseA, _, err := AcquireRegistryResource(ctx, reg, id, apiresource.ModeExclusive)
+	require.NoError(t, err)
+	leaseB, _, err := AcquireRegistryResource(ctx, reg, id, apiresource.ModeExclusive)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), reg.acquires.Load())
+	leaseA.Release()
+	leaseB.Release()
+	assert.Equal(t, int64(2), reg.releases.Load())
 }
 
 func TestStore_AddCleanup(t *testing.T) {

--- a/api/runtime/resource/store.go
+++ b/api/runtime/resource/store.go
@@ -17,6 +17,10 @@ type cleanupNode struct {
 // Designed for fast access from both Lua and WASM runtimes.
 type Store struct {
 	table *Table
+	// leases indexes registry-backed resources acquired by this process. The
+	// table owns the underlying resource lifecycle; each Lease is only a logical
+	// borrow of the keyed table entry.
+	leases map[registryLeaseKey]Handle
 	// head and tail bound a doubly-linked list of live cleanups.
 	// Nodes are appended at tail; Close walks tail->head for LIFO order.
 	head, tail *cleanupNode
@@ -114,6 +118,9 @@ func (s *Store) Close() error {
 	s.head = nil
 	s.tail = nil
 	s.count = 0
+	if s.leases != nil {
+		clear(s.leases)
+	}
 	s.mu.Unlock()
 
 	var firstErr error

--- a/runtime/lua/modules/cloudstorage/module.go
+++ b/runtime/lua/modules/cloudstorage/module.go
@@ -3,7 +3,6 @@
 package cloudstorage
 
 import (
-	"context"
 	"io"
 
 	lua "github.com/wippyai/go-lua"
@@ -44,10 +43,9 @@ var Module = &luaapi.ModuleDef{
 
 // storageWrapper wraps a cloud storage instance with resource tracking.
 type storageWrapper struct {
-	storage   csapi.Storage
-	resource  resource.Resource[any]
-	onRelease context.CancelFunc
-	released  bool
+	storage  csapi.Storage
+	resource resource.Resource[any]
+	released bool
 }
 
 var storageMethods = map[string]lua.LGoFunc{
@@ -83,13 +81,6 @@ func apiGet(l *lua.LState) int {
 	}
 
 	ctx := l.Context()
-	store := rtresource.GetStore(ctx)
-	if store == nil {
-		l.Push(lua.LNil)
-		l.Push(lua.NewLuaError(l, "resource store not found").WithKind(lua.Internal).WithRetryable(false))
-		return 2
-	}
-
 	reg := resource.GetRegistry(ctx)
 	if reg == nil {
 		l.Push(lua.LNil)
@@ -104,23 +95,10 @@ func apiGet(l *lua.LState) int {
 		return 0
 	}
 
-	res, err := reg.Acquire(ctx, resID, resource.ModeNormal)
+	res, storageRes, err := rtresource.AcquireRegistryResource(ctx, reg, resID, resource.ModeNormal)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, err.Error()).WithKind(lua.NotFound).WithRetryable(false))
-		return 2
-	}
-
-	onRelease := store.AddCleanup(func() error {
-		res.Release()
-		return nil
-	})
-
-	storageRes, err := res.Get()
-	if err != nil {
-		res.Release()
-		l.Push(lua.LNil)
-		l.Push(lua.NewLuaError(l, err.Error()).WithKind(lua.Internal).WithRetryable(false))
 		return 2
 	}
 
@@ -133,9 +111,8 @@ func apiGet(l *lua.LState) int {
 	}
 
 	wrapper := &storageWrapper{
-		storage:   csRes,
-		resource:  res,
-		onRelease: onRelease,
+		storage:  csRes,
+		resource: res,
 	}
 
 	value.PushTypedUserData(l, wrapper, storageTypeName)
@@ -162,11 +139,6 @@ func storageRelease(l *lua.LState) int {
 	if wrapper.resource != nil {
 		wrapper.resource.Release()
 		wrapper.resource = nil
-	}
-
-	if wrapper.onRelease != nil {
-		wrapper.onRelease()
-		wrapper.onRelease = nil
 	}
 
 	wrapper.released = true

--- a/runtime/lua/modules/exec/executor.go
+++ b/runtime/lua/modules/exec/executor.go
@@ -17,34 +17,18 @@ import (
 )
 
 type Executor struct {
-	resource      resource.Resource[any]
-	factory       apiexec.ProcessExecutor
-	cancelCleanup func()
-	mu            sync.Mutex
-	released      bool
+	resource resource.Resource[any]
+	factory  apiexec.ProcessExecutor
+	mu       sync.Mutex
+	released bool
 }
 
-func NewExecutor(ctx context.Context, res resource.Resource[any], factory apiexec.ProcessExecutor) *Executor {
-	e := &Executor{
+func NewExecutor(_ context.Context, res resource.Resource[any], factory apiexec.ProcessExecutor) *Executor {
+	return &Executor{
 		resource: res,
 		factory:  factory,
 		released: false,
 	}
-
-	store := rtresource.GetStore(ctx)
-	if store != nil {
-		e.cancelCleanup = store.AddCleanup(func() error {
-			e.mu.Lock()
-			defer e.mu.Unlock()
-			if !e.released && e.resource != nil {
-				e.resource.Release()
-				e.released = true
-			}
-			return nil
-		})
-	}
-
-	return e
 }
 
 var executorMethods = map[string]lua.LGoFunc{
@@ -90,18 +74,10 @@ func execGet(l *lua.LState) int {
 	}
 
 	resID := registry.ParseID(id)
-	res, err := reg.Acquire(ctx, resID, resource.ModeNormal)
+	res, execRes, err := rtresource.AcquireRegistryResource(ctx, reg, resID, resource.ModeNormal)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.WrapErrorWithLua(l, err, "acquire resource").WithKind(lua.Internal).WithRetryable(false))
-		return 2
-	}
-
-	execRes, err := res.Get()
-	if err != nil {
-		res.Release()
-		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "get resource").WithKind(lua.Internal).WithRetryable(false))
 		return 2
 	}
 
@@ -194,12 +170,7 @@ func executorRelease(l *lua.LState) int {
 		e.resource.Release()
 		e.resource = nil
 		e.released = true
-		cancel := e.cancelCleanup
-		e.cancelCleanup = nil
 		e.mu.Unlock()
-		if cancel != nil {
-			cancel()
-		}
 	} else {
 		e.mu.Unlock()
 	}

--- a/runtime/lua/modules/pg/module.go
+++ b/runtime/lua/modules/pg/module.go
@@ -4,7 +4,6 @@
 package pg
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -44,37 +43,21 @@ const pgInstanceTypeName = "pg.Instance"
 // Created by pg.open() and released automatically on frame cleanup or manually
 // via :release().
 type Instance struct {
-	resource      resource.Resource[any]
-	svc           pgapi.ScopeService
-	cancelCleanup func()
-	id            string
-	mu            sync.Mutex
-	released      bool
+	resource resource.Resource[any]
+	svc      pgapi.ScopeService
+	id       string
+	mu       sync.Mutex
+	released bool
 }
 
 // newPGInstance creates an Instance with automatic cleanup registration.
-func newPGInstance(ctx context.Context, id string, res resource.Resource[any], svc pgapi.ScopeService) *Instance {
-	inst := &Instance{
+func newPGInstance(id string, res resource.Resource[any], svc pgapi.ScopeService) *Instance {
+	return &Instance{
 		id:       id,
 		resource: res,
 		svc:      svc,
 		released: false,
 	}
-
-	resStore := rtresource.GetStore(ctx)
-	if resStore != nil {
-		inst.cancelCleanup = resStore.AddCleanup(func() error {
-			inst.mu.Lock()
-			defer inst.mu.Unlock()
-			if !inst.released && inst.resource != nil {
-				inst.resource.Release()
-				inst.released = true
-			}
-			return nil
-		})
-	}
-
-	return inst
 }
 
 var pgInstanceMethods = map[string]lua.LGoFunc{
@@ -134,12 +117,7 @@ func pgInstanceRelease(l *lua.LState) int {
 		inst.resource.Release()
 		inst.resource = nil
 		inst.released = true
-		cancel := inst.cancelCleanup
-		inst.cancelCleanup = nil
 		inst.mu.Unlock()
-		if cancel != nil {
-			cancel()
-		}
 	} else {
 		inst.mu.Unlock()
 	}
@@ -521,15 +499,9 @@ func pgOpen(l *lua.LState) int {
 	}
 
 	resID := registry.ParseID(id)
-	res, err := reg.Acquire(ctx, resID, resource.ModeNormal)
+	res, raw, err := rtresource.AcquireRegistryResource(ctx, reg, resID, resource.ModeNormal)
 	if err != nil {
 		return pushPGError(l, lua.LNil, newPGError(l, lua.Internal, fmt.Sprintf("failed to acquire pg scope: %v", err)))
-	}
-
-	raw, err := res.Get()
-	if err != nil {
-		res.Release()
-		return pushPGError(l, lua.LNil, newPGError(l, lua.Internal, fmt.Sprintf("failed to get pg scope resource: %v", err)))
 	}
 
 	svc, ok := raw.(pgapi.ScopeService)
@@ -538,7 +510,7 @@ func pgOpen(l *lua.LState) int {
 		return pushPGError(l, lua.LNil, newPGError(l, lua.Invalid, fmt.Sprintf("resource is not a pg scope: %T", raw)))
 	}
 
-	inst := newPGInstance(ctx, id, res, svc)
+	inst := newPGInstance(id, res, svc)
 	value.PushTypedUserData(l, inst, pgInstanceTypeName)
 	return 1
 }

--- a/runtime/lua/modules/security/token_store.go
+++ b/runtime/lua/modules/security/token_store.go
@@ -22,37 +22,21 @@ const tokenStoreTypeName = "security.TokenStore"
 
 // TokenStore wraps a token store resource with cleanup handling.
 type TokenStore struct {
-	resource      resource.Resource[any]
-	tokenStore    security.TokenStore
-	cancelCleanup func()
-	id            registry.ID
-	mu            sync.Mutex
-	released      bool
+	resource   resource.Resource[any]
+	tokenStore security.TokenStore
+	id         registry.ID
+	mu         sync.Mutex
+	released   bool
 }
 
 // NewTokenStore creates a new token store wrapper.
-func NewTokenStore(ctx context.Context, id registry.ID, res resource.Resource[any], ts security.TokenStore) *TokenStore {
-	wrapper := &TokenStore{
+func NewTokenStore(_ context.Context, id registry.ID, res resource.Resource[any], ts security.TokenStore) *TokenStore {
+	return &TokenStore{
 		id:         id,
 		resource:   res,
 		tokenStore: ts,
 		released:   false,
 	}
-
-	store := rtresource.GetStore(ctx)
-	if store != nil {
-		wrapper.cancelCleanup = store.AddCleanup(func() error {
-			wrapper.mu.Lock()
-			defer wrapper.mu.Unlock()
-			if !wrapper.released && wrapper.resource != nil {
-				wrapper.resource.Release()
-				wrapper.released = true
-			}
-			return nil
-		})
-	}
-
-	return wrapper
 }
 
 var tokenStoreMethods = map[string]lua.LGoFunc{
@@ -100,18 +84,10 @@ func tokenStoreGet(l *lua.LState) int {
 	}
 
 	id := registry.ParseID(idStr)
-	res, err := reg.Acquire(ctx, id, resource.ModeNormal)
+	res, storeRes, err := rtresource.AcquireRegistryResource(ctx, reg, id, resource.ModeNormal)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.WrapErrorWithLua(l, err, "acquire token store").WithKind(lua.Internal).WithRetryable(false))
-		return 2
-	}
-
-	storeRes, err := res.Get()
-	if err != nil {
-		res.Release()
-		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "get token store").WithKind(lua.Internal).WithRetryable(false))
 		return 2
 	}
 
@@ -293,12 +269,7 @@ func tokenStoreClose(l *lua.LState) int {
 		ts.resource.Release()
 		ts.resource = nil
 		ts.released = true
-		cancel := ts.cancelCleanup
-		ts.cancelCleanup = nil
 		ts.mu.Unlock()
-		if cancel != nil {
-			cancel()
-		}
 	} else {
 		ts.mu.Unlock()
 	}

--- a/runtime/lua/modules/sql/db.go
+++ b/runtime/lua/modules/sql/db.go
@@ -17,11 +17,10 @@ import (
 )
 
 type DB struct {
-	resource      resource.Resource[any]
-	db            *sql.DB
-	cancelCleanup func()
-	dbType        string
-	released      bool
+	resource resource.Resource[any]
+	db       *sql.DB
+	dbType   string
+	released bool
 }
 
 func (d *DB) GetRawDB() *sql.DB {
@@ -32,25 +31,13 @@ func (d *DB) GetDBType() string {
 	return d.dbType
 }
 
-func NewDB(ctx context.Context, res resource.Resource[any], db *sql.DB, dbType string) *DB {
-	dbWrapper := &DB{
+func NewDB(_ context.Context, res resource.Resource[any], db *sql.DB, dbType string) *DB {
+	return &DB{
 		resource: res,
 		db:       db,
 		dbType:   dbType,
 		released: false,
 	}
-
-	store := rtresource.GetStore(ctx)
-	if store != nil {
-		dbWrapper.cancelCleanup = store.AddCleanup(func() error {
-			if !dbWrapper.released && dbWrapper.resource != nil {
-				dbWrapper.resource.Release()
-			}
-			return nil
-		})
-	}
-
-	return dbWrapper
 }
 
 var dbMethods = map[string]lua.LGoFunc{
@@ -101,18 +88,10 @@ func sqlGet(l *lua.LState) int {
 	}
 
 	resID := registry.ParseID(id)
-	res, err := reg.Acquire(ctx, resID, resource.ModeNormal)
+	res, dbRes, err := rtresource.AcquireRegistryResource(ctx, reg, resID, resource.ModeNormal)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.WrapErrorWithLua(l, err, "acquire resource"))
-		return 2
-	}
-
-	dbRes, err := res.Get()
-	if err != nil {
-		res.Release()
-		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "get resource"))
 		return 2
 	}
 
@@ -267,10 +246,6 @@ func dbRelease(l *lua.LState) int {
 		db.resource.Release()
 		db.resource = nil
 		db.released = true
-		if db.cancelCleanup != nil {
-			db.cancelCleanup()
-			db.cancelCleanup = nil
-		}
 	}
 
 	l.Push(lua.LTrue)

--- a/runtime/lua/modules/store/leak_repro_test.go
+++ b/runtime/lua/modules/store/leak_repro_test.go
@@ -124,3 +124,64 @@ func TestStoreGetWithoutReleaseReproducesPerCallResourceLeak(t *testing.T) {
 			calls, acquires, releases, liveCleanups)
 	}
 }
+
+func TestStoreGetLeasedHandlesReleaseIndependently(t *testing.T) {
+	reg := newLeakReproRegistry(newMemoryStore())
+	l, resStore := setupLeakReproState(t, reg)
+
+	if err := l.DoString(`
+		local a, err = store.get("test:mystore")
+		if err then error(tostring(err)) end
+		local b, err = store.get("test:mystore")
+		if err then error(tostring(err)) end
+
+		a:release()
+
+		local info, info_err = b:info()
+		if info_err then error(tostring(info_err)) end
+		if info.id ~= "test:mystore" then error("wrong store id: " .. tostring(info.id)) end
+
+		b:release()
+	`); err != nil {
+		t.Fatalf("independent release script failed: %v", err)
+	}
+
+	if acquires := reg.acquires.Load(); acquires != 1 {
+		t.Fatalf("registry acquires = %d, want 1", acquires)
+	}
+	if releases := reg.releases.Load(); releases != 1 {
+		t.Fatalf("registry releases = %d, want 1 after last handle release", releases)
+	}
+	if liveCleanups := runtimeStoreLiveCleanups(resStore); liveCleanups != 0 {
+		t.Fatalf("live resource cleanups = %d, want 0", liveCleanups)
+	}
+}
+
+func TestStoreGetLeasedHandlesReleaseOnProcessResourceClose(t *testing.T) {
+	reg := newLeakReproRegistry(newMemoryStore())
+	l, resStore := setupLeakReproState(t, reg)
+
+	if err := l.DoString(`
+		for i = 1, 100 do
+			local s, err = store.get("test:mystore")
+			if err then error(tostring(err)) end
+			if s == nil then error("store.get returned nil") end
+		end
+	`); err != nil {
+		t.Fatalf("store.get loop failed: %v", err)
+	}
+
+	if acquires := reg.acquires.Load(); acquires != 1 {
+		t.Fatalf("registry acquires before close = %d, want 1", acquires)
+	}
+	if releases := reg.releases.Load(); releases != 0 {
+		t.Fatalf("registry releases before close = %d, want 0", releases)
+	}
+
+	if err := resStore.Close(); err != nil {
+		t.Fatalf("resource store close: %v", err)
+	}
+	if releases := reg.releases.Load(); releases != 1 {
+		t.Fatalf("registry releases after close = %d, want 1", releases)
+	}
+}

--- a/runtime/lua/modules/store/leak_repro_test.go
+++ b/runtime/lua/modules/store/leak_repro_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/registry"
+	apiresource "github.com/wippyai/runtime/api/resource"
+	rtresource "github.com/wippyai/runtime/api/runtime/resource"
+	"github.com/wippyai/runtime/api/security"
+	storeapi "github.com/wippyai/runtime/api/store"
+)
+
+type leakReproRegistry struct {
+	store    storeapi.Store
+	acquires atomic.Int64
+	releases atomic.Int64
+}
+
+func newLeakReproRegistry(s storeapi.Store) *leakReproRegistry {
+	return &leakReproRegistry{store: s}
+}
+
+func (r *leakReproRegistry) Acquire(_ context.Context, id registry.ID, _ apiresource.AccessMode) (apiresource.Resource[any], error) {
+	if id.String() != "test:mystore" {
+		return nil, apiresource.ErrNotFound
+	}
+	r.acquires.Add(1)
+	return &leakReproResource{store: r.store, releases: &r.releases}, nil
+}
+
+func (r *leakReproRegistry) List() ([]registry.ID, error) {
+	return []registry.ID{registry.ParseID("test:mystore")}, nil
+}
+
+func (r *leakReproRegistry) Exists(id registry.ID) bool {
+	return id.String() == "test:mystore"
+}
+
+type leakReproResource struct {
+	store    storeapi.Store
+	releases *atomic.Int64
+	released atomic.Bool
+}
+
+func (r *leakReproResource) Get() (any, error) {
+	if r.released.Load() {
+		return nil, apiresource.ErrReleased
+	}
+	return r.store, nil
+}
+
+func (r *leakReproResource) Release() {
+	if r.released.CompareAndSwap(false, true) {
+		r.releases.Add(1)
+	}
+}
+
+func setupLeakReproState(t *testing.T, reg apiresource.Registry) (*lua.LState, *rtresource.Store) {
+	t.Helper()
+
+	l := setupState()
+	ctx, fc := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+	ctx = security.SetStrictMode(ctx, false)
+	ctx = apiresource.WithRegistry(ctx, reg)
+	ctx = payload.WithTranscoder(ctx, &mockTranscoder{})
+
+	resStore := rtresource.NewStore()
+	if err := rtresource.SetStore(ctx, resStore); err != nil {
+		t.Fatalf("set runtime resource store: %v", err)
+	}
+
+	l.SetContext(ctx)
+	t.Cleanup(func() {
+		_ = resStore.Close()
+		ctxapi.ReleaseFrameContext(fc)
+		l.Close()
+	})
+
+	return l, resStore
+}
+
+func runtimeStoreLiveCleanups(s *rtresource.Store) int {
+	v := reflect.ValueOf(s).Elem().FieldByName("count")
+	return int(v.Int())
+}
+
+func TestStoreGetWithoutReleaseReproducesPerCallResourceLeak(t *testing.T) {
+	const calls = 50000
+
+	reg := newLeakReproRegistry(newMemoryStore())
+	l, resStore := setupLeakReproState(t, reg)
+
+	if err := l.DoString(fmt.Sprintf(`
+		for i = 1, %d do
+			local s, err = store.get("test:mystore")
+			if err then error(tostring(err)) end
+			if s == nil then error("store.get returned nil") end
+		end
+	`, calls)); err != nil {
+		t.Fatalf("store.get loop failed: %v", err)
+	}
+
+	runtime.GC()
+
+	acquires := int(reg.acquires.Load())
+	releases := int(reg.releases.Load())
+	liveCleanups := runtimeStoreLiveCleanups(resStore)
+
+	t.Logf("calls=%d registry_acquires=%d registry_releases=%d live_resource_cleanups=%d",
+		calls, acquires, releases, liveCleanups)
+
+	if acquires > 1 || liveCleanups > 1 {
+		t.Fatalf("reproduced per-call retained resource leak: calls=%d registry_acquires=%d registry_releases=%d live_resource_cleanups=%d; want acquires and live cleanups bounded",
+			calls, acquires, releases, liveCleanups)
+	}
+}

--- a/runtime/lua/modules/store/store.go
+++ b/runtime/lua/modules/store/store.go
@@ -21,36 +21,20 @@ import (
 )
 
 type Store struct {
-	resource      resource.Resource[any]
-	store         store.Store
-	cancelCleanup func()
-	id            string
-	mu            sync.Mutex
-	released      bool
+	resource resource.Resource[any]
+	store    store.Store
+	id       string
+	mu       sync.Mutex
+	released bool
 }
 
-func NewStore(ctx context.Context, id string, res resource.Resource[any], s store.Store) *Store {
-	storeWrapper := &Store{
+func NewStore(_ context.Context, id string, res resource.Resource[any], s store.Store) *Store {
+	return &Store{
 		id:       id,
 		resource: res,
 		store:    s,
 		released: false,
 	}
-
-	resStore := rtresource.GetStore(ctx)
-	if resStore != nil {
-		storeWrapper.cancelCleanup = resStore.AddCleanup(func() error {
-			storeWrapper.mu.Lock()
-			defer storeWrapper.mu.Unlock()
-			if !storeWrapper.released && storeWrapper.resource != nil {
-				storeWrapper.resource.Release()
-				storeWrapper.released = true
-			}
-			return nil
-		})
-	}
-
-	return storeWrapper
 }
 
 var storeMethods = map[string]lua.LGoFunc{
@@ -149,15 +133,9 @@ func storeGet(l *lua.LState) int {
 	}
 
 	resID := registry.ParseID(id)
-	res, err := reg.Acquire(ctx, resID, resource.ModeNormal)
+	res, storeRes, err := rtresource.AcquireRegistryResource(ctx, reg, resID, resource.ModeNormal)
 	if err != nil {
 		return internalError(l, err, "failed to acquire resource")
-	}
-
-	storeRes, err := res.Get()
-	if err != nil {
-		res.Release()
-		return internalError(l, err, "failed to get resource")
 	}
 
 	storeImpl, ok := storeRes.(store.Store)
@@ -447,12 +425,7 @@ func storeRelease(l *lua.LState) int {
 		s.resource.Release()
 		s.resource = nil
 		s.released = true
-		cancel := s.cancelCleanup
-		s.cancelCleanup = nil
 		s.mu.Unlock()
-		if cancel != nil {
-			cancel()
-		}
 	} else {
 		s.mu.Unlock()
 	}

--- a/runtime/lua/modules/template/module.go
+++ b/runtime/lua/modules/template/module.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/resource"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	rtresource "github.com/wippyai/runtime/api/runtime/resource"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
 	"github.com/wippyai/runtime/runtime/security"
 	servicetemplate "github.com/wippyai/runtime/service/template"
@@ -88,18 +89,9 @@ func templateGet(l *lua.LState) int {
 	}
 
 	resID := registry.ParseID(id)
-	res, acquireErr := reg.Acquire(ctx, resID, resource.ModeNormal)
+	res, templateRes, acquireErr := rtresource.AcquireRegistryResource(ctx, reg, resID, resource.ModeNormal)
 	if acquireErr != nil {
 		err := lua.WrapErrorWithLua(l, acquireErr, "failed to acquire resource").
-			WithKind(lua.Internal).
-			WithRetryable(false)
-		return pushError(l, err)
-	}
-
-	templateRes, getErr := res.Get()
-	if getErr != nil {
-		res.Release()
-		err := lua.WrapErrorWithLua(l, getErr, "failed to get resource").
 			WithKind(lua.Internal).
 			WithRetryable(false)
 		return pushError(l, err)


### PR DESCRIPTION
## Summary
- add a process-local registry lease manager backed by the unified runtime resource table
- dedupe repeated normal-mode registry acquisitions while returning independent logical handles
- migrate registry-backed Lua modules to the shared lease path: store, sql, pg, cloudstorage, exec, template, security token stores
- keep exclusive-mode acquisitions uncached

## Repro / Proof
Before the fix, the repro commit showed repeated store.get calls retained one acquire and cleanup per call:

```
calls=50000 registry_acquires=50000 registry_releases=0 live_resource_cleanups=50000
```

After the fix:

```
calls=50000 registry_acquires=1 registry_releases=0 live_resource_cleanups=0
```

## Tests
- `go test ./api/runtime/resource ./runtime/lua/modules/store ./runtime/lua/modules/sql ./runtime/lua/modules/pg ./runtime/lua/modules/cloudstorage ./runtime/lua/modules/exec ./runtime/lua/modules/template ./runtime/lua/modules/security -count=1`
- `go test ./runtime/lua/modules/... -count=1`
- `go test -race ./api/runtime/resource -count=1`