### PR TITLE
feat(cloudgraph): cloud-graph control-plane PoC vertical slice

### DIFF
--- a/api/service/cloudgraph/config.go
+++ b/api/service/cloudgraph/config.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package cloudgraph defines the registry kinds and configuration for the
+// cloud-graph deployment control plane (see docs/design/cloud-graph.md).
+package cloudgraph
+
+import (
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+const (
+	// Engine identifies the cloud-graph engine entry in the registry.
+	Engine registry.Kind = "cloudgraph.engine"
+
+	// Provider identifies a cloud-graph provider binding manifest in the registry.
+	Provider registry.Kind = "cloudgraph.provider"
+)
+
+// DefaultWorkflowName is the Temporal workflow type the engine registers when
+// the entry does not override it.
+const DefaultWorkflowName = "cg_deploy"
+
+// EngineConfig configures one cloud-graph engine instance (one shard).
+type EngineConfig struct {
+	// Meta holds arbitrary metadata associated with this engine entry.
+	Meta attrs.Bag `json:"meta"`
+	// Worker references the temporal.worker entry the deploy workflow and
+	// activities register on.
+	Worker registry.ID `json:"worker"`
+	// Client references the temporal.client entry used to start deploy workflows.
+	Client registry.ID `json:"client"`
+	// Database references the db.sql.* entry backing the ledger.
+	Database registry.ID `json:"database"`
+	// Host references the process.host entry provider actors are spawned on.
+	Host registry.ID `json:"host"`
+	// Shard names the shard this engine owns.
+	Shard string `json:"shard"`
+	// WorkflowName is the Temporal workflow type name for deploys.
+	WorkflowName string `json:"workflow_name"`
+}
+
+// InitDefaults initializes default values for EngineConfig.
+func (c *EngineConfig) InitDefaults() {
+	if c.WorkflowName == "" {
+		c.WorkflowName = DefaultWorkflowName
+	}
+}
+
+// Validate checks that EngineConfig is valid.
+func (c *EngineConfig) Validate() error {
+	if c.Worker.Name == "" {
+		return ErrWorkerRequired
+	}
+	if c.Client.Name == "" {
+		return ErrClientRequired
+	}
+	if c.Database.Name == "" {
+		return ErrDatabaseRequired
+	}
+	if c.Host.Name == "" {
+		return ErrHostRequired
+	}
+	return nil
+}
+
+// ProviderConfig is the provider binding manifest carried by a
+// cloudgraph.provider entry. Manifests are immutable for the process lifetime
+// after registration.
+type ProviderConfig struct {
+	// Meta holds arbitrary metadata associated with this provider entry.
+	Meta attrs.Bag `json:"meta"`
+	// ProviderType is the unique provider identifier resource specs reference.
+	ProviderType string `json:"provider_type"`
+	// ActorProcess references the process.lua entry implementing the apply actor.
+	ActorProcess registry.ID `json:"actor_process"`
+	// Executor references the exec.* entry the actor uses for external commands.
+	Executor registry.ID `json:"executor"`
+	// ResourceTypes lists the resource types this provider handles.
+	ResourceTypes []string `json:"resource_types"`
+}
+
+// Validate checks that ProviderConfig is valid.
+func (c *ProviderConfig) Validate() error {
+	if c.ProviderType == "" {
+		return ErrProviderTypeRequired
+	}
+	if c.ActorProcess.Name == "" {
+		return ErrActorProcessRequired
+	}
+	if len(c.ResourceTypes) == 0 {
+		return ErrResourceTypesRequired
+	}
+	return nil
+}

--- a/api/service/cloudgraph/errors.go
+++ b/api/service/cloudgraph/errors.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudgraph
+
+import apierror "github.com/wippyai/runtime/api/error"
+
+// Validation errors for cloud-graph configuration. All are non-retryable and
+// surface during entry decoding.
+var (
+	ErrWorkerRequired        = apierror.New(apierror.Invalid, "worker reference is required").WithRetryable(apierror.False)
+	ErrClientRequired        = apierror.New(apierror.Invalid, "client reference is required").WithRetryable(apierror.False)
+	ErrDatabaseRequired      = apierror.New(apierror.Invalid, "database reference is required").WithRetryable(apierror.False)
+	ErrHostRequired          = apierror.New(apierror.Invalid, "host reference is required").WithRetryable(apierror.False)
+	ErrProviderTypeRequired  = apierror.New(apierror.Invalid, "provider_type is required").WithRetryable(apierror.False)
+	ErrActorProcessRequired  = apierror.New(apierror.Invalid, "actor_process reference is required").WithRetryable(apierror.False)
+	ErrResourceTypesRequired = apierror.New(apierror.Invalid, "resource_types must not be empty").WithRetryable(apierror.False)
+)
+
+// NewProviderNotFoundError reports a provider_type with no registered manifest.
+// Resolution fails hard by design; there is no fallback provider.
+func NewProviderNotFoundError(providerType string) apierror.Error {
+	return apierror.New(apierror.NotFound, "no provider registered for provider_type: "+providerType).WithRetryable(apierror.False)
+}
+
+// NewProviderConflictError reports a second manifest claiming an existing
+// provider_type, which is a hard configuration error.
+func NewProviderConflictError(providerType string) apierror.Error {
+	return apierror.New(apierror.Conflict, "provider_type already registered: "+providerType).WithRetryable(apierror.False)
+}

--- a/api/service/temporal/context.go
+++ b/api/service/temporal/context.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/registry"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/interceptor"
 )
@@ -19,7 +20,17 @@ var (
 	workerInterceptorRegKey = &ctxapi.Key{Name: "temporal.interceptor.worker"}
 	dataConverterRegKey     = &ctxapi.Key{Name: "temporal.dataconverter.registry"}
 	runHandoffRegKey        = &ctxapi.Key{Name: "temporal.run.handoff.registry"}
+	workerRegistrarKey      = &ctxapi.Key{Name: "temporal.worker.registrar"}
 )
+
+// WorkerRegistrar registers native Go workflows and function-registry-backed
+// activities on managed workers. The worker manager implements it; other boot
+// components reach it through the context.
+type WorkerRegistrar interface {
+	RegisterWorkflow(ctx context.Context, workerID registry.ID, workflowName string, handler any) error
+	RegisterActivity(ctx context.Context, workerID registry.ID, activityName string, funcID registry.ID) error
+	GetConfig(id registry.ID) (*WorkerConfig, bool)
+}
 
 // ClientInterceptorRegistry provides methods to register client interceptors
 type ClientInterceptorRegistry interface {
@@ -159,6 +170,36 @@ func GetWorkflowRunHandoff(ctx context.Context) WorkflowRunHandoff {
 	}
 	if val := ctx.Value(runHandoffRegKey); val != nil {
 		if reg, ok := val.(WorkflowRunHandoff); ok {
+			return reg
+		}
+	}
+	return nil
+}
+
+// WithWorkerRegistrar stores the worker registrar in context.
+func WithWorkerRegistrar(ctx context.Context, reg WorkerRegistrar) context.Context {
+	ac := ctxapi.AppFromContext(ctx)
+	if ac == nil {
+		return context.WithValue(ctx, workerRegistrarKey, reg)
+	}
+	if ac.Get(workerRegistrarKey) == nil {
+		ac.With(workerRegistrarKey, reg)
+	}
+	return ctx
+}
+
+// GetWorkerRegistrar retrieves the worker registrar from context.
+func GetWorkerRegistrar(ctx context.Context) WorkerRegistrar {
+	ac := ctxapi.AppFromContext(ctx)
+	if ac != nil {
+		if val := ac.Get(workerRegistrarKey); val != nil {
+			if reg, ok := val.(WorkerRegistrar); ok {
+				return reg
+			}
+		}
+	}
+	if val := ctx.Value(workerRegistrarKey); val != nil {
+		if reg, ok := val.(WorkerRegistrar); ok {
 			return reg
 		}
 	}

--- a/boot/components/service/all.go
+++ b/boot/components/service/all.go
@@ -37,6 +37,7 @@ func All() []boot.Component {
 	components = append(components, prometheus.All()...)
 	components = append(components, otel.All()...)
 	components = append(components, temporal.All()...)
+	components = append(components, CloudGraph())
 
 	return components
 }

--- a/boot/components/service/cloudgraph.go
+++ b/boot/components/service/cloudgraph.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package service
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/api/event"
+	logapi "github.com/wippyai/runtime/api/logs"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/process"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/relay"
+	temporalapi "github.com/wippyai/runtime/api/service/temporal"
+	"github.com/wippyai/runtime/api/topology"
+	bootpkg "github.com/wippyai/runtime/boot"
+	"github.com/wippyai/runtime/boot/components/core"
+	bootservicetemporal "github.com/wippyai/runtime/boot/components/service/temporal"
+	"github.com/wippyai/runtime/boot/components/system"
+	"github.com/wippyai/runtime/service/cloudgraph"
+	"go.uber.org/zap"
+)
+
+// CloudGraph creates the boot component wiring the cloud-graph deployment
+// control plane (docs/design/cloud-graph.md §4.3).
+func CloudGraph() boot.Component {
+	return boot.New(boot.P{
+		Name: CloudGraphName,
+		DependsOn: []boot.Name{
+			core.RegistryName,
+			system.FunctionsName,
+			system.ResourcesName,
+			system.TopologyName,
+			system.ProcessManagerName,
+			core.PIDGenName,
+			bootservicetemporal.Name,
+		},
+		Load: func(ctx context.Context) (context.Context, error) {
+			logger := logapi.GetLogger(ctx)
+			if logger == nil {
+				return ctx, ErrLoggerNotAvailable
+			}
+
+			bus := event.GetBus(ctx)
+			if bus == nil {
+				return ctx, ErrEventBusNotAvailable
+			}
+
+			dtt := payload.GetTranscoder(ctx)
+			if dtt == nil {
+				return ctx, ErrTranscoderNotAvailable
+			}
+
+			pidGen := process.GetPIDGenerator(ctx)
+			if pidGen == nil {
+				return ctx, ErrPIDGeneratorNotAvailable
+			}
+
+			node := relay.GetNode(ctx)
+			if node == nil {
+				return ctx, ErrRelayNotAvailable
+			}
+
+			topo := topology.GetTopology(ctx)
+			if topo == nil {
+				return ctx, ErrTopologyNotAvailable
+			}
+
+			procs := process.GetManager(ctx)
+			if procs == nil {
+				return ctx, ErrProcessManagerNotAvailable
+			}
+
+			registrar := temporalapi.GetWorkerRegistrar(ctx)
+			if registrar == nil {
+				return ctx, ErrWorkerRegistrarNotAvailable
+			}
+
+			handlers := bootpkg.GetHandlerRegistry(ctx)
+			if handlers == nil {
+				return ctx, ErrHandlerRegistryNotAvailable
+			}
+
+			reg := regapi.GetRegistry(ctx)
+			if reg == nil {
+				return ctx, ErrRegistryNotAvailable
+			}
+
+			cgLogger := logger.Named("cloudgraph")
+
+			patterns := []regapi.DependencyPattern{
+				{Path: "data.worker", Description: "Reference to Temporal worker for the cloudgraph engine"},
+				{Path: "data.client", Description: "Reference to Temporal client for the cloudgraph engine"},
+				{Path: "data.database", Description: "Reference to the cloudgraph ledger database"},
+				{Path: "data.host", Description: "Reference to the process host for provider actors"},
+				{Path: "data.actor_process", Description: "Reference to a cloudgraph provider actor process"},
+				{Path: "data.executor", Description: "Reference to the exec entry used by a cloudgraph provider"},
+			}
+			for _, pattern := range patterns {
+				if err := reg.RegisterDependencyPattern(pattern); err != nil {
+					cgLogger.Warn("failed to register cloudgraph dependency pattern",
+						zap.String("path", pattern.Path),
+						zap.Error(err))
+				}
+			}
+
+			manager := cloudgraph.NewManager(cgLogger, bus, dtt, pidGen, node, topo, procs, registrar)
+			handlers.RegisterListener("cloudgraph.(engine|provider)", manager)
+
+			cgLogger.Info("cloudgraph component loaded")
+			return ctx, nil
+		},
+	})
+}

--- a/boot/components/service/constants.go
+++ b/boot/components/service/constants.go
@@ -15,6 +15,7 @@ const (
 	TemplateName          boot.Name = "template"
 	ContractName          boot.Name = "contract"
 	InterceptorRetryName  boot.Name = "interceptor-retry"
+	CloudGraphName        boot.Name = "cloudgraph"
 )
 
 // Network service config keys, read from the network_service subsection of

--- a/boot/components/service/errors.go
+++ b/boot/components/service/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrRelayNotAvailable              = apierror.New(apierror.Internal, "relay node not available").WithRetryable(apierror.False)
 	ErrTopologyNotAvailable           = apierror.New(apierror.Internal, "topology not available in context").WithRetryable(apierror.False)
 	ErrProcessManagerNotAvailable     = apierror.New(apierror.Internal, "process manager not available in context").WithRetryable(apierror.False)
+	ErrWorkerRegistrarNotAvailable    = apierror.New(apierror.Internal, "temporal worker registrar not available in context").WithRetryable(apierror.False)
 )
 
 func NewEndpointFactoryError(cause error) apierror.Error {

--- a/boot/components/service/temporal/temporal.go
+++ b/boot/components/service/temporal/temporal.go
@@ -179,6 +179,10 @@ func Component() boot.Component {
 				return ctx, fmt.Errorf("failed to create worker manager: %w", err)
 			}
 
+			// Expose the worker manager so other components can register
+			// native Go workflows and function-backed activities.
+			ctx = temporalapi.WithWorkerRegistrar(ctx, workerManager)
+
 			// Create activity listener to auto-register functions as activities
 			activityListener := activity.NewListener(
 				logger.Named("activity"),

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/time v0.15.0
+	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1

--- a/service/cloudgraph/attempt/errors.go
+++ b/service/cloudgraph/attempt/errors.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package attempt
+
+import apierror "github.com/wippyai/runtime/api/error"
+
+// NewStaleIncarnationError reports an executor fenced out by a newer actor
+// incarnation; the losing attempt must exit without retrying.
+func NewStaleIncarnationError(opID string) apierror.Error {
+	return apierror.New(apierror.Conflict, "stale incarnation for operation: "+opID).WithRetryable(apierror.False)
+}
+
+// NewOperationFailedError reports a terminally failed operation. The failure
+// is persisted; retrying the activity cannot change the outcome.
+func NewOperationFailedError(opID, detail string) apierror.Error {
+	return apierror.New(apierror.Internal, "operation failed: "+opID+": "+detail).WithRetryable(apierror.False)
+}
+
+// NewGateTimeoutError reports a dispatch gate that never became satisfied
+// within the gate timeout (design §9.4 step 5).
+func NewGateTimeoutError(opID, detail string) apierror.Error {
+	return apierror.New(apierror.Timeout, "gate timeout for operation "+opID+": "+detail).WithRetryable(apierror.False)
+}
+
+// NewActorExitError reports a provider actor that exited without a terminal
+// signal. Retryable: the next activity attempt bumps the incarnation and
+// respawns the actor from its checkpoint (design §9.7, PoC subset).
+func NewActorExitError(opID string) apierror.Error {
+	return apierror.New(apierror.Unavailable, "provider actor exited without terminal signal: "+opID).WithRetryable(apierror.True)
+}
+
+// NewOperationTimeoutError reports an operation that exceeded its deadline.
+func NewOperationTimeoutError(opID string) apierror.Error {
+	return apierror.New(apierror.Timeout, "operation timed out: "+opID).WithRetryable(apierror.False)
+}
+
+// NewIllegalSignalError reports a signal violating the closed FSM; it is a
+// provider bug surfaced non-retryable (design §5.1).
+func NewIllegalSignalError(detail string) apierror.Error {
+	return apierror.New(apierror.Invalid, "illegal signal: "+detail).WithRetryable(apierror.False)
+}
+
+// NewMissingOutputError reports a committed producer without the referenced
+// output key.
+func NewMissingOutputError(resourceID, key string) apierror.Error {
+	return apierror.New(apierror.Invalid, "resource "+resourceID+" has no output "+key).WithRetryable(apierror.False)
+}

--- a/service/cloudgraph/attempt/executor.go
+++ b/service/cloudgraph/attempt/executor.go
@@ -1,0 +1,583 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package attempt executes one whole-resource operation: it spawns the
+// provider actor, consumes the durable signal mailbox as its single writer,
+// and drives the operation FSM to a terminal state
+// (docs/design/cloud-graph.md §9.4, PoC subset).
+package attempt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/wippyai/runtime/api/attrs"
+	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/relay"
+	cgapi "github.com/wippyai/runtime/api/service/cloudgraph"
+	topapi "github.com/wippyai/runtime/api/topology"
+	"github.com/wippyai/runtime/service/cloudgraph/binding"
+	"github.com/wippyai/runtime/service/cloudgraph/ledger"
+	"github.com/wippyai/runtime/service/cloudgraph/plan"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+	"go.uber.org/zap"
+)
+
+// SignalTopic is the relay topic provider actors send signal envelopes on.
+const SignalTopic = "cg.signal"
+
+// Default executor tuning.
+const (
+	DefaultGateTimeout      = 2 * time.Minute
+	DefaultOperationTimeout = 15 * time.Minute
+	DefaultPollInterval     = 500 * time.Millisecond
+	DefaultHeartbeatEvery   = 10 * time.Second
+	DefaultExitGrace        = 3 * time.Second
+)
+
+// pidGenerator, relayNode, topology, and processSpawner are the narrow
+// runtime seams the executor uses; the real process/relay/topology types
+// satisfy them structurally.
+type pidGenerator interface {
+	Generate(host pid.HostID) pid.PID
+}
+
+type relayNode interface {
+	Attach(p pid.PID, ch chan *relay.Package) (context.CancelFunc, error)
+	Send(pkg *relay.Package) error
+}
+
+type topology interface {
+	Register(p pid.PID) error
+	Remove(p pid.PID)
+}
+
+type processSpawner interface {
+	Start(ctx context.Context, start *process.Start) (pid.PID, error)
+}
+
+// Deps carries the executor's runtime dependencies.
+type Deps struct {
+	Log        *zap.Logger
+	PIDGen     pidGenerator
+	Node       relayNode
+	Topo       topology
+	Procs      processSpawner
+	Transcoder payload.Transcoder
+	Store      *ledger.Store
+	Providers  *binding.Registry
+	HostID     pid.HostID
+}
+
+// Executor runs execute_operation activities.
+type Executor struct {
+	deps             Deps
+	gateTimeout      time.Duration
+	operationTimeout time.Duration
+	pollInterval     time.Duration
+	heartbeatEvery   time.Duration
+	exitGrace        time.Duration
+}
+
+// Request identifies one execution attempt. Incarnation is the Temporal
+// activity attempt number; Heartbeat may be nil.
+type Request struct {
+	Heartbeat   func(details ...any)
+	OpID        string
+	Incarnation int64
+}
+
+// Option tunes an Executor.
+type Option func(*Executor)
+
+// WithGateTimeout bounds the dispatch gate wait.
+func WithGateTimeout(d time.Duration) Option {
+	return func(e *Executor) { e.gateTimeout = d }
+}
+
+// WithOperationTimeout bounds one operation execution.
+func WithOperationTimeout(d time.Duration) Option {
+	return func(e *Executor) { e.operationTimeout = d }
+}
+
+// WithPollInterval sets the gate re-check interval.
+func WithPollInterval(d time.Duration) Option {
+	return func(e *Executor) { e.pollInterval = d }
+}
+
+// WithExitGrace sets how long the executor keeps draining trailing signals
+// after the actor exit event before declaring the exit non-terminal.
+func WithExitGrace(d time.Duration) Option {
+	return func(e *Executor) { e.exitGrace = d }
+}
+
+// NewExecutor creates an executor with default tuning.
+func NewExecutor(deps Deps, opts ...Option) *Executor {
+	if deps.Log == nil {
+		deps.Log = zap.NewNop()
+	}
+	e := &Executor{
+		deps:             deps,
+		gateTimeout:      DefaultGateTimeout,
+		operationTimeout: DefaultOperationTimeout,
+		pollInterval:     DefaultPollInterval,
+		heartbeatEvery:   DefaultHeartbeatEvery,
+		exitGrace:        DefaultExitGrace,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// signalWire is the envelope provider actors send on SignalTopic.
+type signalWire struct {
+	Kind    string          `json:"kind"`
+	Phase   string          `json:"phase,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Seq     int64           `json:"seq"`
+}
+
+// terminalPayload is the payload shape of verify_passed and failed signals.
+type terminalPayload struct {
+	Error   string          `json:"error,omitempty"`
+	Outputs json.RawMessage `json:"outputs,omitempty"`
+}
+
+// Execute runs one operation to a terminal state and returns its persisted
+// result JSON (design §9.4).
+func (e *Executor) Execute(ctx context.Context, req Request) (json.RawMessage, error) {
+	store := e.deps.Store
+	log := e.deps.Log.With(zap.String("operation", req.OpID), zap.Int64("incarnation", req.Incarnation))
+
+	op, err := store.GetOperation(ctx, req.OpID)
+	if err != nil {
+		return nil, err
+	}
+	if op.Status.Terminal() {
+		if op.Status == resource.OpCommitted {
+			return op.Result, nil
+		}
+		return nil, NewOperationFailedError(op.ID, op.Error)
+	}
+
+	priorActorPID := op.ActorPID
+
+	ok, err := store.BumpIncarnation(ctx, op.ID, req.Incarnation)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		current, err := store.GetOperation(ctx, req.OpID)
+		if err != nil {
+			return nil, err
+		}
+		if current.Status == resource.OpCommitted {
+			return current.Result, nil
+		}
+		if current.Status == resource.OpFailed {
+			return nil, NewOperationFailedError(current.ID, current.Error)
+		}
+		return nil, NewStaleIncarnationError(op.ID)
+	}
+	op.Incarnation = req.Incarnation
+
+	deploy, err := store.GetDeploy(ctx, op.DeployID)
+	if err != nil {
+		return nil, err
+	}
+	spec, err := store.GetSpec(ctx, op.DeployID, op.ResourceID)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := e.deps.Providers.Provider(spec.ProviderType)
+	if err != nil {
+		return nil, err
+	}
+
+	collectorPID := e.deps.PIDGen.Generate(topapi.ControlHost)
+	if err := e.deps.Topo.Register(collectorPID); err != nil {
+		return nil, err
+	}
+	defer e.deps.Topo.Remove(collectorPID)
+
+	monitorCh := make(chan *relay.Package, 16)
+	detach, err := e.deps.Node.Attach(collectorPID, monitorCh)
+	if err != nil {
+		return nil, err
+	}
+	defer detach()
+
+	e.reapOrphan(collectorPID, priorActorPID, log)
+
+	if err := e.waitForGates(ctx, op, req.Heartbeat, log); err != nil {
+		e.terminalizeIfPermanent(ctx, op, err, log)
+		return nil, err
+	}
+
+	desired, err := e.materialize(ctx, spec.Desired)
+	if err != nil {
+		e.terminalizeIfPermanent(ctx, op, err, log)
+		return nil, err
+	}
+
+	checkpoint, err := store.GetLatestCheckpoint(ctx, op.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	actorPID, err := e.spawnActor(ctx, collectorPID, manifest, op, spec, desired, checkpoint)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.SetActorPID(ctx, op.ID, op.Incarnation, actorPID.String()); err != nil {
+		e.cancelActor(collectorPID, actorPID, "actor pid persistence failed", log)
+		return nil, err
+	}
+	log.Info("provider actor spawned", zap.String("pid", actorPID.String()))
+
+	return e.consumeSignals(ctx, op, spec, deploy.Scope, collectorPID, actorPID, monitorCh, req.Heartbeat, log)
+}
+
+// terminalizeIfPermanent writes the failed terminal status only for
+// permanent domain failures (gate timeout, failed dependency, missing
+// output). Context cancellation and transient store errors pass through
+// untouched so the Temporal retry policy stays in charge.
+func (e *Executor) terminalizeIfPermanent(ctx context.Context, op *resource.Operation, cause error, log *zap.Logger) {
+	var ae apierror.Error
+	if !errors.As(cause, &ae) || ae.Retryable() != apierror.False {
+		return
+	}
+	if _, err := e.deps.Store.Terminalize(ctx, op.ID, op.Incarnation,
+		[]resource.OperationStatus{resource.OpDispatched, resource.OpInProgress},
+		resource.OpFailed, cause.Error()); err != nil {
+		log.Error("terminalize after permanent failure", zap.Error(err))
+	}
+}
+
+// reapOrphan cancels a live actor left by a previous incarnation
+// (design §9.4 step 3). Signal fencing already excludes it; this only frees
+// the process.
+func (e *Executor) reapOrphan(collectorPID pid.PID, priorActorPID string, log *zap.Logger) {
+	if priorActorPID == "" {
+		return
+	}
+	orphan, err := pid.ParsePID(priorActorPID)
+	if err != nil {
+		log.Warn("unparseable prior actor pid", zap.String("pid", priorActorPID), zap.Error(err))
+		return
+	}
+	if err := e.deps.Node.Send(topapi.CancelPackage(collectorPID, orphan, "superseded actor incarnation")); err != nil {
+		log.Debug("orphan cancel not delivered", zap.String("pid", priorActorPID), zap.Error(err))
+	}
+}
+
+// waitForGates re-checks every inbound hard dependency against live ledger
+// state until satisfied or timed out (design §9.4 step 5).
+func (e *Executor) waitForGates(ctx context.Context, op *resource.Operation, heartbeat func(...any), log *zap.Logger) error {
+	edges, err := e.deps.Store.ListEdgesFrom(ctx, op.DeployID, op.ResourceID)
+	if err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(e.gateTimeout)
+	lastBeat := time.Now()
+	for {
+		unsatisfied, err := e.unsatisfiedGate(ctx, op, edges)
+		if err != nil {
+			return err
+		}
+		if unsatisfied == "" {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return NewGateTimeoutError(op.ID, unsatisfied)
+		}
+		if heartbeat != nil && time.Since(lastBeat) >= e.heartbeatEvery {
+			heartbeat("gate-wait")
+			lastBeat = time.Now()
+		}
+		log.Debug("gate unsatisfied, waiting", zap.String("gate", unsatisfied))
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(e.pollInterval):
+		}
+	}
+}
+
+// unsatisfiedGate evaluates the gate predicates of §5.4 (PoC subset) and
+// returns a description of the first unsatisfied gate, or "".
+func (e *Executor) unsatisfiedGate(ctx context.Context, op *resource.Operation, edges []resource.Edge) (string, error) {
+	for _, edge := range edges {
+		if edge.Kind == resource.DepSoft {
+			continue
+		}
+
+		target, err := e.deps.Store.GetOperationByResource(ctx, op.DeployID, edge.TargetResourceID)
+		if err != nil {
+			return "", err
+		}
+		if target.Status == resource.OpFailed {
+			return "", NewOperationFailedError(op.ID, "dependency "+edge.TargetResourceID+" failed")
+		}
+		if target.Status != resource.OpCommitted {
+			return fmt.Sprintf("%s (%s) not committed", edge.TargetResourceID, edge.Kind), nil
+		}
+
+		if edge.Kind == resource.DepConfigure || edge.Kind == resource.DepAttachment {
+			inst, err := e.deps.Store.GetInstance(ctx, edge.TargetResourceID)
+			if err != nil {
+				return "", err
+			}
+			if len(inst.Outputs) == 0 {
+				return fmt.Sprintf("%s (%s) has no outputs", edge.TargetResourceID, edge.Kind), nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// materialize rewrites every $ref in the desired document with the committed
+// producer outputs (design §9.4 step 6).
+func (e *Executor) materialize(ctx context.Context, desired json.RawMessage) (json.RawMessage, error) {
+	return plan.Materialize(desired, func(ref plan.OutputRef) (any, error) {
+		inst, err := e.deps.Store.GetInstance(ctx, ref.ResourceID)
+		if err != nil {
+			return nil, err
+		}
+		var outputs map[string]any
+		if len(inst.Outputs) > 0 {
+			if err := json.Unmarshal(inst.Outputs, &outputs); err != nil {
+				return nil, err
+			}
+		}
+		value, ok := outputs[ref.OutputKey]
+		if !ok {
+			return nil, NewMissingOutputError(ref.ResourceID, ref.OutputKey)
+		}
+		return value, nil
+	})
+}
+
+// spawnActor starts the provider actor with the collector PID and the
+// assembled operation input (design §9.4 steps 6-7).
+func (e *Executor) spawnActor(ctx context.Context, collectorPID pid.PID, manifest *cgapi.ProviderConfig, op *resource.Operation, spec *resource.Spec, desired, checkpoint json.RawMessage) (pid.PID, error) {
+	var desiredDoc any
+	if len(desired) > 0 {
+		if err := json.Unmarshal(desired, &desiredDoc); err != nil {
+			return pid.PID{}, err
+		}
+	}
+	var checkpointDoc any
+	if len(checkpoint) > 0 {
+		if err := json.Unmarshal(checkpoint, &checkpointDoc); err != nil {
+			return pid.PID{}, err
+		}
+	}
+
+	input := map[string]any{
+		"operation_id":  op.ID,
+		"incarnation":   op.Incarnation,
+		"resource_id":   op.ResourceID,
+		"resource_type": spec.Type,
+		"desired":       desiredDoc,
+		"checkpoint":    checkpointDoc,
+		"executor":      manifest.Executor.String(),
+		"collector":     collectorPID.String(),
+	}
+
+	options := attrs.NewBag()
+	options.Set(process.ProcessParentKey, collectorPID)
+	options.Set(process.ProcessMonitorKey, true)
+
+	return e.deps.Procs.Start(ctx, &process.Start{
+		HostID:  e.deps.HostID,
+		Source:  manifest.ActorProcess,
+		Input:   payload.Payloads{payload.New(input)},
+		Options: options,
+	})
+}
+
+// consumeSignals is the single-writer select loop: it appends provider
+// signals to the mailbox under the CAS fence and steps the FSM on acceptance
+// (design §9.4 step 8).
+func (e *Executor) consumeSignals(
+	ctx context.Context,
+	op *resource.Operation,
+	spec *resource.Spec,
+	scope string,
+	collectorPID, actorPID pid.PID,
+	monitorCh chan *relay.Package,
+	heartbeat func(...any),
+	log *zap.Logger,
+) (json.RawMessage, error) {
+	store := e.deps.Store
+	fsm := &signalFSM{}
+	firstAccepted := false
+
+	heartbeatTicker := time.NewTicker(e.heartbeatEvery)
+	defer heartbeatTicker.Stop()
+	opDeadline := time.NewTimer(e.operationTimeout)
+	defer opDeadline.Stop()
+
+	// A nil channel blocks forever; it becomes live once the actor exit event
+	// arrives, giving trailing signals a bounded drain window.
+	var exitGrace <-chan time.Time
+
+	fail := func(detail string) (json.RawMessage, error) {
+		if _, err := store.Terminalize(ctx, op.ID, op.Incarnation,
+			[]resource.OperationStatus{resource.OpDispatched, resource.OpInProgress},
+			resource.OpFailed, detail); err != nil {
+			log.Error("terminalize failed", zap.Error(err))
+		}
+		return nil, NewOperationFailedError(op.ID, detail)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			e.cancelActor(collectorPID, actorPID, "activity context canceled", log)
+			return nil, ctx.Err()
+
+		case <-heartbeatTicker.C:
+			if heartbeat != nil {
+				heartbeat(op.LastSignal)
+			}
+
+		case <-opDeadline.C:
+			e.cancelActor(collectorPID, actorPID, "operation timeout", log)
+			if _, err := store.Terminalize(ctx, op.ID, op.Incarnation,
+				[]resource.OperationStatus{resource.OpDispatched, resource.OpInProgress},
+				resource.OpFailed, "operation timeout"); err != nil {
+				log.Error("terminalize after timeout", zap.Error(err))
+			}
+			return nil, NewOperationTimeoutError(op.ID)
+
+		case <-exitGrace:
+			log.Warn("actor exited without terminal signal")
+			return nil, NewActorExitError(op.ID)
+
+		case batch, chOpen := <-monitorCh:
+			if !chOpen {
+				return nil, NewActorExitError(op.ID)
+			}
+			for _, msg := range batch.Messages {
+				switch msg.Topic {
+				case topapi.TopicEvents:
+					for _, p := range msg.Payloads {
+						if _, isExit := p.Data().(*topapi.ExitEvent); isExit && exitGrace == nil {
+							exitGrace = time.After(e.exitGrace)
+						}
+					}
+
+				case SignalTopic:
+					for _, p := range msg.Payloads {
+						sig, err := e.decodeSignal(op, p)
+						if err != nil {
+							log.Warn("undecodable signal", zap.Error(err))
+							continue
+						}
+
+						accepted, err := store.AppendSignal(ctx, *sig)
+						if err != nil {
+							return nil, err
+						}
+						if !accepted {
+							log.Warn("signal rejected by mailbox fence",
+								zap.Int64("seq", sig.Seq), zap.String("phase", string(sig.Phase)))
+							continue
+						}
+						op.LastSignal = sig.Seq
+
+						if !firstAccepted {
+							firstAccepted = true
+							if err := store.MarkInProgress(ctx, op.ID, op.Incarnation); err != nil {
+								return nil, err
+							}
+						}
+
+						outcome, err := fsm.step(*sig)
+						if err != nil {
+							e.cancelActor(collectorPID, actorPID, "illegal signal", log)
+							return fail(err.Error())
+						}
+
+						switch outcome {
+						case stepCommit:
+							var term terminalPayload
+							if len(sig.Payload) > 0 {
+								if err := json.Unmarshal(sig.Payload, &term); err != nil {
+									return fail("undecodable verify_passed payload: " + err.Error())
+								}
+							}
+							result, err := json.Marshal(map[string]any{
+								"resource_id": op.ResourceID,
+								"outputs":     orEmpty(term.Outputs),
+							})
+							if err != nil {
+								return nil, err
+							}
+							if err := store.CommitOperation(ctx, op, spec, scope, term.Outputs, result); err != nil {
+								return nil, err
+							}
+							log.Info("operation committed")
+							return result, nil
+
+						case stepFailed:
+							var term terminalPayload
+							if len(sig.Payload) > 0 {
+								if err := json.Unmarshal(sig.Payload, &term); err != nil {
+									term.Error = string(sig.Payload)
+								}
+							}
+							if term.Error == "" {
+								term.Error = "provider reported failure"
+							}
+							return fail(term.Error)
+
+						case stepContinue:
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// decodeSignal converts one relay payload into a fenced signal envelope.
+func (e *Executor) decodeSignal(op *resource.Operation, p payload.Payload) (*resource.Signal, error) {
+	var wire signalWire
+	if err := e.deps.Transcoder.Unmarshal(p, &wire); err != nil {
+		return nil, err
+	}
+	return &resource.Signal{
+		OperationID: op.ID,
+		Incarnation: op.Incarnation,
+		Seq:         wire.Seq,
+		Kind:        resource.SignalKind(wire.Kind),
+		Phase:       resource.SignalPhaseName(wire.Phase),
+		Payload:     wire.Payload,
+	}, nil
+}
+
+// cancelActor delivers the cancel package to the actor (PoC: single phase of
+// the three-phase protocol; the rest is documented as skipped).
+func (e *Executor) cancelActor(collectorPID, actorPID pid.PID, reason string, log *zap.Logger) {
+	if err := e.deps.Node.Send(topapi.CancelPackage(collectorPID, actorPID, reason)); err != nil {
+		log.Warn("cancel not delivered", zap.Error(err))
+	}
+}
+
+func orEmpty(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage("{}")
+	}
+	return raw
+}

--- a/service/cloudgraph/attempt/executor_test.go
+++ b/service/cloudgraph/attempt/executor_test.go
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package attempt
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/relay"
+	cgapi "github.com/wippyai/runtime/api/service/cloudgraph"
+	topapi "github.com/wippyai/runtime/api/topology"
+	"github.com/wippyai/runtime/service/cloudgraph/binding"
+	"github.com/wippyai/runtime/service/cloudgraph/ledger"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+)
+
+type jsonTranscoder struct{}
+
+func (jsonTranscoder) Unmarshal(p payload.Payload, v any) error {
+	raw, err := json.Marshal(p.Data())
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, v)
+}
+
+func (jsonTranscoder) Transcode(p payload.Payload, _ payload.Format) (payload.Payload, error) {
+	return p, nil
+}
+
+type fakePIDGen struct{ counter int }
+
+func (g *fakePIDGen) Generate(host pid.HostID) pid.PID {
+	g.counter++
+	return pid.PID{Host: host, UniqID: string(rune('a' + g.counter))}
+}
+
+type fakeTopo struct{}
+
+func (fakeTopo) Register(pid.PID) error { return nil }
+func (fakeTopo) Remove(pid.PID)         {}
+
+type fakeNode struct {
+	channels map[string]chan *relay.Package
+	sent     []*relay.Package
+	mu       sync.Mutex
+}
+
+func newFakeNode() *fakeNode {
+	return &fakeNode{channels: make(map[string]chan *relay.Package)}
+}
+
+func (n *fakeNode) Attach(p pid.PID, ch chan *relay.Package) (context.CancelFunc, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.channels[p.String()] = ch
+	return func() {}, nil
+}
+
+func (n *fakeNode) Send(pkg *relay.Package) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.sent = append(n.sent, pkg)
+	return nil
+}
+
+func (n *fakeNode) channelFor(p pid.PID) chan *relay.Package {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.channels[p.String()]
+}
+
+// actorScript drives the scripted provider actor: it receives the spawn
+// input and a send function that delivers envelopes to the collector.
+type actorScript func(input map[string]any, send func(wire map[string]any), exit func())
+
+type fakeProcs struct {
+	node    *fakeNode
+	script  actorScript
+	started []map[string]any
+	mu      sync.Mutex
+}
+
+func (f *fakeProcs) Start(_ context.Context, start *process.Start) (pid.PID, error) {
+	var input map[string]any
+	if len(start.Input) > 0 {
+		raw, err := json.Marshal(start.Input[0].Data())
+		if err != nil {
+			return pid.PID{}, err
+		}
+		if err := json.Unmarshal(raw, &input); err != nil {
+			return pid.PID{}, err
+		}
+	}
+
+	f.mu.Lock()
+	f.started = append(f.started, input)
+	f.mu.Unlock()
+
+	collector, _ := input["collector"].(string)
+	collectorPID, err := pid.ParsePID(collector)
+	if err != nil {
+		return pid.PID{}, err
+	}
+	ch := f.node.channelFor(collectorPID)
+
+	send := func(wire map[string]any) {
+		pkg := &relay.Package{}
+		pkg.AddMessage(SignalTopic, payload.New(wire))
+		ch <- pkg
+	}
+	exit := func() {
+		pkg := &relay.Package{}
+		pkg.AddMessage(topapi.TopicEvents, payload.New(&topapi.ExitEvent{}))
+		ch <- pkg
+	}
+
+	go f.script(input, send, exit)
+	return pid.PID{Host: "actors", UniqID: "actor-1"}, nil
+}
+
+func (f *fakeProcs) startCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.started)
+}
+
+type execEnv struct {
+	store *ledger.Store
+	procs *fakeProcs
+	node  *fakeNode
+	exec  *Executor
+}
+
+func newExecEnv(t *testing.T, script actorScript) *execEnv {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+t.TempDir()+"/ledger.db?_busy_timeout=5000&_journal_mode=WAL")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	store := ledger.NewStore(db, nil)
+	require.NoError(t, store.Migrate(context.Background()))
+
+	providers := binding.NewRegistry()
+	require.NoError(t, providers.Register(&cgapi.ProviderConfig{
+		ProviderType:  "docker",
+		ActorProcess:  registry.NewID("poc", "docker_actor"),
+		Executor:      registry.NewID("poc", "exec"),
+		ResourceTypes: []string{"container"},
+	}))
+
+	node := newFakeNode()
+	procs := &fakeProcs{node: node, script: script}
+
+	exec := NewExecutor(Deps{
+		PIDGen:     &fakePIDGen{},
+		Node:       node,
+		Topo:       fakeTopo{},
+		Procs:      procs,
+		Transcoder: jsonTranscoder{},
+		Store:      store,
+		Providers:  providers,
+		HostID:     "poc:processes",
+	},
+		WithGateTimeout(2*time.Second),
+		WithOperationTimeout(10*time.Second),
+		WithPollInterval(20*time.Millisecond),
+		WithExitGrace(100*time.Millisecond),
+	)
+
+	return &execEnv{store: store, procs: procs, node: node, exec: exec}
+}
+
+func (env *execEnv) seed(t *testing.T, deployID string, specs []resource.Spec, edges []resource.Edge) {
+	t.Helper()
+	ctx := context.Background()
+
+	created, err := env.store.CreateDeploy(ctx, resource.DeployInput{DeployID: deployID, Scope: "poc", Specs: specs})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	ops := make([]resource.Operation, len(specs))
+	for i, spec := range specs {
+		ops[i] = resource.Operation{
+			ID:         deployID + "/" + spec.ResourceID,
+			DeployID:   deployID,
+			ResourceID: spec.ResourceID,
+			Action:     resource.ActionCreate,
+		}
+	}
+
+	require.NoError(t, env.store.SavePlan(ctx, &ledger.PlanRecord{
+		ID:         "plan/" + deployID,
+		DeployID:   deployID,
+		Operations: json.RawMessage(`[]`),
+		Edges:      json.RawMessage(`[]`),
+		Waves:      json.RawMessage(`[]`),
+		SpecHash:   "hash",
+	}, ops, edges))
+}
+
+func happyScript(outputs string) actorScript {
+	return func(_ map[string]any, send func(map[string]any), _ func()) {
+		send(map[string]any{"seq": 1, "kind": "phase", "phase": "allocate_started"})
+		send(map[string]any{"seq": 2, "kind": "phase", "phase": "allocate_committed"})
+		send(map[string]any{"seq": 3, "kind": "checkpoint", "payload": map[string]any{"stage": "configured"}})
+		send(map[string]any{"seq": 4, "kind": "phase", "phase": "verify_passed",
+			"payload": map[string]any{"outputs": json.RawMessage(outputs)}})
+	}
+}
+
+func TestExecuteHappyPath(t *testing.T) {
+	env := newExecEnv(t, happyScript(`{"container_id":"abc","dsn":"postgres://x"}`))
+	env.seed(t, "d1", []resource.Spec{{
+		ResourceID:   "poc/postgres",
+		Type:         "container",
+		ProviderType: "docker",
+		Desired:      json.RawMessage(`{"image":"postgres:18-alpine"}`),
+	}}, nil)
+
+	result, err := env.exec.Execute(context.Background(), Request{OpID: "d1/poc/postgres", Incarnation: 1})
+	require.NoError(t, err)
+	require.Contains(t, string(result), "container_id")
+
+	op, err := env.store.GetOperation(context.Background(), "d1/poc/postgres")
+	require.NoError(t, err)
+	require.Equal(t, resource.OpCommitted, op.Status)
+
+	inst, err := env.store.GetInstance(context.Background(), "poc/postgres")
+	require.NoError(t, err)
+	require.Equal(t, "active", inst.Lifecycle)
+	require.Contains(t, string(inst.Outputs), "dsn")
+
+	signals, err := env.store.ListSignals(context.Background(), "d1/poc/postgres", 1)
+	require.NoError(t, err)
+	require.Len(t, signals, 4)
+}
+
+func TestExecuteTerminalShortCircuit(t *testing.T) {
+	env := newExecEnv(t, happyScript(`{"container_id":"abc"}`))
+	env.seed(t, "d1", []resource.Spec{{
+		ResourceID: "poc/app", Type: "container", ProviderType: "docker",
+	}}, nil)
+
+	_, err := env.exec.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, env.procs.startCount())
+
+	result, err := env.exec.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 2})
+	require.NoError(t, err)
+	require.Contains(t, string(result), "poc/app")
+	require.Equal(t, 1, env.procs.startCount(), "terminal operation must not respawn the actor")
+}
+
+func TestExecuteStaleIncarnation(t *testing.T) {
+	env := newExecEnv(t, happyScript(`{}`))
+	env.seed(t, "d1", []resource.Spec{{
+		ResourceID: "poc/app", Type: "container", ProviderType: "docker",
+	}}, nil)
+
+	ok, err := env.store.BumpIncarnation(context.Background(), "d1/poc/app", 5)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_, err = env.exec.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 2})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stale incarnation")
+	require.Equal(t, 0, env.procs.startCount())
+}
+
+func TestExecuteProviderFailure(t *testing.T) {
+	env := newExecEnv(t, func(_ map[string]any, send func(map[string]any), _ func()) {
+		send(map[string]any{"seq": 1, "kind": "phase", "phase": "allocate_started"})
+		send(map[string]any{"seq": 2, "kind": "failed",
+			"payload": map[string]any{"error": "image pull failed"}})
+	})
+	env.seed(t, "d1", []resource.Spec{{
+		ResourceID: "poc/app", Type: "container", ProviderType: "docker",
+	}}, nil)
+
+	_, err := env.exec.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "image pull failed")
+
+	op, err := env.store.GetOperation(context.Background(), "d1/poc/app")
+	require.NoError(t, err)
+	require.Equal(t, resource.OpFailed, op.Status)
+	require.Equal(t, "image pull failed", op.Error)
+}
+
+func TestExecuteActorCrashThenRetryResumes(t *testing.T) {
+	firstRun := true
+	env := newExecEnv(t, nil)
+	env.procs.script = func(input map[string]any, send func(map[string]any), exit func()) {
+		if firstRun {
+			firstRun = false
+			send(map[string]any{"seq": 1, "kind": "phase", "phase": "allocate_started"})
+			send(map[string]any{"seq": 2, "kind": "checkpoint", "payload": map[string]any{"stage": "allocated"}})
+			exit()
+			return
+		}
+		if input["checkpoint"] == nil {
+			send(map[string]any{"seq": 1, "kind": "failed",
+				"payload": map[string]any{"error": "expected checkpoint on respawn"}})
+			return
+		}
+		send(map[string]any{"seq": 1, "kind": "phase", "phase": "configure_committed"})
+		send(map[string]any{"seq": 2, "kind": "phase", "phase": "verify_passed",
+			"payload": map[string]any{"outputs": map[string]any{"container_id": "resumed"}}})
+	}
+
+	env.seed(t, "d1", []resource.Spec{{
+		ResourceID: "poc/app", Type: "container", ProviderType: "docker",
+	}}, nil)
+
+	_, err := env.exec.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exited without terminal signal")
+
+	result, err := env.exec.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 2})
+	require.NoError(t, err)
+	require.Contains(t, string(result), "resumed")
+	require.Equal(t, 2, env.procs.startCount())
+}
+
+func TestExecuteGateBlocksThenReleases(t *testing.T) {
+	env := newExecEnv(t, happyScript(`{"container_id":"app"}`))
+	specs := []resource.Spec{
+		{ResourceID: "poc/app", Type: "container", ProviderType: "docker",
+			Desired: json.RawMessage(`{"env":{"DATABASE_URL":{"$ref":{"resource_id":"poc/postgres","output_key":"dsn"}}}}`)},
+		{ResourceID: "poc/postgres", Type: "container", ProviderType: "docker",
+			Desired: json.RawMessage(`{"image":"postgres"}`)},
+	}
+	env.seed(t, "d1", specs, []resource.Edge{
+		{SourceResourceID: "poc/app", TargetResourceID: "poc/postgres", Kind: resource.DepConfigure},
+	})
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() {
+		_, err := env.exec.Execute(ctx, Request{OpID: "d1/poc/app", Incarnation: 1})
+		done <- err
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, 0, env.procs.startCount(), "actor must not spawn while the gate is unsatisfied")
+
+	pgOp, err := env.store.GetOperation(ctx, "d1/poc/postgres")
+	require.NoError(t, err)
+	ok, err := env.store.BumpIncarnation(ctx, pgOp.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	pgOp.Incarnation = 1
+	pgSpec, err := env.store.GetSpec(ctx, "d1", "poc/postgres")
+	require.NoError(t, err)
+	require.NoError(t, env.store.CommitOperation(ctx, pgOp, pgSpec, "poc",
+		json.RawMessage(`{"dsn":"postgres://db:5432/app"}`), nil))
+
+	require.NoError(t, <-done)
+
+	require.Equal(t, 1, env.procs.startCount())
+	input := env.procs.started[0]
+	desired := input["desired"].(map[string]any)
+	env2 := desired["env"].(map[string]any)
+	require.Equal(t, "postgres://db:5432/app", env2["DATABASE_URL"], "$ref must be materialized from committed outputs")
+}
+
+func TestExecuteGateTimeout(t *testing.T) {
+	env := newExecEnv(t, happyScript(`{}`))
+	env.seed(t, "d1", []resource.Spec{
+		{ResourceID: "poc/app", Type: "container", ProviderType: "docker"},
+		{ResourceID: "poc/postgres", Type: "container", ProviderType: "docker"},
+	}, []resource.Edge{
+		{SourceResourceID: "poc/app", TargetResourceID: "poc/postgres", Kind: resource.DepCreate},
+	})
+
+	fast := NewExecutor(env.exec.deps,
+		WithGateTimeout(100*time.Millisecond),
+		WithPollInterval(20*time.Millisecond),
+	)
+
+	_, err := fast.Execute(context.Background(), Request{OpID: "d1/poc/app", Incarnation: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gate timeout")
+
+	op, err := env.store.GetOperation(context.Background(), "d1/poc/app")
+	require.NoError(t, err)
+	require.Equal(t, resource.OpFailed, op.Status)
+}
+
+func TestExecuteFailedDependencyFailsFast(t *testing.T) {
+	env := newExecEnv(t, happyScript(`{}`))
+	env.seed(t, "d1", []resource.Spec{
+		{ResourceID: "poc/app", Type: "container", ProviderType: "docker"},
+		{ResourceID: "poc/postgres", Type: "container", ProviderType: "docker"},
+	}, []resource.Edge{
+		{SourceResourceID: "poc/app", TargetResourceID: "poc/postgres", Kind: resource.DepCreate},
+	})
+
+	ctx := context.Background()
+	ok, err := env.store.BumpIncarnation(ctx, "d1/poc/postgres", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	done, err := env.store.Terminalize(ctx, "d1/poc/postgres", 1,
+		[]resource.OperationStatus{resource.OpDispatched}, resource.OpFailed, "boom")
+	require.NoError(t, err)
+	require.True(t, done)
+
+	_, err = env.exec.Execute(ctx, Request{OpID: "d1/poc/app", Incarnation: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dependency poc/postgres failed")
+	require.Equal(t, 0, env.procs.startCount())
+}

--- a/service/cloudgraph/attempt/fsm.go
+++ b/service/cloudgraph/attempt/fsm.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package attempt
+
+import (
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+)
+
+// createPhaseRank orders the create-action signal ladder. Providers may skip
+// intermediate phases but never move backward within an incarnation
+// (design §9.5, C1 subset for create operations).
+var createPhaseRank = map[resource.SignalPhaseName]int{
+	resource.PhaseAllocateStarted:    1,
+	resource.PhaseAllocateCommitted:  2,
+	resource.PhaseConfigureStarted:   3,
+	resource.PhaseConfigureCommitted: 4,
+	resource.PhaseVerifyStarted:      5,
+	resource.PhaseVerifyPassed:       6,
+	resource.PhaseVerifyFailed:       6,
+}
+
+// stepOutcome is the FSM decision for one accepted signal.
+type stepOutcome int
+
+// Step outcomes.
+const (
+	stepContinue stepOutcome = iota
+	stepCommit
+	stepFailed
+)
+
+// signalFSM tracks the in-incarnation signal ladder position. The sequence
+// fence (C4) lives in the ledger; this covers phase legality (C1).
+type signalFSM struct {
+	rank int
+}
+
+// step validates one signal against the create ladder and returns the
+// outcome. An illegal signal is an error, never silently absorbed.
+func (f *signalFSM) step(sig resource.Signal) (stepOutcome, error) {
+	switch sig.Kind {
+	case resource.SignalCheckpoint, resource.SignalOutput:
+		return stepContinue, nil
+
+	case resource.SignalFailed:
+		return stepFailed, nil
+
+	case resource.SignalPhase:
+		rank, ok := createPhaseRank[sig.Phase]
+		if !ok {
+			return stepContinue, NewIllegalSignalError(string(sig.Phase) + " is not a create phase")
+		}
+		if rank <= f.rank {
+			return stepContinue, NewIllegalSignalError(string(sig.Phase) + " moves the ladder backward")
+		}
+		f.rank = rank
+
+		switch sig.Phase {
+		case resource.PhaseVerifyPassed:
+			return stepCommit, nil
+		case resource.PhaseVerifyFailed:
+			return stepFailed, nil
+		default:
+			return stepContinue, nil
+		}
+
+	default:
+		return stepContinue, NewIllegalSignalError("unknown signal kind: " + string(sig.Kind))
+	}
+}

--- a/service/cloudgraph/attempt/fsm_test.go
+++ b/service/cloudgraph/attempt/fsm_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package attempt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+)
+
+func phaseSignal(phase resource.SignalPhaseName) resource.Signal {
+	return resource.Signal{Kind: resource.SignalPhase, Phase: phase}
+}
+
+func TestFSMHappyLadder(t *testing.T) {
+	fsm := &signalFSM{}
+
+	for _, phase := range []resource.SignalPhaseName{
+		resource.PhaseAllocateStarted,
+		resource.PhaseAllocateCommitted,
+		resource.PhaseConfigureStarted,
+		resource.PhaseConfigureCommitted,
+		resource.PhaseVerifyStarted,
+	} {
+		outcome, err := fsm.step(phaseSignal(phase))
+		require.NoError(t, err, string(phase))
+		require.Equal(t, stepContinue, outcome, string(phase))
+	}
+
+	outcome, err := fsm.step(phaseSignal(resource.PhaseVerifyPassed))
+	require.NoError(t, err)
+	require.Equal(t, stepCommit, outcome)
+}
+
+func TestFSMSkippedPhasesAllowed(t *testing.T) {
+	fsm := &signalFSM{}
+
+	outcome, err := fsm.step(phaseSignal(resource.PhaseAllocateStarted))
+	require.NoError(t, err)
+	require.Equal(t, stepContinue, outcome)
+
+	outcome, err = fsm.step(phaseSignal(resource.PhaseConfigureCommitted))
+	require.NoError(t, err)
+	require.Equal(t, stepContinue, outcome)
+
+	outcome, err = fsm.step(phaseSignal(resource.PhaseVerifyPassed))
+	require.NoError(t, err)
+	require.Equal(t, stepCommit, outcome)
+}
+
+func TestFSMBackwardPhaseRejected(t *testing.T) {
+	fsm := &signalFSM{}
+
+	_, err := fsm.step(phaseSignal(resource.PhaseConfigureCommitted))
+	require.NoError(t, err)
+
+	_, err = fsm.step(phaseSignal(resource.PhaseAllocateStarted))
+	require.Error(t, err)
+
+	_, err = fsm.step(phaseSignal(resource.PhaseConfigureCommitted))
+	require.Error(t, err, "phase repeat must be rejected")
+}
+
+func TestFSMDeletePhasesRejectedForCreate(t *testing.T) {
+	fsm := &signalFSM{}
+
+	_, err := fsm.step(phaseSignal(resource.PhaseDeleteStarted))
+	require.Error(t, err)
+
+	_, err = fsm.step(phaseSignal(resource.PhaseDeleteCommitted))
+	require.Error(t, err)
+}
+
+func TestFSMTerminalsAndEnvelopes(t *testing.T) {
+	fsm := &signalFSM{}
+
+	outcome, err := fsm.step(resource.Signal{Kind: resource.SignalCheckpoint})
+	require.NoError(t, err)
+	require.Equal(t, stepContinue, outcome)
+
+	outcome, err = fsm.step(resource.Signal{Kind: resource.SignalOutput})
+	require.NoError(t, err)
+	require.Equal(t, stepContinue, outcome)
+
+	outcome, err = fsm.step(phaseSignal(resource.PhaseVerifyFailed))
+	require.NoError(t, err)
+	require.Equal(t, stepFailed, outcome)
+
+	outcome, err = fsm.step(resource.Signal{Kind: resource.SignalFailed})
+	require.NoError(t, err)
+	require.Equal(t, stepFailed, outcome)
+
+	_, err = fsm.step(resource.Signal{Kind: "bogus"})
+	require.Error(t, err)
+
+	_, err = fsm.step(resource.Signal{Kind: resource.SignalPhase, Phase: "bogus"})
+	require.Error(t, err)
+}

--- a/service/cloudgraph/binding/registry.go
+++ b/service/cloudgraph/binding/registry.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package binding resolves provider_type strings to registered provider
+// manifests (docs/design/cloud-graph.md §7, PoC subset).
+package binding
+
+import (
+	"sync"
+
+	cgapi "github.com/wippyai/runtime/api/service/cloudgraph"
+)
+
+// Registry is the only path from a provider_type to executable provider
+// configuration. Manifests are immutable after registration; resolution
+// fails hard on a miss (design I20).
+type Registry struct {
+	providers map[string]*cgapi.ProviderConfig
+	mu        sync.RWMutex
+}
+
+// NewRegistry creates an empty provider registry.
+func NewRegistry() *Registry {
+	return &Registry{providers: make(map[string]*cgapi.ProviderConfig)}
+}
+
+// Register installs a validated manifest. A second manifest claiming an
+// existing provider_type is a hard configuration error.
+func (r *Registry) Register(cfg *cgapi.ProviderConfig) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.providers[cfg.ProviderType]; exists {
+		return cgapi.NewProviderConflictError(cfg.ProviderType)
+	}
+	r.providers[cfg.ProviderType] = cfg
+	return nil
+}
+
+// Provider resolves a provider_type to its manifest, failing hard on a miss.
+func (r *Registry) Provider(providerType string) (*cgapi.ProviderConfig, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	cfg, ok := r.providers[providerType]
+	if !ok {
+		return nil, cgapi.NewProviderNotFoundError(providerType)
+	}
+	return cfg, nil
+}

--- a/service/cloudgraph/doc.go
+++ b/service/cloudgraph/doc.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package cloudgraph is a proof-of-concept vertical slice of the
+// wippy.cloud.graph deployment control plane designed in
+// docs/design/cloud-graph.md. It proves the risky seams end to end:
+// deterministic plan computation (gonum graph, Kahn waves), a deterministic
+// Go Temporal deploy workflow, per-operation execute_operation activities,
+// Lua provider actors spawned over the process host, and the durable
+// operation_signals mailbox with CAS-fenced acceptance.
+//
+// PoC relaxations against the design (each section cited is the design
+// document's normative treatment; none of these relaxations weaken what the
+// PoC claims to prove):
+//
+//   - Locks and fencing tokens (design §8 Claim, I1/I8): only the actor
+//     incarnation CAS and the per-incarnation signal seq CAS are enforced.
+//   - Generation CAS on signal acceptance (C2): pinned to 0; the
+//     operation_signals schema keeps the fencing_token and
+//     resource_generation columns so the fences are an additive change.
+//   - Deploy classification (design §8.1): create-only; no canonical
+//     baseline, no update/delete/replace, no targeted deploys.
+//   - operation_blockers (design §8.4): replaced by dispatch-time gate
+//     re-checks reading committed producer outputs.
+//   - Observer/watchers, compensation, and the three-phase cancel protocol
+//     (design §9.5, §9.6, §11): not implemented; cancellation delivers the
+//     cancel package to the actor and terminalizes.
+//   - Recovery (design §9.7): limited to the idempotent already-terminal
+//     check, incarnation fencing, orphan-cancel, and checkpoint replay on
+//     the next activity attempt.
+//   - Ledger dialects (design §10.3): SQLite only.
+//   - Provider contracts (design §7.3): apply actors only; validate, diff,
+//     refresh, import, and create_watcher are not implemented.
+//   - One engine per installation; the shard field is informational.
+//   - Engine entry deletion mid-deploy is unsupported: published handlers and
+//     registered workflow/activities are not unregistered, so the entry must
+//     only be removed at shutdown.
+package cloudgraph

--- a/service/cloudgraph/errors.go
+++ b/service/cloudgraph/errors.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudgraph
+
+import apierror "github.com/wippyai/runtime/api/error"
+
+// Manager-level failures.
+var (
+	ErrResourceRegistryMissing = apierror.New(apierror.Internal, "resource registry not available").WithRetryable(apierror.False)
+	ErrInvalidDatabaseResource = apierror.New(apierror.Invalid, "database entry is not a SQL resource").WithRetryable(apierror.False)
+	ErrInvalidClientResource   = apierror.New(apierror.Invalid, "client entry is not a temporal client resource").WithRetryable(apierror.False)
+	ErrEngineNotReady          = apierror.New(apierror.Unavailable, "cloudgraph engine not ready").WithRetryable(apierror.True)
+)
+
+// NewEngineConflictError reports a second cloudgraph.engine entry; the PoC
+// runs exactly one engine per installation.
+func NewEngineConflictError(id string) apierror.Error {
+	return apierror.New(apierror.Conflict, "cloudgraph engine already loaded, rejecting: "+id).WithRetryable(apierror.False)
+}
+
+// NewInvalidDeployInputError reports a malformed deploy submission.
+func NewInvalidDeployInputError(detail string) apierror.Error {
+	return apierror.New(apierror.Invalid, "invalid deploy input: "+detail).WithRetryable(apierror.False)
+}
+
+// NewWorkerNotFoundError reports an engine referencing an unknown worker.
+func NewWorkerNotFoundError(id string) apierror.Error {
+	return apierror.New(apierror.NotFound, "temporal worker not found: "+id).WithRetryable(apierror.False)
+}

--- a/service/cloudgraph/ledger/errors.go
+++ b/service/cloudgraph/ledger/errors.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package ledger
+
+import apierror "github.com/wippyai/runtime/api/error"
+
+// NewDeployNotFoundError reports a missing deploy row.
+func NewDeployNotFoundError(deployID string) apierror.Error {
+	return apierror.New(apierror.NotFound, "deploy not found: "+deployID).WithRetryable(apierror.False)
+}
+
+// NewPlanNotFoundError reports a missing plan row.
+func NewPlanNotFoundError(planID string) apierror.Error {
+	return apierror.New(apierror.NotFound, "plan not found: "+planID).WithRetryable(apierror.False)
+}
+
+// NewOperationNotFoundError reports a missing operation row.
+func NewOperationNotFoundError(key string) apierror.Error {
+	return apierror.New(apierror.NotFound, "operation not found: "+key).WithRetryable(apierror.False)
+}
+
+// NewSpecNotFoundError reports a missing resource spec row.
+func NewSpecNotFoundError(deployID, resourceID string) apierror.Error {
+	return apierror.New(apierror.NotFound, "spec not found: "+deployID+"/"+resourceID).WithRetryable(apierror.False)
+}
+
+// NewInstanceNotFoundError reports a missing resource instance row.
+func NewInstanceNotFoundError(resourceID string) apierror.Error {
+	return apierror.New(apierror.NotFound, "resource instance not found: "+resourceID).WithRetryable(apierror.False)
+}
+
+// NewIllegalTransitionError reports a state transition outside the closed
+// automata; it is a bug, surfaced non-retryable, never silently absorbed.
+func NewIllegalTransitionError(detail string) apierror.Error {
+	return apierror.New(apierror.Invalid, "illegal transition: "+detail).WithRetryable(apierror.False)
+}
+
+// NewCommitFencedError reports a terminal commit rejected by the incarnation
+// or status fence; the caller must re-read and resolve.
+func NewCommitFencedError(opID string) apierror.Error {
+	return apierror.New(apierror.Conflict, "commit fenced out: "+opID).WithRetryable(apierror.False)
+}
+
+// NewResourceBusyError reports a dispatch blocked by the one-active-operation
+// -per-resource invariant (design I7): another operation on the same resource
+// is live, so this dispatch is retryable and waits its turn.
+func NewResourceBusyError(opID string) apierror.Error {
+	return apierror.New(apierror.Conflict, "another operation is active on this resource: "+opID).WithRetryable(apierror.True)
+}

--- a/service/cloudgraph/ledger/schema/embed.go
+++ b/service/cloudgraph/ledger/schema/embed.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package schema embeds the cloud-graph ledger schema bundle.
+package schema
+
+import (
+	"embed"
+
+	schemamanager "github.com/wippyai/runtime/system/schema"
+)
+
+const (
+	// BundleName is the logical schema bundle name recorded in the version table.
+	BundleName = "cloudgraph_ledger"
+	// InitialVersion is the first schema version of the bundle.
+	InitialVersion = "1.0"
+
+	sqliteSchemaPath = "sqlite/cloudgraph/schema.sql"
+)
+
+//go:embed sqlite/cloudgraph/schema.sql
+var assets embed.FS
+
+// SQLiteBundle returns the SQLite schema bundle for the ledger.
+func SQLiteBundle() schemamanager.Bundle {
+	return schemamanager.Bundle{
+		FS:             assets,
+		Name:           BundleName,
+		InitialVersion: InitialVersion,
+		SchemaPath:     sqliteSchemaPath,
+	}
+}

--- a/service/cloudgraph/ledger/schema/sqlite/cloudgraph/schema.sql
+++ b/service/cloudgraph/ledger/schema/sqlite/cloudgraph/schema.sql
@@ -1,0 +1,97 @@
+CREATE TABLE IF NOT EXISTS deploys (
+	id TEXT PRIMARY KEY,
+	scope TEXT NOT NULL,
+	mode TEXT NOT NULL DEFAULT 'full' CHECK (mode IN ('full')),
+	status TEXT NOT NULL CHECK (status IN ('planning','executing','succeeded','failed','partial')),
+	error TEXT,
+	finalized_seq INTEGER,
+	created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_deploys_scope_finalized ON deploys(scope, status, finalized_seq DESC);
+
+CREATE TABLE IF NOT EXISTS resource_specs (
+	deploy_id TEXT NOT NULL REFERENCES deploys(id),
+	resource_id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	provider_type TEXT NOT NULL,
+	desired TEXT NOT NULL,
+	dependencies TEXT NOT NULL DEFAULT '{}',
+	PRIMARY KEY (deploy_id, resource_id)
+);
+
+CREATE TABLE IF NOT EXISTS plans (
+	id TEXT PRIMARY KEY,
+	deploy_id TEXT NOT NULL REFERENCES deploys(id),
+	operations TEXT NOT NULL,
+	edges TEXT NOT NULL,
+	waves TEXT NOT NULL,
+	spec_hash TEXT NOT NULL,
+	created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_plans_deploy ON plans(deploy_id);
+
+CREATE TABLE IF NOT EXISTS operations (
+	id TEXT PRIMARY KEY,
+	deploy_id TEXT NOT NULL REFERENCES deploys(id),
+	resource_id TEXT NOT NULL,
+	action TEXT NOT NULL CHECK (action IN ('create')),
+	status TEXT NOT NULL CHECK (status IN ('planned','dispatched','in_progress','committed','failed')),
+	current_actor_incarnation INTEGER NOT NULL DEFAULT 0,
+	last_signal_seq INTEGER NOT NULL DEFAULT 0,
+	actor_pid TEXT,
+	error TEXT,
+	result TEXT,
+	created_at INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ops_one_active_per_resource
+ON operations(resource_id)
+WHERE status IN ('dispatched','in_progress');
+
+CREATE INDEX IF NOT EXISTS idx_ops_deploy ON operations(deploy_id);
+
+CREATE TABLE IF NOT EXISTS operation_signals (
+	operation_id TEXT NOT NULL REFERENCES operations(id),
+	incarnation INTEGER NOT NULL,
+	seq INTEGER NOT NULL,
+	kind TEXT NOT NULL CHECK (kind IN ('phase','output','checkpoint','failed')),
+	phase TEXT CHECK (phase IS NULL OR phase IN
+		('allocate_started','allocate_committed','configure_started',
+		 'configure_committed','verify_started','verify_passed',
+		 'verify_failed','delete_started','delete_committed')),
+	payload TEXT NOT NULL,
+	fencing_token INTEGER NOT NULL DEFAULT 0,
+	resource_generation INTEGER NOT NULL DEFAULT 0,
+	accepted INTEGER NOT NULL DEFAULT 0,
+	created_at INTEGER NOT NULL,
+	PRIMARY KEY (operation_id, incarnation, seq)
+);
+
+CREATE TABLE IF NOT EXISTS resource_instances (
+	resource_id TEXT PRIMARY KEY,
+	scope TEXT NOT NULL,
+	type TEXT NOT NULL,
+	provider_type TEXT NOT NULL,
+	lifecycle TEXT NOT NULL CHECK (lifecycle IN ('absent','allocating','configuring','verifying','active','deleting','deleted')),
+	generation INTEGER NOT NULL DEFAULT 0,
+	desired TEXT,
+	outputs TEXT,
+	output_epoch INTEGER NOT NULL DEFAULT 0,
+	created_by_deploy TEXT,
+	updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dependency_edges (
+	deploy_id TEXT NOT NULL,
+	source_resource_id TEXT NOT NULL,
+	target_resource_id TEXT NOT NULL,
+	kind TEXT NOT NULL CHECK (kind IN ('create','configure','health','ordering','placement','attachment','ownership','traffic','soft')),
+	PRIMARY KEY (deploy_id, source_resource_id, target_resource_id, kind)
+);
+
+CREATE TABLE IF NOT EXISTS counters (
+	name TEXT PRIMARY KEY,
+	value INTEGER NOT NULL
+);

--- a/service/cloudgraph/ledger/store.go
+++ b/service/cloudgraph/ledger/store.go
@@ -1,0 +1,631 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package ledger is the only cloud-graph package touching SQL. It persists
+// deploys, plans, operations, signals, and instances with fenced writes
+// (docs/design/cloud-graph.md §10, PoC subset).
+package ledger
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/wippyai/runtime/service/cloudgraph/ledger/schema"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+	schemamanager "github.com/wippyai/runtime/system/schema"
+	"go.uber.org/zap"
+)
+
+// Store persists cloud-graph state on a SQLite database.
+type Store struct {
+	db  *sql.DB
+	log *zap.Logger
+}
+
+// PlanRecord is one persisted plan row; the JSON columns hold ordered arrays
+// produced by the planner (design §8.3).
+type PlanRecord struct {
+	ID         string          `json:"id"`
+	DeployID   string          `json:"deploy_id"`
+	SpecHash   string          `json:"spec_hash"`
+	Operations json.RawMessage `json:"operations"`
+	Edges      json.RawMessage `json:"edges"`
+	Waves      json.RawMessage `json:"waves"`
+}
+
+// NewStore creates a ledger store on the given database handle.
+func NewStore(db *sql.DB, log *zap.Logger) *Store {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &Store{db: db, log: log}
+}
+
+// Migrate applies the ledger schema bundle.
+func (s *Store) Migrate(ctx context.Context) error {
+	manager, err := schemamanager.NewManager(schema.SQLiteBundle(), schemamanager.Target{
+		DB:          s.db,
+		Dialect:     schemamanager.DialectSQLite,
+		LogicalName: schema.BundleName,
+	})
+	if err != nil {
+		return err
+	}
+	return manager.Setup(ctx)
+}
+
+// CreateDeploy idempotently records a deploy and its specs. It reports whether
+// this call created the deploy; a repeated deploy_id is not an error
+// (design §6.1: Submit is idempotent on DeployID).
+func (s *Store) CreateDeploy(ctx context.Context, in resource.DeployInput) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		"INSERT OR IGNORE INTO deploys (id, scope, status, created_at) VALUES (?, ?, ?, ?)",
+		in.DeployID, in.Scope, string(resource.DeployPlanning), now())
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if rows == 0 {
+		return false, tx.Commit()
+	}
+
+	for _, spec := range in.Specs {
+		deps, err := json.Marshal(spec.Dependencies)
+		if err != nil {
+			return false, err
+		}
+		desired := spec.Desired
+		if desired == nil {
+			desired = json.RawMessage("{}")
+		}
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO resource_specs (deploy_id, resource_id, type, provider_type, desired, dependencies) VALUES (?, ?, ?, ?, ?, ?)",
+			in.DeployID, spec.ResourceID, spec.Type, spec.ProviderType, string(desired), string(deps)); err != nil {
+			return false, err
+		}
+	}
+
+	return true, tx.Commit()
+}
+
+// GetDeploy loads one deploy record.
+func (s *Store) GetDeploy(ctx context.Context, deployID string) (*resource.DeployRecord, error) {
+	var rec resource.DeployRecord
+	var errMsg sql.NullString
+	var seq sql.NullInt64
+	err := s.db.QueryRowContext(ctx,
+		"SELECT id, scope, status, error, finalized_seq FROM deploys WHERE id = ?", deployID).
+		Scan(&rec.DeployID, &rec.Scope, &rec.Status, &errMsg, &seq)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, NewDeployNotFoundError(deployID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	rec.Error = errMsg.String
+	rec.FinalizedSeq = seq.Int64
+	return &rec, nil
+}
+
+// SetDeployStatus performs a fenced status transition.
+func (s *Store) SetDeployStatus(ctx context.Context, deployID string, from, to resource.DeployStatus) error {
+	res, err := s.db.ExecContext(ctx,
+		"UPDATE deploys SET status = ? WHERE id = ? AND status = ?",
+		string(to), deployID, string(from))
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		cur, err := s.GetDeploy(ctx, deployID)
+		if err != nil {
+			return err
+		}
+		if cur.Status == to {
+			return nil
+		}
+		return NewIllegalTransitionError(fmt.Sprintf("deploy %s: %s -> %s (current %s)", deployID, from, to, cur.Status))
+	}
+	return nil
+}
+
+// LoadSpecs loads the declared specs of a deploy ordered by resource_id.
+func (s *Store) LoadSpecs(ctx context.Context, deployID string) ([]resource.Spec, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT resource_id, type, provider_type, desired, dependencies FROM resource_specs WHERE deploy_id = ? ORDER BY resource_id",
+		deployID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var specs []resource.Spec
+	for rows.Next() {
+		var spec resource.Spec
+		var desired, deps string
+		if err := rows.Scan(&spec.ResourceID, &spec.Type, &spec.ProviderType, &desired, &deps); err != nil {
+			return nil, err
+		}
+		spec.Desired = json.RawMessage(desired)
+		if err := json.Unmarshal([]byte(deps), &spec.Dependencies); err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
+	}
+	return specs, rows.Err()
+}
+
+// GetSpec loads one declared spec.
+func (s *Store) GetSpec(ctx context.Context, deployID, resourceID string) (*resource.Spec, error) {
+	var spec resource.Spec
+	var desired, deps string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT resource_id, type, provider_type, desired, dependencies FROM resource_specs WHERE deploy_id = ? AND resource_id = ?",
+		deployID, resourceID).
+		Scan(&spec.ResourceID, &spec.Type, &spec.ProviderType, &desired, &deps)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, NewSpecNotFoundError(deployID, resourceID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	spec.Desired = json.RawMessage(desired)
+	if err := json.Unmarshal([]byte(deps), &spec.Dependencies); err != nil {
+		return nil, err
+	}
+	return &spec, nil
+}
+
+// SavePlan idempotently persists a plan with its operations and edges.
+// Identifiers are deterministic, so an activity retry re-inserts identical
+// rows and OR IGNORE keeps the write replay-safe.
+func (s *Store) SavePlan(ctx context.Context, plan *PlanRecord, ops []resource.Operation, edges []resource.Edge) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	ts := now()
+	if _, err := tx.ExecContext(ctx,
+		"INSERT OR IGNORE INTO plans (id, deploy_id, operations, edges, waves, spec_hash, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		plan.ID, plan.DeployID, string(plan.Operations), string(plan.Edges), string(plan.Waves), plan.SpecHash, ts); err != nil {
+		return err
+	}
+
+	for _, op := range ops {
+		if _, err := tx.ExecContext(ctx,
+			"INSERT OR IGNORE INTO operations (id, deploy_id, resource_id, action, status, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			op.ID, op.DeployID, op.ResourceID, string(op.Action), string(resource.OpPlanned), ts); err != nil {
+			return err
+		}
+	}
+
+	for _, edge := range edges {
+		if _, err := tx.ExecContext(ctx,
+			"INSERT OR IGNORE INTO dependency_edges (deploy_id, source_resource_id, target_resource_id, kind) VALUES (?, ?, ?, ?)",
+			plan.DeployID, edge.SourceResourceID, edge.TargetResourceID, string(edge.Kind)); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetPlan loads one plan row.
+func (s *Store) GetPlan(ctx context.Context, planID string) (*PlanRecord, error) {
+	var rec PlanRecord
+	var operations, edges, waves string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT id, deploy_id, operations, edges, waves, spec_hash FROM plans WHERE id = ?", planID).
+		Scan(&rec.ID, &rec.DeployID, &operations, &edges, &waves, &rec.SpecHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, NewPlanNotFoundError(planID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	rec.Operations = json.RawMessage(operations)
+	rec.Edges = json.RawMessage(edges)
+	rec.Waves = json.RawMessage(waves)
+	return &rec, nil
+}
+
+// GetOperation loads one operation row.
+func (s *Store) GetOperation(ctx context.Context, opID string) (*resource.Operation, error) {
+	return scanOperation(s.db.QueryRowContext(ctx,
+		"SELECT id, deploy_id, resource_id, action, status, current_actor_incarnation, last_signal_seq, actor_pid, error, result FROM operations WHERE id = ?",
+		opID), opID)
+}
+
+// GetOperationByResource loads the operation of a resource within a deploy.
+func (s *Store) GetOperationByResource(ctx context.Context, deployID, resourceID string) (*resource.Operation, error) {
+	return scanOperation(s.db.QueryRowContext(ctx,
+		"SELECT id, deploy_id, resource_id, action, status, current_actor_incarnation, last_signal_seq, actor_pid, error, result FROM operations WHERE deploy_id = ? AND resource_id = ?",
+		deployID, resourceID), deployID+"/"+resourceID)
+}
+
+func scanOperation(row *sql.Row, key string) (*resource.Operation, error) {
+	var op resource.Operation
+	var actorPID, errMsg, result sql.NullString
+	err := row.Scan(&op.ID, &op.DeployID, &op.ResourceID, &op.Action, &op.Status,
+		&op.Incarnation, &op.LastSignal, &actorPID, &errMsg, &result)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, NewOperationNotFoundError(key)
+	}
+	if err != nil {
+		return nil, err
+	}
+	op.ActorPID = actorPID.String
+	op.Error = errMsg.String
+	if result.Valid {
+		op.Result = json.RawMessage(result.String)
+	}
+	return &op, nil
+}
+
+// BumpIncarnation installs a newer actor incarnation via CAS, resetting the
+// signal sequence and moving a planned operation to dispatched. A false
+// return means a newer incarnation exists or the operation is terminal; the
+// caller must exit (design §9.4 step 2).
+func (s *Store) BumpIncarnation(ctx context.Context, opID string, incarnation int64) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE operations
+		 SET current_actor_incarnation = ?, last_signal_seq = 0, actor_pid = NULL,
+		     status = CASE WHEN status = 'planned' THEN 'dispatched' ELSE status END
+		 WHERE id = ? AND current_actor_incarnation < ? AND status IN ('planned','dispatched','in_progress')`,
+		incarnation, opID, incarnation)
+	if err != nil {
+		var sqliteErr sqlite3.Error
+		if errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+			return false, NewResourceBusyError(opID)
+		}
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
+// SetActorPID records the live actor PID under the incarnation fence.
+func (s *Store) SetActorPID(ctx context.Context, opID string, incarnation int64, pidStr string) error {
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE operations SET actor_pid = ? WHERE id = ? AND current_actor_incarnation = ?",
+		pidStr, opID, incarnation)
+	return err
+}
+
+// AppendSignal appends a provider signal to the durable mailbox. The write is
+// one transaction enforcing the acceptance conditions: incarnation must match
+// the operation row, seq must be exactly last_signal_seq+1, and the operation
+// must be live. A zero-row CAS rolls back and reports not-accepted
+// (design §10.2, conditions C3/C4).
+func (s *Store) AppendSignal(ctx context.Context, sig resource.Signal) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE operations SET last_signal_seq = last_signal_seq + 1
+		 WHERE id = ? AND current_actor_incarnation = ? AND last_signal_seq = ? AND status IN ('dispatched','in_progress')`,
+		sig.OperationID, sig.Incarnation, sig.Seq-1)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if rows == 0 {
+		return false, nil
+	}
+
+	payload := sig.Payload
+	if payload == nil {
+		payload = json.RawMessage("{}")
+	}
+	var phase any
+	if sig.Phase != "" {
+		phase = string(sig.Phase)
+	}
+	if _, err := tx.ExecContext(ctx,
+		"INSERT INTO operation_signals (operation_id, incarnation, seq, kind, phase, payload, accepted, created_at) VALUES (?, ?, ?, ?, ?, ?, 1, ?)",
+		sig.OperationID, sig.Incarnation, sig.Seq, string(sig.Kind), phase, string(payload), now()); err != nil {
+		return false, err
+	}
+
+	return true, tx.Commit()
+}
+
+// ListSignals loads the accepted signals of one operation incarnation in
+// sequence order (recovery replay, design §9.4 step 4).
+func (s *Store) ListSignals(ctx context.Context, opID string, incarnation int64) ([]resource.Signal, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT seq, kind, phase, payload FROM operation_signals WHERE operation_id = ? AND incarnation = ? AND accepted = 1 ORDER BY seq",
+		opID, incarnation)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var signals []resource.Signal
+	for rows.Next() {
+		sig := resource.Signal{OperationID: opID, Incarnation: incarnation}
+		var phase sql.NullString
+		var payload string
+		if err := rows.Scan(&sig.Seq, &sig.Kind, &phase, &payload); err != nil {
+			return nil, err
+		}
+		sig.Phase = resource.SignalPhaseName(phase.String)
+		sig.Payload = json.RawMessage(payload)
+		signals = append(signals, sig)
+	}
+	return signals, rows.Err()
+}
+
+// GetLatestCheckpoint returns the payload of the newest accepted checkpoint
+// or output signal across all incarnations, or nil when none exists
+// (recovery input, design §9.4 step 4).
+func (s *Store) GetLatestCheckpoint(ctx context.Context, opID string) (json.RawMessage, error) {
+	var payload string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT payload FROM operation_signals WHERE operation_id = ? AND accepted = 1 AND kind IN ('checkpoint','output') ORDER BY incarnation DESC, seq DESC LIMIT 1",
+		opID).Scan(&payload)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(payload), nil
+}
+
+// MarkInProgress moves a dispatched operation to in_progress under the
+// incarnation fence. Already in_progress is not an error.
+func (s *Store) MarkInProgress(ctx context.Context, opID string, incarnation int64) error {
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE operations SET status = 'in_progress' WHERE id = ? AND current_actor_incarnation = ? AND status = 'dispatched'",
+		opID, incarnation)
+	return err
+}
+
+// CommitOperation is the atomic terminal commit: operation status, result,
+// and the resource instance (lifecycle active, bumped generation, published
+// outputs) change in one transaction (design I10, I11 subset).
+func (s *Store) CommitOperation(ctx context.Context, op *resource.Operation, spec *resource.Spec, scope string, outputs, result json.RawMessage) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if outputs == nil {
+		outputs = json.RawMessage("{}")
+	}
+	if result == nil {
+		result = json.RawMessage("{}")
+	}
+
+	res, err := tx.ExecContext(ctx,
+		"UPDATE operations SET status = 'committed', result = ? WHERE id = ? AND current_actor_incarnation = ? AND status IN ('dispatched','in_progress')",
+		string(result), op.ID, op.Incarnation)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return NewCommitFencedError(op.ID)
+	}
+
+	desired := spec.Desired
+	if desired == nil {
+		desired = json.RawMessage("{}")
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO resource_instances (resource_id, scope, type, provider_type, lifecycle, generation, desired, outputs, output_epoch, created_by_deploy, updated_at)
+		 VALUES (?, ?, ?, ?, 'active', 1, ?, ?, 1, ?, ?)
+		 ON CONFLICT(resource_id) DO UPDATE SET
+		     lifecycle = 'active',
+		     generation = generation + 1,
+		     desired = excluded.desired,
+		     outputs = excluded.outputs,
+		     output_epoch = output_epoch + 1,
+		     updated_at = excluded.updated_at`,
+		spec.ResourceID, scope, spec.Type, spec.ProviderType, string(desired), string(outputs), op.DeployID, now()); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// Terminalize is the single terminal-transition primitive for failure exits
+// (design §9.8): it moves an operation to a terminal status only from the
+// given guard set, under the incarnation fence.
+func (s *Store) Terminalize(ctx context.Context, opID string, incarnation int64, from []resource.OperationStatus, to resource.OperationStatus, errMsg string) (bool, error) {
+	if len(from) == 0 {
+		return false, NewIllegalTransitionError("terminalize requires a guard set")
+	}
+
+	guard := make([]string, len(from))
+	for i, st := range from {
+		guard[i] = string(st)
+	}
+
+	query, args, err := sq.Update("operations").
+		Set("status", string(to)).
+		Set("error", errMsg).
+		Where(sq.Eq{"id": opID, "current_actor_incarnation": incarnation, "status": guard}).
+		ToSql()
+	if err != nil {
+		return false, err
+	}
+
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
+// GetInstance loads one resource instance.
+func (s *Store) GetInstance(ctx context.Context, resourceID string) (*resource.Instance, error) {
+	var inst resource.Instance
+	var desired, outputs sql.NullString
+	err := s.db.QueryRowContext(ctx,
+		"SELECT resource_id, scope, type, provider_type, lifecycle, generation, desired, outputs, output_epoch FROM resource_instances WHERE resource_id = ?",
+		resourceID).
+		Scan(&inst.ResourceID, &inst.Scope, &inst.Type, &inst.ProviderType, &inst.Lifecycle,
+			&inst.Generation, &desired, &outputs, &inst.OutputEpoch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, NewInstanceNotFoundError(resourceID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if outputs.Valid {
+		inst.Outputs = json.RawMessage(outputs.String)
+	}
+	return &inst, nil
+}
+
+// ListEdgesFrom loads the outbound dependency edges of a resource within a
+// deploy, ordered deterministically.
+func (s *Store) ListEdgesFrom(ctx context.Context, deployID, sourceResourceID string) ([]resource.Edge, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT source_resource_id, target_resource_id, kind FROM dependency_edges WHERE deploy_id = ? AND source_resource_id = ? ORDER BY target_resource_id, kind",
+		deployID, sourceResourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var edges []resource.Edge
+	for rows.Next() {
+		var edge resource.Edge
+		if err := rows.Scan(&edge.SourceResourceID, &edge.TargetResourceID, &edge.Kind); err != nil {
+			return nil, err
+		}
+		edges = append(edges, edge)
+	}
+	return edges, rows.Err()
+}
+
+// ListOperations loads all operations of a deploy ordered by id.
+func (s *Store) ListOperations(ctx context.Context, deployID string) ([]resource.Operation, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT id, deploy_id, resource_id, action, status, current_actor_incarnation, last_signal_seq, actor_pid, error, result FROM operations WHERE deploy_id = ? ORDER BY id",
+		deployID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ops []resource.Operation
+	for rows.Next() {
+		var op resource.Operation
+		var actorPID, errMsg, result sql.NullString
+		if err := rows.Scan(&op.ID, &op.DeployID, &op.ResourceID, &op.Action, &op.Status,
+			&op.Incarnation, &op.LastSignal, &actorPID, &errMsg, &result); err != nil {
+			return nil, err
+		}
+		op.ActorPID = actorPID.String
+		op.Error = errMsg.String
+		if result.Valid {
+			op.Result = json.RawMessage(result.String)
+		}
+		ops = append(ops, op)
+	}
+	return ops, rows.Err()
+}
+
+// FinalizeDeploy assigns finalized_seq exactly once from the monotonic
+// counter and moves the deploy to its terminal status in one transaction
+// (design I12 subset). A repeat call returns the persisted result.
+func (s *Store) FinalizeDeploy(ctx context.Context, deployID string, status resource.DeployStatus, errMsg string) (int64, error) {
+	if !status.Terminal() {
+		return 0, NewIllegalTransitionError(fmt.Sprintf("finalize to non-terminal status %s", status))
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		"INSERT OR IGNORE INTO counters (name, value) VALUES ('deploys_finalized_seq', 0)"); err != nil {
+		return 0, err
+	}
+
+	var seq int64
+	if err := tx.QueryRowContext(ctx,
+		"UPDATE counters SET value = value + 1 WHERE name = 'deploys_finalized_seq' RETURNING value").
+		Scan(&seq); err != nil {
+		return 0, err
+	}
+
+	res, err := tx.ExecContext(ctx,
+		"UPDATE deploys SET status = ?, error = ?, finalized_seq = ? WHERE id = ? AND finalized_seq IS NULL AND status IN ('planning','executing')",
+		string(status), errMsg, seq, deployID)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if rows == 0 {
+		// Re-read through the open transaction: the pool runs SQLite with a
+		// single connection, so a second s.db query here would self-deadlock.
+		var current string
+		var existingSeq sql.NullInt64
+		err := tx.QueryRowContext(ctx,
+			"SELECT status, finalized_seq FROM deploys WHERE id = ?", deployID).
+			Scan(&current, &existingSeq)
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, NewDeployNotFoundError(deployID)
+		}
+		if err != nil {
+			return 0, err
+		}
+		if resource.DeployStatus(current).Terminal() {
+			return existingSeq.Int64, nil
+		}
+		return 0, NewIllegalTransitionError(fmt.Sprintf("deploy %s cannot finalize from %s", deployID, current))
+	}
+
+	return seq, tx.Commit()
+}
+
+func now() int64 {
+	return time.Now().Unix()
+}

--- a/service/cloudgraph/ledger/store_test.go
+++ b/service/cloudgraph/ledger/store_test.go
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package ledger
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+t.TempDir()+"/ledger.db?_busy_timeout=5000&_journal_mode=WAL")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Mirror the production db.sql.sqlite pool: a single connection, so any
+	// query nested inside an open transaction self-deadlocks in tests too.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	store := NewStore(db, nil)
+	require.NoError(t, store.Migrate(context.Background()))
+	return store
+}
+
+func seedOperation(t *testing.T, store *Store, deployID, resourceID string) *resource.Operation {
+	t.Helper()
+	ctx := context.Background()
+
+	created, err := store.CreateDeploy(ctx, resource.DeployInput{
+		DeployID: deployID,
+		Scope:    "test",
+		Specs: []resource.Spec{{
+			ResourceID:   resourceID,
+			Type:         "container",
+			ProviderType: "docker",
+			Desired:      json.RawMessage(`{"image":"nginx"}`),
+		}},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	opID := deployID + "/" + resourceID
+	err = store.SavePlan(ctx, &PlanRecord{
+		ID:         "plan/" + deployID,
+		DeployID:   deployID,
+		Operations: json.RawMessage(`[]`),
+		Edges:      json.RawMessage(`[]`),
+		Waves:      json.RawMessage(`[]`),
+		SpecHash:   "hash",
+	}, []resource.Operation{{
+		ID:         opID,
+		DeployID:   deployID,
+		ResourceID: resourceID,
+		Action:     resource.ActionCreate,
+	}}, nil)
+	require.NoError(t, err)
+
+	op, err := store.GetOperation(ctx, opID)
+	require.NoError(t, err)
+	return op
+}
+
+func TestMigrateIdempotent(t *testing.T) {
+	store := newTestStore(t)
+	require.NoError(t, store.Migrate(context.Background()))
+}
+
+func TestCreateDeployIdempotent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	in := resource.DeployInput{
+		DeployID: "d1",
+		Scope:    "test",
+		Specs: []resource.Spec{{
+			ResourceID:   "test/app",
+			Type:         "container",
+			ProviderType: "docker",
+		}},
+	}
+
+	created, err := store.CreateDeploy(ctx, in)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	created, err = store.CreateDeploy(ctx, in)
+	require.NoError(t, err)
+	require.False(t, created)
+
+	rec, err := store.GetDeploy(ctx, "d1")
+	require.NoError(t, err)
+	require.Equal(t, resource.DeployPlanning, rec.Status)
+
+	specs, err := store.LoadSpecs(ctx, "d1")
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+}
+
+func TestBumpIncarnationCAS(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	op := seedOperation(t, store, "d1", "test/app")
+
+	ok, err := store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.False(t, ok, "equal incarnation must lose the CAS")
+
+	ok, err = store.BumpIncarnation(ctx, op.ID, 2)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.False(t, ok, "older incarnation must lose the CAS")
+
+	cur, err := store.GetOperation(ctx, op.ID)
+	require.NoError(t, err)
+	require.Equal(t, resource.OpDispatched, cur.Status)
+	require.EqualValues(t, 2, cur.Incarnation)
+	require.EqualValues(t, 0, cur.LastSignal)
+}
+
+func TestBumpIncarnationResourceBusyAcrossDeploys(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	first := seedOperation(t, store, "d1", "test/app")
+	second := seedOperation(t, store, "d2", "test/app")
+
+	ok, err := store.BumpIncarnation(ctx, first.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_, err = store.BumpIncarnation(ctx, second.ID, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "another operation is active", "I7 violation must surface as resource-busy")
+
+	done, err := store.Terminalize(ctx, first.ID, 1,
+		[]resource.OperationStatus{resource.OpDispatched}, resource.OpFailed, "boom")
+	require.NoError(t, err)
+	require.True(t, done)
+
+	ok, err = store.BumpIncarnation(ctx, second.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok, "dispatch must proceed once the resource is free")
+}
+
+func TestAppendSignalContiguity(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	op := seedOperation(t, store, "d1", "test/app")
+
+	ok, err := store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	accepted, err := store.AppendSignal(ctx, resource.Signal{
+		OperationID: op.ID, Incarnation: 1, Seq: 2,
+		Kind: resource.SignalPhase, Phase: resource.PhaseAllocateStarted,
+	})
+	require.NoError(t, err)
+	require.False(t, accepted, "seq gap must be rejected")
+
+	accepted, err = store.AppendSignal(ctx, resource.Signal{
+		OperationID: op.ID, Incarnation: 1, Seq: 1,
+		Kind: resource.SignalPhase, Phase: resource.PhaseAllocateStarted,
+	})
+	require.NoError(t, err)
+	require.True(t, accepted)
+
+	accepted, err = store.AppendSignal(ctx, resource.Signal{
+		OperationID: op.ID, Incarnation: 1, Seq: 1,
+		Kind: resource.SignalPhase, Phase: resource.PhaseAllocateCommitted,
+	})
+	require.NoError(t, err)
+	require.False(t, accepted, "duplicate seq must be rejected")
+
+	accepted, err = store.AppendSignal(ctx, resource.Signal{
+		OperationID: op.ID, Incarnation: 2, Seq: 2,
+		Kind: resource.SignalPhase, Phase: resource.PhaseAllocateCommitted,
+	})
+	require.NoError(t, err)
+	require.False(t, accepted, "stale incarnation must be rejected")
+
+	signals, err := store.ListSignals(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.Len(t, signals, 1)
+	require.Equal(t, resource.PhaseAllocateStarted, signals[0].Phase)
+}
+
+func TestAppendSignalConcurrentWriters(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	op := seedOperation(t, store, "d1", "test/app")
+
+	ok, err := store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	const writers = 8
+	const attempts = 32
+
+	var wg sync.WaitGroup
+	acceptedCount := make([]int, writers)
+	for w := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for seq := int64(1); seq <= attempts; seq++ {
+				accepted, err := store.AppendSignal(ctx, resource.Signal{
+					OperationID: op.ID, Incarnation: 1, Seq: seq,
+					Kind:    resource.SignalCheckpoint,
+					Payload: json.RawMessage(fmt.Sprintf(`{"writer":%d}`, w)),
+				})
+				require.NoError(t, err)
+				if accepted {
+					acceptedCount[w]++
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	total := 0
+	for _, c := range acceptedCount {
+		total += c
+	}
+	require.Equal(t, attempts, total, "each seq must be accepted exactly once across writers")
+
+	signals, err := store.ListSignals(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.Len(t, signals, attempts)
+	for i, sig := range signals {
+		require.EqualValues(t, i+1, sig.Seq, "accepted signals must be contiguous")
+	}
+}
+
+func TestCommitOperation(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	op := seedOperation(t, store, "d1", "test/app")
+
+	ok, err := store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	op.Incarnation = 1
+
+	spec, err := store.GetSpec(ctx, "d1", "test/app")
+	require.NoError(t, err)
+
+	outputs := json.RawMessage(`{"container_id":"abc"}`)
+	require.NoError(t, store.CommitOperation(ctx, op, spec, "test", outputs, nil))
+
+	inst, err := store.GetInstance(ctx, "test/app")
+	require.NoError(t, err)
+	require.Equal(t, "active", inst.Lifecycle)
+	require.EqualValues(t, 1, inst.Generation)
+	require.JSONEq(t, string(outputs), string(inst.Outputs))
+
+	err = store.CommitOperation(ctx, op, spec, "test", outputs, nil)
+	require.Error(t, err, "double commit must be fenced")
+}
+
+func TestTerminalizeGuards(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	op := seedOperation(t, store, "d1", "test/app")
+
+	ok, err := store.BumpIncarnation(ctx, op.ID, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	done, err := store.Terminalize(ctx, op.ID, 1,
+		[]resource.OperationStatus{resource.OpPlanned}, resource.OpFailed, "boom")
+	require.NoError(t, err)
+	require.False(t, done, "guard set mismatch must not terminalize")
+
+	done, err = store.Terminalize(ctx, op.ID, 2,
+		[]resource.OperationStatus{resource.OpDispatched}, resource.OpFailed, "boom")
+	require.NoError(t, err)
+	require.False(t, done, "incarnation mismatch must not terminalize")
+
+	done, err = store.Terminalize(ctx, op.ID, 1,
+		[]resource.OperationStatus{resource.OpDispatched, resource.OpInProgress}, resource.OpFailed, "boom")
+	require.NoError(t, err)
+	require.True(t, done)
+
+	cur, err := store.GetOperation(ctx, op.ID)
+	require.NoError(t, err)
+	require.Equal(t, resource.OpFailed, cur.Status)
+	require.Equal(t, "boom", cur.Error)
+}
+
+func TestFinalizeDeploy(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedOperation(t, store, "d1", "test/app")
+	seedOperation(t, store, "d2", "test/other")
+
+	seq1, err := store.FinalizeDeploy(ctx, "d1", resource.DeploySucceeded, "")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, seq1)
+
+	again, err := store.FinalizeDeploy(ctx, "d1", resource.DeploySucceeded, "")
+	require.NoError(t, err)
+	require.Equal(t, seq1, again, "repeat finalize must return the persisted seq")
+
+	seq2, err := store.FinalizeDeploy(ctx, "d2", resource.DeployFailed, "boom")
+	require.NoError(t, err)
+	require.Greater(t, seq2, seq1, "finalized_seq must be strictly increasing")
+
+	_, err = store.FinalizeDeploy(ctx, "d1", resource.DeployPlanning, "")
+	require.Error(t, err, "non-terminal finalize must be rejected")
+}

--- a/service/cloudgraph/manager.go
+++ b/service/cloudgraph/manager.go
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudgraph
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/function"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/resource"
+	apiruntime "github.com/wippyai/runtime/api/runtime"
+	cgapi "github.com/wippyai/runtime/api/service/cloudgraph"
+	temporalapi "github.com/wippyai/runtime/api/service/temporal"
+	topapi "github.com/wippyai/runtime/api/topology"
+	"github.com/wippyai/runtime/service/cloudgraph/attempt"
+	"github.com/wippyai/runtime/service/cloudgraph/binding"
+	"github.com/wippyai/runtime/service/cloudgraph/ledger"
+	"github.com/wippyai/runtime/service/cloudgraph/plan"
+	cgresource "github.com/wippyai/runtime/service/cloudgraph/resource"
+	cgworkflow "github.com/wippyai/runtime/service/cloudgraph/workflow"
+	servicesql "github.com/wippyai/runtime/service/sql"
+	"github.com/wippyai/runtime/system/entry"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+)
+
+// Function-registry IDs of the engine's Go handlers. One engine per
+// installation (design §1: one engine instance owns one shard).
+const (
+	FuncSubmitIntent     = "wippy.cloudgraph:submit_intent"
+	FuncGetDeploy        = "wippy.cloudgraph:get_deploy"
+	FuncComputePlan      = "wippy.cloudgraph:cg_compute_plan"
+	FuncExecuteOperation = "wippy.cloudgraph:cg_execute_operation"
+	FuncFinalizeDeploy   = "wippy.cloudgraph:cg_finalize_deploy"
+)
+
+// Manager handles cloudgraph.engine and cloudgraph.provider entries.
+type Manager struct {
+	log       *zap.Logger
+	bus       event.Bus
+	dtt       payload.Transcoder
+	pidGen    process.PIDGenerator
+	node      relay.Node
+	topo      topapi.Topology
+	procs     process.Manager
+	registrar temporalapi.WorkerRegistrar
+	providers *binding.Registry
+	engine    *engineRuntime
+	mu        sync.Mutex
+}
+
+// engineRuntime is the state built when the cloudgraph.engine entry loads.
+type engineRuntime struct {
+	cfg       *cgapi.EngineConfig
+	store     *ledger.Store
+	releaseDB func()
+}
+
+// NewManager creates the cloud-graph manager.
+func NewManager(
+	log *zap.Logger,
+	bus event.Bus,
+	dtt payload.Transcoder,
+	pidGen process.PIDGenerator,
+	node relay.Node,
+	topo topapi.Topology,
+	procs process.Manager,
+	registrar temporalapi.WorkerRegistrar,
+) *Manager {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &Manager{
+		log:       log,
+		bus:       bus,
+		dtt:       dtt,
+		pidGen:    pidGen,
+		node:      node,
+		topo:      topo,
+		procs:     procs,
+		registrar: registrar,
+		providers: binding.NewRegistry(),
+	}
+}
+
+// Add implements registry.EntryListener.
+func (m *Manager) Add(ctx context.Context, ent registry.Entry) error {
+	switch ent.Kind {
+	case cgapi.Provider:
+		return m.addProvider(ctx, ent)
+	case cgapi.Engine:
+		return m.addEngine(ctx, ent)
+	default:
+		return nil
+	}
+}
+
+// Update implements registry.EntryListener. Manifests and the engine are
+// immutable for the process lifetime (design I20).
+func (m *Manager) Update(_ context.Context, ent registry.Entry) error {
+	m.log.Warn("cloudgraph entries are immutable at runtime; update ignored",
+		zap.String("id", ent.ID.String()))
+	return nil
+}
+
+// Delete implements registry.EntryListener.
+func (m *Manager) Delete(_ context.Context, ent registry.Entry) error {
+	if ent.Kind != cgapi.Engine {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.engine != nil && m.engine.releaseDB != nil {
+		m.engine.releaseDB()
+	}
+	m.engine = nil
+	return nil
+}
+
+func (m *Manager) addProvider(ctx context.Context, ent registry.Entry) error {
+	cfg, err := entry.DecodeEntryConfig[cgapi.ProviderConfig](ctx, m.dtt, ent)
+	if err != nil {
+		return err
+	}
+	if err := m.providers.Register(cfg); err != nil {
+		return err
+	}
+	m.log.Info("provider manifest registered",
+		zap.String("provider_type", cfg.ProviderType),
+		zap.String("actor", cfg.ActorProcess.String()))
+	return nil
+}
+
+func (m *Manager) addEngine(ctx context.Context, ent registry.Entry) error {
+	cfg, err := entry.DecodeEntryConfig[cgapi.EngineConfig](ctx, m.dtt, ent)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.engine != nil {
+		return NewEngineConflictError(ent.ID.String())
+	}
+
+	reg := resource.GetRegistry(ctx)
+	if reg == nil {
+		return ErrResourceRegistryMissing
+	}
+	res, err := reg.Acquire(ctx, cfg.Database, resource.ModeNormal)
+	if err != nil {
+		return err
+	}
+	conn, err := res.Get()
+	if err != nil {
+		res.Release()
+		return err
+	}
+	dbRes, ok := conn.(servicesql.DBResource)
+	if !ok {
+		res.Release()
+		return ErrInvalidDatabaseResource
+	}
+
+	store := ledger.NewStore(dbRes.DB, m.log.Named("ledger"))
+	if err := store.Migrate(ctx); err != nil {
+		res.Release()
+		return err
+	}
+
+	executor := attempt.NewExecutor(attempt.Deps{
+		Log:        m.log.Named("executor"),
+		PIDGen:     m.pidGen,
+		Node:       m.node,
+		Topo:       m.topo,
+		Procs:      m.procs,
+		Transcoder: m.dtt,
+		Store:      store,
+		Providers:  m.providers,
+		HostID:     cfg.Host.String(),
+	})
+
+	activities := &cgworkflow.Activities{
+		Store:      store,
+		Executor:   executor,
+		Transcoder: m.dtt,
+		Log:        m.log.Named("activities"),
+	}
+
+	m.publishFunc(ctx, FuncSubmitIntent, m.submitIntent)
+	m.publishFunc(ctx, FuncGetDeploy, m.getDeploy)
+	m.publishFunc(ctx, FuncComputePlan, activities.ComputePlan)
+	m.publishFunc(ctx, FuncExecuteOperation, activities.ExecuteOperation)
+	m.publishFunc(ctx, FuncFinalizeDeploy, activities.FinalizeDeploy)
+
+	pairs := []struct {
+		name   string
+		funcID string
+	}{
+		{cgworkflow.ActivityComputePlan, FuncComputePlan},
+		{cgworkflow.ActivityExecuteOperation, FuncExecuteOperation},
+		{cgworkflow.ActivityFinalizeDeploy, FuncFinalizeDeploy},
+	}
+	for _, pair := range pairs {
+		if err := m.registrar.RegisterActivity(ctx, cfg.Worker, pair.name, registry.ParseID(pair.funcID)); err != nil {
+			res.Release()
+			return err
+		}
+	}
+	if err := m.registrar.RegisterWorkflow(ctx, cfg.Worker, cfg.WorkflowName, cgworkflow.Deploy); err != nil {
+		res.Release()
+		return err
+	}
+
+	m.engine = &engineRuntime{cfg: cfg, store: store, releaseDB: res.Release}
+	m.log.Info("cloudgraph engine ready",
+		zap.String("id", ent.ID.String()),
+		zap.String("shard", cfg.Shard),
+		zap.String("worker", cfg.Worker.String()))
+	return nil
+}
+
+func (m *Manager) publishFunc(ctx context.Context, id string, handler function.Func) {
+	m.bus.Send(ctx, event.Event{
+		System: function.System,
+		Kind:   function.FunctionRegister,
+		Path:   id,
+		Data:   &function.FuncEntry{Handler: handler},
+	})
+}
+
+func (m *Manager) runtime() (*engineRuntime, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.engine == nil {
+		return nil, ErrEngineNotReady
+	}
+	return m.engine, nil
+}
+
+// submitIntent is the deploy intake: idempotent persist, then start the
+// Temporal deploy workflow with the deploy-scoped workflow ID (design §6.1).
+func (m *Manager) submitIntent(ctx context.Context, task apiruntime.Task) (*apiruntime.Result, error) {
+	eng, err := m.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if len(task.Payloads) == 0 {
+		return nil, NewInvalidDeployInputError("missing deploy input")
+	}
+
+	var in cgresource.DeployInput
+	if err := m.dtt.Unmarshal(task.Payloads[0], &in); err != nil {
+		return nil, NewInvalidDeployInputError(err.Error())
+	}
+	if in.DeployID == "" || in.Scope == "" || len(in.Specs) == 0 {
+		return nil, NewInvalidDeployInputError("deploy_id, scope, and specs are required")
+	}
+	for _, spec := range in.Specs {
+		if _, err := m.providers.Provider(spec.ProviderType); err != nil {
+			return nil, err
+		}
+	}
+
+	created, err := eng.store.CreateDeploy(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if !created {
+		existing, err := eng.store.LoadSpecs(ctx, in.DeployID)
+		if err != nil {
+			return nil, err
+		}
+		existingHash, err := plan.SpecHash(existing)
+		if err != nil {
+			return nil, err
+		}
+		submittedHash, err := plan.SpecHash(in.Specs)
+		if err != nil {
+			return nil, err
+		}
+		if existingHash != submittedHash {
+			return nil, NewInvalidDeployInputError("deploy_id " + in.DeployID + " already exists with different specs")
+		}
+	}
+
+	if err := m.startDeployWorkflow(ctx, eng, in.DeployID); err != nil {
+		return nil, err
+	}
+
+	rec, err := eng.store.GetDeploy(ctx, in.DeployID)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(rec)
+	if err != nil {
+		return nil, err
+	}
+	return &apiruntime.Result{Value: payload.New(string(out))}, nil
+}
+
+func (m *Manager) startDeployWorkflow(ctx context.Context, eng *engineRuntime, deployID string) error {
+	reg := resource.GetRegistry(ctx)
+	if reg == nil {
+		return ErrResourceRegistryMissing
+	}
+	res, err := reg.Acquire(ctx, eng.cfg.Client, resource.ModeNormal)
+	if err != nil {
+		return err
+	}
+	defer res.Release()
+
+	conn, err := res.Get()
+	if err != nil {
+		return err
+	}
+	clientRes, ok := conn.(temporalapi.ClientResource)
+	if !ok {
+		return ErrInvalidClientResource
+	}
+
+	workerCfg, ok := m.registrar.GetConfig(eng.cfg.Worker)
+	if !ok {
+		return NewWorkerNotFoundError(eng.cfg.Worker.String())
+	}
+
+	_, err = clientRes.Client.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		ID:                    "cloudgraph/deploy/" + deployID,
+		TaskQueue:             clientRes.GetTaskQueueName(workerCfg.TaskQueue),
+		WorkflowIDReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+	}, eng.cfg.WorkflowName, deployID)
+
+	var already *serviceerror.WorkflowExecutionAlreadyStarted
+	if errors.As(err, &already) {
+		return nil
+	}
+	return err
+}
+
+// getDeploy returns the deploy record with its operations for polling.
+func (m *Manager) getDeploy(ctx context.Context, task apiruntime.Task) (*apiruntime.Result, error) {
+	eng, err := m.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if len(task.Payloads) == 0 {
+		return nil, NewInvalidDeployInputError("missing deploy_id")
+	}
+
+	var deployID string
+	if err := m.dtt.Unmarshal(task.Payloads[0], &deployID); err != nil {
+		return nil, NewInvalidDeployInputError(err.Error())
+	}
+
+	rec, err := eng.store.GetDeploy(ctx, deployID)
+	if err != nil {
+		return nil, err
+	}
+	ops, err := eng.store.ListOperations(ctx, deployID)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := json.Marshal(struct {
+		Deploy     *cgresource.DeployRecord `json:"deploy"`
+		Operations []cgresource.Operation   `json:"operations"`
+	}{Deploy: rec, Operations: ops})
+	if err != nil {
+		return nil, err
+	}
+	return &apiruntime.Result{Value: payload.New(string(out))}, nil
+}
+
+var _ registry.EntryListener = (*Manager)(nil)

--- a/service/cloudgraph/plan/errors.go
+++ b/service/cloudgraph/plan/errors.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package plan
+
+import apierror "github.com/wippyai/runtime/api/error"
+
+// NewEmptyDeployError reports a deploy without specs.
+func NewEmptyDeployError(deployID string) apierror.Error {
+	return apierror.New(apierror.Invalid, "deploy has no specs: "+deployID).WithRetryable(apierror.False)
+}
+
+// NewInvalidSpecError reports a declaration validation failure.
+func NewInvalidSpecError(detail string) apierror.Error {
+	return apierror.New(apierror.Invalid, "invalid spec: "+detail).WithRetryable(apierror.False)
+}
+
+// NewDependencyCycleError reports a cycle among hard dependency edges,
+// naming the strongly connected components (design §8.2).
+func NewDependencyCycleError(detail string) apierror.Error {
+	return apierror.New(apierror.Invalid, "dependency_cycle: "+detail).WithRetryable(apierror.False)
+}

--- a/service/cloudgraph/plan/plan.go
+++ b/service/cloudgraph/plan/plan.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package plan computes deterministic execution plans: diff/classify, the
+// operation graph, cycle rejection, and Kahn waves
+// (docs/design/cloud-graph.md §8). Pure functions; no gonum types escape.
+package plan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/topo"
+)
+
+// OpEntry is one planned operation inside the stored plan document.
+type OpEntry struct {
+	OpID       string          `json:"op_id"`
+	ResourceID string          `json:"resource_id"`
+	Action     resource.Action `json:"action"`
+}
+
+// EdgeEntry is one hard dependency edge inside the stored plan document.
+type EdgeEntry struct {
+	Source string                  `json:"source"`
+	Target string                  `json:"target"`
+	Kind   resource.DependencyKind `json:"kind"`
+}
+
+// Document is the persisted plan artifact. All collections are ordered
+// arrays so the workflow never iterates a map (design §8.3).
+type Document struct {
+	PlanID     string      `json:"plan_id"`
+	DeployID   string      `json:"deploy_id"`
+	SpecHash   string      `json:"spec_hash"`
+	Operations []OpEntry   `json:"operations"`
+	Edges      []EdgeEntry `json:"edges"`
+	Waves      [][]string  `json:"waves"`
+}
+
+// Compute builds the plan document for a deploy. Identical inputs produce a
+// byte-identical document (design §8.3). The PoC classifies every spec as
+// create; soft edges are recorded but never scheduled (design §8.2).
+func Compute(deployID string, specs []resource.Spec) (*Document, error) {
+	if len(specs) == 0 {
+		return nil, NewEmptyDeployError(deployID)
+	}
+
+	sorted := make([]resource.Spec, len(specs))
+	copy(sorted, specs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ResourceID < sorted[j].ResourceID })
+
+	index := make(map[string]int64, len(sorted))
+	for i, spec := range sorted {
+		if spec.ResourceID == "" {
+			return nil, NewInvalidSpecError("resource_id is required")
+		}
+		if _, dup := index[spec.ResourceID]; dup {
+			return nil, NewInvalidSpecError("duplicate resource_id: " + spec.ResourceID)
+		}
+		index[spec.ResourceID] = int64(i)
+	}
+
+	edges, err := collectEdges(sorted, index)
+	if err != nil {
+		return nil, err
+	}
+
+	waves, err := computeWaves(sorted, index, edges)
+	if err != nil {
+		return nil, err
+	}
+
+	ops := make([]OpEntry, len(sorted))
+	for i, spec := range sorted {
+		ops[i] = OpEntry{
+			OpID:       OperationID(deployID, spec.ResourceID),
+			ResourceID: spec.ResourceID,
+			Action:     resource.ActionCreate,
+		}
+	}
+
+	waveIDs := make([][]string, len(waves))
+	for w, wave := range waves {
+		waveIDs[w] = make([]string, len(wave))
+		for i, nodeID := range wave {
+			waveIDs[w][i] = OperationID(deployID, sorted[nodeID].ResourceID)
+		}
+	}
+
+	hash, err := hashSortedSpecs(sorted)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Document{
+		PlanID:     "plan/" + deployID + "/" + hash[:12],
+		DeployID:   deployID,
+		SpecHash:   hash,
+		Operations: ops,
+		Edges:      edges,
+		Waves:      waveIDs,
+	}, nil
+}
+
+// OperationID derives the deterministic operation identifier of a resource
+// within a deploy.
+func OperationID(deployID, resourceID string) string {
+	return deployID + "/" + resourceID
+}
+
+// collectEdges merges declared dependencies with $ref-derived configure edges,
+// validated and deduplicated, ordered deterministically.
+func collectEdges(sorted []resource.Spec, index map[string]int64) ([]EdgeEntry, error) {
+	seen := make(map[EdgeEntry]struct{})
+	var edges []EdgeEntry
+
+	add := func(edge EdgeEntry) {
+		if _, dup := seen[edge]; dup {
+			return
+		}
+		seen[edge] = struct{}{}
+		edges = append(edges, edge)
+	}
+
+	for _, spec := range sorted {
+		names := make([]string, 0, len(spec.Dependencies))
+		for name := range spec.Dependencies {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			dep := spec.Dependencies[name]
+			if !dep.Kind.Valid() {
+				return nil, NewInvalidSpecError(fmt.Sprintf("%s: dependency %q has invalid kind %q", spec.ResourceID, name, dep.Kind))
+			}
+			if dep.Target == spec.ResourceID {
+				return nil, NewInvalidSpecError(spec.ResourceID + ": dependency on itself")
+			}
+			if _, ok := index[dep.Target]; !ok {
+				return nil, NewInvalidSpecError(fmt.Sprintf("%s: dependency %q targets unknown resource %q", spec.ResourceID, name, dep.Target))
+			}
+			add(EdgeEntry{Source: spec.ResourceID, Target: dep.Target, Kind: dep.Kind})
+		}
+
+		refs, err := Refs(spec.Desired)
+		if err != nil {
+			return nil, NewInvalidSpecError(spec.ResourceID + ": " + err.Error())
+		}
+		for _, ref := range refs {
+			if ref.ResourceID == spec.ResourceID {
+				return nil, NewInvalidSpecError(spec.ResourceID + ": $ref to itself")
+			}
+			if _, ok := index[ref.ResourceID]; !ok {
+				return nil, NewInvalidSpecError(fmt.Sprintf("%s: $ref targets unknown resource %q", spec.ResourceID, ref.ResourceID))
+			}
+			add(EdgeEntry{Source: spec.ResourceID, Target: ref.ResourceID, Kind: resource.DepConfigure})
+		}
+	}
+
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Source != edges[j].Source {
+			return edges[i].Source < edges[j].Source
+		}
+		if edges[i].Target != edges[j].Target {
+			return edges[i].Target < edges[j].Target
+		}
+		return edges[i].Kind < edges[j].Kind
+	})
+	return edges, nil
+}
+
+// computeWaves builds the hard-edge scheduling graph, rejects cycles, and
+// returns Kahn waves of node indices in ascending order. gonum iterator order
+// is never relied on (design §8.2).
+func computeWaves(sorted []resource.Spec, index map[string]int64, edges []EdgeEntry) ([][]int64, error) {
+	g := simple.NewDirectedGraph()
+	for i := range sorted {
+		g.AddNode(simple.Node(int64(i)))
+	}
+
+	type pair struct{ from, to int64 }
+	hard := make(map[pair]struct{})
+	for _, edge := range edges {
+		if edge.Kind == resource.DepSoft {
+			continue
+		}
+		p := pair{from: index[edge.Target], to: index[edge.Source]}
+		if _, dup := hard[p]; dup {
+			continue
+		}
+		hard[p] = struct{}{}
+		g.SetEdge(g.NewEdge(simple.Node(p.from), simple.Node(p.to)))
+	}
+
+	if _, err := topo.Sort(g); err != nil {
+		return nil, cycleError(sorted, g)
+	}
+
+	n := len(sorted)
+	indegree := make([]int, n)
+	successors := make([][]int64, n)
+	for p := range hard {
+		indegree[p.to]++
+		successors[p.from] = append(successors[p.from], p.to)
+	}
+	for i := range successors {
+		sort.Slice(successors[i], func(a, b int) bool { return successors[i][a] < successors[i][b] })
+	}
+
+	var waves [][]int64
+	var ready []int64
+	for i := range n {
+		if indegree[i] == 0 {
+			ready = append(ready, int64(i))
+		}
+	}
+
+	processed := 0
+	for len(ready) > 0 {
+		sort.Slice(ready, func(a, b int) bool { return ready[a] < ready[b] })
+		waves = append(waves, ready)
+		processed += len(ready)
+
+		var next []int64
+		for _, id := range ready {
+			for _, succ := range successors[id] {
+				indegree[succ]--
+				if indegree[succ] == 0 {
+					next = append(next, succ)
+				}
+			}
+		}
+		ready = next
+	}
+
+	if processed != n {
+		return nil, cycleError(sorted, g)
+	}
+	return waves, nil
+}
+
+// cycleError names every strongly connected component with more than one
+// member, deterministically sorted (design §8.2).
+func cycleError(sorted []resource.Spec, g *simple.DirectedGraph) error {
+	var cycles []string
+	for _, scc := range topo.TarjanSCC(g) {
+		if len(scc) < 2 {
+			continue
+		}
+		members := make([]string, len(scc))
+		for i, node := range scc {
+			members[i] = sorted[node.ID()].ResourceID
+		}
+		sort.Strings(members)
+		cycles = append(cycles, strings.Join(members, " -> "))
+	}
+	sort.Strings(cycles)
+	return NewDependencyCycleError(strings.Join(cycles, "; "))
+}
+
+// SpecHash is the SHA-256 over the canonically ordered spec set; identical
+// declarations hash identically regardless of submission order.
+func SpecHash(specs []resource.Spec) (string, error) {
+	sorted := make([]resource.Spec, len(specs))
+	copy(sorted, specs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ResourceID < sorted[j].ResourceID })
+	return hashSortedSpecs(sorted)
+}
+
+func hashSortedSpecs(sorted []resource.Spec) (string, error) {
+	canonical, err := json.Marshal(sorted)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/service/cloudgraph/plan/plan_test.go
+++ b/service/cloudgraph/plan/plan_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package plan
+
+import (
+	"encoding/json"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+)
+
+func demoSpecs() []resource.Spec {
+	return []resource.Spec{
+		{
+			ResourceID:   "poc/postgres",
+			Type:         "container",
+			ProviderType: "docker",
+			Desired:      json.RawMessage(`{"image":"postgres:18-alpine","env":{"POSTGRES_PASSWORD":"secret"}}`),
+		},
+		{
+			ResourceID:   "poc/app",
+			Type:         "container",
+			ProviderType: "docker",
+			Desired:      json.RawMessage(`{"image":"nginx:alpine","env":{"DATABASE_URL":{"$ref":{"resource_id":"poc/postgres","output_key":"dsn"}}}}`),
+		},
+	}
+}
+
+func TestComputeGoldenDemoPlan(t *testing.T) {
+	doc, err := Compute("d1", demoSpecs())
+	require.NoError(t, err)
+
+	require.Equal(t, []OpEntry{
+		{OpID: "d1/poc/app", ResourceID: "poc/app", Action: resource.ActionCreate},
+		{OpID: "d1/poc/postgres", ResourceID: "poc/postgres", Action: resource.ActionCreate},
+	}, doc.Operations)
+
+	require.Equal(t, []EdgeEntry{
+		{Source: "poc/app", Target: "poc/postgres", Kind: resource.DepConfigure},
+	}, doc.Edges)
+
+	require.Equal(t, [][]string{
+		{"d1/poc/postgres"},
+		{"d1/poc/app"},
+	}, doc.Waves)
+
+	require.Equal(t, "plan/d1/"+doc.SpecHash[:12], doc.PlanID)
+}
+
+func TestComputeDeterministicAcrossOrder(t *testing.T) {
+	specs := []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p", Desired: json.RawMessage(`{"x":1}`)},
+		{ResourceID: "s/b", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"a": {Target: "s/a", Kind: resource.DepCreate},
+				"c": {Target: "s/c", Kind: resource.DepOrdering},
+			}},
+		{ResourceID: "s/c", Type: "t", ProviderType: "p",
+			Desired: json.RawMessage(`{"ref":{"$ref":{"resource_id":"s/a","output_key":"o"}}}`)},
+		{ResourceID: "s/d", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"pref": {Target: "s/b", Kind: resource.DepSoft},
+			}},
+	}
+
+	baseline, err := Compute("d1", specs)
+	require.NoError(t, err)
+	baselineJSON, err := json.Marshal(baseline)
+	require.NoError(t, err)
+
+	rng := rand.New(rand.NewSource(42))
+	for range 50 {
+		shuffled := make([]resource.Spec, len(specs))
+		copy(shuffled, specs)
+		rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+		doc, err := Compute("d1", shuffled)
+		require.NoError(t, err)
+		docJSON, err := json.Marshal(doc)
+		require.NoError(t, err)
+		require.Equal(t, string(baselineJSON), string(docJSON), "plan must be byte-identical across spec order")
+	}
+}
+
+func TestComputeSoftEdgesNeverSchedule(t *testing.T) {
+	specs := []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"b": {Target: "s/b", Kind: resource.DepCreate},
+			}},
+		{ResourceID: "s/b", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"a": {Target: "s/a", Kind: resource.DepSoft},
+			}},
+	}
+
+	doc, err := Compute("d1", specs)
+	require.NoError(t, err, "hard edge plus reverse soft edge must not be a cycle")
+	require.Len(t, doc.Edges, 2, "soft edges stay recorded for observability")
+	require.Equal(t, [][]string{{"d1/s/b"}, {"d1/s/a"}}, doc.Waves)
+}
+
+func TestComputeRejectsCycles(t *testing.T) {
+	specs := []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"b": {Target: "s/b", Kind: resource.DepCreate},
+			}},
+		{ResourceID: "s/b", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"a": {Target: "s/a", Kind: resource.DepConfigure},
+			}},
+	}
+
+	_, err := Compute("d1", specs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dependency_cycle")
+	require.Contains(t, err.Error(), "s/a -> s/b")
+}
+
+func TestComputeValidation(t *testing.T) {
+	_, err := Compute("d1", nil)
+	require.Error(t, err, "empty deploy must be rejected")
+
+	_, err = Compute("d1", []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p"},
+		{ResourceID: "s/a", Type: "t", ProviderType: "p"},
+	})
+	require.Error(t, err, "duplicate resource_id must be rejected")
+
+	_, err = Compute("d1", []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"x": {Target: "s/missing", Kind: resource.DepCreate},
+			}},
+	})
+	require.Error(t, err, "unknown dependency target must be rejected")
+
+	_, err = Compute("d1", []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"x": {Target: "s/a", Kind: resource.DepCreate},
+			}},
+	})
+	require.Error(t, err, "self dependency must be rejected")
+
+	_, err = Compute("d1", []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p",
+			Dependencies: map[string]resource.DependencyRef{
+				"x": {Target: "s/a", Kind: "bogus"},
+			}},
+	})
+	require.Error(t, err, "invalid dependency kind must be rejected")
+
+	_, err = Compute("d1", []resource.Spec{
+		{ResourceID: "s/a", Type: "t", ProviderType: "p",
+			Desired: json.RawMessage(`{"$ref":{"resource_id":"s/ghost","output_key":"o"}}`)},
+	})
+	require.Error(t, err, "unknown $ref target must be rejected")
+}
+
+func TestRefsAndMaterialize(t *testing.T) {
+	desired := json.RawMessage(`{
+		"env": {
+			"DATABASE_URL": {"$ref":{"resource_id":"poc/postgres","output_key":"dsn"}},
+			"BUCKET": {"$ref":{"resource_id":"poc/minio","output_key":"bucket"}},
+			"STATIC": "value"
+		},
+		"list": [{"$ref":{"resource_id":"poc/postgres","output_key":"dsn"}}]
+	}`)
+
+	refs, err := Refs(desired)
+	require.NoError(t, err)
+	require.Equal(t, []OutputRef{
+		{ResourceID: "poc/minio", OutputKey: "bucket"},
+		{ResourceID: "poc/postgres", OutputKey: "dsn"},
+	}, refs)
+
+	materialized, err := Materialize(desired, func(ref OutputRef) (any, error) {
+		return ref.ResourceID + ":" + ref.OutputKey, nil
+	})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(materialized, &doc))
+	env := doc["env"].(map[string]any)
+	require.Equal(t, "poc/postgres:dsn", env["DATABASE_URL"])
+	require.Equal(t, "poc/minio:bucket", env["BUCKET"])
+	require.Equal(t, "value", env["STATIC"])
+	require.Equal(t, "poc/postgres:dsn", doc["list"].([]any)[0])
+
+	_, err = Refs(json.RawMessage(`{"$ref":"bad"}`))
+	require.Error(t, err, "malformed $ref must be rejected")
+}

--- a/service/cloudgraph/plan/refs.go
+++ b/service/cloudgraph/plan/refs.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// OutputRef is a declared reference to another resource's output
+// (design §8.4): serialized as {"$ref":{"resource_id":...,"output_key":...}}.
+type OutputRef struct {
+	ResourceID string `json:"resource_id"`
+	OutputKey  string `json:"output_key"`
+}
+
+// Refs scans a desired document recursively and returns every $ref,
+// deduplicated and deterministically ordered.
+func Refs(desired json.RawMessage) ([]OutputRef, error) {
+	if len(desired) == 0 {
+		return nil, nil
+	}
+
+	var doc any
+	if err := json.Unmarshal(desired, &doc); err != nil {
+		return nil, fmt.Errorf("desired is not valid JSON: %w", err)
+	}
+
+	seen := make(map[OutputRef]struct{})
+	if err := walkRefs(doc, seen); err != nil {
+		return nil, err
+	}
+
+	refs := make([]OutputRef, 0, len(seen))
+	for ref := range seen {
+		refs = append(refs, ref)
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].ResourceID != refs[j].ResourceID {
+			return refs[i].ResourceID < refs[j].ResourceID
+		}
+		return refs[i].OutputKey < refs[j].OutputKey
+	})
+	return refs, nil
+}
+
+func walkRefs(node any, seen map[OutputRef]struct{}) error {
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok, err := parseRef(v); err != nil {
+			return err
+		} else if ok {
+			seen[ref] = struct{}{}
+			return nil
+		}
+		for _, child := range v {
+			if err := walkRefs(child, seen); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if err := walkRefs(child, seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// parseRef recognizes a {"$ref": {...}} object. A $ref key with any other
+// shape is a declaration error, never silently skipped.
+func parseRef(node map[string]any) (OutputRef, bool, error) {
+	raw, ok := node["$ref"]
+	if !ok {
+		return OutputRef{}, false, nil
+	}
+	body, ok := raw.(map[string]any)
+	if !ok {
+		return OutputRef{}, false, fmt.Errorf("$ref must be an object")
+	}
+	resourceID, _ := body["resource_id"].(string)
+	outputKey, _ := body["output_key"].(string)
+	if resourceID == "" || outputKey == "" {
+		return OutputRef{}, false, fmt.Errorf("$ref requires resource_id and output_key")
+	}
+	return OutputRef{ResourceID: resourceID, OutputKey: outputKey}, true, nil
+}
+
+// Materialize replaces every $ref in a desired document with the value found
+// in resolve, returning the rewritten document. resolve receives the ref and
+// returns the replacement value (design §9.4 step 6).
+func Materialize(desired json.RawMessage, resolve func(OutputRef) (any, error)) (json.RawMessage, error) {
+	if len(desired) == 0 {
+		return desired, nil
+	}
+
+	var doc any
+	if err := json.Unmarshal(desired, &doc); err != nil {
+		return nil, fmt.Errorf("desired is not valid JSON: %w", err)
+	}
+
+	rewritten, err := rewriteRefs(doc, resolve)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(rewritten)
+}
+
+func rewriteRefs(node any, resolve func(OutputRef) (any, error)) (any, error) {
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok, err := parseRef(v); err != nil {
+			return nil, err
+		} else if ok {
+			return resolve(ref)
+		}
+		out := make(map[string]any, len(v))
+		for key, child := range v {
+			replaced, err := rewriteRefs(child, resolve)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = replaced
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(v))
+		for i, child := range v {
+			replaced, err := rewriteRefs(child, resolve)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = replaced
+		}
+		return out, nil
+	default:
+		return node, nil
+	}
+}

--- a/service/cloudgraph/resource/types.go
+++ b/service/cloudgraph/resource/types.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package resource holds the cloud-graph domain types shared by the planner,
+// executor, workflow, and ledger (docs/design/cloud-graph.md §5).
+package resource
+
+import "encoding/json"
+
+// Action is the operation an execution plan schedules for a resource.
+// The PoC supports create only; update/delete/replace are reserved.
+type Action string
+
+// ActionCreate provisions a resource that does not exist yet.
+const ActionCreate Action = "create"
+
+// DeployStatus is the deploy state machine (design §9.3, PoC subset without
+// rolling_back and cancelled).
+type DeployStatus string
+
+// Deploy statuses.
+const (
+	DeployPlanning  DeployStatus = "planning"
+	DeployExecuting DeployStatus = "executing"
+	DeploySucceeded DeployStatus = "succeeded"
+	DeployFailed    DeployStatus = "failed"
+	DeployPartial   DeployStatus = "partial"
+)
+
+// Terminal reports whether the deploy status is terminal.
+func (s DeployStatus) Terminal() bool {
+	return s == DeploySucceeded || s == DeployFailed || s == DeployPartial
+}
+
+// OperationStatus is the operation state machine (design §9.5, PoC subset
+// without acknowledged/observed/compensating/cancelled).
+type OperationStatus string
+
+// Operation statuses.
+const (
+	OpPlanned    OperationStatus = "planned"
+	OpDispatched OperationStatus = "dispatched"
+	OpInProgress OperationStatus = "in_progress"
+	OpCommitted  OperationStatus = "committed"
+	OpFailed     OperationStatus = "failed"
+)
+
+// Terminal reports whether the operation status is terminal.
+func (s OperationStatus) Terminal() bool {
+	return s == OpCommitted || s == OpFailed
+}
+
+// DependencyKind is the closed set of dependency edge kinds (design §5.4).
+type DependencyKind string
+
+// Dependency kinds.
+const (
+	DepCreate     DependencyKind = "create"
+	DepConfigure  DependencyKind = "configure"
+	DepHealth     DependencyKind = "health"
+	DepOrdering   DependencyKind = "ordering"
+	DepPlacement  DependencyKind = "placement"
+	DepAttachment DependencyKind = "attachment"
+	DepOwnership  DependencyKind = "ownership"
+	DepTraffic    DependencyKind = "traffic"
+	DepSoft       DependencyKind = "soft"
+)
+
+// Valid reports whether the kind belongs to the closed set.
+func (k DependencyKind) Valid() bool {
+	switch k {
+	case DepCreate, DepConfigure, DepHealth, DepOrdering, DepPlacement,
+		DepAttachment, DepOwnership, DepTraffic, DepSoft:
+		return true
+	}
+	return false
+}
+
+// DependencyRef declares one typed dependency edge from the declaring spec
+// onto a target resource in the same scope.
+type DependencyRef struct {
+	Target string         `json:"target"`
+	Kind   DependencyKind `json:"kind"`
+}
+
+// Spec is one declared resource inside a deploy (design §5.2, PoC
+// subset without mounts, secrets, placement, and watcher config).
+type Spec struct {
+	ResourceID   string                   `json:"resource_id"`
+	Type         string                   `json:"type"`
+	ProviderType string                   `json:"provider_type"`
+	Dependencies map[string]DependencyRef `json:"dependencies,omitempty"`
+	Desired      json.RawMessage          `json:"desired"`
+}
+
+// DeployInput is the deploy request submitted through submit_intent
+// (design §6.1, full mode only).
+type DeployInput struct {
+	DeployID string `json:"deploy_id"`
+	Scope    string `json:"scope"`
+	Specs    []Spec `json:"specs"`
+}
+
+// DeployRecord is the persisted state of one deploy.
+type DeployRecord struct {
+	DeployID     string       `json:"deploy_id"`
+	Scope        string       `json:"scope"`
+	Status       DeployStatus `json:"status"`
+	Error        string       `json:"error,omitempty"`
+	FinalizedSeq int64        `json:"finalized_seq,omitempty"`
+}
+
+// Operation is one persisted operation row.
+type Operation struct {
+	ID          string          `json:"id"`
+	DeployID    string          `json:"deploy_id"`
+	ResourceID  string          `json:"resource_id"`
+	Action      Action          `json:"action"`
+	Status      OperationStatus `json:"status"`
+	ActorPID    string          `json:"actor_pid,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	Result      json.RawMessage `json:"result,omitempty"`
+	Incarnation int64           `json:"incarnation"`
+	LastSignal  int64           `json:"last_signal_seq"`
+}
+
+// Edge is one persisted dependency edge scoped to a deploy.
+type Edge struct {
+	SourceResourceID string         `json:"source"`
+	TargetResourceID string         `json:"target"`
+	Kind             DependencyKind `json:"kind"`
+}
+
+// SignalKind classifies a provider signal envelope.
+type SignalKind string
+
+// Signal kinds.
+const (
+	SignalPhase      SignalKind = "phase"
+	SignalOutput     SignalKind = "output"
+	SignalCheckpoint SignalKind = "checkpoint"
+	SignalFailed     SignalKind = "failed"
+)
+
+// SignalPhaseName is the closed, exhaustive provider phase set (design I2).
+type SignalPhaseName string
+
+// Provider signal phases.
+const (
+	PhaseAllocateStarted    SignalPhaseName = "allocate_started"
+	PhaseAllocateCommitted  SignalPhaseName = "allocate_committed"
+	PhaseConfigureStarted   SignalPhaseName = "configure_started"
+	PhaseConfigureCommitted SignalPhaseName = "configure_committed"
+	PhaseVerifyStarted      SignalPhaseName = "verify_started"
+	PhaseVerifyPassed       SignalPhaseName = "verify_passed"
+	PhaseVerifyFailed       SignalPhaseName = "verify_failed"
+	PhaseDeleteStarted      SignalPhaseName = "delete_started"
+	PhaseDeleteCommitted    SignalPhaseName = "delete_committed"
+)
+
+// ValidPhase reports whether the phase belongs to the closed set.
+func ValidPhase(p SignalPhaseName) bool {
+	switch p {
+	case PhaseAllocateStarted, PhaseAllocateCommitted, PhaseConfigureStarted,
+		PhaseConfigureCommitted, PhaseVerifyStarted, PhaseVerifyPassed,
+		PhaseVerifyFailed, PhaseDeleteStarted, PhaseDeleteCommitted:
+		return true
+	}
+	return false
+}
+
+// Signal is one provider signal envelope traveling through the durable
+// mailbox (design §10.2).
+type Signal struct {
+	OperationID string          `json:"operation_id"`
+	Kind        SignalKind      `json:"kind"`
+	Phase       SignalPhaseName `json:"phase,omitempty"`
+	Payload     json.RawMessage `json:"payload"`
+	Incarnation int64           `json:"incarnation"`
+	Seq         int64           `json:"seq"`
+}
+
+// Instance is the persisted resource instance state (design §5.3, PoC subset
+// of the five axes: lifecycle only).
+type Instance struct {
+	ResourceID   string          `json:"resource_id"`
+	Scope        string          `json:"scope"`
+	Type         string          `json:"type"`
+	ProviderType string          `json:"provider_type"`
+	Lifecycle    string          `json:"lifecycle"`
+	Outputs      json.RawMessage `json:"outputs,omitempty"`
+	Generation   int64           `json:"generation"`
+	OutputEpoch  int64           `json:"output_epoch"`
+}

--- a/service/cloudgraph/workflow/activities.go
+++ b/service/cloudgraph/workflow/activities.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+
+	ctxapi "github.com/wippyai/runtime/api/context"
+	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/runtime"
+	temporalapi "github.com/wippyai/runtime/api/service/temporal"
+	"github.com/wippyai/runtime/service/cloudgraph/attempt"
+	"github.com/wippyai/runtime/service/cloudgraph/ledger"
+	"github.com/wippyai/runtime/service/cloudgraph/plan"
+	"github.com/wippyai/runtime/service/cloudgraph/resource"
+	"go.temporal.io/sdk/activity"
+	"go.uber.org/zap"
+)
+
+// Activities holds the Go activity handlers published to the function
+// registry and registered on the engine worker (design §9.1).
+type Activities struct {
+	Store      *ledger.Store
+	Executor   *attempt.Executor
+	Transcoder payload.Transcoder
+	Log        *zap.Logger
+}
+
+// ComputePlan loads the deploy's specs, computes the deterministic plan,
+// persists it, and moves the deploy to executing (design §8.3).
+func (a *Activities) ComputePlan(ctx context.Context, task runtime.Task) (*runtime.Result, error) {
+	deployID, err := a.stringArg(task, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	specs, err := a.Store.LoadSpecs(ctx, deployID)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := plan.Compute(deployID, specs)
+	if err != nil {
+		return nil, err
+	}
+
+	operations := make([]resource.Operation, len(doc.Operations))
+	for i, op := range doc.Operations {
+		operations[i] = resource.Operation{
+			ID:         op.OpID,
+			DeployID:   deployID,
+			ResourceID: op.ResourceID,
+			Action:     op.Action,
+		}
+	}
+	edges := make([]resource.Edge, len(doc.Edges))
+	for i, edge := range doc.Edges {
+		edges[i] = resource.Edge{
+			SourceResourceID: edge.Source,
+			TargetResourceID: edge.Target,
+			Kind:             edge.Kind,
+		}
+	}
+
+	opsJSON, err := json.Marshal(doc.Operations)
+	if err != nil {
+		return nil, err
+	}
+	edgesJSON, err := json.Marshal(doc.Edges)
+	if err != nil {
+		return nil, err
+	}
+	wavesJSON, err := json.Marshal(doc.Waves)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := a.Store.SavePlan(ctx, &ledger.PlanRecord{
+		ID:         doc.PlanID,
+		DeployID:   deployID,
+		Operations: opsJSON,
+		Edges:      edgesJSON,
+		Waves:      wavesJSON,
+		SpecHash:   doc.SpecHash,
+	}, operations, edges); err != nil {
+		return nil, err
+	}
+
+	if err := a.Store.SetDeployStatus(ctx, deployID, resource.DeployPlanning, resource.DeployExecuting); err != nil {
+		return nil, err
+	}
+
+	out, err := json.Marshal(ComputePlanResult{PlanID: doc.PlanID, Waves: doc.Waves})
+	if err != nil {
+		return nil, err
+	}
+	return &runtime.Result{Value: payload.New(string(out))}, nil
+}
+
+// ExecuteOperation runs one operation through the executor, threading the
+// activity attempt as the actor incarnation and heartbeating through the raw
+// activity context (design §9.4).
+func (a *Activities) ExecuteOperation(ctx context.Context, task runtime.Task) (*runtime.Result, error) {
+	opID, err := a.stringArg(task, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	req := attempt.Request{OpID: opID, Incarnation: 1}
+	if actx := rawActivityContext(ctx); actx != nil {
+		req.Incarnation = int64(activity.GetInfo(actx).Attempt)
+		req.Heartbeat = func(details ...any) {
+			activity.RecordHeartbeat(actx, details...)
+		}
+	}
+
+	result, err := a.Executor.Execute(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &runtime.Result{Value: payload.New(string(result))}, nil
+}
+
+// FinalizeDeploy terminalizes abandoned operations, derives the terminal
+// deploy status, and assigns finalized_seq exactly once (design §9.3, I12).
+func (a *Activities) FinalizeDeploy(ctx context.Context, task runtime.Task) (*runtime.Result, error) {
+	deployID, err := a.stringArg(task, 0)
+	if err != nil {
+		return nil, err
+	}
+	failureDetail, err := a.stringArg(task, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	ops, err := a.Store.ListOperations(ctx, deployID)
+	if err != nil {
+		return nil, err
+	}
+
+	committed, failed := 0, 0
+	for _, op := range ops {
+		switch op.Status {
+		case resource.OpCommitted:
+			committed++
+		case resource.OpFailed:
+			failed++
+		default:
+			done, err := a.Store.Terminalize(ctx, op.ID, op.Incarnation,
+				[]resource.OperationStatus{resource.OpPlanned, resource.OpDispatched, resource.OpInProgress},
+				resource.OpFailed, "abandoned at deploy finalize")
+			if err != nil {
+				return nil, err
+			}
+			if done {
+				failed++
+			} else {
+				current, err := a.Store.GetOperation(ctx, op.ID)
+				if err != nil {
+					return nil, err
+				}
+				if current.Status == resource.OpCommitted {
+					committed++
+				} else {
+					failed++
+				}
+			}
+		}
+	}
+
+	status := resource.DeployFailed
+	switch {
+	case len(ops) > 0 && failed == 0 && committed == len(ops):
+		status = resource.DeploySucceeded
+	case committed > 0:
+		status = resource.DeployPartial
+	}
+	if status == resource.DeployFailed && failureDetail == "" {
+		failureDetail = "no operations committed"
+	}
+	if status == resource.DeploySucceeded {
+		failureDetail = ""
+	}
+
+	seq, err := a.Store.FinalizeDeploy(ctx, deployID, status, failureDetail)
+	if err != nil {
+		return nil, err
+	}
+
+	if rec, err := a.Store.GetDeploy(ctx, deployID); err == nil && rec.Status.Terminal() {
+		status = rec.Status
+		failureDetail = rec.Error
+	}
+
+	out, err := json.Marshal(DeployResult{
+		DeployID:     deployID,
+		Status:       string(status),
+		FinalizedSeq: seq,
+		Error:        failureDetail,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &runtime.Result{Value: payload.New(string(out))}, nil
+}
+
+// stringArg decodes one positional string payload of the task.
+func (a *Activities) stringArg(task runtime.Task, idx int) (string, error) {
+	if idx >= len(task.Payloads) {
+		return "", apierror.New(apierror.Invalid, "missing activity argument").WithRetryable(apierror.False)
+	}
+	var value string
+	if err := a.Transcoder.Unmarshal(task.Payloads[idx], &value); err != nil {
+		return "", apierror.New(apierror.Invalid, "undecodable activity argument: "+err.Error()).WithRetryable(apierror.False)
+	}
+	return value, nil
+}
+
+// rawActivityContext extracts the raw Temporal activity context threaded by
+// the worker through the frame context (design §9.4 step 2).
+func rawActivityContext(ctx context.Context) context.Context {
+	fc := ctxapi.FrameFromContext(ctx)
+	if fc == nil {
+		return nil
+	}
+	val, ok := fc.Get(temporalapi.ActivityContextKey())
+	if !ok {
+		return nil
+	}
+	actx, ok := val.(context.Context)
+	if !ok {
+		return nil
+	}
+	return actx
+}

--- a/service/cloudgraph/workflow/deploy.go
+++ b/service/cloudgraph/workflow/deploy.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package workflow holds the deterministic Temporal deploy workflow and its
+// activity payload types (docs/design/cloud-graph.md §9.2). The workflow
+// walks only stored, ordered arrays: no maps, no time.Now, no goroutines,
+// no gonum.
+package workflow
+
+import (
+	"encoding/json"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Activity names registered on the engine worker.
+const (
+	ActivityComputePlan      = "cg_compute_plan"
+	ActivityExecuteOperation = "cg_execute_operation"
+	ActivityFinalizeDeploy   = "cg_finalize_deploy"
+)
+
+// Activity tuning (design §9.2: generous StartToClose, liveness via
+// heartbeat; §9.4: HeartbeatTimeout must be set explicitly).
+const (
+	planStartToClose    = 2 * time.Minute
+	executeStartToClose = 30 * time.Minute
+	executeHeartbeat    = 90 * time.Second
+	maxActivityAttempts = 5
+)
+
+// ComputePlanResult is the compute_plan activity result carried as JSON.
+type ComputePlanResult struct {
+	PlanID string     `json:"plan_id"`
+	Waves  [][]string `json:"waves"`
+}
+
+// DeployResult is the finalize_deploy activity result carried as JSON; the
+// workflow returns it verbatim.
+type DeployResult struct {
+	DeployID     string `json:"deploy_id"`
+	Status       string `json:"status"`
+	Error        string `json:"error,omitempty"`
+	FinalizedSeq int64  `json:"finalized_seq"`
+}
+
+// Deploy is the deterministic deploy workflow: compute_plan, then every wave
+// in stored order with per-wave parallel execute_operation activities, then
+// finalize_deploy — which always runs, so the deploy record reaches a
+// terminal status on every path.
+func Deploy(ctx workflow.Context, deployID string) (string, error) {
+	planCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: planStartToClose,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumAttempts:    maxActivityAttempts,
+		},
+	})
+
+	var failureDetail string
+
+	var planJSON string
+	if err := workflow.ExecuteActivity(planCtx, ActivityComputePlan, deployID).Get(ctx, &planJSON); err != nil {
+		failureDetail = err.Error()
+	}
+
+	var planResult ComputePlanResult
+	if failureDetail == "" {
+		if err := json.Unmarshal([]byte(planJSON), &planResult); err != nil {
+			failureDetail = "undecodable plan result: " + err.Error()
+		}
+	}
+
+	if failureDetail == "" {
+		execCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: executeStartToClose,
+			HeartbeatTimeout:    executeHeartbeat,
+			RetryPolicy: &temporal.RetryPolicy{
+				InitialInterval:    time.Second,
+				BackoffCoefficient: 2.0,
+				MaximumAttempts:    maxActivityAttempts,
+			},
+		})
+
+	waves:
+		for _, wave := range planResult.Waves {
+			futures := make([]workflow.Future, len(wave))
+			for i, opID := range wave {
+				futures[i] = workflow.ExecuteActivity(execCtx, ActivityExecuteOperation, opID)
+			}
+			for i := range futures {
+				var opResult string
+				if err := futures[i].Get(ctx, &opResult); err != nil {
+					if failureDetail == "" {
+						failureDetail = wave[i] + ": " + err.Error()
+					}
+				}
+			}
+			if failureDetail != "" {
+				break waves
+			}
+		}
+	}
+
+	finalizeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: planStartToClose,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumAttempts:    maxActivityAttempts,
+		},
+	})
+
+	var resultJSON string
+	if err := workflow.ExecuteActivity(finalizeCtx, ActivityFinalizeDeploy, deployID, failureDetail).Get(ctx, &resultJSON); err != nil {
+		return "", err
+	}
+	return resultJSON, nil
+}

--- a/service/cloudgraph/workflow/deploy_test.go
+++ b/service/cloudgraph/workflow/deploy_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type recordedOps struct {
+	ids []string
+	mu  sync.Mutex
+}
+
+func (r *recordedOps) add(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ids = append(r.ids, id)
+}
+
+func (r *recordedOps) list() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.ids...)
+}
+
+func planJSON(t *testing.T, waves [][]string) string {
+	t.Helper()
+	out, err := json.Marshal(ComputePlanResult{PlanID: "plan/d1/abc", Waves: waves})
+	require.NoError(t, err)
+	return string(out)
+}
+
+func registerStubs(
+	env *testsuite.TestWorkflowEnvironment,
+	computePlan func(ctx context.Context, deployID string) (string, error),
+	executeOperation func(ctx context.Context, opID string) (string, error),
+	finalize func(ctx context.Context, deployID, failureDetail string) (string, error),
+) {
+	env.RegisterWorkflow(Deploy)
+	env.RegisterActivityWithOptions(computePlan, activity.RegisterOptions{Name: ActivityComputePlan})
+	env.RegisterActivityWithOptions(executeOperation, activity.RegisterOptions{Name: ActivityExecuteOperation})
+	env.RegisterActivityWithOptions(finalize, activity.RegisterOptions{Name: ActivityFinalizeDeploy})
+}
+
+func TestDeployWorkflowSuccess(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	ops := &recordedOps{}
+	var finalizeDetail string
+
+	registerStubs(env,
+		func(_ context.Context, deployID string) (string, error) {
+			require.Equal(t, "d1", deployID)
+			return planJSON(t, [][]string{{"d1/a", "d1/b"}, {"d1/c"}}), nil
+		},
+		func(_ context.Context, opID string) (string, error) {
+			ops.add(opID)
+			return `{"resource_id":"` + opID + `"}`, nil
+		},
+		func(_ context.Context, deployID, failureDetail string) (string, error) {
+			finalizeDetail = failureDetail
+			out, err := json.Marshal(DeployResult{DeployID: deployID, Status: "succeeded", FinalizedSeq: 1})
+			return string(out), err
+		},
+	)
+
+	env.ExecuteWorkflow(Deploy, "d1")
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var resultJSON string
+	require.NoError(t, env.GetWorkflowResult(&resultJSON))
+	var result DeployResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.Equal(t, "succeeded", result.Status)
+	require.Empty(t, finalizeDetail)
+
+	executed := ops.list()
+	require.Len(t, executed, 3)
+	require.ElementsMatch(t, []string{"d1/a", "d1/b"}, executed[:2], "wave 0 runs before wave 1")
+	require.Equal(t, "d1/c", executed[2])
+}
+
+func TestDeployWorkflowMidWaveFailureSkipsRemainingWaves(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	ops := &recordedOps{}
+	var finalizeDetail string
+
+	registerStubs(env,
+		func(context.Context, string) (string, error) {
+			return planJSON(t, [][]string{{"d1/a", "d1/b"}, {"d1/c"}}), nil
+		},
+		func(_ context.Context, opID string) (string, error) {
+			ops.add(opID)
+			if opID == "d1/b" {
+				return "", temporal.NewNonRetryableApplicationError("operation failed: d1/b: boom", "Internal", nil)
+			}
+			return `{}`, nil
+		},
+		func(_ context.Context, deployID, failureDetail string) (string, error) {
+			finalizeDetail = failureDetail
+			out, err := json.Marshal(DeployResult{DeployID: deployID, Status: "partial", FinalizedSeq: 2, Error: failureDetail})
+			return string(out), err
+		},
+	)
+
+	env.ExecuteWorkflow(Deploy, "d1")
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError(), "a failed deploy still completes the workflow with a terminal status")
+
+	var resultJSON string
+	require.NoError(t, env.GetWorkflowResult(&resultJSON))
+	var result DeployResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.Equal(t, "partial", result.Status)
+
+	require.Contains(t, finalizeDetail, "d1/b")
+	require.NotContains(t, ops.list(), "d1/c", "waves after a hard failure must not run")
+}
+
+func TestDeployWorkflowPlanFailureStillFinalizes(t *testing.T) {
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	ops := &recordedOps{}
+	var finalizeDetail string
+
+	registerStubs(env,
+		func(context.Context, string) (string, error) {
+			return "", temporal.NewNonRetryableApplicationError("invalid spec: dependency_cycle", "Invalid", nil)
+		},
+		func(_ context.Context, opID string) (string, error) {
+			ops.add(opID)
+			return `{}`, nil
+		},
+		func(_ context.Context, deployID, failureDetail string) (string, error) {
+			finalizeDetail = failureDetail
+			out, err := json.Marshal(DeployResult{DeployID: deployID, Status: "failed", FinalizedSeq: 3, Error: failureDetail})
+			return string(out), err
+		},
+	)
+
+	env.ExecuteWorkflow(Deploy, "d1")
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	require.Empty(t, ops.list(), "no operations run when planning fails")
+	require.Contains(t, finalizeDetail, "dependency_cycle")
+}

--- a/tests/cloudgraph-poc/.gitignore
+++ b/tests/cloudgraph-poc/.gitignore
@@ -1,0 +1,3 @@
+cloudgraph.db
+cloudgraph.db-shm
+cloudgraph.db-wal

--- a/tests/cloudgraph-poc/.wippy.yaml
+++ b/tests/cloudgraph-poc/.wippy.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MPL-2.0
+
+version: "1.0"
+
+logger:
+  mode: development
+  level: info
+  encoding: console
+
+registry:
+  enable_history: false
+
+relay:
+  node_name: local
+
+lua:
+  type_system:
+    enabled: true
+    strict: true
+
+shutdown:
+  timeout: 30s

--- a/tests/cloudgraph-poc/src/_index.yaml
+++ b/tests/cloudgraph-poc/src/_index.yaml
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MPL-2.0
+
+version: "1.0"
+namespace: poc
+entries:
+  # poc:processes - Process host for provider actors and the demo command
+  - name: processes
+    kind: process.host
+    meta:
+      comment: Process host for cloudgraph provider actors
+    lifecycle:
+      auto_start: true
+
+  # poc:terminal - Terminal host so wippy run can attach the demo command
+  - name: terminal
+    kind: terminal.host
+    meta:
+      comment: Terminal host for the demo command
+    hide_logs: false
+    lifecycle:
+      auto_start: true
+
+  # poc:exec - Native executor the docker provider actor drives the docker CLI with
+  - name: exec
+    kind: exec.native
+    meta:
+      comment: Native executor for the docker provider actor
+
+  # poc:db - SQLite ledger database
+  - name: db
+    kind: db.sql.sqlite
+    meta:
+      comment: Cloudgraph ledger
+    file: ./cloudgraph.db
+    lifecycle:
+      auto_start: true
+
+  # poc:temporal_client - Temporal dev server connection
+  - name: temporal_client
+    kind: temporal.client
+    meta:
+      comment: Temporal dev server (tests/docker-compose.yml)
+    address: localhost:7233
+    namespace: default
+    auth:
+      type: none
+    lifecycle:
+      auto_start: true
+
+  # poc:temporal_worker - Worker running the deploy workflow and activities
+  - name: temporal_worker
+    kind: temporal.worker
+    meta:
+      comment: Cloudgraph engine worker
+    client: poc:temporal_client
+    task_queue: cloudgraph-poc
+    lifecycle:
+      auto_start: true
+
+  # poc:docker_actor - Lua provider actor provisioning docker containers
+  - name: docker_actor
+    kind: process.lua
+    meta:
+      comment: Cloudgraph docker provider actor
+    source: file://docker_actor.lua
+    method: main
+    modules:
+      - exec
+      - time
+
+  # poc:docker_provider - Provider binding manifest
+  - name: docker_provider
+    kind: cloudgraph.provider
+    meta:
+      comment: Docker provider for cloudgraph
+    provider_type: docker
+    actor_process: poc:docker_actor
+    executor: poc:exec
+    resource_types:
+      - container
+
+  # poc:engine - The cloudgraph engine (one shard)
+  - name: engine
+    kind: cloudgraph.engine
+    meta:
+      comment: Cloudgraph engine
+    worker: poc:temporal_worker
+    client: poc:temporal_client
+    database: poc:db
+    host: poc:processes
+    shard: local
+
+  # poc:deploy_demo - CLI demo command submitting the two-wave deploy
+  - name: deploy_demo
+    kind: process.lua
+    meta:
+      comment: Submits the demo deploy and polls it to a terminal status
+      default_host: poc:processes
+      command:
+        name: deploy-demo
+        short: Deploy the cloudgraph PoC demo stack
+    source: file://deploy_demo.lua
+    method: main
+    modules:
+      - funcs
+      - json
+      - time
+      - io

--- a/tests/cloudgraph-poc/src/deploy_demo.lua
+++ b/tests/cloudgraph-poc/src/deploy_demo.lua
@@ -1,0 +1,97 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Demo command: submits the two-wave PoC deploy (postgres, then an app
+-- container whose DATABASE_URL is a $ref onto the postgres outputs) and
+-- polls the deploy to a terminal status.
+local funcs = require("funcs")
+local json = require("json")
+local time = require("time")
+local io = require("io")
+
+local POLL_ATTEMPTS = 600
+
+local function main()
+	local deploy_id = "demo-" .. tostring(time.now():unix_nano())
+
+	local input = {
+		deploy_id = deploy_id,
+		scope = "poc",
+		specs = {
+			{
+				resource_id = "poc/postgres",
+				type = "container",
+				provider_type = "docker",
+				desired = {
+					name = "poc-postgres",
+					image = "postgres:18-alpine",
+					env = { POSTGRES_PASSWORD = "pocsecret" },
+					ports = { "15432:5432" },
+					verify = "pg_isready",
+					outputs = {
+						dsn = "postgres://postgres:pocsecret@127.0.0.1:15432/postgres",
+					},
+				},
+			},
+			{
+				resource_id = "poc/app",
+				type = "container",
+				provider_type = "docker",
+				desired = {
+					name = "poc-app",
+					image = "nginx:alpine",
+					env = {
+						DATABASE_URL = {
+							["$ref"] = { resource_id = "poc/postgres", output_key = "dsn" },
+						},
+					},
+					verify = "running",
+				},
+			},
+		},
+	}
+
+	io.print("submitting deploy " .. deploy_id)
+	local submitted, submit_err = funcs.call("wippy.cloudgraph:submit_intent", input)
+	if submit_err ~= nil then
+		error("submit_intent failed: " .. tostring(submit_err))
+	end
+
+	io.print("accepted: " .. tostring(submitted))
+
+	for _ = 1, POLL_ATTEMPTS do
+		local raw, get_err = funcs.call("wippy.cloudgraph:get_deploy", deploy_id)
+		if get_err ~= nil then
+			error("get_deploy failed: " .. tostring(get_err))
+		end
+
+		local state = json.decode(tostring(raw))
+		local deploy = state.deploy or {}
+		local status = tostring(deploy.status)
+
+		local line = "status=" .. status
+		local operations = state.operations or {}
+		for i = 1, #operations do
+			local op = operations[i]
+			if type(op) == "table" then
+				line = line .. "  " .. tostring(op.resource_id) .. "=" .. tostring(op.status)
+			end
+		end
+
+		io.print(line)
+
+		if status == "succeeded" then
+			io.print("deploy succeeded, finalized_seq=" .. tostring(deploy.finalized_seq))
+			return { ok = true, deploy_id = deploy_id }
+		end
+
+		if status == "failed" or status == "partial" then
+			error("deploy finished " .. status .. ": " .. tostring(deploy.error))
+		end
+
+		time.sleep(1 * time.SECOND)
+	end
+
+	error("timed out waiting for deploy " .. deploy_id)
+end
+
+return { main = main }

--- a/tests/cloudgraph-poc/src/docker_actor.lua
+++ b/tests/cloudgraph-poc/src/docker_actor.lua
@@ -1,0 +1,234 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Cloudgraph docker provider actor: provisions one container per operation
+-- and reports the closed signal ladder through the durable mailbox
+-- (docs/design/cloud-graph.md I2, I19).
+local exec = require("exec")
+local time = require("time")
+
+local VERIFY_ATTEMPTS = 60
+
+local function shell_quote(value)
+	local s = tostring(value)
+	if string.find(s, '"', 1, true) then
+		return nil
+	end
+
+	return '"' .. s .. '"'
+end
+
+local function main(input)
+	input = input or {}
+	local collector = tostring(input.collector or "")
+	if collector == "" then
+		return { ok = false, error = "collector pid missing" }
+	end
+
+	local seq = 0
+	local function next_seq()
+		seq = seq + 1
+		return seq
+	end
+
+	local function send_phase(phase)
+		process.send(collector, "cg.signal", { seq = next_seq(), kind = "phase", phase = phase })
+	end
+
+	local function send_verify_passed(outputs)
+		process.send(collector, "cg.signal", {
+			seq = next_seq(),
+			kind = "phase",
+			phase = "verify_passed",
+			payload = { outputs = outputs },
+		})
+	end
+
+	local function send_checkpoint(container_id)
+		process.send(collector, "cg.signal", {
+			seq = next_seq(),
+			kind = "checkpoint",
+			payload = { container_id = container_id },
+		})
+	end
+
+	local function fail(message)
+		local text = tostring(message)
+		process.send(collector, "cg.signal", {
+			seq = next_seq(),
+			kind = "failed",
+			payload = { error = text },
+		})
+		return { ok = false, error = text }
+	end
+
+	local desired = input.desired
+	if type(desired) ~= "table" then
+		return fail("desired document missing")
+	end
+
+	local name = tostring(desired.name or "")
+	local image = tostring(desired.image or "")
+	if name == "" or image == "" then
+		return fail("desired.name and desired.image are required")
+	end
+
+	local quoted_name = shell_quote(name)
+	local quoted_image = shell_quote(image)
+	if quoted_name == nil or quoted_image == nil then
+		return fail("double quotes are not allowed in name or image")
+	end
+
+	local executor, exec_err = exec.get(tostring(input.executor or ""))
+	if executor == nil then
+		return fail("executor unavailable: " .. tostring(exec_err))
+	end
+
+	local function abort(message)
+		executor:release()
+		return fail(message)
+	end
+
+	local function run(cmd)
+		local proc, proc_err = executor:exec(cmd)
+		if proc == nil then
+			return nil, "exec: " .. tostring(proc_err)
+		end
+
+		local stdout = proc:stdout_stream()
+		local started, start_err = proc:start()
+		if not started then
+			return nil, "start: " .. tostring(start_err)
+		end
+
+		local output = ""
+		if stdout ~= nil then
+			while true do
+				local data = stdout:read()
+				if data == nil or data == "" then
+					break
+				end
+
+				output = output .. tostring(data)
+			end
+
+			stdout:close()
+		end
+
+		local code, wait_err = proc:wait()
+		if wait_err ~= nil then
+			return nil, "wait: " .. tostring(wait_err)
+		end
+
+		return { code = tonumber(code) or -1, output = output }
+	end
+
+	local function is_running()
+		local res = run("docker inspect -f {{.State.Running}} " .. quoted_name)
+		return res ~= nil and res.code == 0 and string.find(res.output, "true", 1, true) ~= nil
+	end
+
+	send_phase("allocate_started")
+
+	local container_id = ""
+	local checkpoint = input.checkpoint
+	if type(checkpoint) == "table" and checkpoint.container_id ~= nil then
+		container_id = tostring(checkpoint.container_id)
+	end
+
+	local resumed = container_id ~= "" and is_running()
+	if not resumed then
+		run("docker rm -f " .. quoted_name)
+
+		local cmd = "docker run -d --name " .. quoted_name
+		if type(desired.env) == "table" then
+			local keys = {}
+			for key in pairs(desired.env) do
+				keys[#keys + 1] = tostring(key)
+			end
+
+			table.sort(keys)
+			for i = 1, #keys do
+				local pair = shell_quote(keys[i] .. "=" .. tostring(desired.env[keys[i]]))
+				if pair == nil then
+					return abort("double quotes are not allowed in env values")
+				end
+
+				cmd = cmd .. " -e " .. pair
+			end
+		end
+
+		if type(desired.ports) == "table" then
+			for i = 1, #desired.ports do
+				local port = shell_quote(desired.ports[i])
+				if port == nil then
+					return abort("double quotes are not allowed in port specs")
+				end
+
+				cmd = cmd .. " -p " .. port
+			end
+		end
+
+		cmd = cmd .. " " .. quoted_image
+		local res, run_err = run(cmd)
+		if res == nil then
+			return abort(run_err)
+		end
+
+		if res.code ~= 0 then
+			return abort("docker run exited " .. tostring(res.code) .. ": " .. res.output)
+		end
+
+		container_id = string.gsub(res.output, "%s+", "")
+		if container_id == "" then
+			return abort("docker run returned no container id")
+		end
+	end
+
+	send_phase("allocate_committed")
+	send_checkpoint(container_id)
+	send_phase("configure_committed")
+
+	local verify = tostring(desired.verify or "running")
+	local healthy = false
+	local last_error = "container never became ready"
+	for _ = 1, VERIFY_ATTEMPTS do
+		if is_running() then
+			if verify == "pg_isready" then
+				local probe = run("docker exec " .. quoted_name .. " pg_isready")
+				if probe ~= nil and probe.code == 0 then
+					healthy = true
+					break
+				end
+
+				last_error = "pg_isready: " .. tostring(probe ~= nil and probe.output or "probe failed")
+			else
+				healthy = true
+				break
+			end
+		else
+			last_error = "container is not running"
+		end
+
+		time.sleep(1 * time.SECOND)
+	end
+
+	if not healthy then
+		return abort("verify failed: " .. last_error)
+	end
+
+	local outputs = {}
+	if type(desired.outputs) == "table" then
+		for key, value in pairs(desired.outputs) do
+			outputs[tostring(key)] = value
+		end
+	end
+
+	outputs.container_id = container_id
+	outputs.name = name
+
+	send_verify_passed(outputs)
+	executor:release()
+	return { ok = true, container_id = container_id }
+end
+
+return { main = main }

--- a/tests/cloudgraph-poc/wippy.lock
+++ b/tests/cloudgraph-poc/wippy.lock
@@ -1,0 +1,2 @@
+directories:
+    src: ./src


### PR DESCRIPTION
Proof-of-concept vertical slice of the cloud-graph deployment control plane (design: `docs/design/cloud-graph.md` on the `docs/cloud-graph-design` branch): applications declare infrastructure as typed resource specs, a deterministic planner builds a DAG (gonum, Kahn waves), and a Temporal workflow executes it through Lua provider actors over a durable, CAS-fenced signal mailbox.

Scope (PoC relaxations documented in `service/cloudgraph/doc.go`):

- `cloudgraph.engine` / `cloudgraph.provider` registry kinds + boot component
- SQLite ledger: deploys, plans, operations, `operation_signals` with incarnation/seq CAS fencing
- Deterministic planner: create-only classification, `$ref`-derived edges, cycle rejection, waves
- Deterministic Go deploy workflow; per-wave parallel `execute_operation` activities (first heartbeating activities in the repo)
- Go↔Lua actor seam (processfunc pattern) with orphan reaping and checkpoint resume
- Docker provider actor + runnable demo app (`tests/cloudgraph-poc`)
- Existing code touched: worker manager exposed as `WorkerRegistrar` in context; gonum promoted to a direct dependency

## Setup

```
make otel-up        # Temporal dev server (tests/docker-compose.yml)
make build-wippy
cd tests/cloudgraph-poc && ../../dist/wippy-<os>-<arch> run deploy-demo
```

## Testing

- `make test` green; pinned `golangci-lint` v2.8.0: 0 issues repo-wide; `wippy lint` clean; cloudgraph packages under `-race` with a production-like single-connection SQLite pool
- Unit: plan-determinism property test, FSM/CAS/fencing tables, Temporal testsuite (success / mid-wave failure / plan failure)
- Live E2E (real Temporal + Docker): two-wave deploy succeeded with `$ref` output materialization:

```
status=executing  poc/app=planned  poc/postgres=in_progress
status=succeeded  poc/app=committed  poc/postgres=committed
deploy succeeded, finalized_seq=1

$ docker exec poc-app env | grep DATABASE_URL
DATABASE_URL=postgres://postgres:pocsecret@127.0.0.1:15432/postgres
```

- Crash recovery: runtime SIGKILLed mid-operation; on restart the Temporal activity retry resumed the operation as incarnation 2 from its checkpoint and the interrupted deploy finished `succeeded`:

```
operation_signals (poc/postgres):
incarnation 1: allocate_started            <- killed here
incarnation 2: allocate_started .. verify_passed
```

## Complete Lua example

Both sides of the seam, taken from the runnable demo app (`tests/cloudgraph-poc/src/`).

**Declaring infrastructure and submitting a deploy** — resources are typed specs; the dependency between them is expressed with `$ref`, which the planner turns into a DAG edge and the executor materializes from the producer's committed outputs:

```lua
local funcs = require("funcs")
local json = require("json")
local time = require("time")

local function main()
	local deploy_id = "demo-" .. tostring(time.now():unix_nano())

	local input = {
		deploy_id = deploy_id,
		scope = "poc",
		specs = {
			{
				resource_id = "poc/postgres",
				type = "container",
				provider_type = "docker",
				desired = {
					name = "poc-postgres",
					image = "postgres:18-alpine",
					env = { POSTGRES_PASSWORD = "pocsecret" },
					ports = { "15432:5432" },
					verify = "pg_isready",
					outputs = {
						dsn = "postgres://postgres:pocsecret@127.0.0.1:15432/postgres",
					},
				},
			},
			{
				resource_id = "poc/app",
				type = "container",
				provider_type = "docker",
				desired = {
					name = "poc-app",
					image = "nginx:alpine",
					env = {
						-- "this app requires PostgreSQL": reference the producer's output
						DATABASE_URL = {
							["$ref"] = { resource_id = "poc/postgres", output_key = "dsn" },
						},
					},
					verify = "running",
				},
			},
		},
	}

	funcs.call("wippy.cloudgraph:submit_intent", input)

	-- poll to a terminal status; the plan runs as waves:
	-- wave 0 = poc/postgres, wave 1 = poc/app (DATABASE_URL already resolved)
	while true do
		local raw = funcs.call("wippy.cloudgraph:get_deploy", deploy_id)
		local state = json.decode(tostring(raw))
		local status = tostring(state.deploy.status)
		if status == "succeeded" or status == "failed" or status == "partial" then
			return { ok = status == "succeeded", deploy_id = deploy_id }
		end

		time.sleep(1 * time.SECOND)
	end
end

return { main = main }
```

**The provider actor** — one Lua process per operation. It does the real provisioning and reports the closed signal ladder through the durable mailbox via `process.send` to the collector PID the engine injects. `seq` is 1-based per actor incarnation (the ledger CAS-rejects out-of-order or stale-incarnation signals); on a crash, the Temporal activity retry respawns the actor with `input.checkpoint` filled so it resumes instead of redoing work; outputs are published only on the terminal `verify_passed`:

```lua
local exec = require("exec")

local function main(input)
	local collector = input.collector
	local seq = 0
	local function send(envelope)
		seq = seq + 1
		envelope.seq = seq
		process.send(collector, "cg.signal", envelope)
	end

	send({ kind = "phase", phase = "allocate_started" })

	-- resume from checkpoint when respawned after a crash
	local container_id = ""
	if type(input.checkpoint) == "table" and input.checkpoint.container_id ~= nil then
		container_id = tostring(input.checkpoint.container_id)
	end

	local executor = exec.get(input.executor) -- exec.native entry from the provider manifest

	if container_id == "" then
		local proc = executor:exec('docker run -d --name "' .. input.desired.name
			.. '" "' .. input.desired.image .. '"')
		local stdout = proc:stdout_stream()
		proc:start()
		container_id = read_all(stdout)
		if proc:wait() ~= 0 then
			send({ kind = "failed", payload = { error = "docker run failed" } })
			return { ok = false }
		end
	end

	send({ kind = "phase", phase = "allocate_committed" })
	send({ kind = "checkpoint", payload = { container_id = container_id } })
	send({ kind = "phase", phase = "configure_committed" })

	-- health probe loop (docker inspect / pg_isready) elided; see docker_actor.lua

	send({
		kind = "phase",
		phase = "verify_passed",
		payload = { outputs = { container_id = container_id, name = input.desired.name } },
	})
	executor:release()
	return { ok = true, container_id = container_id }
end

return { main = main }
```

Full versions with quoting, env/ports assembly, the verify loop, and error handling: `tests/cloudgraph-poc/src/deploy_demo.lua` and `tests/cloudgraph-poc/src/docker_actor.lua`.
