### PR TITLE
chore(dependabot): update ownership

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,15 @@ updates:
     schedule:
       interval: daily
     reviewers:
-      - "rustatian"
+      - "wolfy-j"
     assignees:
-      - "rustatian"
+      - "wolfy-j"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
     reviewers:
-      - "rustatian"
+      - "wolfy-j"
     assignees:
-      - "rustatian"
+      - "wolfy-j"


### PR DESCRIPTION
Replace the stale Dependabot reviewer and assignee with `wolfy-j` for both Go modules and GitHub Actions updates.