### PR TITLE
feat(hub): pre-install read surface + cache eviction

### DIFF
--- a/runtime/lua/modules/fs/module.go
+++ b/runtime/lua/modules/fs/module.go
@@ -128,6 +128,13 @@ func fsGet(l *lua.LState) int {
 	return 2
 }
 
+// PushFS wraps fsys in an fs.FS handle and pushes it onto the stack using the
+// shared fs.FS metatable. It lets other modules expose a filesystem through the
+// exact userdata type fs.get returns, so callers use the normal fs verbs.
+func PushFS(l *lua.LState, fsys fsapi.FS, cwd string) *lua.LUserData {
+	return value.PushUserData(l, NewFS(fsys, cwd), fsMetatable)
+}
+
 func checkFS(l *lua.LState, idx int) *FS { //nolint:unparam
 	ud := l.CheckUserData(idx)
 	if v, ok := ud.Value.(*FS); ok {

--- a/runtime/lua/modules/hub/artifact.go
+++ b/runtime/lua/modules/hub/artifact.go
@@ -5,7 +5,9 @@ package hub
 import (
 	"context"
 	"fmt"
+	iofs "io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -136,6 +138,55 @@ func readEntriesFromFile(path string) ([]wapp.Entry, error) {
 		return nil, fmt.Errorf("read artifact entries: %w", err)
 	}
 	return entries, nil
+}
+
+// openArtifactReader opens a cached artifact and returns its file and reader.
+// The caller owns both and must close the file when done; the reader reads
+// lazily from the file, so it must stay open while the reader is in use.
+func openArtifactReader(path string) (*os.File, *wapp.Reader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open artifact: %w", err)
+	}
+	reader, err := wapp.NewReader(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("read artifact: %w", err)
+	}
+	return file, reader, nil
+}
+
+// parseResourceID converts an "ns:name" resource identifier back to a wapp.ID.
+// A missing namespace maps to an empty namespace, the inverse of ID.String.
+func parseResourceID(raw string) wapp.ID {
+	raw = strings.TrimSpace(raw)
+	if i := strings.Index(raw, ":"); i >= 0 {
+		return wapp.NewID(raw[:i], raw[i+1:])
+	}
+	return wapp.NewID("", raw)
+}
+
+// readResourceFile reads a single file from an embedded filesystem resource.
+func readResourceFile(reader *wapp.Reader, resourceID, filePath string) ([]byte, error) {
+	rdfs, err := reader.GetFS(parseResourceID(resourceID))
+	if err != nil {
+		return nil, fmt.Errorf("open resource filesystem: %w", err)
+	}
+
+	name := strings.TrimLeft(filePath, "/")
+	if name == "" {
+		return nil, fmt.Errorf("file path required")
+	}
+	name = path.Clean(name)
+	if name == ".." || strings.HasPrefix(name, "../") {
+		return nil, fmt.Errorf("invalid file path: %s", filePath)
+	}
+
+	data, err := iofs.ReadFile(rdfs, name)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", filePath, err)
+	}
+	return data, nil
 }
 
 type versionEntries struct {

--- a/runtime/lua/modules/hub/cache.go
+++ b/runtime/lua/modules/hub/cache.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/runtime/runtime/security"
+)
+
+// cacheEntry describes one cached artifact under the resolved vendor directory.
+type cacheEntry struct {
+	module  string
+	version string
+	relPath string
+	size    int64
+	pinned  bool
+}
+
+func (h *hubModule) cacheList(l *lua.LState) int {
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.cache.list", "", nil) {
+		return pushError(l, permissionDenied(l, "hub.cache.list", ""))
+	}
+
+	entries, _, cerr := collectCacheEntries()
+	if cerr != nil {
+		return pushError(l, hubCallError(l, cerr))
+	}
+
+	arr := lua.CreateTable(len(entries), 0)
+	for i, e := range entries {
+		arr.RawSetInt(i+1, cacheEntryToTable(e))
+	}
+	l.Push(arr)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func (h *hubModule) cacheRemove(l *lua.LState) int {
+	module := strings.TrimSpace(l.CheckString(1))
+	version := strings.TrimSpace(l.CheckString(2))
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.cache.remove", module, nil) {
+		return pushError(l, permissionDenied(l, "hub.cache.remove", module))
+	}
+
+	if module == "" || version == "" {
+		return pushError(l, invalidArgument(l, "module and version required"))
+	}
+
+	force, err := parseForceOption(l, 3)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	name, parseErr := graph.ParseName(module)
+	if parseErr != nil {
+		return pushError(l, invalidArgument(l, parseErr.Error()))
+	}
+
+	lockObj, vendorDir, loadErr := loadLockAndVendor()
+	if loadErr != nil {
+		return pushError(l, hubCallError(l, loadErr))
+	}
+
+	if mod, ok := lockObj.GetModule(module); ok && mod.Version == version && !force {
+		return pushError(l, lua.NewLuaError(l, "cannot remove lock-pinned artifact: "+module+"@"+version).
+			WithKind(lua.Conflict).WithRetryable(false).WithDetails(map[string]any{
+			"module":  module,
+			"version": version,
+		}))
+	}
+
+	target := filepath.Join(vendorDir, lock.WappPath(name, version))
+	if removeErr := os.RemoveAll(target); removeErr != nil {
+		return pushError(l, hubCallError(l, removeErr))
+	}
+
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func (h *hubModule) cachePrune(l *lua.LState) int {
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.cache.prune", "", nil) {
+		return pushError(l, permissionDenied(l, "hub.cache.prune", ""))
+	}
+
+	dryRun, err := parseDryRunOption(l, 1)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	entries, vendorDir, cerr := collectCacheEntries()
+	if cerr != nil {
+		return pushError(l, hubCallError(l, cerr))
+	}
+
+	arr := lua.CreateTable(0, 0)
+	count := 0
+	for _, e := range entries {
+		if e.pinned {
+			continue
+		}
+		if !dryRun {
+			target := filepath.Join(vendorDir, filepath.FromSlash(e.relPath))
+			if removeErr := os.RemoveAll(target); removeErr != nil {
+				return pushError(l, hubCallError(l, removeErr))
+			}
+		}
+		count++
+		arr.RawSetInt(count, cacheEntryToTable(e))
+	}
+
+	l.Push(arr)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func cacheEntryToTable(e cacheEntry) *lua.LTable {
+	t := lua.CreateTable(0, 4)
+	t.RawSetString("module", lua.LString(e.module))
+	t.RawSetString("version", lua.LString(e.version))
+	t.RawSetString("size", lua.LNumber(e.size))
+	t.RawSetString("pinned", lua.LBool(e.pinned))
+	return t
+}
+
+// loadLockAndVendor loads the project lock file and resolves the vendor dir.
+// A missing lock file yields an empty lock with default directories.
+func loadLockAndVendor() (*lock.Lock, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, "", err
+	}
+	lockObj, err := lock.New(filepath.Join(cwd, lock.DefaultFilename))
+	if err != nil {
+		return nil, "", err
+	}
+	vendorDir := lock.ResolveLockPath(filepath.Dir(lockObj.Path()), lockObj.GetVendorPath())
+	return lockObj, vendorDir, nil
+}
+
+// collectCacheEntries scans the vendor directory for cached .wapp artifacts and
+// annotates each with lock-file pin status. Lock modules provide exact
+// module/version for pinned artifacts; orphans are parsed from their path.
+func collectCacheEntries() ([]cacheEntry, string, error) {
+	lockObj, vendorDir, err := loadLockAndVendor()
+	if err != nil {
+		return nil, "", err
+	}
+
+	pinned := make(map[string]lock.Module)
+	for _, mod := range lockObj.GetModules() {
+		name, parseErr := graph.ParseName(mod.Name)
+		if parseErr != nil {
+			continue
+		}
+		pinned[filepath.ToSlash(lock.WappPath(name, mod.Version))] = mod
+	}
+
+	var entries []cacheEntry
+	walkErr := filepath.WalkDir(vendorDir, func(p string, d iofs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".wapp") {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(vendorDir, p)
+		if relErr != nil {
+			return nil
+		}
+		relSlash := filepath.ToSlash(rel)
+
+		var size int64
+		if info, infoErr := d.Info(); infoErr == nil {
+			size = info.Size()
+		}
+
+		entry := cacheEntry{relPath: relSlash, size: size}
+		if mod, ok := pinned[relSlash]; ok {
+			entry.module = mod.Name
+			entry.version = mod.Version
+			entry.pinned = true
+		} else {
+			entry.module, entry.version = parseWappRelPath(relSlash)
+		}
+		entries = append(entries, entry)
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return nil, vendorDir, walkErr
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].module != entries[j].module {
+			return entries[i].module < entries[j].module
+		}
+		return entries[i].version < entries[j].version
+	})
+
+	return entries, vendorDir, nil
+}
+
+// parseWappRelPath reverses lock.WappPath ("org/module-version.wapp") into a
+// module name and version. The version is taken after the final hyphen, which
+// round-trips module names containing hyphens but not hyphenated versions.
+func parseWappRelPath(rel string) (string, string) {
+	rel = strings.TrimSuffix(rel, ".wapp")
+
+	org := ""
+	file := rel
+	if slash := strings.LastIndex(rel, "/"); slash >= 0 {
+		org = rel[:slash]
+		file = rel[slash+1:]
+	}
+
+	dash := strings.LastIndex(file, "-")
+	if dash < 0 {
+		return strings.Trim(org+"/"+file, "/"), ""
+	}
+
+	module := file[:dash]
+	if org != "" {
+		module = org + "/" + module
+	}
+	return module, file[dash+1:]
+}
+
+func parseForceOption(l *lua.LState, idx int) (bool, *lua.Error) {
+	return parseBoolOption(l, idx, "force")
+}
+
+func parseDryRunOption(l *lua.LState, idx int) (bool, *lua.Error) {
+	return parseBoolOption(l, idx, "dry_run")
+}
+
+func parseBoolOption(l *lua.LState, idx int, key string) (bool, *lua.Error) {
+	if l.GetTop() < idx {
+		return false, nil
+	}
+	val := l.Get(idx)
+	if val == lua.LNil {
+		return false, nil
+	}
+	tbl, ok := val.(*lua.LTable)
+	if !ok {
+		return false, invalidOptionError(l, "options", "table", val)
+	}
+	value, _, err := tableBool(l, tbl, key)
+	if err != nil {
+		return false, err
+	}
+	return value, nil
+}

--- a/runtime/lua/modules/hub/module.go
+++ b/runtime/lua/modules/hub/module.go
@@ -85,7 +85,7 @@ func (h *hubModule) authStore() *bootauth.Store {
 }
 
 func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
-	mod := lua.CreateTable(0, 6)
+	mod := lua.CreateTable(0, 7)
 
 	modules := lua.CreateTable(0, 4)
 	modules.RawSetString("list", lua.LGoFunc(h.modulesList))
@@ -94,11 +94,14 @@ func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
 	modules.RawSetString("readme", lua.LGoFunc(h.modulesReadme))
 	modules.Immutable = true
 
-	versions := lua.CreateTable(0, 4)
+	versions := lua.CreateTable(0, 7)
 	versions.RawSetString("list", lua.LGoFunc(h.versionsList))
 	versions.RawSetString("get", lua.LGoFunc(h.versionsGet))
 	versions.RawSetString("inspect", lua.LGoFunc(h.versionsInspect))
 	versions.RawSetString("entries", lua.LGoFunc(h.versionsEntries))
+	versions.RawSetString("open", lua.LGoFunc(h.versionsOpen))
+	versions.RawSetString("resources", lua.LGoFunc(h.versionsResources))
+	versions.RawSetString("read_file", lua.LGoFunc(h.versionsReadFile))
 	versions.Immutable = true
 
 	dependencies := lua.CreateTable(0, 1)
@@ -119,12 +122,19 @@ func (h *hubModule) build() (*lua.LTable, []luaapi.YieldType) {
 	auth.RawSetString("status", lua.LGoFunc(h.authStatus))
 	auth.Immutable = true
 
+	cache := lua.CreateTable(0, 3)
+	cache.RawSetString("list", lua.LGoFunc(h.cacheList))
+	cache.RawSetString("remove", lua.LGoFunc(h.cacheRemove))
+	cache.RawSetString("prune", lua.LGoFunc(h.cachePrune))
+	cache.Immutable = true
+
 	mod.RawSetString("modules", modules)
 	mod.RawSetString("versions", versions)
 	mod.RawSetString("dependencies", dependencies)
 	mod.RawSetString("dependents", dependents)
 	mod.RawSetString("files", files)
 	mod.RawSetString("auth", auth)
+	mod.RawSetString("cache", cache)
 	mod.Immutable = true
 
 	return mod, nil
@@ -466,6 +476,178 @@ func (h *hubModule) versionsEntries(l *lua.LState) int {
 	}
 	l.Push(out)
 	return 1
+}
+
+func (h *hubModule) versionsOpen(l *lua.LState) int {
+	moduleRef, moduleKey, err := parseModuleRef(l, 1)
+	if err != nil {
+		return pushError(l, err)
+	}
+	versionRef, err := parseVersionRef(l, 2)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.versions.open", moduleKey, nil) {
+		return pushError(l, permissionDenied(l, "hub.versions.open", moduleKey))
+	}
+
+	base, err := parseBaseOptions(l, 3)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	client, err := h.artifactClient(l, base)
+	if err != nil {
+		return pushError(l, err)
+	}
+	params, paramsErr := downloadParamsFromRefs(moduleRef, versionRef)
+	if paramsErr != nil {
+		return pushError(l, invalidArgument(l, paramsErr.Error()))
+	}
+
+	reqCtx, cancel := withTimeout(ctx, base.timeout)
+	defer cancel()
+
+	path, info, callErr := ensureCachedArtifact(reqCtx, client, params, "")
+	if callErr != nil {
+		return pushError(l, hubCallError(l, callErr))
+	}
+
+	file, reader, openErr := openArtifactReader(path)
+	if openErr != nil {
+		return pushError(l, hubCallError(l, openErr))
+	}
+
+	version := firstNonEmpty(info.Version, params.Version, params.VersionID, params.Label)
+	handle := newPackageHandle(ctx, file, reader, version, info.Digest)
+	pushPackageHandle(l, handle)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func (h *hubModule) versionsResources(l *lua.LState) int {
+	moduleRef, moduleKey, err := parseModuleRef(l, 1)
+	if err != nil {
+		return pushError(l, err)
+	}
+	versionRef, err := parseVersionRef(l, 2)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.versions.resources", moduleKey, nil) {
+		return pushError(l, permissionDenied(l, "hub.versions.resources", moduleKey))
+	}
+
+	base, err := parseBaseOptions(l, 3)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	client, err := h.artifactClient(l, base)
+	if err != nil {
+		return pushError(l, err)
+	}
+	params, paramsErr := downloadParamsFromRefs(moduleRef, versionRef)
+	if paramsErr != nil {
+		return pushError(l, invalidArgument(l, paramsErr.Error()))
+	}
+
+	reqCtx, cancel := withTimeout(ctx, base.timeout)
+	defer cancel()
+
+	path, _, callErr := ensureCachedArtifact(reqCtx, client, params, "")
+	if callErr != nil {
+		return pushError(l, hubCallError(l, callErr))
+	}
+
+	file, reader, openErr := openArtifactReader(path)
+	if openErr != nil {
+		return pushError(l, hubCallError(l, openErr))
+	}
+	defer func() { _ = file.Close() }()
+
+	arr, convErr := resourcesToArray(l, reader.ListResources())
+	if convErr != nil {
+		return pushError(l, hubCallError(l, convErr))
+	}
+	l.Push(arr)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func (h *hubModule) versionsReadFile(l *lua.LState) int {
+	moduleRef, moduleKey, err := parseModuleRef(l, 1)
+	if err != nil {
+		return pushError(l, err)
+	}
+	versionRef, err := parseVersionRef(l, 2)
+	if err != nil {
+		return pushError(l, err)
+	}
+	resourceID := strings.TrimSpace(l.CheckString(3))
+	filePath := l.CheckString(4)
+
+	ctx, err := h.requireContext(l)
+	if err != nil {
+		return pushError(l, err)
+	}
+	if !security.IsAllowed(ctx, "hub.versions.read_file", moduleKey, nil) {
+		return pushError(l, permissionDenied(l, "hub.versions.read_file", moduleKey))
+	}
+
+	if resourceID == "" {
+		return pushError(l, invalidArgument(l, "resource id required"))
+	}
+	if strings.TrimSpace(filePath) == "" {
+		return pushError(l, invalidArgument(l, "file path required"))
+	}
+
+	base, err := parseBaseOptions(l, 5)
+	if err != nil {
+		return pushError(l, err)
+	}
+
+	client, err := h.artifactClient(l, base)
+	if err != nil {
+		return pushError(l, err)
+	}
+	params, paramsErr := downloadParamsFromRefs(moduleRef, versionRef)
+	if paramsErr != nil {
+		return pushError(l, invalidArgument(l, paramsErr.Error()))
+	}
+
+	reqCtx, cancel := withTimeout(ctx, base.timeout)
+	defer cancel()
+
+	path, _, callErr := ensureCachedArtifact(reqCtx, client, params, "")
+	if callErr != nil {
+		return pushError(l, hubCallError(l, callErr))
+	}
+
+	file, reader, openErr := openArtifactReader(path)
+	if openErr != nil {
+		return pushError(l, hubCallError(l, openErr))
+	}
+	defer func() { _ = file.Close() }()
+
+	data, readErr := readResourceFile(reader, resourceID, filePath)
+	if readErr != nil {
+		return pushError(l, lua.WrapErrorWithLua(l, readErr, "read resource file").WithKind(lua.NotFound).WithRetryable(false))
+	}
+
+	l.Push(lua.LString(data))
+	l.Push(lua.LNil)
+	return 2
 }
 
 func (h *hubModule) dependenciesGet(l *lua.LState) int {

--- a/runtime/lua/modules/hub/package_handle.go
+++ b/runtime/lua/modules/hub/package_handle.go
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	lua "github.com/wippyai/go-lua"
+	fsapi "github.com/wippyai/runtime/api/fs"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	luaconv "github.com/wippyai/runtime/runtime/lua/engine/payload"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	fsmod "github.com/wippyai/runtime/runtime/lua/modules/fs"
+	"github.com/wippyai/wapp"
+)
+
+const packageTypeName = "hub.Package"
+
+var packageMetatable *lua.LTable
+
+func init() {
+	packageMetatable = value.RegisterTypeMethods(nil, packageTypeName,
+		map[string]lua.LGoFunc{
+			"__index":    packageIndex,
+			"__tostring": packageToString,
+		},
+		nil)
+}
+
+// packageHandle is an owned artifact handle. It keeps the wapp file and reader
+// open for the lifetime of the frame, mirroring fs.File cleanup semantics: the
+// file must stay open because the resource filesystem reads lazily from the
+// reader. Cleanup is registered on the resource store and cancelled on close.
+type packageHandle struct {
+	file          *os.File
+	reader        *wapp.Reader
+	cancelCleanup func()
+	version       string
+	digest        string
+	mu            sync.Mutex
+	closed        bool
+	packed        bool
+}
+
+func newPackageHandle(ctx context.Context, file *os.File, reader *wapp.Reader, version, digest string) *packageHandle {
+	h := &packageHandle{
+		version: version,
+		digest:  digest,
+		file:    file,
+		reader:  reader,
+		packed:  true,
+	}
+
+	store := resource.GetStore(ctx)
+	if store != nil {
+		h.cancelCleanup = store.AddCleanup(func() error {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			if !h.closed {
+				h.closed = true
+				return h.file.Close()
+			}
+			return nil
+		})
+	}
+
+	return h
+}
+
+func (h *packageHandle) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
+		return nil
+	}
+
+	h.closed = true
+	cancel := h.cancelCleanup
+	h.cancelCleanup = nil
+
+	if cancel != nil {
+		cancel()
+	}
+
+	return h.file.Close()
+}
+
+func (h *packageHandle) isClosed() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.closed
+}
+
+func pushPackageHandle(l *lua.LState, h *packageHandle) {
+	value.PushUserData(l, h, packageMetatable)
+}
+
+func checkPackage(l *lua.LState, idx int) *packageHandle {
+	ud := l.CheckUserData(idx)
+	if v, ok := ud.Value.(*packageHandle); ok {
+		return v
+	}
+	l.ArgError(idx, "hub package expected")
+	return nil
+}
+
+func pushPackageClosed(l *lua.LState) int {
+	l.Push(lua.LNil)
+	l.Push(lua.NewLuaError(l, "package handle is closed").WithKind(lua.Invalid).WithRetryable(false))
+	return 2
+}
+
+func packageIndex(l *lua.LState) int {
+	if checkPackage(l, 1) == nil {
+		return 0
+	}
+	h := l.CheckUserData(1).Value.(*packageHandle)
+	key := l.CheckString(2)
+	switch key {
+	case "version":
+		l.Push(lua.LString(h.version))
+	case "digest":
+		l.Push(lua.LString(h.digest))
+	case "packed":
+		l.Push(lua.LBool(h.packed))
+	case "metadata":
+		l.Push(lua.LGoFunc(packageMetadata))
+	case "entries":
+		l.Push(lua.LGoFunc(packageEntries))
+	case "resources":
+		l.Push(lua.LGoFunc(packageResources))
+	case "fs":
+		l.Push(lua.LGoFunc(packageFS))
+	case "close":
+		l.Push(lua.LGoFunc(packageClose))
+	default:
+		l.Push(lua.LNil)
+	}
+	return 1
+}
+
+func packageToString(l *lua.LState) int {
+	h := checkPackage(l, 1)
+	if h == nil {
+		return 0
+	}
+	l.Push(lua.LString(fmt.Sprintf("hub.Package{version=%s}", h.version)))
+	return 1
+}
+
+func packageMetadata(l *lua.LState) int {
+	h := checkPackage(l, 1)
+	if h == nil {
+		return 0
+	}
+	if h.isClosed() {
+		return pushPackageClosed(l)
+	}
+
+	meta, err := h.reader.GetMetadata()
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "read pack metadata").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	tbl, convErr := luaconv.GoToLua(map[string]any(meta))
+	if convErr != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, convErr, "convert pack metadata").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	l.Push(tbl)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func packageEntries(l *lua.LState) int {
+	h := checkPackage(l, 1)
+	if h == nil {
+		return 0
+	}
+	if h.isClosed() {
+		return pushPackageClosed(l)
+	}
+
+	kinds, includeData, optErr := parsePackageEntryOptions(l, 2)
+	if optErr != nil {
+		return pushError(l, optErr)
+	}
+
+	entries, err := h.reader.GetEntries()
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "read artifact entries").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	arr, convErr := entriesToArray(l, entries, kinds, includeData)
+	if convErr != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, convErr, "convert artifact entries").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	l.Push(arr)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func packageResources(l *lua.LState) int {
+	h := checkPackage(l, 1)
+	if h == nil {
+		return 0
+	}
+	if h.isClosed() {
+		return pushPackageClosed(l)
+	}
+
+	arr, err := resourcesToArray(l, h.reader.ListResources())
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "convert artifact resources").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	l.Push(arr)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func packageFS(l *lua.LState) int {
+	h := checkPackage(l, 1)
+	if h == nil {
+		return 0
+	}
+	if h.isClosed() {
+		return pushPackageClosed(l)
+	}
+
+	resourceID := l.CheckString(2)
+	if resourceID == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "resource id required").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	rdfs, err := h.reader.GetFS(parseResourceID(resourceID))
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "open resource filesystem").WithKind(lua.NotFound).WithRetryable(false))
+		return 2
+	}
+
+	fsmod.PushFS(l, fsapi.NewReadOnlyFS(rdfs), ".")
+	l.Push(lua.LNil)
+	return 2
+}
+
+func packageClose(l *lua.LState) int {
+	h := checkPackage(l, 1)
+	if h == nil {
+		return 0
+	}
+	if err := h.Close(); err != nil {
+		l.Push(lua.LFalse)
+		l.Push(lua.WrapErrorWithLua(l, err, "close package").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}
+
+// parsePackageEntryOptions parses the { kind?, include_data? } table accepted by
+// pkg:entries. include_data defaults to true, matching hub.versions.entries.
+func parsePackageEntryOptions(l *lua.LState, idx int) (map[string]struct{}, bool, *lua.Error) {
+	includeData := true
+	if l.GetTop() < idx {
+		return nil, includeData, nil
+	}
+	val := l.Get(idx)
+	if val == lua.LNil {
+		return nil, includeData, nil
+	}
+	tbl, ok := val.(*lua.LTable)
+	if !ok {
+		return nil, includeData, invalidOptionError(l, "options", "table", val)
+	}
+
+	kinds, _, err := parseKindFilter(l, tbl)
+	if err != nil {
+		return nil, includeData, err
+	}
+
+	if include, ok, err := tableBool(l, tbl, "include_data"); err != nil {
+		return nil, includeData, err
+	} else if ok {
+		includeData = include
+	}
+
+	return kinds, includeData, nil
+}
+
+// entriesToArray converts wapp entries to a bare Lua array of
+// { id = "ns:name", kind, meta, data }. data is omitted when includeData is
+// false and stays raw (GoToLua does not resolve ${env:...}/_env literals).
+func entriesToArray(_ *lua.LState, entries []wapp.Entry, kinds map[string]struct{}, includeData bool) (*lua.LTable, error) {
+	arr := lua.CreateTable(len(entries), 0)
+	count := 0
+	for _, entry := range entries {
+		if kinds != nil {
+			if _, ok := kinds[entry.Kind]; !ok {
+				continue
+			}
+		}
+
+		result := lua.CreateTable(0, 4)
+		result.RawSetString("id", lua.LString(entry.ID.String()))
+		result.RawSetString("kind", lua.LString(entry.Kind))
+
+		meta, err := luaconv.GoToLua(map[string]any(entry.Meta))
+		if err != nil {
+			return nil, fmt.Errorf("convert entry %s meta: %w", entry.ID.String(), err)
+		}
+		result.RawSetString("meta", meta)
+
+		if includeData {
+			data, err := luaconv.GoToLua(entry.Data)
+			if err != nil {
+				return nil, fmt.Errorf("convert entry %s data: %w", entry.ID.String(), err)
+			}
+			result.RawSetString("data", data)
+		}
+
+		count++
+		arr.RawSetInt(count, result)
+	}
+	return arr, nil
+}
+
+// resourcesToArray converts resource info to a bare Lua array of
+// { id = "ns:name", type, hash, size, file_count, meta }.
+func resourcesToArray(_ *lua.LState, resources []wapp.ResourceInfo) (*lua.LTable, error) {
+	arr := lua.CreateTable(len(resources), 0)
+	for i, info := range resources {
+		result := lua.CreateTable(0, 6)
+		result.RawSetString("id", lua.LString(info.ID.String()))
+		result.RawSetString("type", lua.LString(info.Type))
+		result.RawSetString("hash", lua.LString(info.Hash))
+		result.RawSetString("size", lua.LNumber(info.Size))
+		result.RawSetString("file_count", lua.LNumber(info.FileCount))
+
+		meta, err := luaconv.GoToLua(map[string]any(info.Meta))
+		if err != nil {
+			return nil, fmt.Errorf("convert resource %s meta: %w", info.ID.String(), err)
+		}
+		result.RawSetString("meta", meta)
+
+		arr.RawSetInt(i+1, result)
+	}
+	return arr, nil
+}

--- a/runtime/lua/modules/hub/read_surface_test.go
+++ b/runtime/lua/modules/hub/read_surface_test.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	boothub "github.com/wippyai/runtime/boot/deps/hub"
+	"github.com/wippyai/wapp"
+)
+
+func buildWappWithResourceForHubTest(t *testing.T, entries []wapp.Entry, resID wapp.ID, files map[string]string) []byte {
+	t.Helper()
+	fsys := fstest.MapFS{}
+	for name, content := range files {
+		fsys[name] = &fstest.MapFile{Data: []byte(content)}
+	}
+	var buf bytes.Buffer
+	writer := wapp.NewWriter()
+	require.NoError(t, writer.Pack(wapp.Metadata{"name": "dummy"}, entries, fsys, resID, wapp.Metadata{"role": "assets"}, &buf))
+	return buf.Bytes()
+}
+
+func newReadSurfaceState(t *testing.T, fake *fakeArtifactClient) *lua.LState {
+	t.Helper()
+	mod := NewModule(Options{ArtifactClient: fake})
+	l := lua.NewState()
+	t.Cleanup(l.Close)
+	l.SetContext(setupContext())
+	tbl, _ := mod.Build()
+	l.SetGlobal(mod.Name, tbl)
+	return l
+}
+
+func artifactClientReturning(t *testing.T, artifact []byte, downloads *int) *fakeArtifactClient {
+	t.Helper()
+	sum := sha256.Sum256(artifact)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+	return &fakeArtifactClient{
+		getDownloadFn: func(_ context.Context, _ *boothub.DownloadParams) (*boothub.DownloadInfo, error) {
+			return &boothub.DownloadInfo{URL: "memory://dummy", Version: "v0.1.2", Digest: digest}, nil
+		},
+		downloadFn: func(_ context.Context, url, destPath string) error {
+			if downloads != nil {
+				*downloads++
+			}
+			require.Equal(t, "memory://dummy", url)
+			return os.WriteFile(destPath, artifact, 0600)
+		},
+	}
+}
+
+func TestVersionsOpenInspectsPackage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	artifact := buildWappWithResourceForHubTest(t,
+		[]wapp.Entry{
+			{
+				ID:   wapp.NewID("wippy.dummy", "router"),
+				Kind: "ns.requirement",
+				Meta: wapp.Metadata{"description": "Router"},
+				Data: map[string]any{"default": "app:router"},
+			},
+			{ID: wapp.NewID("wippy.dummy", "ping"), Kind: "function.lua"},
+		},
+		wapp.NewID("wippy.dummy", "assets"),
+		map[string]string{"config/app.yaml": "name: dummy\n"},
+	)
+
+	var downloads int
+	l := newReadSurfaceState(t, artifactClientReturning(t, artifact, &downloads))
+
+	if err := l.DoString(`
+		local pkg, err = hub.versions.open("wippy/dummy", "v0.1.2")
+		if err then error(err) end
+		if pkg.version ~= "v0.1.2" then error("version mismatch: " .. tostring(pkg.version)) end
+		if pkg.digest:sub(1, 7) ~= "sha256:" then error("digest mismatch: " .. tostring(pkg.digest)) end
+		if pkg.packed ~= true then error("packed mismatch") end
+
+		local meta, merr = pkg:metadata()
+		if merr then error(merr) end
+		if meta.name ~= "dummy" then error("metadata name mismatch: " .. tostring(meta.name)) end
+
+		local entries, eerr = pkg:entries()
+		if eerr then error(eerr) end
+		if #entries ~= 2 then error("entries count mismatch: " .. tostring(#entries)) end
+		local router
+		for _, e in ipairs(entries) do
+			if e.id == "wippy.dummy:router" then router = e end
+		end
+		if router == nil then error("router entry missing") end
+		if router.kind ~= "ns.requirement" then error("kind mismatch") end
+		if router.meta.description ~= "Router" then error("meta mismatch") end
+		if router.data.default ~= "app:router" then error("raw data mismatch") end
+
+		local filtered, ferr = pkg:entries({ kind = "function.lua", include_data = false })
+		if ferr then error(ferr) end
+		if #filtered ~= 1 then error("filtered count mismatch: " .. tostring(#filtered)) end
+		if filtered[1].id ~= "wippy.dummy:ping" then error("filtered id mismatch") end
+		if filtered[1].data ~= nil then error("expected no data when include_data=false") end
+
+		local resources, rerr = pkg:resources()
+		if rerr then error(rerr) end
+		if #resources ~= 1 then error("resources count mismatch: " .. tostring(#resources)) end
+		if resources[1].id ~= "wippy.dummy:assets" then error("resource id mismatch: " .. tostring(resources[1].id)) end
+		if resources[1].type ~= "tree" then error("resource type mismatch: " .. tostring(resources[1].type)) end
+		if resources[1].file_count ~= 1 then error("file_count mismatch: " .. tostring(resources[1].file_count)) end
+
+		local vfs, verr = pkg:fs("wippy.dummy:assets")
+		if verr then error(verr) end
+		local body, berr = vfs:read_file("config/app.yaml")
+		if berr then error(berr) end
+		if body ~= "name: dummy\n" then error("fs read mismatch: " .. tostring(body)) end
+
+		local ok, cerr = pkg:close()
+		if cerr then error(cerr) end
+		if ok ~= true then error("close did not return true") end
+
+		local _, closedErr = pkg:metadata()
+		if closedErr == nil then error("expected error after close") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	require.Equal(t, 1, downloads)
+}
+
+func TestVersionsFlatResourcesAndReadFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	artifact := buildWappWithResourceForHubTest(t,
+		[]wapp.Entry{{ID: wapp.NewID("wippy.dummy", "ping"), Kind: "function.lua"}},
+		wapp.NewID("wippy.dummy", "assets"),
+		map[string]string{"data/readme.txt": "hello"},
+	)
+
+	l := newReadSurfaceState(t, artifactClientReturning(t, artifact, nil))
+
+	if err := l.DoString(`
+		local resources, err = hub.versions.resources("wippy/dummy", "v0.1.2")
+		if err then error(err) end
+		if #resources ~= 1 then error("resources count mismatch") end
+		if resources[1].id ~= "wippy.dummy:assets" then error("resource id mismatch") end
+
+		local body, rerr = hub.versions.read_file("wippy/dummy", "v0.1.2", "wippy.dummy:assets", "data/readme.txt")
+		if rerr then error(rerr) end
+		if body ~= "hello" then error("read_file mismatch: " .. tostring(body)) end
+
+		local slashBody, serr = hub.versions.read_file("wippy/dummy", "v0.1.2", "wippy.dummy:assets", "/data/readme.txt")
+		if serr then error(serr) end
+		if slashBody ~= "hello" then error("leading slash read mismatch") end
+
+		local _, missErr = hub.versions.read_file("wippy/dummy", "v0.1.2", "wippy.dummy:assets", "data/missing.txt")
+		if missErr == nil then error("expected error for missing file") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+}
+
+func writeCacheArtifact(t *testing.T, vendorDir, org, module, version string) string {
+	t.Helper()
+	dir := filepath.Join(vendorDir, org)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	path := filepath.Join(dir, module+"-"+version+".wapp")
+	require.NoError(t, os.WriteFile(path, []byte("cached artifact bytes"), 0600))
+	return path
+}
+
+func writeLockFile(t *testing.T, dir string, modules ...[2]string) {
+	t.Helper()
+	content := "directories:\n  modules: .wippy\n  src: .\n"
+	if len(modules) > 0 {
+		content += "modules:\n"
+		for _, mod := range modules {
+			content += "  - name: " + mod[0] + "\n    version: " + mod[1] + "\n"
+		}
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wippy.lock"), []byte(content), 0600))
+}
+
+func TestCacheListRemovePrune(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	vendorDir := filepath.Join(root, ".wippy", "vendor")
+
+	pinnedPath := writeCacheArtifact(t, vendorDir, "wippy", "pinned", "v1.0.0")
+	orphanPath := writeCacheArtifact(t, vendorDir, "wippy", "orphan", "v2.0.0")
+	writeLockFile(t, root, [2]string{"wippy/pinned", "v1.0.0"})
+
+	l := newReadSurfaceState(t, artifactClientReturning(t, nil, nil))
+
+	if err := l.DoString(`
+		local list, err = hub.cache.list()
+		if err then error(err) end
+		if #list ~= 2 then error("cache list count mismatch: " .. tostring(#list)) end
+
+		local pinned, orphan
+		for _, e in ipairs(list) do
+			if e.module == "wippy/pinned" then pinned = e end
+			if e.module == "wippy/orphan" then orphan = e end
+		end
+		if pinned == nil then error("pinned entry missing") end
+		if orphan == nil then error("orphan entry missing") end
+		if pinned.pinned ~= true then error("pinned flag wrong") end
+		if pinned.version ~= "v1.0.0" then error("pinned version mismatch: " .. tostring(pinned.version)) end
+		if orphan.pinned ~= false then error("orphan pinned flag wrong") end
+		if orphan.version ~= "v2.0.0" then error("orphan version mismatch: " .. tostring(orphan.version)) end
+
+		local _, refuseErr = hub.cache.remove("wippy/pinned", "v1.0.0")
+		if refuseErr == nil then error("expected refusal removing pinned artifact") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	require.FileExists(t, pinnedPath)
+	require.FileExists(t, orphanPath)
+
+	if err := l.DoString(`
+		local ok, err = hub.cache.remove("wippy/orphan", "v2.0.0")
+		if err then error(err) end
+		if ok ~= true then error("remove did not return true") end
+
+		local forced, ferr = hub.cache.remove("wippy/pinned", "v1.0.0", { force = true })
+		if ferr then error(ferr) end
+		if forced ~= true then error("forced remove did not return true") end
+	`); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	require.NoFileExists(t, orphanPath)
+	require.NoFileExists(t, pinnedPath)
+}
+
+func TestCachePruneDryRun(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	vendorDir := filepath.Join(root, ".wippy", "vendor")
+
+	pinnedPath := writeCacheArtifact(t, vendorDir, "wippy", "pinned", "v1.0.0")
+	orphanPath := writeCacheArtifact(t, vendorDir, "wippy", "orphan", "v2.0.0")
+	writeLockFile(t, root, [2]string{"wippy/pinned", "v1.0.0"})
+
+	l := newReadSurfaceState(t, artifactClientReturning(t, nil, nil))
+
+	if err := l.DoString(`
+		local dry, derr = hub.cache.prune({ dry_run = true })
+		if derr then error(derr) end
+		if #dry ~= 1 then error("dry run prune count mismatch: " .. tostring(#dry)) end
+		if dry[1].module ~= "wippy/orphan" then error("dry run module mismatch") end
+	`); err != nil {
+		t.Fatalf("lua dry-run error: %v", err)
+	}
+
+	require.FileExists(t, orphanPath, "dry run must not delete")
+
+	if err := l.DoString(`
+		local pruned, perr = hub.cache.prune()
+		if perr then error(perr) end
+		if #pruned ~= 1 then error("prune count mismatch: " .. tostring(#pruned)) end
+		if pruned[1].module ~= "wippy/orphan" then error("prune module mismatch") end
+	`); err != nil {
+		t.Fatalf("lua prune error: %v", err)
+	}
+
+	require.NoFileExists(t, orphanPath)
+	require.FileExists(t, pinnedPath, "pinned artifact must survive prune")
+}

--- a/runtime/lua/modules/hub/spec.md
+++ b/runtime/lua/modules/hub/spec.md
@@ -76,6 +76,47 @@ Returns `{ items, total, version, digest, cache_path }`.
 `total` is the number of entries in the artifact before `kind` filtering; each item
 is `{ id = { ns, name }, kind, meta, data }` (`data` omitted when `include_data = false`).
 
+### `hub.versions.open(module, version, opts?)`
+Open a version artifact for inspection before install and return an owned package
+handle. The artifact goes through the verified `.wippy/vendor` disk cache. The
+handle keeps the underlying file open until it is closed or the frame ends, so
+`pkg:fs()` can read lazily from it.
+
+Options: `registry`, `token`, `timeout`.
+
+The handle exposes fields and methods:
+- `pkg.version` (string), `pkg.digest` (string), `pkg.packed` (boolean, currently always `true`).
+- `pkg:metadata()` — the pack manifest as a Lua table.
+- `pkg:entries({ kind?, include_data? })` — a bare array of `{ id = "ns:name", kind, meta, data }`. `include_data` defaults to `true`; `data` is raw (`${env:...}`/`_env` literals are preserved).
+- `pkg:resources()` — a bare array of `{ id = "ns:name", type, hash, size, file_count, meta }`.
+- `pkg:fs(resource_id)` — an `fs.FS` handle over the named resource, using the same handle type `fs.get` returns; read it with the normal fs verbs (`stat`, `readdir`, `read_file`, ...).
+- `pkg:close()` — close the handle explicitly. It is also closed automatically at frame end.
+
+### `hub.versions.resources(module, version, opts?)`
+Open, read, and close in one call. Returns the same bare array as `pkg:resources()`.
+
+Options: `registry`, `token`, `timeout`.
+
+### `hub.versions.read_file(module, version, resource, path, opts?)`
+Read a single file from an embedded filesystem `resource` inside a version
+artifact and return its bytes as a Lua string. Opens, reads, and closes per call.
+
+Options: `registry`, `token`, `timeout`.
+
+### `hub.cache.list(opts?)`
+List cached artifacts under the resolved vendor directory. Returns a bare array of
+`{ module, version, size, pinned }`. `pinned` is `true` when the artifact is
+referenced by the lock file.
+
+### `hub.cache.remove(module, version, opts?)`
+Remove a cached artifact addressed by `module` name and `version`. Refuses to
+remove a lock-pinned artifact unless `opts.force` is `true`. Returns `true`.
+
+### `hub.cache.prune(opts?)`
+Remove cached artifacts not referenced by the lock file. With `opts.dry_run = true`
+nothing is deleted. Returns a bare array of the pruned (or would-be-pruned)
+`{ module, version, size, pinned }` entries.
+
 ### `hub.dependencies.get(module, version?, opts?)`
 Get dependencies for a module version.
 

--- a/runtime/lua/modules/hub/types.go
+++ b/runtime/lua/modules/hub/types.go
@@ -48,6 +48,15 @@ func ModuleTypes() *io.Manifest {
 		{Name: "get", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "inspect", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "entries", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(entriesResponse, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "open", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "resources", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).OptParam("opts", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "read_file", Type: typ.Func().Param("module", typ.Any).Param("version", typ.Any).Param("resource", typ.String).Param("path", typ.String).OptParam("opts", typ.Any).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	})
+
+	cacheIface := typ.NewInterface("hub.cache", []typ.Method{
+		{Name: "list", Type: typ.Func().OptParam("opts", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "remove", Type: typ.Func().Param("module", typ.String).Param("version", typ.String).OptParam("opts", typ.Any).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "prune", Type: typ.Func().OptParam("opts", typ.Any).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
 	dependenciesIface := typ.NewInterface("hub.dependencies", []typ.Method{
@@ -81,6 +90,7 @@ func ModuleTypes() *io.Manifest {
 		Field("dependents", dependentsIface).
 		Field("files", filesIface).
 		Field("auth", authIface).
+		Field("cache", cacheIface).
 		Build()
 
 	m.SetExport(moduleType)


### PR DESCRIPTION
Builds on #417 (its `hub.versions.entries` is the base of this branch) to give the hub module a full **pre-install read surface** — so a caller (esp. an AI agent) can inspect a module's metadata, entries, and actual file contents *before* installing it, to scan dependencies and run security checks — plus a cache-eviction surface so inspected-but-uninstalled artifacts don't accumulate forever.

Design was reviewed for idiomaticity against the existing `registry` / `fs` / `resource` / `lock` modules (two independent passes) before implementation.

## Surface

```lua
-- owned handle (fs.File pattern): opens the cached .wapp once, auto-closed at frame end
local pkg = hub.versions.open(module, version, opts?)   -- opts {registry, token, timeout}
pkg.version, pkg.digest, pkg.packed
pkg:metadata()                       -- pack manifest table
pkg:entries({kind?, include_data?})  -- array of { id="ns:name", kind, meta, data }  (data RAW)
pkg:resources()                      -- array of { id, type, hash, size, file_count, meta }
local vfs = pkg:fs(resource_id)      -- a real fs handle (same as fs.get) over the embedded filesystem
pkg:close()

-- flat one-shot sugar
hub.versions.resources(module, version, opts?)
hub.versions.read_file(module, version, resource, path, opts?)   -- file bytes as a string

-- cache eviction (name+version addressed, lockfile = pins; mirrors pruneModuleArtifacts)
hub.cache.list(opts?)                       -- { {module, version, size, pinned}, ... }
hub.cache.remove(module, version, {force?}) -- refuses lock-pinned unless force
hub.cache.prune({dry_run?})                 -- removes only artifacts absent from the lockfile
```

## Idioms followed

- **Handle is the `fs.File` owned-handle pattern, not a resource lease** — an uninstalled artifact has no registry entry to `Acquire`. It keeps the open `*os.File` + `*wapp.Reader`, registers `resource.GetStore(ctx).AddCleanup(...)` for frame-end auto-close, and `:close()` is idempotent. The file stays open so `pkg:fs()` reads lazily.
- **`pkg:fs()` returns the real fs handle** — `wapp.Reader.GetFS` → `fsapi.NewReadOnlyFS` → the fs module (new exported `fs.PushFS`), so callers use the standard `stat`/`readdir`/`read_file` verbs. No parallel fs abstraction.
- **Entries**: bare array, `id="ns:name"` string, data converted structurally (raw — `${env:...}`/`_env` stay literal, matching the sealing model).
- **Cache**: name+version-addressed under the vendor dir, lockfile modules are the pin set; `prune` skips pinned, `remove` refuses pinned unless `force` — same semantics as `pruneModuleArtifacts`.
- Base opts / error-as-second-value / dotted security actions / gate-once-at-call-site match the existing hub methods.

## Notes / decisions

- Scoped to packed `.wapp` modules. Unpacked-directory modules load entries from `_index.yaml` rather than `wapp.Reader`; a directory-backed path can be a follow-up (`pkg.packed` already exposes the distinction).
- Orphan cache filenames are parsed by splitting version at the final hyphen; pinned artifacts get exact module/version from the lockfile (hyphenated prerelease orphans noted in a code comment).

## Tests
`read_surface_test.go`: open → metadata/entries(raw + kind/include_data filters)/resources/`pkg:fs` read/close(+use-after-close); flat resources + read_file (incl. leading-slash + missing-file); cache list/remove(pinned-refusal + force)/prune(dry-run + orphan-only). Build, vet, `go test`, gofmt, and `golangci-lint` all green.

Credit to @msmakouz for the `entries()` groundwork this builds on.
