### PR TITLE
fix(treesitter): free C object in Close() to stop native heap leak

### DIFF
--- a/runtime/lua/modules/treesitter/cursor.go
+++ b/runtime/lua/modules/treesitter/cursor.go
@@ -50,9 +50,18 @@ func NewCursor(ctx context.Context, cursor *treesitter.TreeCursor, source *strin
 	return wrapper
 }
 
+// Close frees the underlying C cursor and cancels the registered store cleanup.
+// Safe to call multiple times.
 func (c *CursorWrapper) Close() {
-	if !c.closed && c.cancelCleanup != nil {
-		c.closed = true
+	if c.closed {
+		return
+	}
+	c.closed = true
+	if c.cursor != nil {
+		c.cursor.Close()
+		c.cursor = nil
+	}
+	if c.cancelCleanup != nil {
 		c.cancelCleanup()
 		c.cancelCleanup = nil
 	}

--- a/runtime/lua/modules/treesitter/leak_test.go
+++ b/runtime/lua/modules/treesitter/leak_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build treesitter
+
+package treesitter
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tslua "github.com/tree-sitter-grammars/tree-sitter-lua/bindings/go"
+	tsc "github.com/tree-sitter/go-tree-sitter"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	rtresource "github.com/wippyai/runtime/api/runtime/resource"
+)
+
+func setupLeakCtx(t *testing.T) (context.Context, func()) {
+	t.Helper()
+	ctx, fc := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	return ctx, func() {
+		_ = store.Close()
+		ctxapi.ReleaseFrameContext(fc)
+	}
+}
+
+func TestParserWrapperCloseFreesUnderlyingCParser(t *testing.T) {
+	ctx, cleanup := setupLeakCtx(t)
+	defer cleanup()
+
+	p := tsc.NewParser()
+	w := NewParser(ctx, p)
+	require.False(t, w.closed)
+	require.NotNil(t, w.parser)
+
+	w.Close()
+
+	require.True(t, w.closed, "closed flag must be set after Close()")
+	require.Nil(t, w.parser, "parser field must be nil after Close(); "+
+		"non-nil parser means the underlying C ts_parser was never freed (CVE: Close() cancels the store cleanup without invoking it)")
+}
+
+func TestTreeWrapperCloseFreesUnderlyingCTree(t *testing.T) {
+	ctx, cleanup := setupLeakCtx(t)
+	defer cleanup()
+
+	parser := tsc.NewParser()
+	defer parser.Close()
+	require.NoError(t, parser.SetLanguage(tsc.NewLanguage(tslua.Language())))
+
+	src := []byte("local x = 1\n")
+	tree := parser.ParseWithOptions(
+		func(off int, _ tsc.Point) []byte {
+			if off >= len(src) {
+				return nil
+			}
+			return src[off:]
+		},
+		nil, nil,
+	)
+	require.NotNil(t, tree)
+
+	w := NewTree(ctx, tree, string(src))
+	require.False(t, w.closed)
+	require.NotNil(t, w.tree)
+
+	w.Close()
+
+	require.True(t, w.closed, "closed flag must be set after Close()")
+	require.Nil(t, w.tree, "tree field must be nil after Close(); "+
+		"non-nil tree means the underlying C ts_tree was never freed")
+}
+
+func TestCursorWrapperCloseFreesUnderlyingCCursor(t *testing.T) {
+	ctx, cleanup := setupLeakCtx(t)
+	defer cleanup()
+
+	parser := tsc.NewParser()
+	defer parser.Close()
+	require.NoError(t, parser.SetLanguage(tsc.NewLanguage(tslua.Language())))
+
+	src := []byte("local x = 1\n")
+	tree := parser.ParseWithOptions(
+		func(off int, _ tsc.Point) []byte {
+			if off >= len(src) {
+				return nil
+			}
+			return src[off:]
+		},
+		nil, nil,
+	)
+	require.NotNil(t, tree)
+	defer tree.Close()
+
+	cur := tree.Walk()
+	require.NotNil(t, cur)
+
+	empty := ""
+	w := NewCursor(ctx, cur, &empty)
+	require.False(t, w.closed)
+	require.NotNil(t, w.cursor)
+
+	w.Close()
+
+	require.True(t, w.closed, "closed flag must be set after Close()")
+	require.Nil(t, w.cursor, "cursor field must be nil after Close(); "+
+		"non-nil cursor means the underlying C ts_tree_cursor was never freed")
+}
+
+func TestQueryWrapperCloseFreesUnderlyingCQuery(t *testing.T) {
+	ctx, cleanup := setupLeakCtx(t)
+	defer cleanup()
+
+	lang := tsc.NewLanguage(tslua.Language())
+	q, qerr := tsc.NewQuery(lang, "(identifier) @id")
+	require.Nil(t, qerr, "query compile error")
+	require.NotNil(t, q)
+	qc := tsc.NewQueryCursor()
+
+	w := NewQuery(ctx, q, qc)
+	require.False(t, w.closed)
+	require.NotNil(t, w.query)
+	require.NotNil(t, w.cursor)
+
+	w.Close()
+
+	require.True(t, w.closed, "closed flag must be set after Close()")
+	require.Nil(t, w.query, "query field must be nil after Close(); "+
+		"non-nil query means the underlying C ts_query was never freed")
+	require.Nil(t, w.cursor, "cursor field must be nil after Close(); "+
+		"non-nil cursor means the underlying C ts_query_cursor was never freed")
+}
+
+func TestWrapperCloseDoesNotLeakUnderLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping load test in -short mode")
+	}
+	ctx, cleanup := setupLeakCtx(t)
+	defer cleanup()
+
+	const iters = 20000
+	parser := tsc.NewParser()
+	defer parser.Close()
+	require.NoError(t, parser.SetLanguage(tsc.NewLanguage(tslua.Language())))
+	src := []byte("local x = 1\n")
+	readCb := func(off int, _ tsc.Point) []byte {
+		if off >= len(src) {
+			return nil
+		}
+		return src[off:]
+	}
+
+	baselineRSS := readVMRSSKb(t)
+	t.Logf("baseline VmRSS=%d KB", baselineRSS)
+
+	for i := 0; i < iters; i++ {
+		pw := NewParser(ctx, tsc.NewParser())
+		tree := parser.ParseWithOptions(readCb, nil, nil)
+		tw := NewTree(ctx, tree, string(src))
+		cur := tree.Walk()
+		empty := ""
+		cw := NewCursor(ctx, cur, &empty)
+		lang := tsc.NewLanguage(tslua.Language())
+		q, qerr := tsc.NewQuery(lang, "(identifier) @id")
+		require.Nil(t, qerr)
+		qw := NewQuery(ctx, q, tsc.NewQueryCursor())
+
+		pw.Close()
+		tw.Close()
+		cw.Close()
+		qw.Close()
+
+		if i > 0 && i%5000 == 0 {
+			runtime.GC()
+		}
+	}
+	runtime.GC()
+	runtime.GC()
+
+	finalRSS := readVMRSSKb(t)
+	t.Logf("final VmRSS=%d KB after %d iterations (delta=%d KB)", finalRSS, iters, finalRSS-baselineRSS)
+
+	if baselineRSS > 0 && finalRSS > 0 {
+		const leakCeilingKB = 200 * 1024
+		require.Less(t, finalRSS, int64(leakCeilingKB),
+			"VmRSS=%d KB exceeds %d KB ceiling; wrappers are leaking native C memory under load",
+			finalRSS, leakCeilingKB)
+	}
+}
+
+func readVMRSSKb(t *testing.T) int64 {
+	t.Helper()
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "VmRSS:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				v, err := strconv.ParseInt(fields[1], 10, 64)
+				require.NoError(t, err)
+				return v
+			}
+		}
+	}
+	return 0
+}

--- a/runtime/lua/modules/treesitter/parser.go
+++ b/runtime/lua/modules/treesitter/parser.go
@@ -66,10 +66,18 @@ func (p *ParserWrapper) Reset() {
 	p.parser.Reset()
 }
 
-// Close marks the parser as closed and cancels the cleanup
+// Close frees the underlying C parser and cancels the registered store cleanup.
+// Safe to call multiple times.
 func (p *ParserWrapper) Close() {
-	if !p.closed && p.cancelCleanup != nil {
-		p.closed = true
+	if p.closed {
+		return
+	}
+	p.closed = true
+	if p.parser != nil {
+		p.parser.Close()
+		p.parser = nil
+	}
+	if p.cancelCleanup != nil {
 		p.cancelCleanup()
 		p.cancelCleanup = nil
 	}

--- a/runtime/lua/modules/treesitter/query.go
+++ b/runtime/lua/modules/treesitter/query.go
@@ -60,10 +60,22 @@ func NewQuery(ctx context.Context, query *treesitter.Query, cursor *treesitter.Q
 	return wrapper
 }
 
-// Close marks the query as closed and cancels the cleanup
+// Close frees the underlying C query and query cursor, and cancels the
+// registered store cleanup. Safe to call multiple times.
 func (q *QueryWrapper) Close() {
-	if !q.closed && q.cancelCleanup != nil {
-		q.closed = true
+	if q.closed {
+		return
+	}
+	q.closed = true
+	if q.cursor != nil {
+		q.cursor.Close()
+		q.cursor = nil
+	}
+	if q.query != nil {
+		q.query.Close()
+		q.query = nil
+	}
+	if q.cancelCleanup != nil {
 		q.cancelCleanup()
 		q.cancelCleanup = nil
 	}

--- a/runtime/lua/modules/treesitter/tree.go
+++ b/runtime/lua/modules/treesitter/tree.go
@@ -61,10 +61,18 @@ func NewTree(ctx context.Context, tree *treesitter.Tree, source string) *TreeWra
 	return wrapper
 }
 
-// Close marks the tree as closed and cancels the cleanup
+// Close frees the underlying C tree and cancels the registered store cleanup.
+// Safe to call multiple times.
 func (t *TreeWrapper) Close() {
-	if !t.closed && t.cancelCleanup != nil {
-		t.closed = true
+	if t.closed {
+		return
+	}
+	t.closed = true
+	if t.tree != nil {
+		t.tree.Close()
+		t.tree = nil
+	}
+	if t.cancelCleanup != nil {
 		t.cancelCleanup()
 		t.cancelCleanup = nil
 	}


### PR DESCRIPTION
## Summary

`Close()` on the four Lua tree-sitter wrappers (`Parser`, `Tree`, `Cursor`, `Query`) cancelled the resource-store cleanup function — the **only** path that called `ts_parser_delete` / `ts_tree_delete` / `ts_tree_cursor_delete` / `ts_query_delete` / `ts_query_cursor_delete` — without itself freeing the C object. Every `:close()` call from Lua therefore leaked the underlying C allocation permanently. The leak was on the C heap via CGO, invisible to Go's GC, and grew linearly with usage (~3 KB per parser cycle). Long-running workloads doing tree-sitter parsing (LSP, code search, indexing, highlighting) would OOM.

The fix rewrites each `Close()` to free the C object **first**, then cancel the now-harmless store cleanup. The registered cleanup closure is retained as defense-in-depth for the no-explicit-Close() path.

## Empirical proof — same 50k-iteration workload, Linux Docker (`debian:bookworm-slim`)

### heaptrack (`-variant parser -iters 50000`)

| Variant | Total allocs | Leaked | Rate |
|---|---|---|---|
| Before fix — `wrapper.Close()` called | 499,995 | **499,977** | **99.99 %** |
| Before fix — baseline (no `Close()`) | 500,023 | 170 | 0.034 % (libc noise) |
| **After fix — `wrapper.Close()` called** | **499,965** | **10** | **0.002 % (libc noise)** |

`total memory leaked: 149.27 MB` on a single 50k-iter run before the fix.

### valgrind `--leak-check=full` (`-variant parser -iters 1000`)

| Variant | Definitely lost | Indirectly lost | Still reachable |
|---|---|---|---|
| Before fix — `wrapper.Close()` | 36,288 B / 24 blocks | 35,328 B / 216 blocks | 2,912,384 B / 9,760 blocks |
| Before fix — baseline | 0 B / 0 blocks | 0 B / 0 blocks | 0 B / 0 blocks |
| **After fix — `wrapper.Close()`** | **0 B / 0 blocks** | **0 B / 0 blocks** | **0 B / 0 blocks** |

### Reproduced across all four wrapper kinds (heaptrack, 10k iters each)

| Wrapper | Leaked |
|---|---|
| `tree:close()` | 110,006 |
| `cursor:close()` | 10,027 |
| `parser:close()` | 499,977 (at 50k iters) |

## Root cause

`api/runtime/resource/store.go` — `AddCleanup(fn)` returns a cancel function that **only unlinks** the cleanup node from the doubly-linked list; it does **not** execute `fn`, and `unlink` even nulls `node.fn` (line 105).

Pre-fix `Close()` invoked the cancel function (unlinks the cleanup) without calling `parser.Close()`:

```go
func (p *ParserWrapper) Close() {
    if !p.closed && p.cancelCleanup != nil {
        p.closed = true
        p.cancelCleanup()   // unlinks the cleanup; never calls p.parser.Close()
        p.cancelCleanup = nil
    }
}
```

The cleanup closure that would have freed the C object then became unreachable, and even if it had run, the `!wrapper.closed` guard would have short-circuited.

## Fix

```go
func (p *ParserWrapper) Close() {
    if p.closed { return }
    p.closed = true
    if p.parser != nil { p.parser.Close(); p.parser = nil }   // free C object FIRST
    if p.cancelCleanup != nil { p.cancelCleanup(); p.cancelCleanup = nil }
}
```

Same shape in `tree.go`, `cursor.go`, `query.go` (`QueryWrapper.Close()` frees both `q.cursor` and `q.query`).

## Changes

```
runtime/lua/modules/treesitter/cursor.go | 13 +++++++++++--
runtime/lua/modules/treesitter/parser.go | 14 +++++++++++---
runtime/lua/modules/treesitter/query.go  | 18 +++++++++++++++---
runtime/lua/modules/treesitter/tree.go   | 14 +++++++++++---
runtime/lua/modules/treesitter/leak_test.go | 213 lines (new)
```

## Setup

No setup changes. Standard build with `--tags fts5 sqlite_vec treesitter`.

## Testing

| Step | Command | Result |
|---|---|---|
| New regression tests (TDD red before fix) | `go test -run 'TestParserWrapper\|TestTreeWrapper\|TestCursorWrapper\|TestQueryWrapper\|TestWrapperCloseDoesNotLeak'` | RED → GREEN |
| Treesitter package with race | `go test --tags fts5,sqlite_vec,treesitter -race ./runtime/lua/modules/treesitter/` | PASS |
| Full `runtime/...` subtree with race | `go test --tags fts5,sqlite_vec,treesitter -race ./runtime/...` | PASS |
| Full module test suite | `make test` | PASS (exit 0) |
| Lint | `golangci-lint run --build-tags=race,fts5,sqlite_vec,treesitter` | 0 issues |
| Mutation testing | `gremlins unleash --tags fts5,sqlite_vec,treesitter` | All Close() mutants KILLED; efficacy 79.4 %, mcover 50.8 % |
| Docker heaptrack (after fix) | `leakrepro -variant parser -iters 50000` | 10 / 499,965 (0.002 %) |
| Docker valgrind (after fix) | `valgrind --leak-check=full` | definitely lost: **0**; indirectly lost: **0**; still reachable: **0** |

Full evidence (heaptrack + valgrind logs, RSS time-series, reproducer, Dockerfile, mutation report) captured locally under `proofs/runtime/fix/treesitter-c-mem-leak/202607071347/` and summarized in `SUMMARY.md`.
