### PR TITLE
fix(registry): make dependency installs profile-safe

### DIFF
--- a/boot/build/stages/override.go
+++ b/boot/build/stages/override.go
@@ -17,14 +17,30 @@ const (
 	sectionOverride boot.Name = "override"
 )
 
-type overrideStage struct{}
+type OverrideOption func(*overrideStage)
+
+type overrideStage struct {
+	ignoreMissingEntries bool
+}
+
+func WithMissingOverrideEntriesIgnored() OverrideOption {
+	return func(s *overrideStage) {
+		s.ignoreMissingEntries = true
+	}
+}
 
 // Override creates a new stage that applies configuration overrides from boot config.
 // Reads from the "override" config section and applies values to entries.
 // Keys should be in format: namespace:entry:path (e.g., "app:gateway:addr")
 // This format handles dots in namespace and entry names correctly.
-func Override() boot.Stage {
-	return &overrideStage{}
+func Override(opts ...OverrideOption) boot.Stage {
+	stage := &overrideStage{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(stage)
+		}
+	}
+	return stage
 }
 
 func (s *overrideStage) Name() string {
@@ -68,6 +84,9 @@ func (s *overrideStage) Execute(ctx context.Context, entries *[]registry.Entry) 
 
 		targetEntries := findEntries(*entries, namespace, entryName)
 		if len(targetEntries) == 0 {
+			if s.ignoreMissingEntries {
+				continue
+			}
 			errs = append(errs, NewEntryNotFoundError(namespace, entryName))
 			continue
 		}

--- a/boot/build/stages/override_test.go
+++ b/boot/build/stages/override_test.go
@@ -354,6 +354,39 @@ func TestOverride_EntryNotFound(t *testing.T) {
 	}
 }
 
+func TestOverride_EntryNotFoundIgnoredWhenConfigured(t *testing.T) {
+	ctx, _ := setupTestContext()
+
+	entries := []registry.Entry{
+		{
+			ID:   registry.NewID("app", "gateway"),
+			Kind: "process.lua",
+			Data: payload.New(map[string]any{
+				"addr": ":8080",
+			}),
+		},
+	}
+
+	cfg := boot.NewConfig(
+		boot.WithSection("override", map[string]any{
+			"app:notfound:addr": ":9090",
+			"app:gateway:addr":  ":8081",
+		}),
+	)
+
+	ctx = boot.WithConfig(ctx, cfg)
+	stage := Override(WithMissingOverrideEntriesIgnored())
+
+	if err := stage.Execute(ctx, &entries); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	data := entries[0].Data.Data().(map[string]any)
+	if data["addr"] != ":8081" {
+		t.Errorf("Expected addr=:8081, got %v", data["addr"])
+	}
+}
+
 func TestParseOverrideKey_Valid(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1753,11 +1753,14 @@ func markModuleMetaForGraph(
 }
 
 func idKey(id regapi.ID) string {
-	return id.String()
+	if id.NS != "" || id.Name != "" {
+		return strings.TrimSpace(string(id.NS)) + ":" + strings.TrimSpace(string(id.Name))
+	}
+	return strings.TrimSpace(id.String())
 }
 
 func idsEqual(a, b regapi.ID) bool {
-	return a.Equal(b)
+	return idKey(a) == idKey(b)
 }
 
 func entriesEqual(a, b regapi.Entry) bool {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -231,10 +231,10 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 	combined = append(combined, moduleEntries...)
 
 	pipeline := build.New(
-		stages.Override(),
+		stages.Override(stages.WithMissingOverrideEntriesIgnored()),
 		stages.Disable(),
 		stages.Link(stages.WithDependencies(linkDeps), stages.WithStrictRequirementModules(strictModules)),
-		stages.Override(),
+		stages.Override(stages.WithMissingOverrideEntriesIgnored()),
 	)
 	if err := pipeline.Execute(ctx, &combined); err != nil {
 		return regapi.DirectiveResult{}, NewDependencyPipelineError(err)

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1754,7 +1754,7 @@ func markModuleMetaForGraph(
 
 func idKey(id regapi.ID) string {
 	if id.NS != "" || id.Name != "" {
-		return strings.TrimSpace(string(id.NS)) + ":" + strings.TrimSpace(string(id.Name))
+		return strings.TrimSpace(id.NS) + ":" + strings.TrimSpace(id.Name)
 	}
 	return strings.TrimSpace(id.String())
 }

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -194,7 +194,7 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 
 	opComponent := ""
 	for _, dep := range desiredDeps {
-		if dep.entry.ID == op.Entry.ID {
+		if idsEqual(dep.entry.ID, op.Entry.ID) {
 			opComponent = dep.definition.Component
 			break
 		}
@@ -354,7 +354,7 @@ func (h *DependencyHandler) collectDesiredDependencies(
 	snapshot regapi.State,
 	transcoder payload.Transcoder,
 ) ([]desiredDependency, error) {
-	deps := make(map[regapi.ID]desiredDependency)
+	deps := make(map[string]desiredDependency)
 	lockedVersions, err := h.installedModuleVersions(ctx, transcoder, snapshot)
 	if err != nil {
 		return nil, err
@@ -366,15 +366,15 @@ func (h *DependencyHandler) collectDesiredDependencies(
 		return nil, err
 	}
 	for _, dep := range current {
-		if dep.entry.ID != operationID {
+		if !idsEqual(dep.entry.ID, operationID) {
 			dep.definition = pinExistingDependencyVersion(dep.definition, lockedVersions)
 		}
-		deps[dep.entry.ID] = dep
+		deps[idKey(dep.entry.ID)] = dep
 	}
 
 	switch op.Kind {
 	case regapi.EntryDelete:
-		delete(deps, op.Entry.ID)
+		delete(deps, idKey(op.Entry.ID))
 	case regapi.EntryCreate, regapi.EntryUpdate:
 		entry, ok := resolveOperationEntry(op, snapshot)
 		if !ok {
@@ -387,7 +387,7 @@ func (h *DependencyHandler) collectDesiredDependencies(
 		if err != nil {
 			return nil, err
 		}
-		deps[entry.ID] = desiredDependency{
+		deps[idKey(entry.ID)] = desiredDependency{
 			entry:      entry,
 			definition: def,
 		}
@@ -396,7 +396,7 @@ func (h *DependencyHandler) collectDesiredDependencies(
 	result := make([]desiredDependency, 0, len(deps))
 	for id, dep := range deps {
 		if dep.definition.Component == "" {
-			return nil, NewDependencyEntryInvalidError(id.String(), "component is required", "")
+			return nil, NewDependencyEntryInvalidError(id, "component is required", "")
 		}
 		result = append(result, dep)
 	}
@@ -410,8 +410,8 @@ func validateRootDependencyComponents(deps []desiredDependency, operationID rega
 	seen := make(map[string]regapi.ID, len(deps))
 	for _, dep := range deps {
 		component := dep.definition.Component
-		if existingID, ok := seen[component]; ok && existingID != dep.entry.ID {
-			if existingID == operationID {
+		if existingID, ok := seen[component]; ok && !idsEqual(existingID, dep.entry.ID) {
+			if idsEqual(existingID, operationID) {
 				return NewDependencyRootConflictError(component, dep.entry.ID.String(), existingID.String())
 			}
 			return NewDependencyRootConflictError(component, existingID.String(), dep.entry.ID.String())
@@ -489,16 +489,17 @@ func pinExistingDependencyVersion(def DependencyDefinition, moduleVersions map[s
 
 func mergeLinkDependencies(explicitDeps, moduleEntries []regapi.Entry) []regapi.Entry {
 	merged := make([]regapi.Entry, 0, len(explicitDeps)+len(moduleEntries))
-	seen := make(map[regapi.ID]struct{}, len(explicitDeps)+len(moduleEntries))
+	seen := make(map[string]struct{}, len(explicitDeps)+len(moduleEntries))
 
 	appendDep := func(entry regapi.Entry) {
 		if entry.Kind != regapi.NamespaceDependency {
 			return
 		}
-		if _, ok := seen[entry.ID]; ok {
+		key := idKey(entry.ID)
+		if _, ok := seen[key]; ok {
 			return
 		}
-		seen[entry.ID] = struct{}{}
+		seen[key] = struct{}{}
 		merged = append(merged, entry)
 	}
 
@@ -785,10 +786,10 @@ func (h *DependencyHandler) loadModuleEntries(ctx context.Context, modules []Res
 	return entries, nil
 }
 
-func entriesByID(entries regapi.State) map[regapi.ID]regapi.Entry {
-	byID := make(map[regapi.ID]regapi.Entry, len(entries))
+func entriesByID(entries regapi.State) map[string]regapi.Entry {
+	byID := make(map[string]regapi.Entry, len(entries))
 	for _, entry := range entries {
-		byID[entry.ID] = entry
+		byID[idKey(entry.ID)] = entry
 	}
 	return byID
 }
@@ -810,14 +811,14 @@ func rootDependencyModules(ctx context.Context, transcoder payload.Transcoder, e
 	return modules, nil
 }
 
-func preserveHostSnapshotEntry(entry regapi.Entry, moduleName string, snapshot map[regapi.ID]regapi.Entry, installedRoots map[string]struct{}) (regapi.Entry, bool) {
+func preserveHostSnapshotEntry(entry regapi.Entry, moduleName string, snapshot map[string]regapi.Entry, installedRoots map[string]struct{}) (regapi.Entry, bool) {
 	if _, installed := installedRoots[moduleName]; !installed {
 		return regapi.Entry{}, false
 	}
 	if entryModule(entry) != "" {
 		return regapi.Entry{}, false
 	}
-	existing, ok := snapshot[entry.ID]
+	existing, ok := snapshot[idKey(entry.ID)]
 	if !ok || entryModule(existing) != "" {
 		return regapi.Entry{}, false
 	}
@@ -844,14 +845,14 @@ func moduleOwnersByNamespace(modules []ResolvedModule) map[string]moduleOwner {
 	return owners
 }
 
-func moduleOwnersByEntryID(entries regapi.State) map[regapi.ID]moduleOwner {
-	owners := make(map[regapi.ID]moduleOwner, len(entries))
+func moduleOwnersByEntryID(entries regapi.State) map[string]moduleOwner {
+	owners := make(map[string]moduleOwner, len(entries))
 	for _, entry := range entries {
 		module := entryModule(entry)
 		if module == "" {
 			continue
 		}
-		owners[entry.ID] = moduleOwner{
+		owners[idKey(entry.ID)] = moduleOwner{
 			name:    module,
 			version: moduleVersion(entry),
 		}
@@ -1483,25 +1484,26 @@ func buildOperationsWithResolver(
 	mutableModules map[string]struct{},
 	resolver regapi.DependencyResolver,
 ) ([]regapi.Operation, error) {
-	currentByID := make(map[regapi.ID]regapi.Entry, len(current))
+	currentByID := make(map[string]regapi.Entry, len(current))
 	for _, entry := range current {
-		currentByID[entry.ID] = entry
+		currentByID[idKey(entry.ID)] = entry
 	}
 
-	desiredByID := make(map[regapi.ID]regapi.Entry, len(desired))
+	desiredByID := make(map[string]regapi.Entry, len(desired))
 	for _, entry := range desired {
-		desiredByID[entry.ID] = entry
+		desiredByID[idKey(entry.ID)] = entry
 	}
 
 	ops := make([]regapi.Operation, 0)
+	originalKey := idKey(originalID)
 
-	for id, entry := range desiredByID {
-		if id == originalID {
+	for key, entry := range desiredByID {
+		if key == originalKey {
 			continue
 		}
-		if existing, ok := currentByID[id]; ok {
+		if existing, ok := currentByID[key]; ok {
 			if entryConflict(existing, entry) {
-				return nil, NewDependencyEntryConflictError(id.String(), entryModule(existing), entryModule(entry))
+				return nil, NewDependencyEntryConflictError(entry.ID.String(), entryModule(existing), entryModule(entry))
 			}
 			if !entriesEqual(existing, entry) {
 				if existing.Kind != entry.Kind {
@@ -1521,11 +1523,11 @@ func buildOperationsWithResolver(
 		}
 	}
 
-	for id, entry := range currentByID {
-		if id == originalID {
+	for key, entry := range currentByID {
+		if key == originalKey {
 			continue
 		}
-		if _, ok := desiredByID[id]; ok {
+		if _, ok := desiredByID[key]; ok {
 			continue
 		}
 		if module := entryModule(entry); module != "" {
@@ -1534,10 +1536,10 @@ func buildOperationsWithResolver(
 					continue
 				}
 			}
-			if hasLiveDependent(id, currentByID, desiredByID, controlledModules, resolver) {
+			if hasLiveDependent(entry.ID, currentByID, desiredByID, controlledModules, resolver) {
 				continue
 			}
-			ops = append(ops, regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: id}})
+			ops = append(ops, regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: entry.ID}})
 		}
 	}
 
@@ -1546,8 +1548,8 @@ func buildOperationsWithResolver(
 
 func hasLiveDependent(
 	target regapi.ID,
-	currentByID map[regapi.ID]regapi.Entry,
-	desiredByID map[regapi.ID]regapi.Entry,
+	currentByID map[string]regapi.Entry,
+	desiredByID map[string]regapi.Entry,
 	controlledModules map[string]struct{},
 	resolver regapi.DependencyResolver,
 ) bool {
@@ -1555,12 +1557,13 @@ func hasLiveDependent(
 		return false
 	}
 	universe := dependencyEntryUniverse(currentByID)
-	for id, current := range currentByID {
-		if id == target {
+	targetKey := idKey(target)
+	for key, current := range currentByID {
+		if key == targetKey {
 			continue
 		}
 		check := current
-		if desired, ok := desiredByID[id]; ok {
+		if desired, ok := desiredByID[key]; ok {
 			check = desired
 		} else if missingDesiredEntryWillBeDeleted(current, controlledModules) {
 			continue
@@ -1585,24 +1588,24 @@ func missingDesiredEntryWillBeDeleted(entry regapi.Entry, controlledModules map[
 }
 
 type dependencyEntryUniverseView struct {
-	entries map[regapi.ID]struct{}
+	entries map[string]regapi.ID
 	groups  map[string][]regapi.ID
 	ns      map[string][]regapi.ID
 }
 
-func dependencyEntryUniverse(entries map[regapi.ID]regapi.Entry) dependencyEntryUniverseView {
+func dependencyEntryUniverse(entries map[string]regapi.Entry) dependencyEntryUniverseView {
 	universe := dependencyEntryUniverseView{
-		entries: make(map[regapi.ID]struct{}, len(entries)),
+		entries: make(map[string]regapi.ID, len(entries)),
 		groups:  make(map[string][]regapi.ID),
 		ns:      make(map[string][]regapi.ID),
 	}
-	for id, entry := range entries {
-		universe.entries[id] = struct{}{}
+	for key, entry := range entries {
+		universe.entries[key] = entry.ID
 		for _, group := range entry.Meta.GetSlice(regapi.TagGroups) {
-			universe.groups[group] = append(universe.groups[group], id)
+			universe.groups[group] = append(universe.groups[group], entry.ID)
 		}
-		if id.NS != "" {
-			universe.ns[id.NS] = append(universe.ns[id.NS], id)
+		if entry.ID.NS != "" {
+			universe.ns[entry.ID.NS] = append(universe.ns[entry.ID.NS], entry.ID)
 		}
 	}
 	return universe
@@ -1732,12 +1735,12 @@ func markModuleMetaForGraph(
 	moduleName string,
 	moduleVersion string,
 	namespaceOwners map[string]moduleOwner,
-	entryOwners map[regapi.ID]moduleOwner,
+	entryOwners map[string]moduleOwner,
 ) regapi.Entry {
 	if entryModule(entry) != "" {
 		return markModuleMeta(entry, moduleName, moduleVersion)
 	}
-	if owner, ok := entryOwners[entry.ID]; ok && owner.name != "" {
+	if owner, ok := entryOwners[idKey(entry.ID)]; ok && owner.name != "" {
 		if owner.name == moduleName {
 			return markModuleMeta(entry, moduleName, moduleVersion)
 		}
@@ -1749,8 +1752,16 @@ func markModuleMetaForGraph(
 	return markModuleMeta(entry, moduleName, moduleVersion)
 }
 
+func idKey(id regapi.ID) string {
+	return id.String()
+}
+
+func idsEqual(a, b regapi.ID) bool {
+	return a.Equal(b)
+}
+
 func entriesEqual(a, b regapi.Entry) bool {
-	if a.ID != b.ID || a.Kind != b.Kind {
+	if !idsEqual(a.ID, b.ID) || a.Kind != b.Kind {
 		return false
 	}
 	if !reflect.DeepEqual(a.Meta, b.Meta) {
@@ -1773,7 +1784,7 @@ func resolveOperationEntry(op regapi.Operation, snapshot regapi.State) (regapi.E
 		return op.Entry, true
 	}
 	for _, entry := range snapshot {
-		if entry.ID == op.Entry.ID {
+		if idsEqual(entry.ID, op.Entry.ID) {
 			return entry, true
 		}
 	}

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -195,40 +195,40 @@ func TestMarkModuleMeta_PreservesExistingModuleOwner(t *testing.T) {
 	e := regapi.Entry{
 		ID: regapi.NewID("ns", "a"),
 		Meta: attrs.NewBagFrom(map[string]any{
-			metaModuleKey:        "wippy/session",
+			metaModuleKey:        "acme/session",
 			metaModuleVersionKey: "v1.0.0",
 		}),
 	}
 
-	result := markModuleMeta(e, "kickside/uploads", "v2.0.0")
+	result := markModuleMeta(e, "acme/uploads", "v2.0.0")
 
-	assert.Equal(t, "wippy/session", entryModule(result))
+	assert.Equal(t, "acme/session", entryModule(result))
 	assert.Equal(t, "v1.0.0", result.Meta.GetString(metaModuleVersionKey, ""))
 }
 
 func TestMarkModuleMetaForGraph_UsesResolvedNamespaceOwner(t *testing.T) {
-	e := regapi.Entry{ID: regapi.NewID("wippy.session", "delete_session_service")}
+	e := regapi.Entry{ID: regapi.NewID("acme.session", "delete_session_service")}
 	owners := moduleOwnersByNamespace([]ResolvedModule{
-		{Org: "wippy", Name: "session", Version: "v1.0.0"},
-		{Org: "kickside", Name: "uploads", Version: "v2.0.0"},
+		{Org: "acme", Name: "session", Version: "v1.0.0"},
+		{Org: "example", Name: "uploads", Version: "v2.0.0"},
 	})
 
-	result := markModuleMetaForGraph(e, "kickside/uploads", "v2.0.0", owners, nil)
+	result := markModuleMetaForGraph(e, "example/uploads", "v2.0.0", owners, nil)
 
-	assert.Equal(t, "wippy/session", entryModule(result))
+	assert.Equal(t, "acme/session", entryModule(result))
 	assert.Equal(t, "v1.0.0", result.Meta.GetString(metaModuleVersionKey, ""))
 }
 
 func TestMarkModuleMetaForGraph_UsesSnapshotEntryOwner(t *testing.T) {
-	id := regapi.NewID("wippy.llm.openai_compat", "client")
+	id := regapi.NewID("acme.llm.openai_compat", "client")
 	e := regapi.Entry{ID: id}
-	entryOwners := map[regapi.ID]moduleOwner{
-		id: {name: "wippy/llm", version: "v4.0.0"},
+	entryOwners := map[string]moduleOwner{
+		idKey(id): {name: "acme/llm", version: "v4.0.0"},
 	}
 
-	result := markModuleMetaForGraph(e, "kickside/skills", "v2.0.0", nil, entryOwners)
+	result := markModuleMetaForGraph(e, "example/skills", "v2.0.0", nil, entryOwners)
 
-	assert.Equal(t, "wippy/llm", entryModule(result))
+	assert.Equal(t, "acme/llm", entryModule(result))
 	assert.Equal(t, "v4.0.0", result.Meta.GetString(metaModuleVersionKey, ""))
 }
 
@@ -248,9 +248,9 @@ func TestPreserveHostSnapshotEntry_KeepsExistingUnownedEntry(t *testing.T) {
 
 	result, ok := preserveHostSnapshotEntry(
 		loaded,
-		"kickside/security",
-		map[regapi.ID]regapi.Entry{id: existing},
-		map[string]struct{}{"kickside/security": {}},
+		"acme/security",
+		map[string]regapi.Entry{idKey(id): existing},
+		map[string]struct{}{"acme/security": {}},
 	)
 
 	require.True(t, ok)
@@ -388,9 +388,9 @@ func TestBuildOperations_DeletesOnlyControlledModules(t *testing.T) {
 			Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: "acme/http"}),
 		},
 		{
-			ID:   regapi.NewID("keeper.hub.tools", "dependencies"),
+			ID:   regapi.NewID("example.tools", "dependencies"),
 			Kind: "function.lua",
-			Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: "keeper/keeper"}),
+			Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: "example/keeper"}),
 		},
 	}
 	desired := []regapi.Entry{
@@ -558,11 +558,11 @@ func TestNewDependencyResolutionErrors_NoHintWithoutAuthCause(t *testing.T) {
 
 func TestNewDependencyResolutionErrors_MessageIncludesCause(t *testing.T) {
 	errs := []ResolutionError{
-		{Org: "kickside", Name: "research", Constraint: "0.1.0", Message: "module not found", Err: errors.New("module not found")},
+		{Org: "acme", Name: "research", Constraint: "0.1.0", Message: "module not found", Err: errors.New("module not found")},
 	}
 
 	apiErr := NewDependencyResolutionErrors(errs)
-	assert.Contains(t, apiErr.Error(), "kickside/research@0.1.0")
+	assert.Contains(t, apiErr.Error(), "acme/research@0.1.0")
 	assert.Contains(t, apiErr.Error(), "module not found")
 }
 

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -961,6 +961,41 @@ func TestDependencyHandler_Expand_RejectsDuplicateRootComponentBeforeLinking(t *
 	assert.Equal(t, "app:dep.wippy.bootloader", apiErr.Details().GetString("requested_entry_id", ""))
 }
 
+func TestDependencyHandler_CollectDesiredDependencies_TreatsHydratedSameIDAsSameRoot(t *testing.T) {
+	ctx := newTestContext()
+	transcoder := payload.GetTranscoder(ctx)
+	require.NotNil(t, transcoder)
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       &fakeHub{},
+		Logger:    zap.NewNop(),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	hydratedDep := regapi.Entry{
+		ID:   regapi.ID{NS: "app.deps", Name: "bootloader"},
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/bootloader","version":"0.3.12"}`, payload.JSON),
+	}
+	updatedDep := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "bootloader"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/bootloader","version":"*"}`, payload.JSON),
+	}
+
+	deps, err := handler.collectDesiredDependencies(ctx,
+		regapi.Operation{Kind: regapi.EntryCreate, Entry: updatedDep},
+		regapi.State{hydratedDep},
+		transcoder,
+	)
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "app.deps:bootloader", deps[0].entry.ID.String())
+	assert.Equal(t, "acme/bootloader", deps[0].definition.Component)
+	assert.Equal(t, "*", deps[0].definition.Version)
+}
+
 func TestDependencyHandler_Expand_RootParametersOverrideModuleOwnedTransitiveParameters(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -58,11 +58,41 @@ func (l *Lock) Read() error {
 		return NewReadFileError(err)
 	}
 
-	if err := yaml.Unmarshal(data, &l.data); err != nil {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return NewUnmarshalYAMLError(err)
+	}
+	normalizeEmptySequenceField(&root, "modules")
+	normalizeEmptySequenceField(&root, "replacements")
+
+	if err := root.Decode(&l.data); err != nil {
 		return NewUnmarshalYAMLError(err)
 	}
 
 	return nil
+}
+
+func normalizeEmptySequenceField(root *yaml.Node, field string) {
+	if root == nil {
+		return
+	}
+	doc := root
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		doc = root.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		key := doc.Content[i]
+		value := doc.Content[i+1]
+		if key.Value == field && value.Kind == yaml.MappingNode && len(value.Content) == 0 {
+			value.Kind = yaml.SequenceNode
+			value.Tag = "!!seq"
+			value.Content = nil
+			return
+		}
+	}
 }
 
 // Write saves the lock file to disk with deduplication and sorting.

--- a/boot/deps/lock/lock_test.go
+++ b/boot/deps/lock/lock_test.go
@@ -164,6 +164,52 @@ func TestLock_Write(t *testing.T) {
 	})
 }
 
+func TestLock_Read_NormalizesEmptySequenceFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "test.lock")
+	content := `directories:
+  modules: .wippy
+  src: .
+modules:
+  - name: wippy/test
+    version: v1.0.0
+replacements: {}
+`
+	if err := os.WriteFile(lockPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write test lock: %v", err)
+	}
+
+	lockObj, err := New(lockPath)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if got := len(lockObj.data.Replacements); got != 0 {
+		t.Fatalf("expected no replacements, got %d", got)
+	}
+	if got := len(lockObj.data.Modules); got != 1 {
+		t.Fatalf("expected one module, got %d", got)
+	}
+}
+
+func TestLock_Read_RejectsNonEmptyReplacementMap(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "test.lock")
+	content := `directories:
+  modules: .wippy
+  src: .
+modules: []
+replacements:
+  from: wippy/local
+`
+	if err := os.WriteFile(lockPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write test lock: %v", err)
+	}
+
+	if _, err := New(lockPath); err == nil {
+		t.Fatal("expected error for non-empty replacement map")
+	}
+}
+
 func TestLock_GetModule(t *testing.T) {
 	lock, _ := New(filepath.Join(t.TempDir(), "test.lock"))
 	lock.SetModule(Module{Name: "wippy/test", Version: "v1.0.0"})

--- a/boot/loader/entry_loader_test.go
+++ b/boot/loader/entry_loader_test.go
@@ -338,6 +338,45 @@ entries:
 	require.True(t, strings.Contains(err.Error(), "kind"), "error should name the rejected field: %v", err)
 }
 
+func TestLoader_LoadFSSkipsMalformedNonManifestAsset(t *testing.T) {
+	suite := NewTestSuite()
+	ldr := NewLoader(suite.transcoder, nil, interpolate.NewEntryInterpolator(suite.transcoder))
+	fsys := fstest.MapFS{
+		"_index.yaml": &fstest.MapFile{Data: []byte(`version: "1.0"
+namespace: app
+entries:
+  - name: ok
+    kind: service
+`)},
+		"ui/node_modules/es-errors/tsconfig.json": &fstest.MapFile{Data: []byte(`{
+  "extends": "./tsconfig.base.json",
+  // JSONC comments are valid for tsconfig, but not for Wippy manifests.
+  "compilerOptions": {}
+}`)},
+	}
+
+	entries, err := ldr.LoadFS(ctxapi.NewRootContext(), fsys)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "app:ok", entries[0].ID.String())
+}
+
+func TestLoader_LoadFileSkipsMalformedNonManifestAsset(t *testing.T) {
+	suite := NewTestSuite()
+	ldr := NewLoader(suite.transcoder, nil, interpolate.NewEntryInterpolator(suite.transcoder))
+	fsys := fstest.MapFS{
+		"ui/node_modules/es-errors/tsconfig.json": &fstest.MapFile{Data: []byte(`{
+  "extends": "./tsconfig.base.json",
+  // JSONC comments are valid for tsconfig, but not for Wippy manifests.
+  "compilerOptions": {}
+}`)},
+	}
+
+	entries, err := ldr.LoadFile(ctxapi.NewRootContext(), fsys, "ui/node_modules/es-errors/tsconfig.json")
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
 // TestEntryProcessor tests the EntryProcessor functionality
 func TestEntryProcessor(t *testing.T) {
 	suite := NewTestSuite()

--- a/boot/loader/loader.go
+++ b/boot/loader/loader.go
@@ -5,6 +5,7 @@ package loader
 import (
 	"context"
 	iofs "io/fs"
+	"path/filepath"
 
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
@@ -91,6 +92,18 @@ func (l *Loader) LoadFile(ctx context.Context, fs iofs.FS, filePath string) ([]r
 
 // processFile processes a single file and returns registry entries
 func (l *Loader) processFile(ctx context.Context, fSys iofs.FS, p *FilePayload) ([]registry.Entry, error) {
+	processor := NewEntryProcessor(l.dtt)
+	candidate, err := processor.isEntryFileCandidate(p)
+	if err != nil {
+		if !isStrictManifestSource(p.Source()) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !candidate {
+		return nil, nil
+	}
+
 	// Interpolate values
 	interpolated, err := l.interpolator.Interpolate(p, interpolate.EntryContext{
 		Filename: p.Source(),
@@ -102,7 +115,7 @@ func (l *Loader) processFile(ctx context.Context, fSys iofs.FS, p *FilePayload) 
 	}
 
 	// Extract entries
-	newEntries, err := ExtractDependenciesToEntries(interpolated, l.dtt)
+	newEntries, err := processor.ExtractDependenciesToEntries(ctx, interpolated)
 	if err != nil {
 		return nil, NewExtractEntriesError(err)
 	}
@@ -115,6 +128,16 @@ func (l *Loader) processFile(ctx context.Context, fSys iofs.FS, p *FilePayload) 
 	}
 
 	return newEntries, nil
+}
+
+func isStrictManifestSource(source string) bool {
+	base := filepath.Base(source)
+	switch base {
+	case "_index.json", "_index.yaml", "_index.yml":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateEntry(entry registry.Entry) error {

--- a/system/registry/history/sqlite/sqlite.go
+++ b/system/registry/history/sqlite/sqlite.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 
@@ -56,6 +58,12 @@ func newMsgpackHandle() *codec.MsgpackHandle {
 func NewSQLite(dbPath string, log *zap.Logger) (*History, error) {
 	openMu.Lock()
 	defer openMu.Unlock()
+
+	if dir := filepath.Dir(dbPath); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return nil, NewOpenDatabaseError(err)
+		}
+	}
 
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000", dbPath))
 	if err != nil {

--- a/system/registry/history/sqlite/sqlite_test.go
+++ b/system/registry/history/sqlite/sqlite_test.go
@@ -58,6 +58,18 @@ func TestHistory_Basic(t *testing.T) {
 	assert.Equal(t, uint(0), head.ID())
 }
 
+func TestHistory_CreatesParentDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "nested", "registry", "history.db")
+
+	hist, err := NewSQLite(dbPath, zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	_, err = os.Stat(dbPath)
+	require.NoError(t, err)
+}
+
 func TestHistory_SaveAndGet(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")

--- a/system/registry/load_state_test.go
+++ b/system/registry/load_state_test.go
@@ -163,6 +163,96 @@ func TestRegistry_LoadState_WithHistory(t *testing.T) {
 	assert.True(t, found, "entry1 should be updated")
 }
 
+func TestRegistry_LoadState_ReplaysHistoryThroughDirectives(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	hist := history.NewMemory()
+	resolver := topology.NewResolver()
+
+	run := func(state registry.State, changes registry.ChangeSet) (registry.State, error) {
+		stateMap := make(map[registry.ID]registry.Entry)
+		for _, e := range state {
+			stateMap[e.ID] = e
+		}
+		for _, op := range changes {
+			switch op.Kind {
+			case registry.EntryCreate, registry.EntryUpdate:
+				stateMap[op.Entry.ID] = op.Entry
+			case registry.EntryDelete:
+				delete(stateMap, op.Entry.ID)
+			}
+		}
+		result := make(registry.State, 0, len(stateMap))
+		for _, e := range stateMap {
+			result = append(result, e)
+		}
+		return result, nil
+	}
+
+	depEntry := registry.Entry{
+		ID:   registry.NewID("app.deps", "sso"),
+		Kind: registry.NamespaceDependency,
+		Data: payload.New("dep"),
+	}
+	expandedEntry := registry.Entry{
+		ID:   registry.NewID("kickside.sso", "flow_store"),
+		Kind: "store.memory",
+		Data: payload.New("expanded"),
+	}
+	expander := directiveFunc(func(_ context.Context, op registry.Operation, _ registry.State) (registry.DirectiveResult, error) {
+		if op.Entry.Kind != registry.NamespaceDependency {
+			return registry.DirectiveResult{}, nil
+		}
+		return registry.DirectiveResult{
+			Applied: true,
+			Additional: []registry.ScopedOperation{{
+				Operation: registry.Operation{Kind: registry.EntryCreate, Entry: expandedEntry},
+				Scope:     registry.ScopeBaseline,
+			}},
+		}, nil
+	})
+
+	runner := NewMockRunner()
+	runner.RunFunc = run
+	reg := NewRegistry(
+		hist,
+		runner,
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+		WithKindDirective(registry.NamespaceDependency, expander),
+	)
+
+	v1, err := reg.Apply(ctx, registry.ChangeSet{{Kind: registry.EntryCreate, Entry: depEntry}})
+	require.NoError(t, err)
+	require.Equal(t, uint(1), v1.ID())
+
+	stored, err := hist.Get(v1)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.Equal(t, depEntry.ID, stored[0].Entry.ID)
+
+	runner2 := NewMockRunner()
+	runner2.RunFunc = run
+	reg2 := NewRegistry(
+		hist,
+		runner2,
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+		WithKindDirective(registry.NamespaceDependency, expander),
+	)
+
+	head, err := hist.Head()
+	require.NoError(t, err)
+	require.NoError(t, reg2.LoadState(ctx, nil, head))
+
+	_, err = reg2.GetEntry(depEntry.ID)
+	require.NoError(t, err)
+	_, err = reg2.GetEntry(expandedEntry.ID)
+	require.NoError(t, err)
+}
+
 func TestRegistry_LoadState_MultipleVersions(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.NewNop()

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -520,10 +520,11 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Build state map once from baseline
-	stateMap := make(map[registry.ID]registry.Entry, len(baseline))
-	for _, entry := range baseline {
-		stateMap[entry.ID] = entry
+	stateMap := topology.NewStateMap(baseline)
+	var planner *regexp.Planner
+	var preparedEff []registry.Effect
+	if len(r.directivesByKind) > 0 {
+		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
 	}
 
 	if targetVersion.ID() > 0 {
@@ -539,14 +540,43 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			zap.Uint("target_version", targetVersion.ID()),
 			zap.Int("changeset_count", len(versions)))
 
-		// Apply all operations directly to the map
 		for _, ver := range versions {
 			cs, err := r.history.Get(ver)
 			if err != nil {
+				if planner != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+				}
 				return NewGetChangesetError(ver.ID(), err)
 			}
 
-			for _, op := range cs {
+			ops := cs
+			snapshot := topology.StateMapToSlice(stateMap)
+			if planner != nil {
+				plan, err := planner.Expand(ctx, cs, snapshot)
+				if err != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+					return NewExpandChangesError(err)
+				}
+				plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
+				if err != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+					return NewSortChangesError(err)
+				}
+				ops, _ = plan.SplitScopes()
+
+				prepared, err := planner.PrepareEffects(ctx, plan.Effects)
+				if err != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+					planner.RollbackEffects(ctx, prepared)
+					return NewPrepareEffectsError(err)
+				}
+				preparedEff = append(preparedEff, prepared...)
+			}
+			if sorted, err := r.builder.SortChangeSet(snapshot, ops); err == nil {
+				ops = sorted
+			}
+
+			for _, op := range ops {
 				switch op.Kind {
 				case registry.EntryCreate, registry.EntryUpdate:
 					stateMap[op.Entry.ID] = op.Entry
@@ -557,21 +587,35 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		}
 	}
 
-	// Convert map to slice once at the end
-	finalState := make(registry.State, 0, len(stateMap))
-	for _, entry := range stateMap {
-		finalState = append(finalState, entry)
-	}
+	finalState := topology.StateMapToSlice(stateMap)
 
 	newState, err := r.transitionState(ctx, r.state, finalState)
 	if err != nil {
 		r.log.Error("failed to load state", zap.String("version", targetVersion.String()), zap.Error(err))
 		if newState != nil && ctx.Err() == nil {
 			if rerr := r.rollback(ctx, newState, r.state); rerr != nil {
+				if planner != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+				}
 				return NewLoadStateError(err, rerr)
 			}
 		}
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
 		return NewLoadStateError(err, nil)
+	}
+
+	if planner != nil {
+		if err := planner.CommitEffects(ctx, preparedEff); err != nil {
+			r.log.Error("failed to commit load-state effects", zap.Error(err))
+			if rerr := r.rollback(ctx, newState, r.state); rerr != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewCommitEffectsError(err, rerr)
+			}
+			planner.RollbackEffects(ctx, preparedEff)
+			return NewCommitEffectsError(err, nil)
+		}
 	}
 
 	r.state = newState


### PR DESCRIPTION
## Summary
- allow dependency expansion to ignore active profile overrides for entries outside the partial install graph
- create SQLite registry-history parent directories on first boot
- replay registry history through directives so installed dependency entries are reconstructed after restart
- tolerate old empty lock sequence fields written as empty maps

## Why
Running a packaged app with active runtime profiles can leave global overrides in boot config. Later Hub installs expand only a partial dependency graph, so strict override application fails on app-owned entries such as app:db, app:gateway, or app.env:defaults that are not part of that partial graph.

## Tests
- go test ./boot/build/stages ./boot/deps/hub ./boot/deps/lock ./system/registry/history/sqlite ./system/registry