### PR TITLE
feat(definition): declare wiki pages in ns.definition

### DIFF
--- a/boot/build/stages/definition.go
+++ b/boot/build/stages/definition.go
@@ -14,8 +14,9 @@ import (
 // This entry is required for publishing and contains module metadata.
 // Release notes are NOT part of definition - they're provided at publish time.
 type ModuleDefinition struct {
-	Module string `json:"module" yaml:"module"` // Module display name (defaults to entry name if empty)
-	Readme string `json:"readme" yaml:"readme"`
+	Wiki   map[string]string `json:"wiki" yaml:"wiki"`
+	Module string            `json:"module" yaml:"module"`
+	Readme string            `json:"readme" yaml:"readme"`
 }
 
 // FindDefinition finds the ns.definition entry in the entries slice.


### PR DESCRIPTION
## Why
Modules need a way to ship a small documentation set (a mini-wiki) alongside the README so the hub can serve browsable, LLM-friendly pages.

## What
Adds a `wiki` map (relative path → `file://` reference) to the `ns.definition` entry. Each value is resolved to inline content by the existing `file://` interpolator and packed into the entry, mirroring how `readme` already works — **no pack-format change**.

```yaml
- name: definition
  kind: ns.definition
  readme: file://README.md
  wiki:
    BUILD.md: file://BUILD.md
    docs/architecture.md: file://docs/architecture.md
```

Consumed by the hub (separate MR) to store and serve a per-module wiki.

## Testing
`go test ./boot/build/stages/... ./boot/loader/...` green; `golangci-lint` clean. Verified end-to-end by packing a 10-page sample module with the built `wippy` binary and confirming the hub extractor resolves all 9 declared pages + README to inline content.