### PR TITLE
fix: preserve declared root dependency ranges

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -355,10 +355,6 @@ func (h *DependencyHandler) collectDesiredDependencies(
 	transcoder payload.Transcoder,
 ) ([]desiredDependency, error) {
 	deps := make(map[string]desiredDependency)
-	lockedVersions, err := h.installedModuleVersions(ctx, transcoder, snapshot)
-	if err != nil {
-		return nil, err
-	}
 	operationID := op.Entry.ID
 
 	current, err := h.collectSnapshotDependencies(ctx, snapshot, transcoder)
@@ -366,9 +362,6 @@ func (h *DependencyHandler) collectDesiredDependencies(
 		return nil, err
 	}
 	for _, dep := range current {
-		if !idsEqual(dep.entry.ID, operationID) {
-			dep.definition = pinExistingDependencyVersion(dep.definition, lockedVersions)
-		}
 		deps[idKey(dep.entry.ID)] = dep
 	}
 
@@ -475,16 +468,6 @@ func snapshotModuleVersions(snapshot regapi.State) map[string]string {
 		versions[module] = version
 	}
 	return versions
-}
-
-func pinExistingDependencyVersion(def DependencyDefinition, moduleVersions map[string]string) DependencyDefinition {
-	if def.Component == "" {
-		return def
-	}
-	if version := moduleVersions[def.Component]; version != "" {
-		def.Version = version
-	}
-	return def
 }
 
 func mergeLinkDependencies(explicitDeps, moduleEntries []regapi.Entry) []regapi.Entry {

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -2212,7 +2212,7 @@ func TestDependencyHandler_CollectDesiredDependencies_IgnoresModuleOwnedDependen
 	assert.Equal(t, "acme/root", deps[0].definition.Component)
 }
 
-func TestDependencyHandler_CollectDesiredDependencies_PinsExistingInstalledVersions(t *testing.T) {
+func TestDependencyHandler_CollectDesiredDependencies_PreservesExistingDeclaredVersions(t *testing.T) {
 	ctx := newTestContext()
 	transcoder := payload.GetTranscoder(ctx)
 	require.NotNil(t, transcoder)
@@ -2258,7 +2258,7 @@ func TestDependencyHandler_CollectDesiredDependencies_PinsExistingInstalledVersi
 	for _, dep := range deps {
 		versions[dep.definition.Component] = dep.definition.Version
 	}
-	assert.Equal(t, "0.5.39", versions["wippy/facade"])
+	assert.Equal(t, ">=v0.5.16", versions["wippy/facade"])
 	assert.Equal(t, ">=v0.0.0", versions["wippy/dummy"])
 }
 


### PR DESCRIPTION
Preserves existing root dependency declarations during changeset expansion instead of replacing them with installed lock versions. Regression test covers an unrelated changeset preserving a declared range. Focused test: go test ./boot/deps/hub. Local binary built but not installed.