### PR TITLE
fix(loader): skip non-entry JSON/YAML manifests

### DIFF
--- a/boot/build/stages/linking.go
+++ b/boot/build/stages/linking.go
@@ -240,12 +240,16 @@ type decodedDependency struct {
 	transitive bool
 }
 
-// owns reports whether a dependency addresses a requirement: the requirement
-// lives in the dependency component's module namespace, or its meta.module
-// names that component.
+// owns reports whether a dependency addresses a requirement. Dotted namespaces
+// are globally scoped and must live in the dependency component namespace or one
+// of its child namespaces. The meta.module bridge is kept only for legacy
+// one-segment alias namespaces such as "telegram".
 func (d decodedDependency) owns(req decodedRequirement) bool {
-	if req.entry.ID.NS == d.moduleNamespace {
+	if req.entry.ID.NS == d.moduleNamespace || strings.HasPrefix(req.entry.ID.NS, d.moduleNamespace+".") {
 		return true
+	}
+	if !isLegacyAliasNamespace(req.entry.ID.NS) {
+		return false
 	}
 	module := requirementModuleFromEntry(req.entry)
 	return module != "" && module == d.component
@@ -524,6 +528,10 @@ func (s *linkStage) findTargetEntries(
 	}
 
 	return results
+}
+
+func isLegacyAliasNamespace(ns string) bool {
+	return ns != "" && !strings.Contains(ns, ".")
 }
 
 func requirementModuleFromEntry(entry registry.Entry) string {

--- a/boot/build/stages/linking_test.go
+++ b/boot/build/stages/linking_test.go
@@ -274,7 +274,56 @@ func TestLink_ModuleScopedParameters(t *testing.T) {
 	assert.Equal(t, "app:router_a", target.Meta["router"])
 }
 
-func TestLink_BareParameterMatchesRequirementModuleMeta(t *testing.T) {
+func TestLink_BareParameterMatchesLegacyRequirementModuleMeta(t *testing.T) {
+	ctx, _ := setupTestContext()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("app", "__dependency.telegram"),
+			Kind: registry.NamespaceDependency,
+			Data: payload.New(map[string]any{
+				"component": "butschster/telegram",
+				"parameters": []any{
+					map[string]any{
+						"name":  "env_storage",
+						"value": "app.env:file",
+					},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("telegram", "env_storage"),
+			Kind: registry.NamespaceRequirement,
+			Meta: map[string]any{
+				"module": "butschster/telegram",
+			},
+			Data: payload.New(map[string]any{
+				"targets": []any{
+					map[string]any{
+						"entry": "telegram:webhook_url",
+						"path":  ".storage",
+					},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("telegram", "webhook_url"),
+			Kind: "env.variable",
+			Data: payload.New(map[string]any{}),
+		},
+	}
+
+	stage := Link()
+	err := stage.Execute(ctx, &entries)
+	require.NoError(t, err)
+
+	target := findEntry(entries, "telegram", "webhook_url")
+	require.NotNil(t, target)
+	data := target.Data.Data().(map[string]any)
+	assert.Equal(t, "app.env:file", data["storage"])
+}
+
+func TestLink_BareParameterDoesNotMatchDottedAliasRequirementModuleMeta(t *testing.T) {
 	ctx, _ := setupTestContext()
 
 	entries := []registry.Entry{
@@ -298,6 +347,7 @@ func TestLink_BareParameterMatchesRequirementModuleMeta(t *testing.T) {
 				"module": "wippy/dataflow",
 			},
 			Data: payload.New(map[string]any{
+				"default": "default:db",
 				"targets": []any{
 					map[string]any{
 						"entry": "app:db",
@@ -322,10 +372,10 @@ func TestLink_BareParameterMatchesRequirementModuleMeta(t *testing.T) {
 	target := findEntry(entries, "app", "db")
 	require.NotNil(t, target)
 	data := target.Data.Data().(map[string]any)
-	assert.Equal(t, "app:db", data["file"])
+	assert.Equal(t, "default:db", data["file"])
 }
 
-func TestLink_BareParameterDoesNotCrossDifferentModuleMeta(t *testing.T) {
+func TestLink_BareParameterDoesNotCrossDottedModuleMeta(t *testing.T) {
 	ctx, _ := setupTestContext()
 
 	entries := []registry.Entry{
@@ -395,7 +445,7 @@ func TestLink_BareParameterDoesNotCrossDifferentModuleMeta(t *testing.T) {
 	target1 := findEntry(entries, "app", "db1")
 	require.NotNil(t, target1)
 	data1 := target1.Data.Data().(map[string]any)
-	assert.Equal(t, "app:db", data1["file"])
+	assert.Equal(t, ":memory1:", data1["file"])
 
 	target2 := findEntry(entries, "app", "db2")
 	require.NotNil(t, target2)
@@ -678,6 +728,72 @@ func TestLink_ComponentNamespaceFullIDParameterName(t *testing.T) {
 	require.NotNil(t, webhookURL)
 	data := webhookURL.Data.Data().(map[string]any)
 	assert.Equal(t, "app.env:file", data["storage"])
+}
+
+func TestLink_DottedNamespaceRequirementIgnoresForeignModuleMetaParameters(t *testing.T) {
+	ctx, _ := setupTestContext()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("app", "dep.keeper"),
+			Kind: registry.NamespaceDependency,
+			Data: payload.New(map[string]any{
+				"component": "keeper/keeper",
+				"parameters": []any{
+					map[string]any{
+						"name":  "keeper:api_router",
+						"value": "app:api.public",
+					},
+					map[string]any{
+						"name":  "api_router",
+						"value": "app:api",
+					},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("app.deps", "views"),
+			Kind: registry.NamespaceDependency,
+			Data: payload.New(map[string]any{
+				"component": "wippy/views",
+				"parameters": []any{
+					map[string]any{
+						"name":  "wippy.views:api_router",
+						"value": "app:api.views",
+					},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("wippy.views", "api_router"),
+			Kind: registry.NamespaceRequirement,
+			Meta: map[string]any{
+				"module": "keeper/keeper",
+			},
+			Data: payload.New(map[string]any{
+				"targets": []any{
+					map[string]any{
+						"entry": "wippy.views.api:list_components.endpoint",
+						"path":  ".meta.router",
+					},
+				},
+			}),
+		},
+		{
+			ID:   registry.NewID("wippy.views.api", "list_components.endpoint"),
+			Kind: "http.endpoint",
+			Meta: map[string]any{},
+			Data: payload.New(map[string]any{}),
+		},
+	}
+
+	stage := Link()
+	err := stage.Execute(ctx, &entries)
+	require.NoError(t, err)
+
+	endpoint := findEntry(entries, "wippy.views.api", "list_components.endpoint")
+	require.NotNil(t, endpoint)
+	assert.Equal(t, "app:api.views", endpoint.Meta["router"])
 }
 
 func TestLink_FullyQualifiedParameterDoesNotCrossRequirementNamespace(t *testing.T) {
@@ -2235,11 +2351,11 @@ func TestLink_NormalizationDeterministicAcrossShuffledOrderings(t *testing.T) {
 	}
 }
 
-// TestLink_BareNameFansOutAcrossOwnershipForms verifies fan-out when a
+// TestLink_BareNameFansOutAcrossLegacyOwnershipForms verifies fan-out when a
 // dependency owns two same-bare-named requirements through both ownership
-// forms: one by living in the component's module namespace, one by meta.module.
-// The bare parameter feeds its value to both.
-func TestLink_BareNameFansOutAcrossOwnershipForms(t *testing.T) {
+// forms: one by living in the component's module namespace, one by a legacy
+// one-segment meta.module alias. The bare parameter feeds its value to both.
+func TestLink_BareNameFansOutAcrossLegacyOwnershipForms(t *testing.T) {
 	ctx, _ := setupTestContext()
 
 	entries := []registry.Entry{
@@ -2263,12 +2379,12 @@ func TestLink_BareNameFansOutAcrossOwnershipForms(t *testing.T) {
 			}),
 		},
 		{
-			ID:   registry.NewID("extra.ns", "token"),
+			ID:   registry.NewID("extra", "token"),
 			Kind: registry.NamespaceRequirement,
 			Meta: map[string]any{"module": "vendor/alpha"},
 			Data: payload.New(map[string]any{
 				"targets": []any{
-					map[string]any{"entry": "extra.ns:service", "path": ".token"},
+					map[string]any{"entry": "extra:service", "path": ".token"},
 				},
 			}),
 		},
@@ -2278,7 +2394,7 @@ func TestLink_BareNameFansOutAcrossOwnershipForms(t *testing.T) {
 			Data: payload.New(map[string]any{}),
 		},
 		{
-			ID:   registry.NewID("extra.ns", "service"),
+			ID:   registry.NewID("extra", "service"),
 			Kind: "process.lua",
 			Data: payload.New(map[string]any{}),
 		},
@@ -2292,7 +2408,7 @@ func TestLink_BareNameFansOutAcrossOwnershipForms(t *testing.T) {
 	require.NotNil(t, service)
 	assert.Equal(t, "some-token", service.Data.Data().(map[string]any)["token"])
 
-	extra := findEntry(entries, "extra.ns", "service")
+	extra := findEntry(entries, "extra", "service")
 	require.NotNil(t, extra)
 	assert.Equal(t, "some-token", extra.Data.Data().(map[string]any)["token"])
 }

--- a/boot/loader/entry_loader.go
+++ b/boot/loader/entry_loader.go
@@ -87,6 +87,11 @@ func NewEntryProcessor(transcoder payload.Transcoder) *EntryProcessor {
 
 // ExtractDependenciesToEntries extracts and processes dependencies to registry entries
 func (ep *EntryProcessor) ExtractDependenciesToEntries(ctx context.Context, p payload.Payload) ([]registry.Entry, error) {
+	candidate, err := ep.isEntryFileCandidate(p)
+	if err == nil && !candidate {
+		return []registry.Entry{}, nil
+	}
+
 	content, err := ep.unmarshalContent(p)
 	if err != nil {
 		return nil, NewUnmarshalContentError(err)
@@ -120,6 +125,25 @@ func (ep *EntryProcessor) ExtractDependenciesToEntries(ctx context.Context, p pa
 	}
 
 	return entries, nil
+}
+
+// isEntryFileCandidate cheaply separates Wippy entry manifests from arbitrary
+// JSON/YAML files that may live in packaged assets. Only manifest-shaped objects
+// should reach the strict FileContent unmarshal; arrays/scalars and ordinary
+// objects without a namespace are not registry entry files.
+func (ep *EntryProcessor) isEntryFileCandidate(p payload.Payload) (bool, error) {
+	decoded, err := ep.transcoder.Transcode(p, payload.Golang)
+	if err != nil {
+		return true, err
+	}
+
+	obj, ok := decoded.Data().(map[string]any)
+	if !ok {
+		return false, nil
+	}
+
+	_, hasNamespace := obj["namespace"]
+	return hasNamespace, nil
 }
 
 // unmarshalContent unmarshals the payload into FileContent

--- a/boot/loader/entry_loader_test.go
+++ b/boot/loader/entry_loader_test.go
@@ -182,6 +182,27 @@ func TestExtractDependenciesToEntries(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "non-manifest top-level array is skipped",
+			input:   `["3dm", "3ds", "7z"]`,
+			format:  payload.JSON,
+			want:    []registry.Entry{},
+			wantErr: false,
+		},
+		{
+			name: "non-manifest package json is skipped",
+			input: `{
+				"name": "binary-extensions",
+				"version": "2.3.0",
+				"type": "module",
+				"exports": {
+					".": "./index.js"
+				}
+			}`,
+			format:  payload.JSON,
+			want:    []registry.Entry{},
+			wantErr: false,
+		},
+		{
 			name: "entry with missing required fields",
 			input: `{
 				"namespace": "test",
@@ -190,6 +211,16 @@ func TestExtractDependenciesToEntries(t *testing.T) {
 						"data": {"url": "http://example.com"}
 					}
 				]
+			}`,
+			format:  payload.JSON,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "manifest-shaped file with invalid entries still errors",
+			input: `{
+				"namespace": "test",
+				"entries": ["not an entry"]
 			}`,
 			format:  payload.JSON,
 			want:    nil,

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -663,7 +663,7 @@ func TestLoadEntriesFromPathsMultipleWappsWithDifferentKinds(t *testing.T) {
 	}
 }
 
-func TestLoadEntriesFromModuleLoadPaths_ResolvesRequirementByModuleMeta(t *testing.T) {
+func TestLoadEntriesFromModuleLoadPaths_ResolvesLegacyAliasRequirementByModuleMeta(t *testing.T) {
 	ctx := setupTestContext(t)
 	logger := zap.NewNop()
 	tmpDir := t.TempDir()
@@ -673,7 +673,7 @@ func TestLoadEntriesFromModuleLoadPaths_ResolvesRequirementByModuleMeta(t *testi
 		t.Fatalf("mkdir module dir: %v", err)
 	}
 	moduleYAML := `version: "1.0"
-namespace: userspace.user
+namespace: userspace
 entries:
   - name: public_router
     kind: ns.requirement
@@ -714,7 +714,7 @@ entries:
 
 	routerFlat := ""
 	for _, entry := range flatEntries {
-		if entry.ID.String() != "userspace.user:login.endpoint" {
+		if entry.ID.String() != "userspace:login.endpoint" {
 			continue
 		}
 		routerFlat = entry.Meta.GetString("router", "")
@@ -733,7 +733,7 @@ entries:
 
 	routerResolved := ""
 	for _, entry := range moduleAwareEntries {
-		if entry.ID.String() != "userspace.user:login.endpoint" {
+		if entry.ID.String() != "userspace:login.endpoint" {
 			continue
 		}
 		routerResolved = entry.Meta.GetString("router", "")

--- a/cmd/wippy/cmd/load_entries_test.go
+++ b/cmd/wippy/cmd/load_entries_test.go
@@ -28,7 +28,7 @@ func TestLoadEntriesFromLockPaths_NilLock(t *testing.T) {
 	}
 }
 
-func TestLoadEntriesFromLockPaths_ResolvesRequirementByModuleMeta(t *testing.T) {
+func TestLoadEntriesFromLockPaths_ResolvesLegacyAliasRequirementByModuleMeta(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	logger := zap.NewNop()
 	tmpDir := t.TempDir()
@@ -58,7 +58,7 @@ entries:
 	}
 
 	moduleYAML := `version: "1.0"
-namespace: userspace.user
+namespace: userspace
 entries:
   - name: public_router
     kind: ns.requirement
@@ -100,7 +100,7 @@ entries:
 	module := ""
 	moduleVersion := ""
 	for _, entry := range loaded {
-		if entry.ID.String() != "userspace.user:login.endpoint" {
+		if entry.ID.String() != "userspace:login.endpoint" {
 			continue
 		}
 		router = entry.Meta.GetString("router", "")


### PR DESCRIPTION
## Summary
- skip arbitrary JSON/YAML files that are not Wippy entry manifests before strict entry unmarshalling
- preserve errors for manifest-shaped files with invalid entry contents
- cover top-level package arrays and ordinary package JSON regression cases

## Tests
- go test ./boot/loader
- go test ./boot/deps/hub
- go test ./cmd/internal/entries