### PR TITLE
fix: refresh static filesystems after registry updates

### DIFF
--- a/service/http/factory.go
+++ b/service/http/factory.go
@@ -190,40 +190,31 @@ func (f *StaticFactory) CreateHandler(_ context.Context, cfg *config.StaticConfi
 		return nil, NewInvalidStaticConfigError(err)
 	}
 
-	fsys, ok := f.fsReg.GetFS(cfg.FS.String())
-	if !ok {
+	if _, ok := f.fsReg.GetFS(cfg.FS.String()); !ok {
 		return nil, NewFilesystemNotFoundError(cfg.FS.String())
 	}
-
-	// Create base handler
-	var handler http.Handler
-
-	// For SPA mode, use our custom handler
-	if cfg.StaticOptions.SPA {
-		if cfg.StaticOptions.IndexFile == "" {
-			return nil, ErrIndexFileRequired
-		}
-		handler = NewSPAHandler(fsys, cfg.StaticOptions.IndexFile)
-
-		if cfg.StaticOptions.CacheControl != "" {
-			handler = wrapWithCacheControl(handler, cfg.StaticOptions.CacheControl)
-		}
-	} else {
-		handler = http.FileServer(http.FS(fsys))
-
-		// Always strip the path prefix so the file server receives paths relative to the fs root
-		if cfg.Path != "" && cfg.Path != "/" {
-			handler = http.StripPrefix(cfg.Path, handler)
-		}
-
-		if cfg.StaticOptions.CacheControl != "" {
-			handler = wrapWithCacheControl(handler, cfg.StaticOptions.CacheControl)
-		}
+	if cfg.StaticOptions.SPA && cfg.StaticOptions.IndexFile == "" {
+		return nil, ErrIndexFileRequired
 	}
 
-	// Apply middleware if configured
+	// Do not retain a filesystem instance here. fs.directory and fs.embed can
+	// publish a replacement through the filesystem registry while this HTTP
+	// mount remains live. Resolving the current instance per request makes the
+	// mount observe that event instead of serving a closed or stale filesystem.
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fsys, ok := f.fsReg.GetFS(cfg.FS.String())
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		newStaticContentHandler(fsys, cfg).ServeHTTP(w, r)
+	})
+	if cfg.StaticOptions.CacheControl != "" {
+		handler = wrapWithCacheControl(handler, cfg.StaticOptions.CacheControl)
+	}
+
+	// Apply middleware once around the dynamic filesystem resolver.
 	if len(cfg.Middleware) > 0 {
-		// Build middleware chain
 		middlewareHandlers := make([]func(http.Handler) http.Handler, len(cfg.Middleware))
 		for i, name := range cfg.Middleware {
 			mw, err := f.middlewareFactory.CreateMiddleware(name, cfg.Options)
@@ -233,13 +224,28 @@ func (f *StaticFactory) CreateHandler(_ context.Context, cfg *config.StaticConfi
 			middlewareHandlers[i] = mw
 		}
 
-		// Apply middleware chain in reverse order
 		for i := len(middlewareHandlers) - 1; i >= 0; i-- {
 			handler = middlewareHandlers[i](handler)
 		}
 	}
 
 	return handler, nil
+}
+
+// newStaticContentHandler creates a content handler for one filesystem
+// generation. Callers should resolve that generation from the registry at the
+// boundary where a request is served.
+func newStaticContentHandler(fsys fs.FS, cfg *config.StaticConfig) http.Handler {
+	if cfg.StaticOptions.SPA {
+		return NewSPAHandler(fsys, cfg.StaticOptions.IndexFile)
+	}
+
+	handler := http.FileServer(http.FS(fsys))
+	if cfg.Path != "" && cfg.Path != "/" {
+		handler = http.StripPrefix(cfg.Path, handler)
+	}
+
+	return handler
 }
 
 // ServerFactory creates HTTP server instances

--- a/service/http/factory_test.go
+++ b/service/http/factory_test.go
@@ -18,12 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/event"
 	apifsLib "github.com/wippyai/runtime/api/fs"
 	"github.com/wippyai/runtime/api/function"
 	"github.com/wippyai/runtime/api/payload"
 	apiregistry "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/runtime"
 	config "github.com/wippyai/runtime/api/service/http"
+	"github.com/wippyai/runtime/system/eventbus"
+	fsregistry "github.com/wippyai/runtime/system/fs"
 	"go.uber.org/zap"
 )
 
@@ -415,6 +418,63 @@ func TestStaticFactory_CreateHandler(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "index file must be specified for SPA mode")
 	})
+}
+
+func TestStaticFactory_RefreshesMountedFilesAfterFilesystemRegisterEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := eventbus.NewBus()
+	defer bus.Stop()
+	registry := fsregistry.NewRegistry(bus, zap.NewNop())
+	require.NoError(t, registry.Start(ctx))
+	defer func() { require.NoError(t, registry.Stop()) }()
+
+	oldDir, cleanupOld := createFactoryTempDir(t, map[string]string{"app.html": "old bundle"})
+	defer cleanupOld()
+	newDir, cleanupNew := createFactoryTempDir(t, map[string]string{"app.html": "new bundle"})
+	defer cleanupNew()
+
+	oldFS := NewMockFS(oldDir)
+	newFS := NewMockFS(newDir)
+	fsID := "test:bundle"
+
+	bus.Send(ctx, event.Event{System: apifsLib.System, Kind: apifsLib.FsRegister, Path: fsID, Data: oldFS})
+	require.Eventually(t, func() bool {
+		got, ok := registry.GetFS(fsID)
+		return ok && got == oldFS
+	}, time.Second, 10*time.Millisecond)
+
+	factory, err := NewStaticFactory(registry, NewMiddlewareRegistry(nil))
+	require.NoError(t, err)
+	handler, err := factory.CreateHandler(ctx, &config.StaticConfig{
+		Meta: map[string]any{config.ServerID: "test:gateway"},
+		Path: "/app/keeper",
+		FS:   apiregistry.ParseID(fsID),
+	})
+	require.NoError(t, err)
+
+	serve := func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "http://example.com/app/keeper/app.html", nil))
+		return w
+	}
+
+	first := serve()
+	require.Equal(t, http.StatusOK, first.Code)
+	assert.Equal(t, "old bundle", first.Body.String())
+
+	// This is the same event emitted when fs.directory or fs.embed publishes a
+	// new package generation. The mounted HTTP route must now use newFS.
+	bus.Send(ctx, event.Event{System: apifsLib.System, Kind: apifsLib.FsRegister, Path: fsID, Data: newFS})
+	require.Eventually(t, func() bool {
+		got, ok := registry.GetFS(fsID)
+		return ok && got == newFS
+	}, time.Second, 10*time.Millisecond)
+
+	second := serve()
+	require.Equal(t, http.StatusOK, second.Code)
+	assert.Equal(t, "new bundle", second.Body.String())
 }
 
 func TestNewStaticFactory(t *testing.T) {


### PR DESCRIPTION
Makes http.static resolve its filesystem from the registry per request, so fs.register replacement events from fs.directory/fs.embed immediately refresh an existing mount instead of leaving it bound to a stale or closed filesystem.\n\nRegression: publishes old and new filesystems through the real fs registry event bus; the same mounted /app/keeper/app.html route must change from old bundle to new bundle.\n\nVerified: go test ./service/http; make build-wippy-local; local Kickside smoke GET /app/keeper/app.html -> 200.