### PR TITLE
fix(http): buffer body-read channels to stop request goroutine leak

### DIFF
--- a/runtime/lua/modules/http/leak_test.go
+++ b/runtime/lua/modules/http/leak_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package http
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	httpservice "github.com/wippyai/runtime/api/service/http"
+)
+
+// delayedErrReader returns err after delay, regardless of ctx. Used to drive
+// the requestBody / requestBodyJSON error path AFTER the request's timeout
+// has already fired — exactly the condition under which the production code
+// used to block forever on an unbuffered errChan, leaking the body-reader
+// goroutine.
+type delayedErrReader struct {
+	done  chan struct{}
+	err   error
+	delay time.Duration
+}
+
+func newDelayedErrReader(delay time.Duration, err error) *delayedErrReader {
+	r := &delayedErrReader{delay: delay, err: err, done: make(chan struct{})}
+	go func() {
+		time.Sleep(delay)
+		close(r.done)
+	}()
+	return r
+}
+
+func (r *delayedErrReader) Read([]byte) (int, error) {
+	<-r.done
+	return 0, r.err
+}
+
+func (r *delayedErrReader) Close() error { return nil }
+
+// TestRequestBodyDoesNotLeakGoroutineOnErrorAfterTimeout reproduces a
+// goroutine leak in requestBody / requestBodyJSON:
+//
+// The body-reader goroutine performs `errChan <- err` (an unbuffered channel)
+// when io.ReadAll returns an error. The outer select may have already chosen
+// <-ctx.Done() (timeout), in which case nobody reads errChan and the goroutine
+// blocks forever. Each request that times out AND whose body read subsequently
+// errors leaks one goroutine permanently.
+func TestRequestBodyDoesNotLeakGoroutineOnErrorAfterTimeout(t *testing.T) {
+	const iters = 50
+	before := runtime.NumGoroutine()
+	t.Logf("goroutines before=%d", before)
+
+	l := lua.NewState()
+	defer l.Close()
+	bind(l)
+	ctx, fc := newTestContext()
+	defer ctxapi.ReleaseFrameContext(fc)
+	l.SetContext(ctx)
+
+	for i := 0; i < iters; i++ {
+		// Body errors 200 ms after construction; request timeout is 50 ms.
+		// The outer select fires ctx.Done first; then the goroutine's
+		// io.ReadAll returns the error and tries errChan <- err.
+		body := newDelayedErrReader(200*time.Millisecond, errors.New("simulated read error"))
+		req, err := http.NewRequestWithContext(context.Background(), "POST", "/test", body)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		reqCtx := httpservice.NewRequestContext(req, recorder)
+		require.NoError(t, fc.Set(httpservice.RequestKey(), reqCtx))
+
+		err = l.DoString(`
+			local req = http.request({timeout = 50})
+			local body, err = req:body()
+			assert(body == nil, "body should be nil on timeout")
+			assert(err ~= nil, "should return error on timeout")
+		`)
+		require.NoError(t, err, "lua iteration %d", i)
+	}
+
+	// Wait long enough that every goroutine's delayedErrReader has fired and
+	// (pre-fix) parked on the blocking errChan send. Then GC several times to
+	// recycle anything legitimately short-lived.
+	time.Sleep(500 * time.Millisecond)
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	after := runtime.NumGoroutine()
+	t.Logf("goroutines after=%d (delta=%d over %d timed-out+errored body reads)",
+		after, after-before, iters)
+
+	// Tolerate small framework noise. A real leak would be ~+iters.
+	const tolerance = 5
+	require.Less(t, after-before, tolerance,
+		"goroutine count grew by %d after %d timed-out body reads with subsequent errors; "+
+			"the body-reader goroutine must not block forever on errChan after the outer "+
+			"select has chosen ctx.Done",
+		after-before, iters)
+}
+
+// TestRequestBodyJSONDoesNotLeakGoroutineOnErrorAfterTimeout is the same
+// contract for the body_json code path, which has the identical bug.
+func TestRequestBodyJSONDoesNotLeakGoroutineOnErrorAfterTimeout(t *testing.T) {
+	const iters = 50
+	before := runtime.NumGoroutine()
+	t.Logf("goroutines before=%d", before)
+
+	l := lua.NewState()
+	defer l.Close()
+	bind(l)
+	ctx, fc := newTestContext()
+	defer ctxapi.ReleaseFrameContext(fc)
+	l.SetContext(ctx)
+
+	for i := 0; i < iters; i++ {
+		body := newDelayedErrReader(200*time.Millisecond, io.ErrUnexpectedEOF)
+		req, err := http.NewRequestWithContext(context.Background(), "POST", "/test", body)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		reqCtx := httpservice.NewRequestContext(req, recorder)
+		require.NoError(t, fc.Set(httpservice.RequestKey(), reqCtx))
+
+		err = l.DoString(`
+			local req = http.request({timeout = 50})
+			local data, err = req:body_json()
+			assert(data == nil, "data should be nil on timeout")
+			assert(err ~= nil, "should return error on timeout")
+		`)
+		require.NoError(t, err, "lua iteration %d", i)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	after := runtime.NumGoroutine()
+	t.Logf("goroutines after=%d (delta=%d over %d timed-out+errored body_json reads)",
+		after, after-before, iters)
+
+	const tolerance = 5
+	require.Less(t, after-before, tolerance,
+		"goroutine count grew by %d after %d timed-out body_json reads with subsequent errors",
+		after-before, iters)
+}

--- a/runtime/lua/modules/http/request.go
+++ b/runtime/lua/modules/http/request.go
@@ -308,8 +308,8 @@ func requestBody(l *lua.LState) int {
 	)
 	defer cancel()
 
-	bodyChan := make(chan []byte)
-	errChan := make(chan error)
+	bodyChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
 
 	go func() {
 		b, err := io.ReadAll(limitedReader)
@@ -317,10 +317,7 @@ func requestBody(l *lua.LState) int {
 			errChan <- err
 			return
 		}
-		select {
-		case bodyChan <- b:
-		case <-ctx.Done():
-		}
+		bodyChan <- b
 	}()
 
 	select {
@@ -400,8 +397,8 @@ func requestBodyJSON(l *lua.LState) int {
 	var body []byte
 	var readErr error
 
-	bodyChan := make(chan []byte)
-	errChan := make(chan error)
+	bodyChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
 
 	go func() {
 		b, err := io.ReadAll(limitedReader)
@@ -409,10 +406,7 @@ func requestBodyJSON(l *lua.LState) int {
 			errChan <- err
 			return
 		}
-		select {
-		case bodyChan <- b:
-		case <-ctx.Done():
-		}
+		bodyChan <- b
 	}()
 
 	select {


### PR DESCRIPTION
## Summary

`requestBody` and `requestBodyJSON` (the Lua bindings for `req:body()` / `req:body_json()`) read the HTTP request body in a goroutine and forwarded the result on two **unbuffered** channels. The success path correctly escaped via `select { case bodyChan <- b: case <-ctx.Done(): }`, but the error path used a plain `errChan <- err`. When the outer select already chose `<-ctx.Done()` (request timeout) and the goroutine subsequently completed `io.ReadAll` with an error, the goroutine blocked forever on the unbuffered `errChan` send. Each timed-out request whose body read later errored permanently leaked one goroutine.

This is a very common production scenario: any client that uploads a body and then disconnects mid-stream (network blip, mobile backgrounding, proxy timeout returning a partial response) trips this leak on every affected request. A service handling sustained traffic with non-trivial body uploads would see goroutine count and RSS grow without bound.

The fix is one character per call site: `make(chan …, 1)`. The goroutine's send always completes immediately regardless of whether the receiver is still listening, and the goroutine exits cleanly.

## Empirical proof — TDD red → green via the actual Lua `req:body()` / `req:body_json()` API

| Test (50 timed-out+errored body reads) | Pre-fix | **Post-fix** |
|---|---|---|
| `TestRequestBodyDoesNotLeakGoroutineOnErrorAfterTimeout` (`req:body()`) | +50 goroutines — **FAIL** | **+0 goroutines** — **PASS** |
| `TestRequestBodyJSONDoesNotLeakGoroutineOnErrorAfterTimeout` (`req:body_json()`) | +50 goroutines — **FAIL** | **+0 goroutines** — **PASS** |

The pre-fix leak is exactly 1 goroutine per affected request. Running both tests back-to-back on the buggy code showed the second test starting at +50 goroutines left over from the first — confirming the leak is process-wide and not test-scoped.

## Root cause

`runtime/lua/modules/http/request.go` (pre-fix, identical pattern in both functions):

```go
bodyChan := make(chan []byte)        // unbuffered
errChan := make(chan error)          // unbuffered

go func() {
    b, err := io.ReadAll(limitedReader)
    if err != nil {
        errChan <- err               // BLOCKING; no ctx.Done escape
        return
    }
    select {
    case bodyChan <- b:              // success path correctly escapes
    case <-ctx.Done():
    }
}()

select {
case body = <-bodyChan:
case readErr = <-errChan:
case <-ctx.Done():
    readErr = fmt.Errorf("request timeout after %dms", timeout)
}
```

Leak trigger:
1. Client uploads a body; the producer hangs or dies mid-stream.
2. Outer `select` fires `<-ctx.Done()` (timeout), returns the timeout error.
3. Goroutine eventually completes `io.ReadAll` with an error (e.g. `io.ErrUnexpectedEOF`).
4. Goroutine executes `errChan <- err`. Channel is unbuffered, nobody is reading. Goroutine blocks forever.

## Fix

```go
bodyChan := make(chan []byte, 1)
errChan := make(chan error, 1)

go func() {
    b, err := io.ReadAll(limitedReader)
    if err != nil {
        errChan <- err
        return
    }
    bodyChan <- b
}()
```

The outer `select` is unchanged; the buffered channels preserve its non-deterministic semantics (the race between data arrival and ctx timeout is resolved by Go's runtime as before).

## Changes

```
 runtime/lua/modules/http/leak_test.go | 156 ++++++++++++++++++++++++++++++++++
 runtime/lua/modules/http/request.go   |  18 ++--
 2 files changed, 162 insertions(+), 12 deletions(-)
```

## Setup

No setup changes.

## Testing

| Step | Command | Result |
|---|---|---|
| New regression tests (TDD red before fix) | `go test -run TestRequestBody…DoesNotLeakGoroutine…` | RED → GREEN |
| HTTP module with race | `go test -race ./runtime/lua/modules/http/...` | PASS |
| Full module test suite | `make test` | PASS (exit 0) |
| Lint | `golangci-lint run --build-tags=race` | 0 issues |
| Mutation testing | `gremlins unleash` | All body-channel mutations on changed lines KILLED; efficacy 86.7 %, mcover 92.5 % |

Full evidence (diff, mutation report) captured locally under `proofs/runtime/fix/http-body-goroutine-leak/202607071521/` and summarized in `SUMMARY.md`.
