### PR TITLE
fix(hub): resolve dependencies against the declared range, not the resolved pin

### DIFF
--- a/api/hub/wippy/api/hub/manifest/v1/message.pb.go
+++ b/api/hub/wippy/api/hub/manifest/v1/message.pb.go
@@ -202,15 +202,19 @@ func (x *ModuleManifest) GetProtected() bool {
 
 // Resolved dependency with download info.
 type ResolvedDependency struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Org           string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Version       string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
-	VersionId     string                 `protobuf:"bytes,4,opt,name=version_id,json=versionId,proto3" json:"version_id,omitempty"`
-	Digest        string                 `protobuf:"bytes,5,opt,name=digest,proto3" json:"digest,omitempty"`
-	SizeBytes     uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
-	Download      *v11.DownloadInfo      `protobuf:"bytes,7,opt,name=download,proto3" json:"download,omitempty"`
-	Protected     bool                   `protobuf:"varint,8,opt,name=protected,proto3" json:"protected,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Org       string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`
+	Name      string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Version   string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+	VersionId string                 `protobuf:"bytes,4,opt,name=version_id,json=versionId,proto3" json:"version_id,omitempty"`
+	Digest    string                 `protobuf:"bytes,5,opt,name=digest,proto3" json:"digest,omitempty"`
+	SizeBytes uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Download  *v11.DownloadInfo      `protobuf:"bytes,7,opt,name=download,proto3" json:"download,omitempty"`
+	Protected bool                   `protobuf:"varint,8,opt,name=protected,proto3" json:"protected,omitempty"`
+	// Version range the parent module declared for this dependency, verbatim
+	// (e.g. ">=v0.4.10"). Consumers resolve and lock against this range; version
+	// above is only the release it resolved to at request time.
+	Constraint    string `protobuf:"bytes,9,opt,name=constraint,proto3" json:"constraint,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -299,6 +303,13 @@ func (x *ResolvedDependency) GetProtected() bool {
 		return x.Protected
 	}
 	return false
+}
+
+func (x *ResolvedDependency) GetConstraint() string {
+	if x != nil {
+		return x.Constraint
+	}
+	return ""
 }
 
 // Dependency specification for resolution.
@@ -713,7 +724,7 @@ const file_wippy_api_hub_manifest_v1_message_proto_rawDesc = "" +
 	"\fdependencies\x18\t \x03(\v2-.wippy.api.hub.manifest.v1.ResolvedDependencyR\fdependencies\x12A\n" +
 	"\bdownload\x18\n" +
 	" \x01(\v2%.wippy.api.hub.common.v1.DownloadInfoR\bdownload\x12\x1c\n" +
-	"\tprotected\x18\v \x01(\bR\tprotected\"\x8b\x02\n" +
+	"\tprotected\x18\v \x01(\bR\tprotected\"\xab\x02\n" +
 	"\x12ResolvedDependency\x12\x10\n" +
 	"\x03org\x18\x01 \x01(\tR\x03org\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -724,7 +735,10 @@ const file_wippy_api_hub_manifest_v1_message_proto_rawDesc = "" +
 	"\n" +
 	"size_bytes\x18\x06 \x01(\x04R\tsizeBytes\x12A\n" +
 	"\bdownload\x18\a \x01(\v2%.wippy.api.hub.common.v1.DownloadInfoR\bdownload\x12\x1c\n" +
-	"\tprotected\x18\b \x01(\bR\tprotected\"V\n" +
+	"\tprotected\x18\b \x01(\bR\tprotected\x12\x1e\n" +
+	"\n" +
+	"constraint\x18\t \x01(\tR\n" +
+	"constraint\"V\n" +
 	"\x0eDependencySpec\x12\x10\n" +
 	"\x03org\x18\x01 \x01(\tR\x03org\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1e\n" +

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -66,14 +66,18 @@ type ModuleManifest struct {
 
 // ManifestDep represents a dependency declared by a resolved manifest.
 type ManifestDep struct {
-	Org       string
-	Name      string
-	Version   string
-	VersionID string
-	Digest    string
-	URL       string
-	SizeBytes uint64
-	Protected bool
+	Org     string
+	Name    string
+	Version string
+	// Constraint is the range the parent module declared, verbatim (e.g.
+	// ">=v0.4.10"). Version is only what the server resolved it to; resolving or
+	// locking against Version would collapse the range into a pin.
+	Constraint string
+	VersionID  string
+	Digest     string
+	URL        string
+	SizeBytes  uint64
+	Protected  bool
 }
 
 // GetManifest retrieves the manifest for a single module version. The
@@ -130,13 +134,14 @@ func (c *Client) GetManifest(ctx context.Context, org, module, constraint string
 
 	for _, dep := range m.Dependencies {
 		md := ManifestDep{
-			Org:       dep.Org,
-			Name:      dep.Name,
-			Version:   dep.Version,
-			VersionID: dep.VersionId,
-			Digest:    dep.Digest,
-			SizeBytes: dep.SizeBytes,
-			Protected: dep.Protected,
+			Org:        dep.Org,
+			Name:       dep.Name,
+			Version:    dep.Version,
+			VersionID:  dep.VersionId,
+			Digest:     dep.Digest,
+			SizeBytes:  dep.SizeBytes,
+			Protected:  dep.Protected,
+			Constraint: dep.Constraint,
 		}
 		if dep.Download != nil {
 			md.URL = dep.Download.Url

--- a/boot/deps/hub/manifest_test.go
+++ b/boot/deps/hub/manifest_test.go
@@ -3,9 +3,16 @@
 package hub
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	manifestv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/manifest/v1"
+	manifestv1connect "github.com/wippyai/runtime/api/hub/wippy/api/hub/manifest/v1/manifestv1connect"
 )
 
 func TestResolutionError_String_WithConstraint(t *testing.T) {
@@ -25,4 +32,49 @@ func TestResolutionError_String_WithoutConstraint(t *testing.T) {
 		Message: "module not found",
 	}
 	assert.Equal(t, "wippyai/stdlib: module not found", e.String())
+}
+
+type constraintManifestService struct {
+	manifestv1connect.UnimplementedManifestServiceHandler
+}
+
+func (s *constraintManifestService) GetManifest(
+	_ context.Context,
+	_ *connect.Request[manifestv1.GetManifestRequest],
+) (*connect.Response[manifestv1.GetManifestResponse], error) {
+	return connect.NewResponse(&manifestv1.GetManifestResponse{
+		Manifest: &manifestv1.ModuleManifest{
+			Org:     "keeper",
+			Name:    "keeper",
+			Version: "0.5.57",
+			Dependencies: []*manifestv1.ResolvedDependency{{
+				Org:        "wippy",
+				Name:       "dataflow",
+				Version:    "0.5.2",
+				Constraint: ">=v0.4.10",
+			}},
+		},
+	}), nil
+}
+
+// The declared constraint must survive the wire: hub sends the range it was
+// published with, and the client must decode it rather than seeing only the
+// version hub resolved that range to.
+func TestGetManifest_DecodesDeclaredConstraintFromWire(t *testing.T) {
+	mux := http.NewServeMux()
+	path, handler := manifestv1connect.NewManifestServiceHandler(&constraintManifestService{})
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(Options{BaseURL: server.URL})
+	require.NoError(t, err)
+
+	manifest, err := client.GetManifest(context.Background(), "keeper", "keeper", "0.5.57")
+	require.NoError(t, err)
+	require.Len(t, manifest.Dependencies, 1)
+
+	assert.Equal(t, ">=v0.4.10", manifest.Dependencies[0].Constraint)
+	assert.Equal(t, "0.5.2", manifest.Dependencies[0].Version)
 }

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -266,8 +266,20 @@ func (r *resolver) process(ctx context.Context, key string) {
 
 	source := moduleSource(key, version)
 	for _, dep := range manifest.Dependencies {
-		r.addConstraint(dep.Org+"/"+dep.Name, source, dep.Version)
+		r.addConstraint(dep.Org+"/"+dep.Name, source, declaredConstraint(dep))
 	}
+}
+
+// declaredConstraint returns the range the parent module declared for a
+// dependency. A hub that predates the constraint field sends only the version it
+// resolved to; fall back to it so an older server still yields a usable graph.
+// Grafting a resolved version in place of a real range would pin the dependency,
+// discarding any lock that satisfies the range and defeating intersection.
+func declaredConstraint(dep ManifestDep) string {
+	if dep.Constraint != "" {
+		return dep.Constraint
+	}
+	return dep.Version
 }
 
 // orphan removes a module that no live constraint demands and retracts its subtree.
@@ -383,6 +395,12 @@ func (r *resolver) resolveVersion(ctx context.Context, org, name string, live []
 
 // resolveIntersection selects the highest available version satisfying every
 // constraint, or errConstraintsIncompatible when none does.
+//
+// The constraints are matched individually rather than concatenated into one
+// string and reparsed: the parser caps a constraint at maxConstraintParts, a
+// budget sized for a single authored range, and a handful of parents each
+// declaring a two-sided range exceeds it. Concatenating would turn a perfectly
+// satisfiable set into a parse failure reported as a version conflict.
 func (r *resolver) resolveIntersection(ctx context.Context, org, name string, constraints []string) (string, error) {
 	key := org + "/" + name
 
@@ -390,9 +408,13 @@ func (r *resolver) resolveIntersection(ctx context.Context, org, name string, co
 		return locked, nil
 	}
 
-	merged, err := semver.ParseConstraint(strings.Join(constraints, " "))
-	if err != nil {
-		return "", errConstraintsIncompatible
+	parsed := make([]semver.Constraint, 0, len(constraints))
+	for _, c := range constraints {
+		p, err := semver.ParseConstraint(c)
+		if err != nil {
+			return "", fmt.Errorf("invalid constraint %q: %w", c, err)
+		}
+		parsed = append(parsed, p)
 	}
 
 	versions, err := r.provider.ListAllVersions(ctx, org, name)
@@ -400,34 +422,42 @@ func (r *resolver) resolveIntersection(ctx context.Context, org, name string, co
 		return "", fmt.Errorf("list versions: %w", err)
 	}
 
-	type indexedVersion struct {
-		original string
-		parsed   semver.Version
-	}
+	var best, bestStable *VersionInfo
+	var bestSem, bestStableSem semver.Version
 
-	indexed := make([]indexedVersion, 0, len(versions))
-	semverVersions := make([]semver.Version, 0, len(versions))
-	for _, v := range versions {
+	for i := range versions {
+		v := &versions[i]
 		sv, err := semver.ParseVersion(v.Version)
-		if err != nil {
+		if err != nil || !matchesAll(parsed, sv) {
 			continue
 		}
-		indexed = append(indexed, indexedVersion{parsed: sv, original: v.Version})
-		semverVersions = append(semverVersions, sv)
-	}
-
-	best, err := merged.FindBestMatch(semverVersions)
-	if err != nil {
-		return "", errConstraintsIncompatible
-	}
-
-	for _, iv := range indexed {
-		if iv.parsed.Equal(best) {
-			return iv.original, nil
+		if best == nil || sv.GreaterThan(bestSem) {
+			best, bestSem = v, sv
+		}
+		if !sv.IsPrerelease() && (bestStable == nil || sv.GreaterThan(bestStableSem)) {
+			bestStable, bestStableSem = v, sv
 		}
 	}
 
-	return best.String(), nil
+	// Mirror FindBestMatch: a stable release always wins over a prerelease.
+	if bestStable != nil {
+		return bestStable.Version, nil
+	}
+	if best != nil {
+		return best.Version, nil
+	}
+
+	return "", errConstraintsIncompatible
+}
+
+// matchesAll reports whether a version satisfies every constraint.
+func matchesAll(constraints []semver.Constraint, v semver.Version) bool {
+	for _, c := range constraints {
+		if !c.Match(v) {
+			return false
+		}
+	}
+	return true
 }
 
 // lockedSatisfiesAll reports whether a locked version satisfies every constraint.

--- a/boot/deps/hub/resolve_test.go
+++ b/boot/deps/hub/resolve_test.go
@@ -990,3 +990,146 @@ func TestManifestCache_TTLExpiry(t *testing.T) {
 	_, hit := cache.store.Get("acme/http@1.0.0")
 	assert.False(t, hit, "expired entry must not be served after TTL")
 }
+
+// dataflowProvider mirrors the real keeper/dataflow graph: keeper declares
+// ">=v0.4.10" for dataflow, and the hub resolved that range to 0.5.2 at request
+// time. dataflow ships 0.4.x releases and a breaking 0.5.x line.
+func dataflowProvider(constraint string) *fakeManifestProvider {
+	p := newFakeProvider()
+	p.addModule("keeper", "keeper", "0.5.57", ManifestDep{
+		Org:        "wippy",
+		Name:       "dataflow",
+		Version:    "0.5.2",
+		Constraint: constraint,
+	})
+	for _, v := range []string{"0.4.10", "0.4.31", "0.5.0", "0.5.2"} {
+		p.addModule("wippy", "dataflow", v)
+	}
+	return p
+}
+
+func resolveKeeper(t *testing.T, p *fakeManifestProvider, opts *ResolveOptions) map[string]string {
+	t.Helper()
+
+	result, err := Resolve(context.Background(), p, []DependencySpec{
+		{Org: "keeper", Name: "keeper", Constraint: "0.5.57"},
+	}, opts)
+	require.NoError(t, err)
+	assert.Empty(t, result.Errors)
+
+	got := make(map[string]string, len(result.Modules))
+	for _, m := range result.Modules {
+		got[m.Org+"/"+m.Name] = m.Version
+	}
+	return got
+}
+
+// A lock pinning a version that satisfies the declared range must survive. The
+// hub resolving ">=v0.4.10" to 0.5.2 is not a demand for 0.5.2; treating it as
+// one discards the lock and force-bumps the install to latest.
+func TestResolve_LockedVersionSurvivesDeclaredRange(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider(">=v0.4.10"), &ResolveOptions{
+		LockedVersions: map[string]string{"wippy/dataflow": "0.4.31"},
+	})
+
+	assert.Equal(t, "0.4.31", got["wippy/dataflow"])
+}
+
+// Without a lock the range still selects the newest matching release: preserving
+// the constraint must not change what ">=" means.
+func TestResolve_UnlockedDeclaredRangeTakesNewest(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider(">=v0.4.10"), nil)
+
+	assert.Equal(t, "0.5.2", got["wippy/dataflow"])
+}
+
+// A hub predating the constraint field sends only the resolved version, so the
+// resolver has nothing but that pin to go on. Asserted against a lock the pin
+// does not satisfy: the lock must lose, which is what distinguishes this path
+// from a real range (where the lock would win). Without the lock the assertion
+// would hold either way and prove nothing.
+func TestResolve_MissingConstraintFallsBackToResolvedVersion(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider(""), &ResolveOptions{
+		LockedVersions: map[string]string{"wippy/dataflow": "0.4.31"},
+	})
+
+	assert.Equal(t, "0.5.2", got["wippy/dataflow"])
+}
+
+// An unconstrained dependency accepts any version, so a locked one still holds.
+// Hub reports it as "*"; treating that as a pin would bump it to latest.
+func TestResolve_LockedVersionSurvivesAnyConstraint(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider("*"), &ResolveOptions{
+		LockedVersions: map[string]string{"wippy/dataflow": "0.4.31"},
+	})
+
+	assert.Equal(t, "0.4.31", got["wippy/dataflow"])
+}
+
+// Many modules depending on one module, each declaring its own compatible
+// two-sided range, is an ordinary graph. Preserving the declared ranges makes
+// those constraints distinct, so the module now resolves through the
+// intersection path -- which must still resolve, not report a conflict.
+func TestResolve_ManyParentsWithCompatibleRanges(t *testing.T) {
+	p := newFakeProvider()
+
+	// Distinct ranges: each parent pins its own floor, all mutually compatible.
+	parents := map[string]string{
+		"alpha":   ">=v0.4.10 <v0.5.0",
+		"bravo":   ">=v0.4.11 <v0.5.0",
+		"charlie": ">=v0.4.12 <v0.5.0",
+		"delta":   ">=v0.4.13 <v0.5.0",
+		"echo":    ">=v0.4.14 <v0.5.0",
+		"foxtrot": ">=v0.4.15 <v0.5.0",
+	}
+	roots := make([]DependencySpec, 0, len(parents))
+	for parent, constraint := range parents {
+		p.addModule("acme", parent, "1.0.0", ManifestDep{
+			Org:        "wippy",
+			Name:       "dataflow",
+			Version:    "0.4.31",
+			Constraint: constraint,
+		})
+		roots = append(roots, DependencySpec{Org: "acme", Name: parent, Constraint: "1.0.0"})
+	}
+	for _, v := range []string{"0.4.10", "0.4.31", "0.5.0"} {
+		p.addModule("wippy", "dataflow", v)
+	}
+
+	result, err := Resolve(context.Background(), p, roots, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Errors, "compatible ranges must not be reported as a conflict")
+
+	for _, m := range result.Modules {
+		if m.Org == "wippy" && m.Name == "dataflow" {
+			assert.Equal(t, "0.4.31", m.Version)
+			return
+		}
+	}
+	t.Fatal("wippy/dataflow was not resolved at all")
+}
+
+// A genuinely unsatisfiable set must still be reported as a conflict: matching
+// each constraint individually must not turn an incompatibility into a resolve.
+func TestResolve_IncompatibleRangesStillConflict(t *testing.T) {
+	p := newFakeProvider()
+	p.addModule("acme", "alpha", "1.0.0", ManifestDep{
+		Org: "wippy", Name: "dataflow", Version: "0.4.31", Constraint: ">=v0.4.10 <v0.5.0",
+	})
+	p.addModule("acme", "bravo", "1.0.0", ManifestDep{
+		Org: "wippy", Name: "dataflow", Version: "0.5.0", Constraint: ">=v0.5.0",
+	})
+	for _, v := range []string{"0.4.31", "0.5.0"} {
+		p.addModule("wippy", "dataflow", v)
+	}
+
+	result, err := Resolve(context.Background(), p, []DependencySpec{
+		{Org: "acme", Name: "alpha", Constraint: "1.0.0"},
+		{Org: "acme", Name: "bravo", Constraint: "1.0.0"},
+	}, nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, result.Errors, "no version satisfies both ranges; this must conflict")
+	assert.Contains(t, result.Errors[0].Message, "conflicting version constraints")
+}


### PR DESCRIPTION
## The bug

keeper declares a **range**:

```yaml
component: wippy/dataflow
version: ">=v0.4.10"      # any dataflow at 0.4.10 or newer
```

Hub picks the newest thing that fits and replies:

```json
{ "org": "wippy", "name": "dataflow", "version": "0.5.2" }
```

The range is not in that reply. Hub answered the question and threw away the question itself — there was no field to carry it.

That breaks the lock. `wippy.lock` pins dataflow at `0.4.31`, and before installing, the resolver asks one thing: *is my locked version still allowed?* But the only thing it has to compare against is what hub sent, so the question it actually asks is:

> is `0.4.31` allowed by `0.5.2`? → **no**

Of course not — `0.5.2` is an exact version, not a range, and nothing satisfies it but itself. So the lock is judged invalid, discarded, and the dependency is force-bumped to latest. The lock never had a chance: it was being tested against the wrong thing.

## The fix

Hub now sends the range as well:

```json
{ "org": "wippy", "name": "dataflow", "version": "0.5.2", "constraint": ">=v0.4.10" }
```

and the resolver compares the lock against the constraint instead of the version. Now it asks the right question:

> is `0.4.31` allowed by `>=v0.4.10`? → **yes**

Lock kept. In `resolver.process` that is one line:

```go
- r.addConstraint(dep.Org+"/"+dep.Name, source, dep.Version)               // "0.5.2"      the answer
+ r.addConstraint(dep.Org+"/"+dep.Name, source, declaredConstraint(dep))   // ">=v0.4.10"  the question
```

It falls back to `dep.Version` when the server does not report a constraint, so an older hub still yields a usable graph.

**With no lock, `>=v0.4.10` still resolves to 0.5.2 — that is correct, and unchanged.** The bug was never that hub picked the wrong version; `>=` genuinely permits 0.5.2. The bug is that the range never reached the client, so the lock could not be checked against it.

## Second change, required by the first

`resolveIntersection` joined all of a module's constraints into one string and reparsed it. The parser caps a constraint at 10 parts — a budget sized for one authored range. While every parent contributed the same *pin*, they deduplicated to one and never hit it. Now that parents contribute their own distinct *ranges*, six parents with two-sided ranges make 12 parts, overflow the cap, and a perfectly satisfiable set gets reported as a **version conflict naming every requester**, with the module not resolving at all.

So each constraint is now matched independently, selecting the highest release satisfying all of them (stable preferred, as before). Without this, preserving ranges would break ordinary graphs.

## Relationship to #468

No file overlap; trial-merged, clean, 306/306 combined.

#468 preserves **root** declarations, which the lock already protects (`dependency_handler.go:527` passes `LockedVersions`). But **transitive** deps get a pin from hub, which no older lock can satisfy — so they bump regardless. That is plausibly why #466 bumped everything and was reverted: the root pinning came off while the transitive path still pinned to latest. This PR fixes that half; the two are complementary.

## Testing

Full suite green (306/306). Lint clean. Mutation testing (gremlins): 0 surviving mutants in changed files.

Seven regression tests, each verified to fail when its fix is reverted:
- `TestResolve_LockedVersionSurvivesDeclaredRange` — the bug (`expected 0.4.31, actual 0.5.2` without the fix)
- `TestResolve_ManyParentsWithCompatibleRanges` — the intersection overflow
- `TestResolve_IncompatibleRangesStillConflict` — genuine conflicts still detected, not masked
- `TestGetManifest_DecodesDeclaredConstraintFromWire` — real Connect round-trip

## Order

Needs the hub change (wippy/hub!44) and the proto field (wippy/proto!2). Deploy hub first; this client degrades to current behavior against an un-upgraded hub.