### PR TITLE
fix(registry): canonicalize dependency root IDs

### DIFF
--- a/api/registry/id.go
+++ b/api/registry/id.go
@@ -19,6 +19,14 @@ type ID struct {
 	str string
 }
 
+func canonicalIDParts(id ID) (Namespace, Name) {
+	if id.NS == "" && strings.Contains(id.Name, ":") {
+		parsed := parseIDString(id.Name)
+		return parsed.NS, parsed.Name
+	}
+	return id.NS, id.Name
+}
+
 // NewID creates a new interned ID with the given namespace and name.
 // Use this instead of direct ID{} construction to ensure string deduplication.
 func NewID(ns, name string) ID {
@@ -39,7 +47,9 @@ func (t *ID) String() string {
 
 // Equal returns true if both IDs have the same namespace and name.
 func (t *ID) Equal(other ID) bool {
-	return t.NS == other.NS && t.Name == other.Name
+	ns, name := canonicalIDParts(*t)
+	otherNS, otherName := canonicalIDParts(other)
+	return ns == otherNS && name == otherName
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -95,7 +105,11 @@ func (t *ID) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &obj); err != nil {
 			return err
 		}
-		id = ID{NS: obj.NS, Name: obj.Name, str: obj.NS + ":" + obj.Name}
+		if obj.NS == "" && strings.Contains(obj.Name, ":") {
+			id = parseIDString(obj.Name)
+		} else {
+			id = ID{NS: obj.NS, Name: obj.Name, str: obj.NS + ":" + obj.Name}
+		}
 	}
 
 	*t = unique.Make(id).Value()

--- a/api/registry/id_test.go
+++ b/api/registry/id_test.go
@@ -67,6 +67,12 @@ func TestID_UnmarshalJSON(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "object format with qualified name and missing namespace",
+			input:    `{"name":"test-ns:test-name"}`,
+			expected: ID{NS: "test-ns", Name: "test-name"},
+			wantErr:  false,
+		},
+		{
 			name:     "invalid json",
 			input:    `{"ns":test-ns","name":"test-name"}`,
 			expected: ID{},
@@ -343,6 +349,12 @@ func TestID_Equal(t *testing.T) {
 			name:     "equal IDs",
 			id1:      ID{NS: "ns", Name: "name"},
 			id2:      ID{NS: "ns", Name: "name"},
+			expected: true,
+		},
+		{
+			name:     "qualified name matches parsed id",
+			id1:      ID{Name: "ns:name"},
+			id2:      NewID("ns", "name"),
 			expected: true,
 		},
 		{

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1753,6 +1753,24 @@ func markModuleMetaForGraph(
 }
 
 func idKey(id regapi.ID) string {
+	if strings.TrimSpace(id.NS) == "" {
+		name := strings.TrimSpace(id.Name)
+		if strings.Contains(name, ":") {
+			parsed := regapi.ParseID(name)
+			if parsed.NS != "" || parsed.Name != "" {
+				return strings.TrimSpace(parsed.NS) + ":" + strings.TrimSpace(parsed.Name)
+			}
+		}
+	}
+	if s := strings.TrimSpace(id.String()); s != "" {
+		if strings.HasPrefix(s, ":") && strings.Contains(strings.TrimPrefix(s, ":"), ":") {
+			s = strings.TrimPrefix(s, ":")
+		}
+		parsed := regapi.ParseID(s)
+		if parsed.NS != "" || parsed.Name != "" {
+			return strings.TrimSpace(parsed.NS) + ":" + strings.TrimSpace(parsed.Name)
+		}
+	}
 	if id.NS != "" || id.Name != "" {
 		return strings.TrimSpace(id.NS) + ":" + strings.TrimSpace(id.Name)
 	}
@@ -1760,7 +1778,10 @@ func idKey(id regapi.ID) string {
 }
 
 func idsEqual(a, b regapi.ID) bool {
-	return idKey(a) == idKey(b)
+	if idKey(a) == idKey(b) {
+		return true
+	}
+	return strings.TrimSpace(a.String()) == strings.TrimSpace(b.String())
 }
 
 func entriesEqual(a, b regapi.Entry) bool {

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -996,6 +996,34 @@ func TestDependencyHandler_CollectDesiredDependencies_TreatsHydratedSameIDAsSame
 	assert.Equal(t, "*", deps[0].definition.Version)
 }
 
+func TestValidateRootDependencyComponents_AllowsSameRootIDReplacement(t *testing.T) {
+	rootID := regapi.NewID("app.deps", "tools")
+	hydratedID := regapi.ID{Name: "app.deps:tools"}
+	err := validateRootDependencyComponents([]desiredDependency{
+		{
+			entry:      regapi.Entry{ID: hydratedID, Kind: regapi.NamespaceDependency},
+			definition: DependencyDefinition{Component: "acme/tools", Version: "0.1.0"},
+		},
+		{
+			entry:      regapi.Entry{ID: rootID, Kind: regapi.NamespaceDependency},
+			definition: DependencyDefinition{Component: "acme/tools", Version: "0.2.0"},
+		},
+	}, rootID)
+	require.NoError(t, err)
+
+	err = validateRootDependencyComponents([]desiredDependency{
+		{
+			entry:      regapi.Entry{ID: regapi.NewID("app.deps", "tools"), Kind: regapi.NamespaceDependency},
+			definition: DependencyDefinition{Component: "acme/tools", Version: "0.1.0"},
+		},
+		{
+			entry:      regapi.Entry{ID: regapi.NewID("app.deps", "other_tools"), Kind: regapi.NamespaceDependency},
+			definition: DependencyDefinition{Component: "acme/tools", Version: "0.2.0"},
+		},
+	}, rootID)
+	require.Error(t, err)
+}
+
 func TestDependencyHandler_Expand_RootParametersOverrideModuleOwnedTransitiveParameters(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- canonicalize object-form registry IDs where a qualified ID is stored in name without ns
- use canonical dependency root IDs when validating same-component dependency replacement
- add regressions for ID unmarshal/equality and same-root dependency update validation

## Proof
- go test ./api/registry ./system/registry/... ./boot/deps/hub
- local patched runtime on poisoned Kickside app: dataflow dependency update applied, kickside/workflows update applied, spiralscout/stat-analysis install/uninstall applied

## Notes
This fixes the false conflict where an install/update tried to update an existing root but the runtime compared app.deps:name against :app.deps:name and rejected it as a duplicate component. Keeper self-update still has a separate self-restart/canceled transaction issue.