### PR TITLE
fix(cli): keep publish unbundled and pack app containers

### DIFF
--- a/boot/build/stages/embed_fs.go
+++ b/boot/build/stages/embed_fs.go
@@ -100,12 +100,20 @@ func setResources(res []wapp.ResourceSpec) {
 }
 
 func filterEmbeddableEntries(entries []registry.Entry, embedPatterns []string) []registry.ID {
+	embedAll := false
+	for _, pattern := range embedPatterns {
+		if pattern == "*" || pattern == "**" {
+			embedAll = true
+			break
+		}
+	}
+
 	var embeddable []registry.ID
 	for _, entry := range entries {
 		if entry.Kind != dirapi.Kind {
 			continue
 		}
-		if len(embedPatterns) == 0 {
+		if len(embedPatterns) == 0 || embedAll {
 			embeddable = append(embeddable, entry.ID)
 			continue
 		}

--- a/boot/build/stages/embed_fs_test.go
+++ b/boot/build/stages/embed_fs_test.go
@@ -219,6 +219,14 @@ func TestFilterEmbeddableEntries(t *testing.T) {
 		}
 	})
 
+	t.Run("wildcard pattern embeds every directory", func(t *testing.T) {
+		got := ids(filterEmbeddableEntries(all, []string{"**"}))
+		want := []string{"acme.app:ui_fs", "acme.app:wasm_fs"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
 	t.Run("match by full id", func(t *testing.T) {
 		got := ids(filterEmbeddableEntries(all, []string{"acme.app:wasm_fs"}))
 		if len(got) != 1 || got[0] != "acme.app:wasm_fs" {

--- a/cmd/wippy/cmd/errors.go
+++ b/cmd/wippy/cmd/errors.go
@@ -110,6 +110,10 @@ func NewPackIntegrityError(cause error) apierror.Error {
 	return apierror.New(apierror.Internal, "pack integrity verification failed").WithCause(cause).WithRetryable(apierror.False)
 }
 
+func NewPackConfigError(cause error) apierror.Error {
+	return apierror.New(apierror.Invalid, "failed to load pack config").WithCause(cause).WithRetryable(apierror.False)
+}
+
 func NewStatOutputFileError(cause error) apierror.Error {
 	return apierror.New(apierror.Internal, "failed to stat output file").WithCause(cause).WithRetryable(apierror.False)
 }

--- a/cmd/wippy/cmd/lint.go
+++ b/cmd/wippy/cmd/lint.go
@@ -486,7 +486,7 @@ func runLintWithUI(luaEntries []regapi.Entry, reportSet map[regapi.ID]bool, lint
 		totalEntries: len(luaEntries),
 	}
 
-	p := tea.NewProgram(m)
+	p := newCLIProgram(m)
 
 	go func() {
 		defer func() {

--- a/cmd/wippy/cmd/pack.go
+++ b/cmd/wippy/cmd/pack.go
@@ -3,9 +3,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +21,7 @@ import (
 	"github.com/wippyai/runtime/api/version"
 	"github.com/wippyai/runtime/boot/build"
 	"github.com/wippyai/runtime/boot/build/stages"
+	moduleconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	appinit "github.com/wippyai/runtime/cmd/internal/app"
 	"github.com/wippyai/runtime/cmd/internal/entries"
@@ -350,7 +353,10 @@ func runPack(cmd *cobra.Command, args []string) error {
 		return runListMode(app, lockPath, folderPath)
 	}
 
-	embedPatterns, _ := cmd.Flags().GetStringSlice("embed")
+	embedPatterns, err := resolvePackEmbedPatterns(cmd, folderPath)
+	if err != nil {
+		return NewPackConfigError(err)
+	}
 	verboseMode := rootCmd.PersistentFlags().Lookup("verbose").Changed
 
 	prog := progress.New(progress.WithDefaultGradient())
@@ -364,7 +370,7 @@ func runPack(cmd *cobra.Command, args []string) error {
 		maxLogs:       20,
 	}
 
-	p := tea.NewProgram(m)
+	p := newCLIProgram(m)
 
 	go func() {
 		if err := performPack(cmd, args, app, p); err != nil {
@@ -389,7 +395,10 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 	outputFile := args[0]
 	lockFile, _ := cmd.Flags().GetString("lock-file")
 	folderPath := "."
-	embedPatterns, _ := cmd.Flags().GetStringSlice("embed")
+	embedPatterns, err := resolvePackEmbedPatterns(cmd, folderPath)
+	if err != nil {
+		return NewPackConfigError(err)
+	}
 	excludeNS, _ := cmd.Flags().GetStringSlice("exclude-ns")
 	excludeEntries, _ := cmd.Flags().GetStringSlice("exclude")
 	bytecodePatterns, _ := cmd.Flags().GetStringSlice("bytecode")
@@ -411,6 +420,7 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 		return NewInvalidLockFileError(fmt.Errorf("lock file %s: %w", lockObj.Path(), err))
 	}
 
+	modulePaths := lockObj.GetModuleLoadPaths()
 	paths := lockObj.GetLoadPaths()
 
 	p.Send(progressMsg{stage: stageLoadEntries, percent: 0.2, status: fmt.Sprintf("Loading entries from %d paths...", len(paths))})
@@ -501,6 +511,18 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 	// Add bytecode resource if compiled
 	if bcRes := stages.GetBytecodeResource(); bcRes != nil {
 		resources = append(resources, *bcRes)
+	}
+
+	carriedResources, carriedHandles, err := collectEmbeddedPackResources(modulePaths, resources)
+	if err != nil {
+		return NewPackWithResourcesError(err)
+	}
+	defer func() { _ = closeEmbeddedPackResourceHandles(carriedHandles) }()
+	if len(carriedResources) > 0 {
+		resources = append(resources, carriedResources...)
+		p.Send(logMsg{level: "info", message: "Carried embedded resources from dependency packs", fields: map[string]any{
+			"count": len(carriedResources),
+		}})
 	}
 
 	var resInfos []resourceInfo
@@ -630,6 +652,125 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 	})
 
 	return nil
+}
+
+func resolvePackEmbedPatterns(cmd *cobra.Command, configDir string) ([]string, error) {
+	flagPatterns, _ := cmd.Flags().GetStringSlice("embed")
+	if cmd.Flags().Changed("embed") {
+		return flagPatterns, nil
+	}
+
+	configPath := filepath.Join(configDir, moduleconfig.DefaultConfigFile)
+	if _, err := os.Stat(configPath); err != nil {
+		if os.IsNotExist(err) {
+			return flagPatterns, nil
+		}
+		return nil, fmt.Errorf("stat %s: %w", configPath, err)
+	}
+
+	cfg, err := moduleconfig.Load(configDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Embed) == 0 {
+		return flagPatterns, nil
+	}
+	return cfg.Embed, nil
+}
+
+type embeddedPackResourceHandle struct {
+	file *os.File
+}
+
+func collectEmbeddedPackResources(modulePaths []lock.ModuleLoadPath, existing []wapp.ResourceSpec) ([]wapp.ResourceSpec, []embeddedPackResourceHandle, error) {
+	seen := make(map[wapp.ID]string, len(existing))
+	for _, res := range existing {
+		seen[res.ID] = "current pack"
+	}
+
+	var resources []wapp.ResourceSpec
+	var handles []embeddedPackResourceHandle
+
+	fail := func(err error) ([]wapp.ResourceSpec, []embeddedPackResourceHandle, error) {
+		_ = closeEmbeddedPackResourceHandles(handles)
+		return nil, nil, err
+	}
+
+	for _, mp := range modulePaths {
+		if !hasWappExtension(mp.Path) {
+			continue
+		}
+
+		file, err := os.Open(mp.Path)
+		if err != nil {
+			return fail(fmt.Errorf("open embedded dependency pack %s: %w", mp.Path, err))
+		}
+
+		reader, err := wapp.NewReader(file)
+		if err != nil {
+			_ = file.Close()
+			return fail(fmt.Errorf("read embedded dependency pack %s: %w", mp.Path, err))
+		}
+
+		infos := reader.ListResources()
+		if len(infos) == 0 {
+			_ = file.Close()
+			continue
+		}
+
+		handleAdded := false
+		for _, info := range infos {
+			if prev, ok := seen[info.ID]; ok {
+				_ = file.Close()
+				return fail(fmt.Errorf("duplicate embedded resource %s from %s already provided by %s", info.ID.String(), embeddedPackResourceOrigin(mp), prev))
+			}
+
+			fsys, err := reader.GetFS(info.ID)
+			if err != nil {
+				_ = file.Close()
+				return fail(fmt.Errorf("open embedded resource %s from %s: %w", info.ID.String(), embeddedPackResourceOrigin(mp), err))
+			}
+
+			resources = append(resources, wapp.ResourceSpec{
+				ID:   info.ID,
+				Meta: info.Meta,
+				FS:   fsys,
+			})
+			seen[info.ID] = embeddedPackResourceOrigin(mp)
+			handleAdded = true
+		}
+
+		if handleAdded {
+			handles = append(handles, embeddedPackResourceHandle{file: file})
+		} else {
+			_ = file.Close()
+		}
+	}
+
+	return resources, handles, nil
+}
+
+func embeddedPackResourceOrigin(mp lock.ModuleLoadPath) string {
+	if mp.Module == "" {
+		return mp.Path
+	}
+	if mp.Version == "" {
+		return mp.Module + " at " + mp.Path
+	}
+	return mp.Module + "@" + mp.Version + " at " + mp.Path
+}
+
+func closeEmbeddedPackResourceHandles(handles []embeddedPackResourceHandle) error {
+	var errs []error
+	for _, handle := range handles {
+		if handle.file == nil {
+			continue
+		}
+		if err := handle.file.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func parseMetadataFlags(metaFlags []string, metadata attrs.Bag, logger *zap.Logger) error {

--- a/cmd/wippy/cmd/pack.go
+++ b/cmd/wippy/cmd/pack.go
@@ -40,7 +40,8 @@ The pack file contains fully linked entries ready for loading without additional
 Examples:
   wippy pack snapshot.wapp
   wippy pack release-v1.2.3.wapp
-  wippy pack --embed app:assets snapshot.wapp`,
+  wippy pack --embed app:assets snapshot.wapp
+  wippy pack --embed-all snapshot.wapp`,
 	Args: cobra.ExactArgs(1),
 	RunE: runPack,
 }
@@ -53,6 +54,7 @@ func init() {
 	packCmd.Flags().StringSliceP("tags", "t", nil, "pack tags")
 	packCmd.Flags().StringArray("meta", nil, "custom metadata (key=value, supports dotted notation)")
 	packCmd.Flags().StringSlice("embed", nil, "embed patterns (entry IDs or names to embed, e.g., app:assets,app:static)")
+	packCmd.Flags().Bool("embed-all", false, "embed all fs.directory entries")
 	packCmd.Flags().Bool("list", false, "list all fs.directory entries and exit (dry-run mode)")
 	packCmd.Flags().StringSlice("exclude-ns", nil, "exclude entries by namespace patterns (e.g., app.**,test.*)")
 	packCmd.Flags().StringSlice("exclude", nil, "exclude entries by ID patterns (e.g., app:internal,test:*)")
@@ -76,18 +78,19 @@ const (
 type packModel struct {
 	err           error
 	metadata      attrs.Bag
+	outputFile    string
 	status        string
 	stage         packStage
-	outputFile    string
+	embedPatterns []string
 	logs          []string
 	resources     []resourceInfo
-	embedPatterns []string
 	progress      progress.Model
-	entryCount    int
 	fileSize      int64
-	resourceCount int
 	percent       float64
+	entryCount    int
+	resourceCount int
 	maxLogs       int
+	embedAll      bool
 	done          bool
 	verbose       bool
 }
@@ -295,7 +298,9 @@ func (m *packModel) View() string {
 		Foreground(lipgloss.Color("8"))
 
 	var embedInfo string
-	if len(m.embedPatterns) > 0 {
+	if m.embedAll {
+		embedInfo = statusStyle.Render("  Embed patterns: all fs.directory entries\n")
+	} else if len(m.embedPatterns) > 0 {
 		embedInfo = statusStyle.Render(fmt.Sprintf("  Embed patterns: %s\n", strings.Join(m.embedPatterns, ", ")))
 	}
 
@@ -353,7 +358,7 @@ func runPack(cmd *cobra.Command, args []string) error {
 		return runListMode(app, lockPath, folderPath)
 	}
 
-	embedPatterns, err := resolvePackEmbedPatterns(cmd, folderPath)
+	embedConfig, err := resolvePackEmbedConfig(cmd, folderPath)
 	if err != nil {
 		return NewPackConfigError(err)
 	}
@@ -364,7 +369,8 @@ func runPack(cmd *cobra.Command, args []string) error {
 		stage:         stageInit,
 		progress:      prog,
 		status:        "Initializing...",
-		embedPatterns: embedPatterns,
+		embedPatterns: embedConfig.patterns,
+		embedAll:      embedConfig.all,
 		outputFile:    outputFile,
 		verbose:       verboseMode,
 		maxLogs:       20,
@@ -395,10 +401,11 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 	outputFile := args[0]
 	lockFile, _ := cmd.Flags().GetString("lock-file")
 	folderPath := "."
-	embedPatterns, err := resolvePackEmbedPatterns(cmd, folderPath)
+	embedConfig, err := resolvePackEmbedConfig(cmd, folderPath)
 	if err != nil {
 		return NewPackConfigError(err)
 	}
+	embedPatterns := embedConfig.patterns
 	excludeNS, _ := cmd.Flags().GetStringSlice("exclude-ns")
 	excludeEntries, _ := cmd.Flags().GetStringSlice("exclude")
 	bytecodePatterns, _ := cmd.Flags().GetStringSlice("bytecode")
@@ -491,13 +498,17 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 		}
 	}
 
-	if len(embedPatterns) > 0 {
+	if embedConfig.enabled() {
+		status := "Processing all embed-capable directories"
+		if !embedConfig.all {
+			status = fmt.Sprintf("Processing embed patterns: %s", strings.Join(embedPatterns, ", "))
+		}
 		p.Send(progressMsg{
 			stage:   stagePipeline,
 			percent: 0.55,
-			status:  fmt.Sprintf("Processing embed patterns: %s", strings.Join(embedPatterns, ", ")),
+			status:  status,
 		})
-		pipelineStages = append(pipelineStages, stages.EmbedFS("", embedPatterns...))
+		pipelineStages = append(pipelineStages, stages.EmbedFS("", embedConfig.stagePatterns()...))
 	}
 
 	pipeline := build.New(pipelineStages...)
@@ -654,28 +665,60 @@ func performPack(cmd *cobra.Command, args []string, app *appinit.Context, p *tea
 	return nil
 }
 
-func resolvePackEmbedPatterns(cmd *cobra.Command, configDir string) ([]string, error) {
+type packEmbedConfig struct {
+	patterns []string
+	all      bool
+}
+
+func (c packEmbedConfig) enabled() bool {
+	return c.all || len(c.patterns) > 0
+}
+
+func (c packEmbedConfig) stagePatterns() []string {
+	if c.all {
+		return nil
+	}
+	return c.patterns
+}
+
+func resolvePackEmbedConfig(cmd *cobra.Command, configDir string) (packEmbedConfig, error) {
 	flagPatterns, _ := cmd.Flags().GetStringSlice("embed")
+	flagAll, _ := cmd.Flags().GetBool("embed-all")
+	if flagAll && cmd.Flags().Changed("embed") && len(flagPatterns) > 0 {
+		return packEmbedConfig{}, fmt.Errorf("--embed-all cannot be combined with --embed")
+	}
+	if flagAll {
+		return packEmbedConfig{all: true}, nil
+	}
 	if cmd.Flags().Changed("embed") {
-		return flagPatterns, nil
+		return packEmbedConfig{patterns: flagPatterns, all: hasEmbedAllPattern(flagPatterns)}, nil
 	}
 
 	configPath := filepath.Join(configDir, moduleconfig.DefaultConfigFile)
 	if _, err := os.Stat(configPath); err != nil {
 		if os.IsNotExist(err) {
-			return flagPatterns, nil
+			return packEmbedConfig{patterns: flagPatterns}, nil
 		}
-		return nil, fmt.Errorf("stat %s: %w", configPath, err)
+		return packEmbedConfig{}, fmt.Errorf("stat %s: %w", configPath, err)
 	}
 
 	cfg, err := moduleconfig.Load(configDir)
 	if err != nil {
-		return nil, err
+		return packEmbedConfig{}, err
 	}
 	if len(cfg.Embed) == 0 {
-		return flagPatterns, nil
+		return packEmbedConfig{patterns: flagPatterns}, nil
 	}
-	return cfg.Embed, nil
+	return packEmbedConfig{patterns: cfg.Embed, all: hasEmbedAllPattern(cfg.Embed)}, nil
+}
+
+func hasEmbedAllPattern(patterns []string) bool {
+	for _, pattern := range patterns {
+		if pattern == "*" || pattern == "**" {
+			return true
+		}
+	}
+	return false
 }
 
 type embeddedPackResourceHandle struct {

--- a/cmd/wippy/cmd/pack_hardening_test.go
+++ b/cmd/wippy/cmd/pack_hardening_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/wippyai/runtime/boot/deps/hub"
+)
+
+type fakeHubPackDownloader struct {
+	err     error
+	payload []byte
+	calls   int
+}
+
+func (f *fakeHubPackDownloader) DownloadToFile(_ context.Context, _ string, destPath string) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(destPath, f.payload, 0o644)
+}
+
+func TestEnsureHubPackCachedUsesVerifiedCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	packPath := filepath.Join(tmpDir, "ui-1.2.3.wapp")
+	payload := []byte("cached pack")
+	if err := os.WriteFile(packPath, payload, 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	downloader := &fakeHubPackDownloader{payload: []byte("downloaded pack")}
+	err := ensureHubPackCached(context.Background(), downloader, hub.ResolvedModule{
+		Version:   "1.2.3",
+		URL:       "https://hub.example/download",
+		Digest:    sha256Digest(payload),
+		SizeBytes: uint64(len(payload)),
+	}, packPath, "acme/ui", "https://hub.example")
+	if err != nil {
+		t.Fatalf("ensureHubPackCached: %v", err)
+	}
+	if downloader.calls != 0 {
+		t.Fatalf("download calls = %d, want 0", downloader.calls)
+	}
+}
+
+func TestEnsureHubPackCachedRedownloadsInvalidCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	packPath := filepath.Join(tmpDir, "ui-1.2.3.wapp")
+	if err := os.WriteFile(packPath, []byte("corrupt cache"), 0o644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	payload := []byte("downloaded pack")
+	downloader := &fakeHubPackDownloader{payload: payload}
+	err := ensureHubPackCached(context.Background(), downloader, hub.ResolvedModule{
+		Version:   "1.2.3",
+		URL:       "https://hub.example/download",
+		Digest:    sha256Digest(payload),
+		SizeBytes: uint64(len(payload)),
+	}, packPath, "acme/ui", "https://hub.example")
+	if err != nil {
+		t.Fatalf("ensureHubPackCached: %v", err)
+	}
+	if downloader.calls != 1 {
+		t.Fatalf("download calls = %d, want 1", downloader.calls)
+	}
+	got, err := os.ReadFile(packPath)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("cache payload = %q, want %q", got, payload)
+	}
+}
+
+func TestEnsureHubPackCachedRejectsInvalidDownload(t *testing.T) {
+	tmpDir := t.TempDir()
+	packPath := filepath.Join(tmpDir, "ui-1.2.3.wapp")
+
+	downloader := &fakeHubPackDownloader{payload: []byte("wrong pack")}
+	err := ensureHubPackCached(context.Background(), downloader, hub.ResolvedModule{
+		Version:   "1.2.3",
+		URL:       "https://hub.example/download",
+		Digest:    sha256Digest([]byte("expected pack")),
+		SizeBytes: uint64(len("expected pack")),
+	}, packPath, "acme/ui", "https://hub.example")
+	if err == nil {
+		t.Fatal("expected integrity error")
+	}
+	if !strings.Contains(err.Error(), "failed to verify downloaded acme/ui@1.2.3") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(packPath); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid download should be removed, stat err = %v", statErr)
+	}
+}
+
+func TestResolvePackEmbedConfigAll(t *testing.T) {
+	t.Run("flag", func(t *testing.T) {
+		cmd := newTestPackCommand(t)
+		if err := cmd.Flags().Set("embed-all", "true"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+
+		cfg, err := resolvePackEmbedConfig(cmd, t.TempDir())
+		if err != nil {
+			t.Fatalf("resolvePackEmbedConfig: %v", err)
+		}
+		if !cfg.enabled() || !cfg.all || cfg.stagePatterns() != nil {
+			t.Fatalf("embed config = %+v, want all with nil stage patterns", cfg)
+		}
+	})
+
+	t.Run("config wildcard", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(tmpDir, "wippy.yaml"), []byte("embed:\n  - \"**\"\n"), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		cfg, err := resolvePackEmbedConfig(newTestPackCommand(t), tmpDir)
+		if err != nil {
+			t.Fatalf("resolvePackEmbedConfig: %v", err)
+		}
+		if !cfg.enabled() || !cfg.all || cfg.stagePatterns() != nil {
+			t.Fatalf("embed config = %+v, want config wildcard all", cfg)
+		}
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		cmd := newTestPackCommand(t)
+		if err := cmd.Flags().Set("embed-all", "true"); err != nil {
+			t.Fatalf("set embed-all: %v", err)
+		}
+		if err := cmd.Flags().Set("embed", "app:assets"); err != nil {
+			t.Fatalf("set embed: %v", err)
+		}
+
+		_, err := resolvePackEmbedConfig(cmd, t.TempDir())
+		if err == nil {
+			t.Fatal("expected conflict error")
+		}
+	})
+}
+
+func newTestPackCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("embed", nil, "")
+	cmd.Flags().Bool("embed-all", false, "")
+	return cmd
+}
+
+func sha256Digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -264,11 +264,6 @@ func publishViaHubOrLegacy(
 		FilePath:     outputFile,
 		Protected:    protected,
 	}
-	if label != "" {
-		// When publishing a label, the version is resolved server-side.
-		in.Version = ""
-	}
-
 	out, err := client.PublishViaHub(ctx, in)
 	if err == nil {
 		return out.PublishID, nil

--- a/cmd/wippy/cmd/publish_test.go
+++ b/cmd/wippy/cmd/publish_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wippyai/runtime/boot/deps/config"
+	"github.com/wippyai/runtime/boot/deps/hub"
+)
+
+func TestPublishViaHubOrLegacy_LabelUploadKeepsVersionHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	wappPath := filepath.Join(tmpDir, "module.wapp")
+	if err := os.WriteFile(wappPath, []byte("packed module"), 0o600); err != nil {
+		t.Fatalf("write wapp: %v", err)
+	}
+
+	var gotVersion, gotLabel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/publish/upload" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		gotVersion = r.Header.Get("X-Wippy-Version")
+		gotLabel = r.Header.Get("X-Wippy-Label")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"publish_id":"publish-1"}`))
+	}))
+	defer server.Close()
+
+	client, err := hub.NewClient(hub.Options{
+		BaseURL: server.URL,
+		Token:   "test-token",
+	})
+	if err != nil {
+		t.Fatalf("new hub client: %v", err)
+	}
+
+	cfg := &config.ModuleConfig{
+		Organization: "acme",
+		ModuleName:   "app",
+		Version:      "1.2.3",
+	}
+	publishID, err := publishViaHubOrLegacy(
+		context.Background(),
+		client,
+		server.URL,
+		cfg,
+		wappPath,
+		"latest",
+		"release notes",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("publishViaHubOrLegacy failed: %v", err)
+	}
+	if publishID != "publish-1" {
+		t.Fatalf("publish id = %q, want publish-1", publishID)
+	}
+	if gotVersion != "1.2.3" {
+		t.Fatalf("X-Wippy-Version = %q, want 1.2.3", gotVersion)
+	}
+	if gotLabel != "latest" {
+		t.Fatalf("X-Wippy-Label = %q, want latest", gotLabel)
+	}
+}

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -84,6 +84,27 @@ func collectCommands(ctx context.Context) ([]packCommand, error) {
 	return commandsFromEntries(allEntries), nil
 }
 
+func collectPackCommands(ctx context.Context, mainModule string) ([]packCommand, error) {
+	reg := registry.GetRegistry(ctx)
+	if reg == nil {
+		return nil, fmt.Errorf("registry not available")
+	}
+
+	allEntries, err := reg.GetAllEntries()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query registry for commands: %w", err)
+	}
+
+	filtered := allEntries[:0]
+	for _, entry := range allEntries {
+		if !packCommandAllowed(entry.Meta, mainModule) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return commandsFromEntries(filtered), nil
+}
+
 // commandForUseCase maps a declared use case to the top-level CLI command that
 // targets it (the default use case maps to `wippy run`, every other use case
 // maps to a command of the same name, e.g. `wippy test`).
@@ -95,15 +116,29 @@ func commandForUseCase(useCase string) string {
 	return useCase
 }
 
-// findPackCommand resolves the entrypoint to execute from the loaded registry
-// for the given use case. See selectEntrypoint for the selection rules.
-func findPackCommand(ctx context.Context, commandName, useCase string) (string, error) {
-	commands, err := collectCommands(ctx)
+func findPackCommandForModule(ctx context.Context, commandName, useCase, mainModule string) (string, error) {
+	commands, err := collectPackCommands(ctx, mainModule)
 	if err != nil {
 		return "", err
 	}
 
 	return selectEntrypoint(commands, commandName, useCase)
+}
+
+func moduleMeta(meta map[string]any) string {
+	if meta == nil {
+		return ""
+	}
+	module, _ := meta["module"].(string)
+	return module
+}
+
+func packCommandAllowed(meta map[string]any, mainModule string) bool {
+	module := moduleMeta(meta)
+	if mainModule == "" {
+		return module == ""
+	}
+	return module == "" || module == mainModule
 }
 
 // selectEntrypoint picks the entrypoint to execute for a use case.
@@ -402,9 +437,14 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase
 		return NewLoadEntriesError(packFile, err)
 	}
 
+	mainModule, _, err := moduleIdentityFromPackFile(packFile)
+	if err != nil {
+		return fmt.Errorf("failed to load main module identity from pack metadata: %w", err)
+	}
+
 	runLogger.Info("loaded entries from pack", zap.Int("count", len(packEntries)))
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule)
 }
 
 // runFromPackFiles executes runtime from multiple already resolved .wapp files.
@@ -435,6 +475,15 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, use
 	}
 	defer embedReg.Close()
 
+	mainModule := ""
+	if len(packFiles) > 0 {
+		var err error
+		mainModule, _, err = moduleIdentityFromPackFile(packFiles[len(packFiles)-1])
+		if err != nil {
+			return fmt.Errorf("failed to load main module identity from pack metadata: %w", err)
+		}
+	}
+
 	packEntries, err := loadPackEntries(packFiles, embedReg)
 	if err != nil {
 		runLogger.Error("failed to load entries from packs", zap.Error(err))
@@ -443,7 +492,7 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, use
 
 	runLogger.Info("loaded entries from packs", zap.Int("count", len(packEntries)))
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule)
 }
 
 // runPackEntries starts runtime, applies pack entries to registry, optionally
@@ -455,6 +504,7 @@ func runPackEntries(
 	packEntries []registry.Entry,
 	args []string,
 	useCase string,
+	mainModule string,
 ) error {
 	sigChan := setupSupervisorSignalChannel(ctx)
 	defer signal.Stop(sigChan)
@@ -481,7 +531,7 @@ func runPackEntries(
 		args = args[1:]
 	}
 
-	entryID, err := findPackCommand(appCtx, commandName, useCase)
+	entryID, err := findPackCommandForModule(appCtx, commandName, useCase, mainModule)
 	if err != nil {
 		logger.Error("failed to find command", zap.Error(err))
 		return err
@@ -503,6 +553,22 @@ func runPackEntries(
 	}
 
 	return nil
+}
+
+func moduleIdentityFromPackFile(packFile string) (moduleName string, moduleVersion string, err error) {
+	file, err := os.Open(packFile)
+	if err != nil {
+		return "", "", fmt.Errorf("open pack %s: %w", packFile, err)
+	}
+	defer file.Close()
+
+	reader, err := entries.NewPackReader(file, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("read pack %s: %w", packFile, err)
+	}
+
+	moduleName, moduleVersion = moduleIdentityFromPackMetadata(reader.Reader())
+	return moduleName, moduleVersion, nil
 }
 
 // applyPackEntries restores packed entries as baseline state after applying the
@@ -555,6 +621,10 @@ func loadPackEntries(packFiles []string, embedReg packReaderRegistry) ([]registr
 
 		if moduleName != "" {
 			annotateEntriesModuleMeta(loadedEntries, moduleName, moduleVersion)
+		} else {
+			if err := registerMonolithicPackResourceAliases(embedReg, packFile, packReader.Reader(), loadedEntries); err != nil {
+				return nil, fmt.Errorf("register embed resource aliases for %s: %w", packFile, err)
+			}
 		}
 
 		packEntries = append(packEntries, loadedEntries...)
@@ -570,6 +640,45 @@ func registerPackResources(embedReg packReaderRegistry, packFile, moduleName, mo
 		}
 	}
 	return embedReg.Register(packFile, reader, file)
+}
+
+func registerMonolithicPackResourceAliases(embedReg packReaderRegistry, packFile string, reader *wapp.Reader, loadedEntries []registry.Entry) error {
+	moduleReg, ok := embedReg.(modulePackReaderRegistry)
+	if !ok {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, entry := range loadedEntries {
+		if entry.Meta == nil {
+			continue
+		}
+
+		moduleName, _ := entry.Meta["module"].(string)
+		if moduleName == "" {
+			continue
+		}
+
+		moduleVersion, _ := entry.Meta["module_version"].(string)
+		key := moduleName + "\x00" + moduleVersion
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		if err := moduleReg.RegisterPack(monolithicPackAliasPath(packFile, moduleName, moduleVersion), moduleName, moduleVersion, reader, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func monolithicPackAliasPath(packFile, moduleName, moduleVersion string) string {
+	if moduleVersion == "" {
+		return packFile + "#" + moduleName
+	}
+	return packFile + "#" + moduleName + "@" + moduleVersion
 }
 
 func moduleIdentityFromPackMetadata(reader *wapp.Reader) (moduleName string, moduleVersion string) {

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -28,6 +28,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type hubPackDownloader interface {
+	DownloadToFile(ctx context.Context, url, destPath string) error
+}
+
 // hubModulePattern matches hub references like org/module[@version|@label].
 var hubModulePattern = regexp.MustCompile(`^([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)(?:@(.+))?$`)
 var hubIdentPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
@@ -315,16 +319,8 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 		moduleName := fmt.Sprintf("%s/%s", m.Org, m.Name)
 		packPath := filepath.Join(cacheDir, m.Org, fmt.Sprintf("%s-%s.wapp", m.Name, m.Version))
 
-		if _, err := os.Stat(packPath); err == nil {
-			fmt.Printf("%s %s@%s (cached)\n", dimStyle.Render(""), moduleName, m.Version)
-		} else {
-			fmt.Printf("%s Downloading %s@%s...\n", dimStyle.Render(""), moduleName, m.Version)
-			if m.URL == "" {
-				return nil, fmt.Errorf("no download URL for %s@%s from %s", moduleName, m.Version, registryURL)
-			}
-			if err := client.DownloadToFile(downloadCtx, m.URL, packPath); err != nil {
-				return nil, fmt.Errorf("failed to download %s@%s from %s to %s: %w", moduleName, m.Version, registryURL, packPath, err)
-			}
+		if err := ensureHubPackCached(downloadCtx, client, m, packPath, moduleName, registryURL); err != nil {
+			return nil, err
 		}
 
 		if err := updateLockFile(moduleName, m.Version, m.Digest); err != nil {
@@ -346,6 +342,35 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 
 	fmt.Println()
 	return packPaths, nil
+}
+
+func ensureHubPackCached(ctx context.Context, client hubPackDownloader, m hub.ResolvedModule, packPath, moduleName, registryURL string) error {
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	if _, err := os.Stat(packPath); err == nil {
+		if err := hub.VerifyDownloadedArtifact(packPath, m.Digest, m.SizeBytes); err == nil {
+			fmt.Printf("%s %s@%s (cached)\n", dimStyle.Render(""), moduleName, m.Version)
+			return nil
+		}
+		fmt.Printf("%s Cached %s@%s failed integrity check; redownloading...\n", dimStyle.Render(""), moduleName, m.Version)
+		if err := os.Remove(packPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove invalid cached pack %s: %w", packPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat cached pack %s: %w", packPath, err)
+	}
+
+	fmt.Printf("%s Downloading %s@%s...\n", dimStyle.Render(""), moduleName, m.Version)
+	if m.URL == "" {
+		return fmt.Errorf("no download URL for %s@%s from %s", moduleName, m.Version, registryURL)
+	}
+	if err := client.DownloadToFile(ctx, m.URL, packPath); err != nil {
+		return fmt.Errorf("failed to download %s@%s from %s to %s: %w", moduleName, m.Version, registryURL, packPath, err)
+	}
+	if err := hub.VerifyDownloadedArtifact(packPath, m.Digest, m.SizeBytes); err != nil {
+		_ = os.Remove(packPath)
+		return fmt.Errorf("failed to verify downloaded %s@%s from %s: %w", moduleName, m.Version, registryURL, err)
+	}
+	return nil
 }
 
 // updateLockFile persists resolved module version/hash into wippy.lock.

--- a/cmd/wippy/cmd/run_pack_shutdown_test.go
+++ b/cmd/wippy/cmd/run_pack_shutdown_test.go
@@ -76,7 +76,7 @@ func TestRunPackEntries_GracefulShutdownStopsRunningService(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runPackEntries(ctx, loader, baseLogger, nil, nil, defaultUseCase)
+		done <- runPackEntries(ctx, loader, baseLogger, nil, nil, defaultUseCase, "")
 	}()
 
 	waitForLogMessage(t, logs, "supervisor started")

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -18,6 +19,7 @@ import (
 	supervisorapi "github.com/wippyai/runtime/api/supervisor"
 	"github.com/wippyai/runtime/boot/build"
 	"github.com/wippyai/runtime/boot/build/stages"
+	"github.com/wippyai/runtime/boot/deps/lock"
 	"github.com/wippyai/runtime/cmd/internal/shutdown"
 	embedpkg "github.com/wippyai/runtime/service/fs/embed"
 	"github.com/wippyai/wapp"
@@ -68,7 +70,7 @@ func TestRunPackEntries_InvalidRequirementFailsNormalizationPipeline(t *testing.
 		},
 	}
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, defaultUseCase)
+	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, defaultUseCase, "")
 	if err == nil {
 		t.Fatal("expected normalization pipeline error")
 	}
@@ -105,7 +107,7 @@ func TestRunPackEntries_NoEntrypointRunsAsServer(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, defaultUseCase)
+		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, defaultUseCase, "")
 	}()
 
 	select {
@@ -147,7 +149,7 @@ func TestRunPackEntries_TestModeWithoutTestEntrypointErrors(t *testing.T) {
 		_ = embedReg.Close()
 	})
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, "test")
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, "test", "")
 	if err == nil {
 		t.Fatal("expected an error when there is no test entrypoint")
 	}
@@ -177,7 +179,7 @@ func TestRunPackEntries_RunModeUnknownCommandErrors(t *testing.T) {
 		_ = embedReg.Close()
 	})
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, defaultUseCase)
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, defaultUseCase, "")
 	if err == nil {
 		t.Fatal("expected an error for an unknown command")
 	}
@@ -435,6 +437,122 @@ func TestCommandsFromEntries(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("command[%d] = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+func TestCollectPackCommandsFiltersDependencyModules(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevConfigFile := configFile
+	configFile = cfgPath
+	t.Cleanup(func() {
+		configFile = prevConfigFile
+	})
+
+	ctx, loader, _, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("bootstrap pack runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = embedReg.Close()
+	})
+	appCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if err := loader.Start(appCtx); err != nil {
+		t.Fatalf("start loader: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = shutdown.Perform(appCtx, loader, zap.NewNop(), true)
+	})
+
+	entries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("wippy.test", "runner"),
+			Kind: "process.lua",
+			Data: payload.New(map[string]any{"source": "return {}"}),
+			Meta: map[string]any{
+				"module":  "wippy/test",
+				"command": map[string]any{"name": "test"},
+			},
+		},
+		{
+			ID:   regapi.NewID("app", "serve"),
+			Kind: "process.lua",
+			Data: payload.New(map[string]any{"source": "return {}"}),
+			Meta: map[string]any{
+				"module":  "kickside/kickside",
+				"command": map[string]any{"name": "serve", "main": true},
+			},
+		},
+	}
+	if err := applyPackEntries(appCtx, entries, zap.NewNop()); err != nil {
+		t.Fatalf("apply entries: %v", err)
+	}
+
+	commands, err := collectPackCommands(appCtx, "kickside/kickside")
+	if err != nil {
+		t.Fatalf("collect pack commands: %v", err)
+	}
+	if len(commands) != 1 || commands[0].entryID != "app:serve" {
+		t.Fatalf("commands = %#v, want only app:serve", commands)
+	}
+
+	entryID, err := findPackCommandForModule(appCtx, "", defaultUseCase, "kickside/kickside")
+	if err != nil {
+		t.Fatalf("find pack command: %v", err)
+	}
+	if entryID != "app:serve" {
+		t.Fatalf("entryID = %q, want app:serve", entryID)
+	}
+}
+
+func TestPackCommandAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		meta       map[string]any
+		mainModule string
+		want       bool
+	}{
+		{
+			name: "moduleless command allowed without pack identity",
+			meta: map[string]any{"command": map[string]any{"name": "serve"}},
+			want: true,
+		},
+		{
+			name: "dependency command excluded without pack identity",
+			meta: map[string]any{"module": "wippy/test", "command": map[string]any{"name": "test"}},
+			want: false,
+		},
+		{
+			name:       "main module command allowed",
+			meta:       map[string]any{"module": "kickside/kickside", "command": map[string]any{"name": "serve"}},
+			mainModule: "kickside/kickside",
+			want:       true,
+		},
+		{
+			name:       "dependency command excluded when main module known",
+			meta:       map[string]any{"module": "wippy/test", "command": map[string]any{"name": "test"}},
+			mainModule: "kickside/kickside",
+			want:       false,
+		},
+		{
+			name:       "moduleless command allowed when main module known",
+			meta:       map[string]any{"command": map[string]any{"name": "serve"}},
+			mainModule: "kickside/kickside",
+			want:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := packCommandAllowed(tc.meta, tc.mainModule); got != tc.want {
+				t.Fatalf("packCommandAllowed() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -754,6 +872,87 @@ func TestLoadPackEntries_DoesNotOverrideExistingModuleMetadata(t *testing.T) {
 	}
 }
 
+func TestLoadPackEntries_MonolithicPackRegistersModuleResourceAliases(t *testing.T) {
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "static")
+	writeTestFile(t, root, "index.html", []byte("<html>module</html>\n"))
+
+	packPath := createTestResourcePackFile(t, tmpDir, "snapshot", wapp.Metadata{
+		"name": "snapshot",
+	}, []wapp.Entry{{
+		ID:   wapp.NewID("acme.ui", "static_fs"),
+		Kind: "fs.embed",
+		Meta: wapp.Metadata{
+			"module":         "acme/ui",
+			"module_version": "1.2.3",
+		},
+	}}, []wapp.ResourceSpec{{
+		ID: wapp.NewID("acme.ui", "static_fs"),
+		FS: os.DirFS(root),
+	}})
+
+	embedReg := embedpkg.NewRegistry()
+	defer func() { _ = embedReg.Close() }()
+
+	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	if err != nil {
+		t.Fatalf("loadPackEntries failed: %v", err)
+	}
+	if len(packEntries) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(packEntries))
+	}
+
+	fsys, err := embedReg.GetFSForEntry(packEntries[0])
+	if err != nil {
+		t.Fatalf("GetFSForEntry failed: %v", err)
+	}
+	data, err := fs.ReadFile(fsys, "index.html")
+	if err != nil {
+		t.Fatalf("read aliased resource: %v", err)
+	}
+	if string(data) != "<html>module</html>\n" {
+		t.Fatalf("aliased resource data = %q", string(data))
+	}
+}
+
+func TestCollectEmbeddedPackResourcesCarriesDependencyResources(t *testing.T) {
+	tmpDir := t.TempDir()
+	depRoot := filepath.Join(tmpDir, "dep")
+	writeTestFile(t, depRoot, "index.html", []byte("<html>dep</html>\n"))
+
+	depPack := createTestResourcePackFile(t, tmpDir, "dep", wapp.Metadata{
+		"name":      "ui",
+		"namespace": "acme.ui",
+		"version":   "1.2.3",
+	}, []wapp.Entry{{
+		ID:   wapp.NewID("acme.ui", "static_fs"),
+		Kind: "fs.embed",
+	}}, []wapp.ResourceSpec{{
+		ID: wapp.NewID("acme.ui", "static_fs"),
+		FS: os.DirFS(depRoot),
+	}})
+
+	resources, handles, err := collectEmbeddedPackResources([]lock.ModuleLoadPath{{
+		Module:  "acme/ui",
+		Version: "1.2.3",
+		Path:    depPack,
+	}}, nil)
+	defer func() { _ = closeEmbeddedPackResourceHandles(handles) }()
+	if err != nil {
+		t.Fatalf("collectEmbeddedPackResources failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(resources))
+	}
+	data, err := fs.ReadFile(resources[0].FS, "index.html")
+	if err != nil {
+		t.Fatalf("read carried resource: %v", err)
+	}
+	if string(data) != "<html>dep</html>\n" {
+		t.Fatalf("carried resource data = %q", string(data))
+	}
+}
+
 func TestLoadBootConfig_OverridesAppliedToPipelineEntries(t *testing.T) {
 	t.Run("overrides from wippy.yaml are applied to entries", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -986,6 +1185,27 @@ func createModulePackWithEmbeddedResource(t *testing.T, dir, name string, metada
 	}
 	if err != nil {
 		t.Fatalf("pack with resource: %v", err)
+	}
+
+	return packPath
+}
+
+func createTestResourcePackFile(t *testing.T, dir, name string, metadata wapp.Metadata, entries []wapp.Entry, resources []wapp.ResourceSpec) string {
+	t.Helper()
+
+	packPath := filepath.Join(dir, name+".wapp")
+	file, err := os.Create(packPath)
+	if err != nil {
+		t.Fatalf("create pack file: %v", err)
+	}
+
+	writer := wapp.NewWriter()
+	err = writer.PackWithResources(metadata, entries, resources, file)
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("pack with resources: %v", err)
 	}
 
 	return packPath

--- a/cmd/wippy/cmd/tea_program.go
+++ b/cmd/wippy/cmd/tea_program.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+)
+
+func newCLIProgram(model tea.Model) *tea.Program {
+	return tea.NewProgram(model, cliTeaProgramOptions(os.Stdin, os.Stdout)...)
+}
+
+func cliTeaProgramOptions(input, output *os.File) []tea.ProgramOption {
+	if !isTerminalFile(input) || !isTerminalFile(output) {
+		return []tea.ProgramOption{
+			tea.WithInput(nil),
+			tea.WithoutRenderer(),
+		}
+	}
+	return nil
+}
+
+func isTerminalFile(file *os.File) bool {
+	return file != nil && term.IsTerminal(int(file.Fd()))
+}

--- a/cmd/wippy/cmd/tea_program_test.go
+++ b/cmd/wippy/cmd/tea_program_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+type quitTestModel struct{}
+
+func (quitTestModel) Init() tea.Cmd {
+	return tea.Quit
+}
+
+func (quitTestModel) Update(tea.Msg) (tea.Model, tea.Cmd) {
+	return quitTestModel{}, nil
+}
+
+func (quitTestModel) View() string {
+	return ""
+}
+
+func TestCLITeaProgramOptionsRunWithoutTTY(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "non-tty-*")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, file.Close()) }()
+
+	require.False(t, isTerminalFile(file))
+
+	program := tea.NewProgram(quitTestModel{}, cliTeaProgramOptions(file, file)...)
+	_, err = program.Run()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- keep hub publish unbundled: app publish still uploads only the app module artifact and relies on dependency resolution at boot
- keep X-Wippy-Version on label uploads so hub-mediated label publish passes current hub validation
- make Bubble Tea CLI UI commands run without a TTY
- make wippy pack use wippy.yaml embed config by default and carry embedded resources from dependency .wapp files for full-container packs
- register module resource aliases only for monolithic .wapp pack runs so packed containers can resolve embedded filesystems by original module metadata

## Verification
- go test ./cmd/wippy/cmd ./boot/deps/hub
- make build-wippy-local
- /tmp/wippy-pr427-clean/dist/wippy-linux-amd64 publish --dry-run --label codex-clean-unbundled-check from Kickside app produced /tmp/kickside-0.1.31.wapp (21.1 MB), confirming default publish remains unbundled
- WIPPY_BIN=/tmp/wippy-pr427-clean/dist/wippy-linux-amd64 SKIP_WEB_HOST=1 PACK_OUT=/tmp/kickside-clean-pr-pack.wapp ./ops/scripts/app/pack-local-webhost.sh