### PR TITLE
fix(s3): multipart uploads for large and streaming bodies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.26
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.25
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.29
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.1
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.44.1
 	github.com/aws/smithy-go v1.27.3

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.25 h1:TzPVjfUZ1hsKafvYE+DIzKXIik2
 github.com/aws/aws-sdk-go-v2/credentials v1.19.25/go.mod h1:K4hw0buguVvtC74HnVfTRr0LzQQHAWPqJbBU9QGk2Pg=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 h1:r6qZHbT+wxgWO/e9vYNUEtg7lv5+UN3pRqKhLXvnArg=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29/go.mod h1:QRnaRcTVGKPGRy8w78HMQtKUGRYcnMZAANATkeVA6Mo=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.29 h1:YteQL/8ZD9nS/eiLq3Ab9ldHBUvfWorEOufALZOXoXY=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.29/go.mod h1:3hj0jtS3hQmQAAZ0yz/jTA+uTAHfDpwxbISkgZ2E0d0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -308,12 +308,15 @@ func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reade
 	// into parts. A single PutObject signs the body as one aws-chunked stream,
 	// which S3-compatible stores (MinIO) reject once a chunk exceeds 16MiB, and
 	// which cannot send a non-seekable body without a Content-Length at all.
-	uploader := manager.NewUploader(s.client, func(u *manager.Uploader) {
+	// SA1019: the s3/manager uploader is the stable, widely-deployed multipart
+	// API; the s3/transfermanager replacement is not yet a dependency and its
+	// migration is out of scope here.
+	uploader := manager.NewUploader(s.client, func(u *manager.Uploader) { //nolint:staticcheck
 		u.PartSize = uploadPartSize
 		u.ClientOptions = apiOptions
 	})
 
-	_, err := uploader.Upload(ctx, input)
+	_, err := uploader.Upload(ctx, input) //nolint:staticcheck
 	if err != nil {
 		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
 			return mapped

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go/middleware"
@@ -22,6 +23,15 @@ import (
 
 // DefaultPresignExpiration is the default expiration time for presigned URLs.
 const DefaultPresignExpiration = 15 * time.Minute
+
+// uploadPartSize is the multipart part size for streaming uploads. 16MiB is the
+// per-chunk ceiling S3-compatible stores (MinIO) allow on an aws-chunked payload,
+// so each part maps to a single acceptable chunk. It also keeps the part count
+// under the 10000-part limit for objects up to 160GiB streamed with unknown
+// length; for seekable bodies larger than that the SDK grows the part size to
+// stay within 10000 parts, which a store enforcing a strict 16MiB chunk cap
+// would then reject.
+const uploadPartSize = 16 * 1024 * 1024
 
 // Compile-time interface check.
 var _ cloudstorage.Storage = (*Storage)(nil)
@@ -293,7 +303,17 @@ func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reade
 		})
 	}
 
-	_, err := s.client.PutObject(ctx, input, apiOptions...)
+	// Upload through the multipart manager so that unbounded streams (unknown
+	// length, non-seekable) and objects larger than a single request are split
+	// into parts. A single PutObject signs the body as one aws-chunked stream,
+	// which S3-compatible stores (MinIO) reject once a chunk exceeds 16MiB, and
+	// which cannot send a non-seekable body without a Content-Length at all.
+	uploader := manager.NewUploader(s.client, func(u *manager.Uploader) {
+		u.PartSize = uploadPartSize
+		u.ClientOptions = apiOptions
+	})
+
+	_, err := uploader.Upload(ctx, input)
 	if err != nil {
 		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrPreconditionFailed) {
 			return mapped

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -437,9 +438,16 @@ func (m *addRequestHeadersMiddleware) ID() string { return "wippyAddRequestHeade
 func (m *addRequestHeadersMiddleware) HandleBuild(
 	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
 ) (middleware.BuildOutput, middleware.Metadata, error) {
-	if req, ok := in.Request.(*smithyhttp.Request); ok {
-		for k, v := range m.headers {
-			req.Header.Set(k, v)
+	// Object-level headers belong only on the object-creating operations. The
+	// multipart uploader also issues UploadPart and CompleteMultipartUpload,
+	// which reject many headers valid on PutObject/CreateMultipartUpload, so
+	// applying the same headers to every request would fail multipart uploads.
+	switch awsmiddleware.GetOperationName(ctx) {
+	case "PutObject", "CreateMultipartUpload":
+		if req, ok := in.Request.(*smithyhttp.Request); ok {
+			for k, v := range m.headers {
+				req.Header.Set(k, v)
+			}
 		}
 	}
 	return next.HandleBuild(ctx, in)

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -438,19 +438,54 @@ func (m *addRequestHeadersMiddleware) ID() string { return "wippyAddRequestHeade
 func (m *addRequestHeadersMiddleware) HandleBuild(
 	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
 ) (middleware.BuildOutput, middleware.Metadata, error) {
-	// Object-level headers belong only on the object-creating operations. The
-	// multipart uploader also issues UploadPart and CompleteMultipartUpload,
-	// which reject many headers valid on PutObject/CreateMultipartUpload, so
-	// applying the same headers to every request would fail multipart uploads.
-	switch awsmiddleware.GetOperationName(ctx) {
-	case "PutObject", "CreateMultipartUpload":
-		if req, ok := in.Request.(*smithyhttp.Request); ok {
-			for k, v := range m.headers {
-				req.Header.Set(k, v)
-			}
+	req, ok := in.Request.(*smithyhttp.Request)
+	if !ok {
+		return next.HandleBuild(ctx, in)
+	}
+	op := awsmiddleware.GetOperationName(ctx)
+	for k, v := range m.headers {
+		if headerAllowedForOperation(k, op) {
+			req.Header.Set(k, v)
 		}
 	}
 	return next.HandleBuild(ctx, in)
+}
+
+// headerAllowedForOperation decides whether a pass-through header may be set on
+// a given S3 operation. Object-metadata headers (tagging, content-type,
+// SSE-KMS/S3, user metadata, ...) belong only on the object-creating
+// operations; applying them to UploadPart or CompleteMultipartUpload fails the
+// upload. A few headers must still reach the multipart subrequests: SSE-C
+// customer-key headers are required on UploadPart, and request-payer /
+// expected-bucket-owner apply to every subrequest.
+func headerAllowedForOperation(header, operation string) bool {
+	switch operation {
+	case "PutObject", "CreateMultipartUpload":
+		return true
+	case "UploadPart":
+		return isSSECustomerHeader(header) || isRequestScopedHeader(header)
+	case "CompleteMultipartUpload", "AbortMultipartUpload":
+		return isRequestScopedHeader(header)
+	default:
+		return false
+	}
+}
+
+// isSSECustomerHeader reports whether header is an SSE-C customer-key header,
+// which multipart UploadPart requires to match the CreateMultipartUpload key.
+func isSSECustomerHeader(header string) bool {
+	return strings.HasPrefix(strings.ToLower(header), "x-amz-server-side-encryption-customer-")
+}
+
+// isRequestScopedHeader reports whether header applies to every request of an
+// operation rather than only object creation.
+func isRequestScopedHeader(header string) bool {
+	switch strings.ToLower(header) {
+	case "x-amz-request-payer", "x-amz-expected-bucket-owner":
+		return true
+	default:
+		return false
+	}
 }
 
 // captureResponseHeadersMiddleware snapshots the raw HTTP response headers

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -902,25 +902,43 @@ func ctxWithS3Operation(t *testing.T, op string) context.Context {
 	return captured
 }
 
-func TestAddRequestHeadersMiddleware_ScopedToObjectCreation(t *testing.T) {
-	mw := &addRequestHeadersMiddleware{headers: map[string]string{"x-amz-tagging": "k=v"}}
+func TestAddRequestHeadersMiddleware_ScopedByOperation(t *testing.T) {
+	const (
+		tagging    = "x-amz-tagging"
+		sseC       = "x-amz-server-side-encryption-customer-key"
+		requestPay = "x-amz-request-payer"
+	)
+	mw := &addRequestHeadersMiddleware{headers: map[string]string{
+		tagging:    "k=v",
+		sseC:       "key-material",
+		requestPay: "requester",
+	}}
 
-	build := func(ctx context.Context) *smithyhttp.Request {
+	headerFor := func(op, header string) string {
 		req, _ := smithyhttp.NewStackRequest().(*smithyhttp.Request)
-		_, _, err := mw.HandleBuild(ctx, middleware.BuildInput{Request: req},
+		_, _, err := mw.HandleBuild(ctxWithS3Operation(t, op), middleware.BuildInput{Request: req},
 			middleware.BuildHandlerFunc(func(ctx context.Context, _ middleware.BuildInput) (middleware.BuildOutput, middleware.Metadata, error) {
 				return middleware.BuildOutput{}, middleware.Metadata{}, nil
 			}))
 		require.NoError(t, err)
-		return req
+		return req.Header.Get(header)
 	}
 
+	// Object-metadata headers only on the object-creating operations.
 	for _, op := range []string{"PutObject", "CreateMultipartUpload"} {
-		req := build(ctxWithS3Operation(t, op))
-		assert.Equal(t, "k=v", req.Header.Get("x-amz-tagging"), "headers must apply to %s", op)
+		assert.Equal(t, "k=v", headerFor(op, tagging), "tagging must apply to %s", op)
 	}
 	for _, op := range []string{"UploadPart", "CompleteMultipartUpload"} {
-		req := build(ctxWithS3Operation(t, op))
-		assert.Empty(t, req.Header.Get("x-amz-tagging"), "headers must not apply to %s", op)
+		assert.Empty(t, headerFor(op, tagging), "tagging must not apply to %s", op)
+	}
+
+	// SSE-C customer key must reach UploadPart but not CompleteMultipartUpload.
+	assert.Equal(t, "key-material", headerFor("CreateMultipartUpload", sseC))
+	assert.Equal(t, "key-material", headerFor("UploadPart", sseC))
+	assert.Empty(t, headerFor("CompleteMultipartUpload", sseC))
+
+	// request-payer applies to every subrequest.
+	for _, op := range []string{"PutObject", "CreateMultipartUpload", "UploadPart", "CompleteMultipartUpload"} {
+		assert.Equal(t, "requester", headerFor(op, requestPay), "request-payer must apply to %s", op)
 	}
 }

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -13,12 +13,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
+	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -883,4 +885,42 @@ func TestFlattenHeaders(t *testing.T) {
 		out := flattenHeaders(h)
 		assert.Equal(t, "a, b, c", out["x-repeated"])
 	})
+}
+
+// ctxWithS3Operation returns a context carrying the given S3 operation name,
+// the way the SDK sets it before the build step runs.
+func ctxWithS3Operation(t *testing.T, op string) context.Context {
+	t.Helper()
+	var captured context.Context
+	md := awsmiddleware.RegisterServiceMetadata{OperationName: op}
+	_, _, err := md.HandleInitialize(context.Background(), middleware.InitializeInput{},
+		middleware.InitializeHandlerFunc(func(ctx context.Context, _ middleware.InitializeInput) (middleware.InitializeOutput, middleware.Metadata, error) {
+			captured = ctx
+			return middleware.InitializeOutput{}, middleware.Metadata{}, nil
+		}))
+	require.NoError(t, err)
+	return captured
+}
+
+func TestAddRequestHeadersMiddleware_ScopedToObjectCreation(t *testing.T) {
+	mw := &addRequestHeadersMiddleware{headers: map[string]string{"x-amz-tagging": "k=v"}}
+
+	build := func(ctx context.Context) *smithyhttp.Request {
+		req, _ := smithyhttp.NewStackRequest().(*smithyhttp.Request)
+		_, _, err := mw.HandleBuild(ctx, middleware.BuildInput{Request: req},
+			middleware.BuildHandlerFunc(func(ctx context.Context, _ middleware.BuildInput) (middleware.BuildOutput, middleware.Metadata, error) {
+				return middleware.BuildOutput{}, middleware.Metadata{}, nil
+			}))
+		require.NoError(t, err)
+		return req
+	}
+
+	for _, op := range []string{"PutObject", "CreateMultipartUpload"} {
+		req := build(ctxWithS3Operation(t, op))
+		assert.Equal(t, "k=v", req.Header.Get("x-amz-tagging"), "headers must apply to %s", op)
+	}
+	for _, op := range []string{"UploadPart", "CompleteMultipartUpload"} {
+		req := build(ctxWithS3Operation(t, op))
+		assert.Empty(t, req.Header.Get("x-amz-tagging"), "headers must not apply to %s", op)
+	}
 }

--- a/service/aws/s3/storage_upload_integration_test.go
+++ b/service/aws/s3/storage_upload_integration_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// readerOnly hides Seek/Len/WriterTo so the S3 client sees an opaque stream of
+// unknown length, matching the io.Reader the Lua runtime passes through.
+type readerOnly struct{ r io.Reader }
+
+func (r readerOnly) Read(p []byte) (int, error) { return r.r.Read(p) }
+
+// newIntegrationStorage builds a Storage bound to a live S3-compatible endpoint
+// (MinIO) from the environment. It returns nil when the harness is not configured
+// so callers can skip.
+func newIntegrationStorage(t *testing.T) *Storage {
+	t.Helper()
+
+	endpoint := os.Getenv("S3_ENDPOINT")
+	access := os.Getenv("S3_ACCESS_KEY")
+	secret := os.Getenv("S3_SECRET_KEY")
+	bucket := os.Getenv("S3_BUCKET")
+	if endpoint == "" || access == "" || secret == "" || bucket == "" {
+		t.Skip("set S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET to run S3 integration tests")
+	}
+
+	client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(endpoint),
+		UsePathStyle: true,
+		Credentials:  credentials.NewStaticCredentialsProvider(access, secret, ""),
+	})
+	return NewStorage(client, bucket, zap.NewNop())
+}
+
+// TestUploadObjectLargeStream proves that a streaming body larger than MinIO's
+// 16MiB aws-chunked chunk cap uploads successfully and reads back byte-identical.
+// A single PutObject with a streaming body fails here with
+// "chunk too big: choose chunk size <= 16MiB"; multipart upload does not.
+func TestUploadObjectLargeStream(t *testing.T) {
+	storage := newIntegrationStorage(t)
+	ctx := context.Background()
+
+	const size = 32 << 20 // 32MiB, well past the 16MiB single-chunk cap
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i * 31)
+	}
+	want := sha256.Sum256(payload)
+
+	key := "integration/large-stream.bin"
+	t.Cleanup(func() { _ = storage.DeleteObjects(context.Background(), []string{key}) })
+
+	// A pure io.Reader with no Seek and no known length: this is what the Lua
+	// runtime hands to UploadObject. The AWS SDK then signs the body as an
+	// aws-chunked stream, which MinIO rejects once a chunk exceeds 16MiB.
+	err := storage.UploadObject(ctx, key, readerOnly{bytes.NewReader(payload)}, nil)
+	require.NoError(t, err, "large streaming upload must not fail on the 16MiB chunk cap")
+
+	var buf bytes.Buffer
+	err = storage.DownloadObject(ctx, key, &buf, nil)
+	require.NoError(t, err)
+	require.Len(t, buf.Bytes(), size)
+	require.Equal(t, want, sha256.Sum256(buf.Bytes()), "read-back must be byte-identical")
+}


### PR DESCRIPTION
## Problem

`cloudstorage.UploadObject` (S3 backend) sent the body through a single `s3.PutObject`. Against S3-compatible stores this fails for large or streaming bodies:

- A **non-seekable** reader with no `Content-Length` returns `411 MissingContentLength`.
- A **large** body signed as one `aws-chunked` stream is rejected by MinIO once a chunk exceeds 16MiB: `chunk too big: choose chunk size <= 16MiB`.

The Lua `cloudstorage:upload_object` path hands `UploadObject` a plain `io.Reader` (string bodies wrap `bytes.Reader`; userdata bodies pass the raw reader), so any multi-gigabyte checkpoint or dataset upload fails.

## Fix

Route `UploadObject` through the SDK multipart manager (`feature/s3/manager`) with a 16MiB part size. The manager buffers the stream into parts of known length, so:

- unbounded / non-seekable streams upload without a caller-supplied `Content-Length`;
- no single request carries an `aws-chunked` chunk larger than MinIO's 16MiB cap;
- objects split into up to 10000 parts (160GiB for unknown-length streams; auto-grown up to S3's object max for known-length bodies).

All existing `PutObjectInput` semantics are preserved (content-type, cache-control, disposition, encoding, metadata, `If-Match`/`If-None-Match`, and the custom request-header middleware, now applied via `Uploader.ClientOptions`); the `ErrPreconditionFailed` mapping is unchanged.

## Test

`TestUploadObjectLargeStream` uploads a 32MiB non-seekable stream and reads it back byte-identical. It is gated on `S3_ENDPOINT`/`S3_ACCESS_KEY`/`S3_SECRET_KEY` (skips without a live endpoint). Verified against a live MinIO: fails on the pre-fix code (`411 MissingContentLength`), passes after.
