### PR TITLE
fix(hub): reuse native client transport

### DIFF
--- a/boot/deps/hub/client.go
+++ b/boot/deps/hub/client.go
@@ -20,8 +20,20 @@ import (
 )
 
 const (
-	defaultTimeout = 5 * time.Minute
+	defaultTimeout         = 5 * time.Minute
+	defaultMaxIdleConns    = 100
+	defaultMaxIdlePerHost  = 10
+	defaultIdleConnTimeout = 90 * time.Second
 )
+
+var sharedTransport = &http.Transport{
+	TLSClientConfig: &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	},
+	MaxIdleConns:        defaultMaxIdleConns,
+	MaxIdleConnsPerHost: defaultMaxIdlePerHost,
+	IdleConnTimeout:     defaultIdleConnTimeout,
+}
 
 type Client struct {
 	Publish  publishv1connect.PublishServiceClient
@@ -68,15 +80,9 @@ func NewClient(opts Options) (*Client, error) {
 		timeout = defaultTimeout
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
-	}
-
 	httpClient := &http.Client{
 		Timeout:   timeout,
-		Transport: transport,
+		Transport: sharedTransport,
 	}
 
 	var connectOpts []connect.ClientOption

--- a/boot/deps/hub/client_test.go
+++ b/boot/deps/hub/client_test.go
@@ -3,6 +3,11 @@
 package hub
 
 import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,4 +64,50 @@ func TestNewClient_TrailingSlash(t *testing.T) {
 	c, err := NewClient(Options{BaseURL: "https://hub.wippy.ai/"})
 	require.NoError(t, err)
 	assert.NotNil(t, c)
+}
+
+func TestNewClient_ReusesBoundedTransport(t *testing.T) {
+	first, err := NewClient(Options{BaseURL: "https://hub.wippy.ai", Token: "first"})
+	require.NoError(t, err)
+	second, err := NewClient(Options{BaseURL: "https://hub.wippy.ai", Token: "second"})
+	require.NoError(t, err)
+
+	assert.Same(t, first.httpClient.Transport, second.httpClient.Transport)
+	transport, ok := first.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, defaultMaxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, defaultMaxIdlePerHost, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, defaultIdleConnTimeout, transport.IdleConnTimeout)
+}
+
+func TestNewClient_ReusesConnectionAcrossClients(t *testing.T) {
+	var connections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+	defer sharedTransport.CloseIdleConnections()
+
+	first, err := NewClient(Options{BaseURL: server.URL, Token: "first"})
+	require.NoError(t, err)
+	second, err := NewClient(Options{BaseURL: server.URL, Token: "second"})
+	require.NoError(t, err)
+
+	for _, client := range []*Client{first, second} {
+		request, requestErr := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+		require.NoError(t, requestErr)
+		resp, requestErr := client.httpClient.Do(request)
+		require.NoError(t, requestErr)
+		_, requestErr = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, requestErr)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	assert.Equal(t, int32(1), connections.Load())
 }


### PR DESCRIPTION
## Summary

- reuse a shared HTTP transport across native Hub clients
- cap idle Hub connections and expire them after 90 seconds
- verify distinct clients reuse both the transport and a live connection

## Root cause

The Lua Hub module constructs a new native Hub client for each call. Each client previously owned a new `http.Transport` with no idle connection timeout, so repeated artifact inspection retained two transport goroutines and idle TLS connections per client indefinitely.

During a Kickside Hub security scan, the live runtime retained 693 TLS connections to `hub.wippy.ai` and more than 2,500 goroutines. A second scan added about 221 more Hub connections.

## Verification

`go test -race ./boot/deps/hub ./runtime/lua/modules/hub`
