### PR TITLE
Add hash.pbkdf2

### DIFF
--- a/runtime/lua/modules/hash/module.go
+++ b/runtime/lua/modules/hash/module.go
@@ -8,7 +8,9 @@ import (
 	"crypto/sha1" //nolint:gosec
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"hash"
 	"hash/fnv"
 
@@ -19,14 +21,14 @@ import (
 // Module is the hash module definition.
 var Module = &luaapi.ModuleDef{
 	Name:        "hash",
-	Description: "Cryptographic hash functions and HMAC",
+	Description: "Cryptographic hash functions, HMAC, and PBKDF2",
 	Class:       []string{luaapi.ClassEncoding, luaapi.ClassSecurity, luaapi.ClassDeterministic},
 	Build:       buildModule,
 	Types:       ModuleTypes,
 }
 
 func buildModule() (*lua.LTable, []luaapi.YieldType) {
-	mod := lua.CreateTable(0, 10)
+	mod := lua.CreateTable(0, 11)
 	mod.RawSetString("md5", lua.LGoFunc(hashMD5))
 	mod.RawSetString("sha1", lua.LGoFunc(hashSHA1))
 	mod.RawSetString("sha256", lua.LGoFunc(hashSHA256))
@@ -37,6 +39,7 @@ func buildModule() (*lua.LTable, []luaapi.YieldType) {
 	mod.RawSetString("hmac_sha512", lua.LGoFunc(hmacSHA512))
 	mod.RawSetString("hmac_sha1", lua.LGoFunc(hmacSHA1))
 	mod.RawSetString("hmac_md5", lua.LGoFunc(hmacMD5))
+	mod.RawSetString("pbkdf2", lua.LGoFunc(pbkdf2Derive))
 	mod.Immutable = true
 	return mod, nil
 }
@@ -67,6 +70,93 @@ func computeHmac(newHash func() hash.Hash, data, secret string, raw bool) lua.LV
 		return lua.LString(result)
 	}
 	return lua.LString(hex.EncodeToString(result))
+}
+
+const maxPBKDF2Iterations = 10_000_000
+
+func derivePBKDF2(password, salt []byte, iterations, keyLength int, newHash func() hash.Hash) []byte {
+	prf := hmac.New(newHash, password)
+	hashLen := prf.Size()
+	out := make([]byte, keyLength)
+	u := make([]byte, 0, hashLen)
+	block := make([]byte, hashLen)
+	saltBlock := make([]byte, len(salt)+4)
+	copy(saltBlock, salt)
+
+	for blockIndex, offset := uint32(1), 0; offset < keyLength; blockIndex++ {
+		binary.BigEndian.PutUint32(saltBlock[len(salt):], blockIndex)
+
+		prf.Reset()
+		_, _ = prf.Write(saltBlock)
+		u = prf.Sum(u[:0])
+		copy(block, u)
+
+		for i := 1; i < iterations; i++ {
+			prf.Reset()
+			_, _ = prf.Write(u)
+			u = prf.Sum(u[:0])
+			for j := range block {
+				block[j] ^= u[j]
+			}
+		}
+
+		offset += copy(out[offset:], block)
+		clear(block)
+	}
+
+	clear(u)
+	clear(saltBlock)
+	return out
+}
+
+func pbkdf2Derive(l *lua.LState) int {
+	if l.Get(1).Type() != lua.LTString {
+		return invalidError(l, "password must be a string")
+	}
+	if l.Get(2).Type() != lua.LTString {
+		return invalidError(l, "salt must be a string")
+	}
+
+	password := l.ToString(1)
+	salt := l.ToString(2)
+	iterations := l.CheckInt(3)
+	keyLength := l.CheckInt(4)
+
+	if password == "" {
+		return invalidError(l, "password cannot be empty")
+	}
+	if salt == "" {
+		return invalidError(l, "salt cannot be empty")
+	}
+	if iterations <= 0 {
+		return invalidError(l, "iterations must be positive")
+	}
+	if iterations > maxPBKDF2Iterations {
+		return invalidError(l, fmt.Sprintf("iterations exceeds maximum (%d)", maxPBKDF2Iterations))
+	}
+	if keyLength <= 0 {
+		return invalidError(l, "key length must be positive")
+	}
+
+	var newHash func() hash.Hash
+	algo := "sha256"
+	if l.GetTop() >= 5 && l.Get(5).Type() == lua.LTString {
+		algo = l.ToString(5)
+	}
+	switch algo {
+	case "sha256":
+		newHash = sha256.New
+	case "sha512":
+		newHash = sha512.New
+	default:
+		return invalidError(l, fmt.Sprintf("unsupported hash function: %s", algo))
+	}
+
+	key := derivePBKDF2([]byte(password), []byte(salt), iterations, keyLength, newHash)
+	l.Push(lua.LString(key))
+	l.Push(lua.LNil)
+	clear(key)
+	return 2
 }
 
 func hashMD5(l *lua.LState) int {

--- a/runtime/lua/modules/hash/module_test.go
+++ b/runtime/lua/modules/hash/module_test.go
@@ -3,9 +3,13 @@
 package hash
 
 import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
 	"testing"
 
 	lua "github.com/wippyai/go-lua"
+	xpbkdf2 "golang.org/x/crypto/pbkdf2"
 )
 
 func TestLoad(t *testing.T) {
@@ -21,7 +25,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	modTbl := mod.(*lua.LTable)
-	funcs := []string{"md5", "sha1", "sha256", "sha512", "fnv32", "fnv64", "hmac_sha256", "hmac_sha512", "hmac_sha1", "hmac_md5"}
+	funcs := []string{"md5", "sha1", "sha256", "sha512", "fnv32", "fnv64", "hmac_sha256", "hmac_sha512", "hmac_sha1", "hmac_md5", "pbkdf2"}
 	for _, fn := range funcs {
 		if modTbl.RawGetString(fn).Type() != lua.LTFunction {
 			t.Errorf("%s function not registered", fn)
@@ -284,6 +288,139 @@ func TestHMACRaw(t *testing.T) {
 	`)
 	if err != nil {
 		t.Errorf("hmac_sha256 raw test failed: %v", err)
+	}
+}
+
+func TestPBKDF2(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+
+	err := l.DoString(`
+		local key, err = hash.pbkdf2("password", "salt", 1000, 32)
+		if err ~= nil then
+			error("unexpected error: " .. tostring(err))
+		end
+		if #key ~= 32 then
+			error("expected 32 byte key")
+		end
+
+		local key2, err2 = hash.pbkdf2("password", "salt", 1000, 32)
+		if err2 ~= nil then
+			error("unexpected error: " .. tostring(err2))
+		end
+		if key ~= key2 then
+			error("pbkdf2 should be deterministic")
+		end
+
+		local key3, err3 = hash.pbkdf2("other", "salt", 1000, 32)
+		if err3 ~= nil then
+			error("unexpected error: " .. tostring(err3))
+		end
+		if key == key3 then
+			error("different password should produce different key")
+		end
+	`)
+	if err != nil {
+		t.Errorf("pbkdf2 test failed: %v", err)
+	}
+}
+
+func TestPBKDF2KnownVectors(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		salt     string
+		algo     string
+		wantHex  string
+
+		iterations int
+		keyLength  int
+	}{
+		{
+			name:       "sha256 iteration 1",
+			password:   "password",
+			salt:       "salt",
+			iterations: 1,
+			keyLength:  32,
+			algo:       "sha256",
+			wantHex:    "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b",
+		},
+		{
+			name:       "sha256 iteration 2",
+			password:   "password",
+			salt:       "salt",
+			iterations: 2,
+			keyLength:  32,
+			algo:       "sha256",
+			wantHex:    "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []byte
+			switch tc.algo {
+			case "sha256":
+				got = derivePBKDF2([]byte(tc.password), []byte(tc.salt), tc.iterations, tc.keyLength, sha256.New)
+			case "sha512":
+				got = derivePBKDF2([]byte(tc.password), []byte(tc.salt), tc.iterations, tc.keyLength, sha512.New)
+			default:
+				t.Fatalf("unsupported test algo %q", tc.algo)
+			}
+
+			gotHex := hex.EncodeToString(got)
+			if gotHex != tc.wantHex {
+				t.Fatalf("pbkdf2 mismatch\nwant %s\n got %s", tc.wantHex, gotHex)
+			}
+		})
+	}
+}
+
+func TestPBKDF2ParityWithReference(t *testing.T) {
+	tests := []struct {
+		name string
+		algo string
+
+		iterations int
+		keyLength  int
+	}{
+		{name: "sha256", iterations: 4096, keyLength: 32, algo: "sha256"},
+		{name: "sha512", iterations: 4096, keyLength: 64, algo: "sha512"},
+		{name: "sha512 partial block", iterations: 4096, keyLength: 50, algo: "sha512"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got, want []byte
+			switch tc.algo {
+			case "sha256":
+				got = derivePBKDF2([]byte("password"), []byte("salt"), tc.iterations, tc.keyLength, sha256.New)
+				want = xpbkdf2.Key([]byte("password"), []byte("salt"), tc.iterations, tc.keyLength, sha256.New)
+			case "sha512":
+				got = derivePBKDF2([]byte("password"), []byte("salt"), tc.iterations, tc.keyLength, sha512.New)
+				want = xpbkdf2.Key([]byte("password"), []byte("salt"), tc.iterations, tc.keyLength, sha512.New)
+			}
+			if string(got) != string(want) {
+				t.Fatalf("pbkdf2 reference mismatch")
+			}
+		})
+	}
+}
+
+func TestPBKDF2AllocationsDoNotScaleWithIterations(t *testing.T) {
+	password := []byte("password")
+	salt := []byte("salt")
+	allocsOne := testing.AllocsPerRun(10, func() {
+		_ = derivePBKDF2(password, salt, 1, 64, sha512.New)
+	})
+	allocsMany := testing.AllocsPerRun(10, func() {
+		_ = derivePBKDF2(password, salt, 4096, 64, sha512.New)
+	})
+
+	if allocsMany > allocsOne+2 {
+		t.Fatalf("pbkdf2 allocations scale with iterations: one=%0.2f many=%0.2f", allocsOne, allocsMany)
 	}
 }
 

--- a/runtime/lua/modules/hash/spec.md
+++ b/runtime/lua/modules/hash/spec.md
@@ -2,7 +2,7 @@
 
 # hash
 
-Cryptographic hash functions and HMAC. Encoding, security, deterministic.
+Cryptographic hash functions, HMAC, and PBKDF2. Encoding, security, deterministic.
 
 ## Loading
 
@@ -207,6 +207,32 @@ Computes HMAC-MD5 of input data with secret key.
 |-----------|------|-----------|
 | data not a string | errors.INVALID | no |
 | secret not a string | errors.INVALID | no |
+
+### pbkdf2(password: string, salt: string, iterations: integer, key_length: integer, algo?: string) → string, error
+
+Derives a key using PBKDF2-HMAC.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| password | string | yes | - | Password or secret input |
+| salt | string | yes | - | Salt bytes |
+| iterations | integer | yes | - | Positive iteration count |
+| key_length | integer | yes | - | Positive output length in bytes |
+| algo | string | no | "sha256" | Hash function: "sha256" or "sha512" |
+
+**Returns:**
+- Success: raw derived key bytes
+- Error: `nil, error` - structured error
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| password not a string or empty | errors.INVALID | no |
+| salt not a string or empty | errors.INVALID | no |
+| iterations not positive or above maximum | errors.INVALID | no |
+| key_length not positive | errors.INVALID | no |
+| algo unsupported | errors.INVALID | no |
 
 ## Errors
 

--- a/runtime/lua/modules/hash/types.go
+++ b/runtime/lua/modules/hash/types.go
@@ -20,6 +20,9 @@ func ModuleTypes() *io.Manifest {
 	// hmac function type: (data: string, secret: string, raw?: boolean): string, Error?
 	hmacFn := typ.Func().Param("data", typ.String).Param("secret", typ.String).OptParam("raw", typ.Boolean).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()
 
+	// pbkdf2 function type: (password: string, salt: string, iterations: number, key_length: number, algo?: string): string, Error?
+	pbkdf2Fn := typ.Func().Param("password", typ.String).Param("salt", typ.String).Param("iterations", typ.Number).Param("key_length", typ.Number).OptParam("algo", typ.String).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()
+
 	moduleType := typ.NewInterface("hash", []typ.Method{
 		{Name: "md5", Type: hashFn},
 		{Name: "sha1", Type: hashFn},
@@ -31,6 +34,7 @@ func ModuleTypes() *io.Manifest {
 		{Name: "hmac_sha512", Type: hmacFn},
 		{Name: "hmac_sha1", Type: hmacFn},
 		{Name: "hmac_md5", Type: hmacFn},
+		{Name: "pbkdf2", Type: pbkdf2Fn},
 	})
 
 	m.SetExport(moduleType)

--- a/runtime/lua/modules/manifest_test.go
+++ b/runtime/lua/modules/manifest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wippyai/runtime/runtime/lua/modules/crypto"
 	"github.com/wippyai/runtime/runtime/lua/modules/ctx"
 	"github.com/wippyai/runtime/runtime/lua/modules/excel"
+	"github.com/wippyai/runtime/runtime/lua/modules/hash"
 	"github.com/wippyai/runtime/runtime/lua/modules/httpclient"
 	"github.com/wippyai/runtime/runtime/lua/modules/metrics"
 	"github.com/wippyai/runtime/runtime/lua/modules/payload"
@@ -82,6 +83,7 @@ func TestModuleTypes_ReturnsWithError(t *testing.T) {
 		{name: "payload.Payload.transcode", manifest: payload.ModuleTypes(), typeName: "Payload", method: "transcode"},
 		{name: "base64.encode", manifest: base64.ModuleTypes(), method: "encode"},
 		{name: "base64.decode", manifest: base64.ModuleTypes(), method: "decode"},
+		{name: "hash.pbkdf2", manifest: hash.ModuleTypes(), method: "pbkdf2"},
 		{name: "metrics.counter_inc", manifest: metrics.ModuleTypes(), method: "counter_inc"},
 		{name: "metrics.counter_add", manifest: metrics.ModuleTypes(), method: "counter_add"},
 		{name: "metrics.gauge_set", manifest: metrics.ModuleTypes(), method: "gauge_set"},

--- a/tests/app/src/test/hash/_index.yaml
+++ b/tests/app/src/test/hash/_index.yaml
@@ -55,3 +55,16 @@ entries:
       assert2: app.lib:assert
     modules:
       - hash
+
+  - name: pbkdf2
+    kind: function.lua
+    meta:
+      type: test
+      suite: hash
+      description: hash.pbkdf2 function
+    source: file://pbkdf2.lua
+    method: main
+    imports:
+      assert2: app.lib:assert
+    modules:
+      - hash

--- a/tests/app/src/test/hash/pbkdf2.lua
+++ b/tests/app/src/test/hash/pbkdf2.lua
@@ -1,0 +1,32 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: hash.pbkdf2 function
+local assert = require("assert2")
+local hash = require("hash")
+
+local function main()
+	local key, err = hash.pbkdf2("password", "salt", 1000, 32)
+	assert.is_nil(err, "pbkdf2 should not error")
+	assert.not_nil(key, "pbkdf2 returns key")
+	assert.eq(#key, 32, "pbkdf2 returns correct length")
+
+	local key2, err2 = hash.pbkdf2("password", "salt", 1000, 32)
+	assert.is_nil(err2, "pbkdf2 repeat should not error")
+	assert.eq(key, key2, "pbkdf2 is deterministic")
+
+	local key3, err3 = hash.pbkdf2("other", "salt", 1000, 32)
+	assert.is_nil(err3, "pbkdf2 different password should not error")
+	assert.neq(key, key3, "different password produces different key")
+
+	local key4, err4 = hash.pbkdf2("password", "salt", 1000, 64, "sha512")
+	assert.is_nil(err4, "pbkdf2 sha512 should not error")
+	assert.eq(#key4, 64, "pbkdf2 sha512 returns correct length")
+
+	local _, err5 = hash.pbkdf2("password", "salt", 1000, 32, "md5")
+	assert.not_nil(err5, "invalid pbkdf2 algo should error")
+	assert.eq(err5:kind(), errors.INVALID, "invalid pbkdf2 algo error kind")
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/types/import_hash.lua
+++ b/tests/app/src/test/types/import_hash.lua
@@ -27,8 +27,13 @@ local function test_hmac(): boolean
 	return #result == 64
 end
 
+local function test_pbkdf2(): boolean
+	local result: string = hash.pbkdf2("password", "salt", 1000, 32)
+	return #result == 32
+end
+
 local function main(): boolean
-	return test_md5() and test_sha256() and test_sha512() and test_hmac()
+	return test_md5() and test_sha256() and test_sha512() and test_hmac() and test_pbkdf2()
 end
 
 return { main = main }


### PR DESCRIPTION
## Summary
- add deterministic hash.pbkdf2(password, salt, iterations, key_length, algo?) to the hash module
- implement PBKDF2 with one keyed HMAC reused via Reset across iterations, so allocation count stays constant as iterations increase
- expose the new function through the hash type manifest and app hash/type tests

## SDK review
- hash is the SDK/import surface used by app code; crypto.pbkdf2 already exists but does not close the hash package gap
- updated runtime/lua/modules/hash/types.go and manifest coverage so typed Lua imports see hash.pbkdf2

## Tests
- go test ./runtime/lua/modules/hash ./runtime/lua/modules
- go test ./runtime/lua/modules/hash ./runtime/lua/modules ./runtime/lua/modules/crypto ./runtime/lua/code
- go test ./cmd/wippy/cmd
- SKIP_SQS_TESTS=1 SKIP_NETWORK_TESTS=1 ./test.sh (hash suite passed 5/5; full local run still failed on unrelated wasm/websocket facade responses)