### PR TITLE
fix(hub): descriptive error when the hub is unavailable or rate limiting

### DIFF
--- a/boot/deps/hub/errors.go
+++ b/boot/deps/hub/errors.go
@@ -4,6 +4,7 @@ package hub
 
 import (
 	"errors"
+	"strconv"
 
 	"connectrpc.com/connect"
 )
@@ -18,7 +19,38 @@ var (
 	ErrUploadExpired     = errors.New("upload URL expired")
 	ErrPublishInProgress = errors.New("publish already in progress")
 	ErrQuotaExceeded     = errors.New("quota exceeded")
+	ErrHubUnavailable    = errors.New("hub unavailable")
 )
+
+type UnavailableError struct {
+	cause      error
+	RetryAfter string
+	Detail     string
+}
+
+func (e *UnavailableError) Error() string {
+	if seconds, err := strconv.Atoi(e.RetryAfter); err == nil && seconds >= 0 {
+		return "hub rate limited the request, retry in " + e.RetryAfter + "s"
+	}
+
+	if e.RetryAfter != "" {
+		return "hub rate limited the request (Retry-After: " + e.RetryAfter + ")"
+	}
+
+	if e.Detail != "" {
+		return "hub unavailable: " + e.Detail
+	}
+
+	return "hub unavailable: network error or service overloaded"
+}
+
+func (e *UnavailableError) Is(target error) bool {
+	return target == ErrHubUnavailable
+}
+
+func (e *UnavailableError) Unwrap() error {
+	return e.cause
+}
 
 type QuotaExceededError struct {
 	Reason string
@@ -82,6 +114,12 @@ func MapConnectError(err error) error {
 			return ErrPublishInProgress
 		}
 		return err
+	case connect.CodeUnavailable:
+		return &UnavailableError{
+			RetryAfter: connectErr.Meta().Get("Retry-After"),
+			Detail:     connectErr.Message(),
+			cause:      err,
+		}
 	default:
 		return err
 	}

--- a/boot/deps/hub/errors_test.go
+++ b/boot/deps/hub/errors_test.go
@@ -165,3 +165,47 @@ func TestSearchSubstring(t *testing.T) {
 	assert.False(t, searchSubstring("abc", "xyz"))
 	assert.True(t, searchSubstring("abc", ""))
 }
+
+func TestMapConnectError_Unavailable_RateLimited(t *testing.T) {
+	connectErr := connect.NewError(connect.CodeUnavailable, errors.New(""))
+	connectErr.Meta().Set("Retry-After", "1")
+
+	mapped := MapConnectError(connectErr)
+	assert.ErrorIs(t, mapped, ErrHubUnavailable)
+	assert.Equal(t, "hub rate limited the request, retry in 1s", mapped.Error())
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(mapped))
+}
+
+func TestMapConnectError_Unavailable_NetworkDetail(t *testing.T) {
+	connectErr := connect.NewError(connect.CodeUnavailable, errors.New("dial tcp 1.2.3.4:443: connection refused"))
+
+	mapped := MapConnectError(connectErr)
+	assert.ErrorIs(t, mapped, ErrHubUnavailable)
+	assert.Equal(t, "hub unavailable: dial tcp 1.2.3.4:443: connection refused", mapped.Error())
+}
+
+func TestMapConnectError_Unavailable_NoDetail(t *testing.T) {
+	connectErr := connect.NewError(connect.CodeUnavailable, errors.New(""))
+
+	mapped := MapConnectError(connectErr)
+	assert.ErrorIs(t, mapped, ErrHubUnavailable)
+	assert.Equal(t, "hub unavailable: network error or service overloaded", mapped.Error())
+}
+
+func TestHubUnavailableError_Unwrap_PreservesConnectError(t *testing.T) {
+	connectErr := connect.NewError(connect.CodeUnavailable, errors.New("boom"))
+	mapped := MapConnectError(connectErr)
+
+	var ce *connect.Error
+	assert.True(t, errors.As(mapped, &ce))
+	assert.Equal(t, connect.CodeUnavailable, ce.Code())
+}
+
+func TestMapConnectError_Unavailable_HTTPDateRetryAfter(t *testing.T) {
+	connectErr := connect.NewError(connect.CodeUnavailable, errors.New(""))
+	connectErr.Meta().Set("Retry-After", "Wed, 21 Oct 2026 07:28:00 GMT")
+
+	mapped := MapConnectError(connectErr)
+	assert.ErrorIs(t, mapped, ErrHubUnavailable)
+	assert.Equal(t, "hub rate limited the request (Retry-After: Wed, 21 Oct 2026 07:28:00 GMT)", mapped.Error())
+}

--- a/boot/deps/hub/module_test.go
+++ b/boot/deps/hub/module_test.go
@@ -173,3 +173,23 @@ func TestGetReadme_VersionPreferredOverLabel(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "1.2.3", ver.Version)
 }
+
+func TestListAllVersions_RateLimited429_FriendlyError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"rate_limited","message":"too many requests"}}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := NewClient(Options{BaseURL: server.URL})
+	require.NoError(t, err)
+
+	_, err = client.ListAllVersions(context.Background(), "wippy", "agent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrHubUnavailable)
+	assert.Equal(t, "hub rate limited the request, retry in 1s", err.Error())
+}

--- a/boot/deps/hub/retry.go
+++ b/boot/deps/hub/retry.go
@@ -118,6 +118,9 @@ func isRetryable(err error) bool {
 			code == http.StatusTooManyRequests ||
 			(code >= http.StatusInternalServerError && code < 600)
 	}
+	if errors.Is(err, ErrHubUnavailable) {
+		return true
+	}
 	return false
 }
 

--- a/boot/deps/hub/retry_test.go
+++ b/boot/deps/hub/retry_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -39,3 +40,9 @@ func TestIsHubEndpointMissing_StructuredVsBare(t *testing.T) {
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
+
+func TestIsRetryable_HubUnavailable(t *testing.T) {
+	assert.True(t, isRetryable(&UnavailableError{RetryAfter: "1"}))
+	assert.True(t, isRetryable(&UnavailableError{Detail: "connection refused"}))
+	assert.True(t, isRetryable(fmt.Errorf("get manifest: %w", &UnavailableError{})))
+}


### PR DESCRIPTION
HTTP 429/5xx and network failures all surfaced as a bare `list versions: unavailable` because connect-go synthesizes a code-only error with an empty message from the hub's 429 JSON body.

- `MapConnectError` now maps `CodeUnavailable` to a typed `UnavailableError` carrying `Retry-After` (from error metadata) and the underlying detail.
- Rate limited: `hub rate limited the request, retry in 1s` (non-numeric Retry-After shown verbatim). Network failure: `hub unavailable: dial tcp ...`.
- Unwraps to the original connect error, so `connect.CodeOf` callers keep working.
- `isRetryable` treats it as retryable, aligning the manifest/download retry paths with their documented 429/5xx policy.

Testing: package tests green including an end-to-end case replicating the exact prod 429 shape (JSON error envelope + `Retry-After: 1`); full `make test` (301 packages) and `make lint` (0 issues) green; mutation testing kills every mutant in the changed lines.