### PR TITLE
Fix queue max_length parsing in driver_options

### DIFF
--- a/api/attrs/attrs.go
+++ b/api/attrs/attrs.go
@@ -3,7 +3,10 @@
 // Package attrs provides a unified key-value attribute bag for metadata, options, and configuration.
 package attrs
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type (
 	// Attributes provides a type-safe interface for accessing key-value pairs.
@@ -64,8 +67,19 @@ func (b Bag) GetString(key string, def string) string {
 // GetInt retrieves the value as an int, returning def if not found or not an int.
 func (b Bag) GetInt(key string, def int) int {
 	if v, ok := b.Get(key); ok {
-		if i, ok := v.(int); ok {
-			return i
+		switch n := v.(type) {
+		case int:
+			return n
+		case int64:
+			return int(n)
+		case int32:
+			return int(n)
+		case float64:
+			return int(n)
+		case json.Number:
+			if i, err := n.Int64(); err == nil {
+				return int(i)
+			}
 		}
 	}
 	return def

--- a/api/attrs/attrs.go
+++ b/api/attrs/attrs.go
@@ -5,6 +5,7 @@ package attrs
 
 import (
 	"encoding/json"
+	"math"
 	"time"
 )
 
@@ -23,6 +24,12 @@ type (
 
 	// Bag is a map-based implementation of Attributes.
 	Bag map[string]any
+)
+
+const (
+	intMax          = int64(^uint(0) >> 1)
+	intMin          = -intMax - 1
+	maxSafeFloatInt = float64(1<<53 - 1)
 )
 
 // NewBag creates a new empty Bag.
@@ -67,22 +74,76 @@ func (b Bag) GetString(key string, def string) string {
 // GetInt retrieves the value as an int, returning def if not found or not an int.
 func (b Bag) GetInt(key string, def int) int {
 	if v, ok := b.Get(key); ok {
-		switch n := v.(type) {
-		case int:
-			return n
-		case int64:
-			return int(n)
-		case int32:
-			return int(n)
-		case float64:
-			return int(n)
-		case json.Number:
-			if i, err := n.Int64(); err == nil {
-				return int(i)
-			}
+		if i, ok := AsInt(v); ok {
+			return i
 		}
 	}
 	return def
+}
+
+// AsInt returns numeric values as int when the conversion is exact and in range.
+func AsInt(value any) (int, bool) {
+	switch n := value.(type) {
+	case int:
+		return n, true
+	case int8:
+		return int(n), true
+	case int16:
+		return int(n), true
+	case int32:
+		return int(n), true
+	case int64:
+		return intFromInt64(n)
+	case uint:
+		return intFromUint64(uint64(n))
+	case uint8:
+		return int(n), true
+	case uint16:
+		return int(n), true
+	case uint32:
+		return intFromUint64(uint64(n))
+	case uint64:
+		return intFromUint64(n)
+	case float32:
+		return intFromFloat64(float64(n))
+	case float64:
+		return intFromFloat64(n)
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return intFromInt64(i)
+	default:
+		return 0, false
+	}
+}
+
+func intFromInt64(n int64) (int, bool) {
+	if n < intMin || n > intMax {
+		return 0, false
+	}
+	return int(n), true
+}
+
+func intFromUint64(n uint64) (int, bool) {
+	if n > uint64(intMax) {
+		return 0, false
+	}
+	return int(n), true
+}
+
+func intFromFloat64(n float64) (int, bool) {
+	if math.IsNaN(n) || math.IsInf(n, 0) || math.Trunc(n) != n {
+		return 0, false
+	}
+	if n < float64(intMin) || n > float64(intMax) {
+		return 0, false
+	}
+	if n < -maxSafeFloatInt || n > maxSafeFloatInt {
+		return 0, false
+	}
+	return int(n), true
 }
 
 // GetFloat retrieves the value as a float64, returning def if not found or not a float64.

--- a/api/attrs/attrs_test.go
+++ b/api/attrs/attrs_test.go
@@ -4,6 +4,7 @@ package attrs
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -41,11 +42,17 @@ func TestBag_GetInt(t *testing.T) {
 		{val: 42, name: "int", want: 42},
 		{val: int64(10000), name: "int64", want: 10000},
 		{val: int32(777), name: "int32", want: 777},
-		{val: float64(10000), name: "float64", want: 10000},
+		{val: uint64(888), name: "uint64", want: 888},
+		{val: float64(10000), name: "integral float64", want: 10000},
+		{val: float32(123), name: "integral float32", want: 123},
 		{val: json.Number("10000"), name: "json.Number", want: 10000},
-		{val: "value", name: "string", want: 99},                             // non-numeric → def
-		{val: json.Number("1.5"), name: "non-integer json.Number", want: 99}, // not an int → def
-		{val: true, name: "bool", want: 99},                                  // wrong type → def
+		{val: "value", name: "string", want: 99},
+		{val: float64(1.5), name: "fractional float64", want: 99},
+		{val: json.Number("1.5"), name: "fractional json.Number", want: 99},
+		{val: uint64(intMax) + 1, name: "uint64 overflow", want: 99},
+		{val: json.Number("9223372036854775808"), name: "json.Number overflow", want: 99},
+		{val: maxSafeFloatInt + 2, name: "unsafe float integer", want: 99},
+		{val: true, name: "bool", want: 99},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -58,6 +65,13 @@ func TestBag_GetInt(t *testing.T) {
 
 	if got := NewBag().GetInt("missing", 99); got != 99 {
 		t.Errorf("GetInt(missing) = %d, want %d", got, 99)
+	}
+
+	if strconv.IntSize == 32 {
+		b := NewBagFrom(map[string]any{"k": int64(1) << 31})
+		if got := b.GetInt("k", 99); got != 99 {
+			t.Errorf("GetInt(int64 overflow) = %d, want %d", got, 99)
+		}
 	}
 }
 

--- a/api/attrs/attrs_test.go
+++ b/api/attrs/attrs_test.go
@@ -34,18 +34,18 @@ func TestBag_GetString(t *testing.T) {
 
 func TestBag_GetInt(t *testing.T) {
 	cases := []struct {
-		name string
 		val  any
+		name string
 		want int
 	}{
-		{"int", 42, 42},
-		{"int64", int64(10000), 10000},
-		{"int32", int32(777), 777},
-		{"float64", float64(10000), 10000},
-		{"json.Number", json.Number("10000"), 10000},
-		{"string", "value", 99},                             // non-numeric → def
-		{"non-integer json.Number", json.Number("1.5"), 99}, // not an int → def
-		{"bool", true, 99},                                  // wrong type → def
+		{val: 42, name: "int", want: 42},
+		{val: int64(10000), name: "int64", want: 10000},
+		{val: int32(777), name: "int32", want: 777},
+		{val: float64(10000), name: "float64", want: 10000},
+		{val: json.Number("10000"), name: "json.Number", want: 10000},
+		{val: "value", name: "string", want: 99},                             // non-numeric → def
+		{val: json.Number("1.5"), name: "non-integer json.Number", want: 99}, // not an int → def
+		{val: true, name: "bool", want: 99},                                  // wrong type → def
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api/attrs/attrs_test.go
+++ b/api/attrs/attrs_test.go
@@ -3,6 +3,7 @@
 package attrs
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -32,21 +33,44 @@ func TestBag_GetString(t *testing.T) {
 }
 
 func TestBag_GetInt(t *testing.T) {
-	b := NewBagFrom(map[string]any{
-		"int": 42,
-		"str": "value",
-	})
-
-	if got := b.GetInt("int", 0); got != 42 {
-		t.Errorf("GetInt(int) = %d, want %d", got, 42)
+	cases := []struct {
+		name string
+		val  any
+		want int
+	}{
+		{"int", 42, 42},
+		{"int64", int64(10000), 10000},
+		{"int32", int32(777), 777},
+		{"float64", float64(10000), 10000},
+		{"json.Number", json.Number("10000"), 10000},
+		{"string", "value", 99},                             // non-numeric → def
+		{"non-integer json.Number", json.Number("1.5"), 99}, // not an int → def
+		{"bool", true, 99},                                  // wrong type → def
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBagFrom(map[string]any{"k": tc.val})
+			if got := b.GetInt("k", 99); got != tc.want {
+				t.Errorf("GetInt(%s=%v) = %d, want %d", tc.name, tc.val, got, tc.want)
+			}
+		})
 	}
 
-	if got := b.GetInt("str", 99); got != 99 {
-		t.Errorf("GetInt(str) = %d, want %d", got, 99)
-	}
-
-	if got := b.GetInt("missing", 99); got != 99 {
+	if got := NewBag().GetInt("missing", 99); got != 99 {
 		t.Errorf("GetInt(missing) = %d, want %d", got, 99)
+	}
+}
+
+func TestBag_GetInt_FromJSONDecode(t *testing.T) {
+	var b Bag
+	if err := json.Unmarshal([]byte(`{"max_length":10000}`), &b); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := b["max_length"].(float64); !ok {
+		t.Fatalf("precondition: expected max_length stored as float64, got %T", b["max_length"])
+	}
+	if got := b.GetInt("max_length", 1000); got != 10000 {
+		t.Errorf("GetInt(max_length) after JSON decode = %d, want 10000", got)
 	}
 }
 

--- a/api/boot/config.go
+++ b/api/boot/config.go
@@ -6,6 +6,8 @@ package boot
 import (
 	"strings"
 	"time"
+
+	"github.com/wippyai/runtime/api/attrs"
 )
 
 // ConfigSep is the separator used for hierarchical config keys.
@@ -103,7 +105,7 @@ func (c *config) GetInt(key string, def int) int {
 	if !ok {
 		return def
 	}
-	if i, ok := v.(int); ok {
+	if i, ok := attrs.AsInt(v); ok {
 		return i
 	}
 	return def

--- a/api/boot/config_test.go
+++ b/api/boot/config_test.go
@@ -5,7 +5,9 @@ package boot
 
 import (
 	"context"
+	"encoding/json"
 	"io/fs"
+	"strconv"
 	"testing"
 	"time"
 
@@ -81,8 +83,16 @@ func TestConfig_GetString(t *testing.T) {
 func TestConfig_GetInt(t *testing.T) {
 	cfg := NewConfig(
 		WithSection("test", map[string]any{
-			"int": 42,
-			"str": "hello",
+			"int":            42,
+			"str":            "hello",
+			"int64":          int64(10000),
+			"float":          float64(10000),
+			"fraction":       float64(1.5),
+			"json":           json.Number("10000"),
+			"json_fraction":  json.Number("1.5"),
+			"uint_overflow":  uint64(1) << 63,
+			"json_overflow":  json.Number("9223372036854775808"),
+			"unsafe_integer": float64(1<<53 + 1),
 		}),
 	)
 
@@ -106,6 +116,33 @@ func TestConfig_GetInt(t *testing.T) {
 			t.Errorf("expected 99, got %d", v)
 		}
 	})
+
+	t.Run("numeric types", func(t *testing.T) {
+		if v := cfg.GetInt("test.int64", 0); v != 10000 {
+			t.Errorf("expected 10000, got %d", v)
+		}
+		if v := cfg.GetInt("test.float", 0); v != 10000 {
+			t.Errorf("expected 10000, got %d", v)
+		}
+		if v := cfg.GetInt("test.json", 0); v != 10000 {
+			t.Errorf("expected 10000, got %d", v)
+		}
+	})
+
+	t.Run("unsafe numeric values return default", func(t *testing.T) {
+		for _, key := range []string{"fraction", "json_fraction", "uint_overflow", "json_overflow", "unsafe_integer"} {
+			if v := cfg.GetInt("test."+key, 99); v != 99 {
+				t.Errorf("expected default for %s, got %d", key, v)
+			}
+		}
+	})
+
+	if strconv.IntSize == 32 {
+		cfg := NewConfig(WithSection("test", map[string]any{"int64_overflow": int64(1) << 31}))
+		if v := cfg.GetInt("test.int64_overflow", 99); v != 99 {
+			t.Errorf("expected default for int64 overflow, got %d", v)
+		}
+	}
 }
 
 func TestConfig_GetBool(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

## Issue                                                                                                                                                                    

A `queue.queue` configured with `driver_options.memory.max_length: 10000` still capped at 1000 (the memory driver's `defaultMaxLen`). Consumer `concurrency`/`prefetch` worked, `max_length` didn't.

## Root cause
****
`concurrency`/`prefetch` are typed `int` fields, but `max_length` lives in the untyped `driver_options` bag (`attrs.Bag` = `map[string]any`). The payload JSON transcoder uses `encoding/json`, which decodes every number in an `interface{}`/map as `float64`. `Bag.GetInt` only asserted `v.(int)`, so it returned the default → drivers fell back to `defaultMaxLen`. 

 ## Fix

`Bag.GetInt` now accepts `int`, `int64`, `int32`, `float64`, and `json.Number` (non-numeric/non-integer values still return the default). Strictly widens behavior — no config change required. Fixes memory and AMQP (`max_length`) drivers and every other bag-based int option at once. 

In theory, an alternative approach would be to type driver_options, but this would require defining strict types for all possible values for each driver.
