### PR TITLE
feat(publish): declare the module type in wippy.yaml

### DIFF
--- a/api/hub/wippy/api/hub/download/v1/downloadv1connect/service.connect.go
+++ b/api/hub/wippy/api/hub/download/v1/downloadv1connect/service.connect.go
@@ -45,7 +45,9 @@ const (
 
 // DownloadServiceClient is a client for the wippy.api.hub.download.v1.DownloadService service.
 type DownloadServiceClient interface {
+	// GetDownloadURL returns a presigned download URL for a single module version.
 	GetDownloadURL(context.Context, *connect.Request[v1.GetDownloadURLRequest]) (*connect.Response[v1.GetDownloadURLResponse], error)
+	// GetBatchDownloadURLs returns presigned download URLs for multiple modules in one call.
 	GetBatchDownloadURLs(context.Context, *connect.Request[v1.GetBatchDownloadURLsRequest]) (*connect.Response[v1.GetBatchDownloadURLsResponse], error)
 }
 
@@ -96,7 +98,9 @@ func (c *downloadServiceClient) GetBatchDownloadURLs(ctx context.Context, req *c
 // DownloadServiceHandler is an implementation of the wippy.api.hub.download.v1.DownloadService
 // service.
 type DownloadServiceHandler interface {
+	// GetDownloadURL returns a presigned download URL for a single module version.
 	GetDownloadURL(context.Context, *connect.Request[v1.GetDownloadURLRequest]) (*connect.Response[v1.GetDownloadURLResponse], error)
+	// GetBatchDownloadURLs returns presigned download URLs for multiple modules in one call.
 	GetBatchDownloadURLs(context.Context, *connect.Request[v1.GetBatchDownloadURLsRequest]) (*connect.Response[v1.GetBatchDownloadURLsResponse], error)
 }
 

--- a/api/hub/wippy/api/hub/download/v1/service.pb.go
+++ b/api/hub/wippy/api/hub/download/v1/service.pb.go
@@ -27,6 +27,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// GetDownloadURLRequest is the request for GetDownloadURL.
 type GetDownloadURLRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -79,6 +80,7 @@ func (x *GetDownloadURLRequest) GetVersion() *v11.VersionRef {
 	return nil
 }
 
+// GetDownloadURLResponse is the response for GetDownloadURL.
 type GetDownloadURLResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Download      *v12.DownloadInfo      `protobuf:"bytes,1,opt,name=download,proto3" json:"download,omitempty"`
@@ -139,6 +141,7 @@ func (x *GetDownloadURLResponse) GetProtected() bool {
 	return false
 }
 
+// GetBatchDownloadURLsRequest is the request for GetBatchDownloadURLs.
 type GetBatchDownloadURLsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Items         []*BatchDownloadItem   `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
@@ -183,6 +186,7 @@ func (x *GetBatchDownloadURLsRequest) GetItems() []*BatchDownloadItem {
 	return nil
 }
 
+// BatchDownloadItem identifies a single module version within a batch download request.
 type BatchDownloadItem struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Org           string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`
@@ -243,6 +247,7 @@ func (x *BatchDownloadItem) GetVersion() string {
 	return ""
 }
 
+// GetBatchDownloadURLsResponse is the response for GetBatchDownloadURLs.
 type GetBatchDownloadURLsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Results       []*BatchDownloadResult `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
@@ -287,6 +292,7 @@ func (x *GetBatchDownloadURLsResponse) GetResults() []*BatchDownloadResult {
 	return nil
 }
 
+// BatchDownloadResult contains the download URL or error for one item in a batch.
 type BatchDownloadResult struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Org           string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`

--- a/api/hub/wippy/api/hub/favorite/v1/favoritev1connect/service.connect.go
+++ b/api/hub/wippy/api/hub/favorite/v1/favoritev1connect/service.connect.go
@@ -51,9 +51,13 @@ const (
 
 // FavoriteServiceClient is a client for the wippy.api.hub.favorite.v1.FavoriteService service.
 type FavoriteServiceClient interface {
+	// AddFavorite adds a module to the authenticated user's favorites.
 	AddFavorite(context.Context, *connect.Request[v1.AddFavoriteRequest]) (*connect.Response[v1.AddFavoriteResponse], error)
+	// RemoveFavorite removes a module from the authenticated user's favorites.
 	RemoveFavorite(context.Context, *connect.Request[v1.RemoveFavoriteRequest]) (*connect.Response[v1.RemoveFavoriteResponse], error)
+	// IsFavorited checks whether the authenticated user has favorited a module.
 	IsFavorited(context.Context, *connect.Request[v1.IsFavoritedRequest]) (*connect.Response[v1.IsFavoritedResponse], error)
+	// ListFavorites returns a paginated list of the authenticated user's favorited modules.
 	ListFavorites(context.Context, *connect.Request[v1.ListFavoritesRequest]) (*connect.Response[v1.ListFavoritesResponse], error)
 }
 
@@ -130,9 +134,13 @@ func (c *favoriteServiceClient) ListFavorites(ctx context.Context, req *connect.
 // FavoriteServiceHandler is an implementation of the wippy.api.hub.favorite.v1.FavoriteService
 // service.
 type FavoriteServiceHandler interface {
+	// AddFavorite adds a module to the authenticated user's favorites.
 	AddFavorite(context.Context, *connect.Request[v1.AddFavoriteRequest]) (*connect.Response[v1.AddFavoriteResponse], error)
+	// RemoveFavorite removes a module from the authenticated user's favorites.
 	RemoveFavorite(context.Context, *connect.Request[v1.RemoveFavoriteRequest]) (*connect.Response[v1.RemoveFavoriteResponse], error)
+	// IsFavorited checks whether the authenticated user has favorited a module.
 	IsFavorited(context.Context, *connect.Request[v1.IsFavoritedRequest]) (*connect.Response[v1.IsFavoritedResponse], error)
+	// ListFavorites returns a paginated list of the authenticated user's favorited modules.
 	ListFavorites(context.Context, *connect.Request[v1.ListFavoritesRequest]) (*connect.Response[v1.ListFavoritesResponse], error)
 }
 

--- a/api/hub/wippy/api/hub/favorite/v1/service.pb.go
+++ b/api/hub/wippy/api/hub/favorite/v1/service.pb.go
@@ -25,6 +25,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// AddFavoriteRequest is the request for AddFavorite.
 type AddFavoriteRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -69,6 +70,7 @@ func (x *AddFavoriteRequest) GetModule() *v1.ModuleRef {
 	return nil
 }
 
+// AddFavoriteResponse is the response for AddFavorite.
 type AddFavoriteResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -105,6 +107,7 @@ func (*AddFavoriteResponse) Descriptor() ([]byte, []int) {
 	return file_wippy_api_hub_favorite_v1_service_proto_rawDescGZIP(), []int{1}
 }
 
+// RemoveFavoriteRequest is the request for RemoveFavorite.
 type RemoveFavoriteRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -149,6 +152,7 @@ func (x *RemoveFavoriteRequest) GetModule() *v1.ModuleRef {
 	return nil
 }
 
+// RemoveFavoriteResponse is the response for RemoveFavorite.
 type RemoveFavoriteResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -185,6 +189,7 @@ func (*RemoveFavoriteResponse) Descriptor() ([]byte, []int) {
 	return file_wippy_api_hub_favorite_v1_service_proto_rawDescGZIP(), []int{3}
 }
 
+// IsFavoritedRequest is the request for IsFavorited.
 type IsFavoritedRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -229,6 +234,7 @@ func (x *IsFavoritedRequest) GetModule() *v1.ModuleRef {
 	return nil
 }
 
+// IsFavoritedResponse is the response for IsFavorited.
 type IsFavoritedResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Favorited     bool                   `protobuf:"varint,1,opt,name=favorited,proto3" json:"favorited,omitempty"`
@@ -273,6 +279,7 @@ func (x *IsFavoritedResponse) GetFavorited() bool {
 	return false
 }
 
+// ListFavoritesRequest is the request for ListFavorites.
 type ListFavoritesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Page          int32                  `protobuf:"varint,1,opt,name=page,proto3" json:"page,omitempty"`
@@ -325,6 +332,7 @@ func (x *ListFavoritesRequest) GetPageSize() int32 {
 	return 0
 }
 
+// ListFavoritesResponse is the response for ListFavorites.
 type ListFavoritesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Modules       []*v1.Module           `protobuf:"bytes,1,rep,name=modules,proto3" json:"modules,omitempty"`

--- a/api/hub/wippy/api/hub/label/v1/labelv1connect/service.connect.go
+++ b/api/hub/wippy/api/hub/label/v1/labelv1connect/service.connect.go
@@ -48,9 +48,13 @@ const (
 
 // LabelServiceClient is a client for the wippy.api.hub.label.v1.LabelService service.
 type LabelServiceClient interface {
+	// SetLabel creates or updates a label to point at a specific module version.
 	SetLabel(context.Context, *connect.Request[v1.SetLabelRequest]) (*connect.Response[v1.SetLabelResponse], error)
+	// DeleteLabel removes a label from a module.
 	DeleteLabel(context.Context, *connect.Request[v1.DeleteLabelRequest]) (*connect.Response[v1.DeleteLabelResponse], error)
+	// GetLabel returns a label and the version it points to.
 	GetLabel(context.Context, *connect.Request[v1.GetLabelRequest]) (*connect.Response[v1.GetLabelResponse], error)
+	// ListLabels returns all labels defined on a module.
 	ListLabels(context.Context, *connect.Request[v1.ListLabelsRequest]) (*connect.Response[v1.ListLabelsResponse], error)
 }
 
@@ -125,9 +129,13 @@ func (c *labelServiceClient) ListLabels(ctx context.Context, req *connect.Reques
 
 // LabelServiceHandler is an implementation of the wippy.api.hub.label.v1.LabelService service.
 type LabelServiceHandler interface {
+	// SetLabel creates or updates a label to point at a specific module version.
 	SetLabel(context.Context, *connect.Request[v1.SetLabelRequest]) (*connect.Response[v1.SetLabelResponse], error)
+	// DeleteLabel removes a label from a module.
 	DeleteLabel(context.Context, *connect.Request[v1.DeleteLabelRequest]) (*connect.Response[v1.DeleteLabelResponse], error)
+	// GetLabel returns a label and the version it points to.
 	GetLabel(context.Context, *connect.Request[v1.GetLabelRequest]) (*connect.Response[v1.GetLabelResponse], error)
+	// ListLabels returns all labels defined on a module.
 	ListLabels(context.Context, *connect.Request[v1.ListLabelsRequest]) (*connect.Response[v1.ListLabelsResponse], error)
 }
 

--- a/api/hub/wippy/api/hub/label/v1/service.pb.go
+++ b/api/hub/wippy/api/hub/label/v1/service.pb.go
@@ -26,6 +26,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// SetLabelRequest is the request for SetLabel.
 type SetLabelRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -86,6 +87,7 @@ func (x *SetLabelRequest) GetVersion() *v11.VersionRef {
 	return nil
 }
 
+// SetLabelResponse is the response for SetLabel.
 type SetLabelResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Label         *v11.Label             `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
@@ -130,6 +132,7 @@ func (x *SetLabelResponse) GetLabel() *v11.Label {
 	return nil
 }
 
+// DeleteLabelRequest is the request for DeleteLabel.
 type DeleteLabelRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -182,6 +185,7 @@ func (x *DeleteLabelRequest) GetName() string {
 	return ""
 }
 
+// DeleteLabelResponse is the response for DeleteLabel.
 type DeleteLabelResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -218,6 +222,7 @@ func (*DeleteLabelResponse) Descriptor() ([]byte, []int) {
 	return file_wippy_api_hub_label_v1_service_proto_rawDescGZIP(), []int{3}
 }
 
+// GetLabelRequest is the request for GetLabel.
 type GetLabelRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -270,6 +275,7 @@ func (x *GetLabelRequest) GetName() string {
 	return ""
 }
 
+// GetLabelResponse is the response for GetLabel.
 type GetLabelResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Label         *v11.Label             `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
@@ -322,6 +328,7 @@ func (x *GetLabelResponse) GetVersion() *v11.Version {
 	return nil
 }
 
+// ListLabelsRequest is the request for ListLabels.
 type ListLabelsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -366,6 +373,7 @@ func (x *ListLabelsRequest) GetModule() *v1.ModuleRef {
 	return nil
 }
 
+// ListLabelsResponse is the response for ListLabels.
 type ListLabelsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Labels        []*v11.Label           `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty"`

--- a/api/hub/wippy/api/hub/manifest/v1/manifestv1connect/service.connect.go
+++ b/api/hub/wippy/api/hub/manifest/v1/manifestv1connect/service.connect.go
@@ -48,8 +48,11 @@ const (
 
 // ManifestServiceClient is a client for the wippy.api.hub.manifest.v1.ManifestService service.
 type ManifestServiceClient interface {
+	// GetManifest returns the full manifest for a specific module version.
 	GetManifest(context.Context, *connect.Request[v1.GetManifestRequest]) (*connect.Response[v1.GetManifestResponse], error)
+	// ResolveDependencies computes a resolved dependency tree from root specifications.
 	ResolveDependencies(context.Context, *connect.Request[v1.ResolveDependenciesRequest]) (*connect.Response[v1.ResolveDependenciesResponse], error)
+	// CheckUpdates returns available updates for a set of installed modules.
 	CheckUpdates(context.Context, *connect.Request[v1.CheckUpdatesRequest]) (*connect.Response[v1.CheckUpdatesResponse], error)
 }
 
@@ -113,8 +116,11 @@ func (c *manifestServiceClient) CheckUpdates(ctx context.Context, req *connect.R
 // ManifestServiceHandler is an implementation of the wippy.api.hub.manifest.v1.ManifestService
 // service.
 type ManifestServiceHandler interface {
+	// GetManifest returns the full manifest for a specific module version.
 	GetManifest(context.Context, *connect.Request[v1.GetManifestRequest]) (*connect.Response[v1.GetManifestResponse], error)
+	// ResolveDependencies computes a resolved dependency tree from root specifications.
 	ResolveDependencies(context.Context, *connect.Request[v1.ResolveDependenciesRequest]) (*connect.Response[v1.ResolveDependenciesResponse], error)
+	// CheckUpdates returns available updates for a set of installed modules.
 	CheckUpdates(context.Context, *connect.Request[v1.CheckUpdatesRequest]) (*connect.Response[v1.CheckUpdatesResponse], error)
 }
 

--- a/api/hub/wippy/api/hub/manifest/v1/service.pb.go
+++ b/api/hub/wippy/api/hub/manifest/v1/service.pb.go
@@ -26,6 +26,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// GetManifestRequest is the request for GetManifest.
 type GetManifestRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -78,6 +79,7 @@ func (x *GetManifestRequest) GetVersion() *v11.VersionRef {
 	return nil
 }
 
+// GetManifestResponse is the response for GetManifest.
 type GetManifestResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Manifest      *ModuleManifest        `protobuf:"bytes,1,opt,name=manifest,proto3" json:"manifest,omitempty"`
@@ -122,6 +124,7 @@ func (x *GetManifestResponse) GetManifest() *ModuleManifest {
 	return nil
 }
 
+// ResolveDependenciesRequest is the request for ResolveDependencies.
 type ResolveDependenciesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Roots         []*DependencySpec      `protobuf:"bytes,1,rep,name=roots,proto3" json:"roots,omitempty"`
@@ -182,6 +185,7 @@ func (x *ResolveDependenciesRequest) GetStrategy() ResolutionStrategy {
 	return ResolutionStrategy_RESOLUTION_STRATEGY_UNSPECIFIED
 }
 
+// ResolveDependenciesResponse is the response for ResolveDependencies.
 type ResolveDependenciesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Modules       []*ResolvedModule      `protobuf:"bytes,1,rep,name=modules,proto3" json:"modules,omitempty"`
@@ -234,6 +238,7 @@ func (x *ResolveDependenciesResponse) GetErrors() []*ResolutionError {
 	return nil
 }
 
+// CheckUpdatesRequest is the request for CheckUpdates.
 type CheckUpdatesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Installed     []*InstalledModule     `protobuf:"bytes,1,rep,name=installed,proto3" json:"installed,omitempty"`
@@ -278,6 +283,7 @@ func (x *CheckUpdatesRequest) GetInstalled() []*InstalledModule {
 	return nil
 }
 
+// CheckUpdatesResponse is the response for CheckUpdates.
 type CheckUpdatesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Updates       []*ModuleUpdate        `protobuf:"bytes,1,rep,name=updates,proto3" json:"updates,omitempty"`

--- a/api/hub/wippy/api/hub/module/v1/message.pb.go
+++ b/api/hub/wippy/api/hub/module/v1/message.pb.go
@@ -25,6 +25,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Visibility controls who can see and access a module.
 type Visibility int32
 
 const (
@@ -77,6 +78,7 @@ func (Visibility) EnumDescriptor() ([]byte, []int) {
 	return file_wippy_api_hub_module_v1_message_proto_rawDescGZIP(), []int{0}
 }
 
+// ModuleType classifies the kind of module.
 type ModuleType int32
 
 const (
@@ -293,8 +295,10 @@ type Module struct {
 	Protected          bool                   `protobuf:"varint,20,opt,name=protected,proto3" json:"protected,omitempty"`
 	Contracts          []*Contract            `protobuf:"bytes,21,rep,name=contracts,proto3" json:"contracts,omitempty"`
 	DownloadStats      []*DownloadStat        `protobuf:"bytes,22,rep,name=download_stats,json=downloadStats,proto3" json:"download_stats,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Owner name (user or org). Prefer this over organization_name for new clients.
+	OwnerName     string `protobuf:"bytes,23,opt,name=owner_name,json=ownerName,proto3" json:"owner_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Module) Reset() {
@@ -479,6 +483,13 @@ func (x *Module) GetDownloadStats() []*DownloadStat {
 		return x.DownloadStats
 	}
 	return nil
+}
+
+func (x *Module) GetOwnerName() string {
+	if x != nil {
+		return x.OwnerName
+	}
+	return ""
 }
 
 // Organization in the hub.
@@ -769,7 +780,7 @@ const file_wippy_api_hub_module_v1_message_proto_rawDesc = "" +
 	"\n" +
 	"ModuleName\x12\x1b\n" +
 	"\x03org\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18@R\x03org\x12\x1d\n" +
-	"\x04name\x18\x02 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18@R\x04name\"\xda\a\n" +
+	"\x04name\x18\x02 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18@R\x04name\"\xf9\a\n" +
 	"\x06Module\x12\x18\n" +
 	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\x120\n" +
 	"\x04name\x18\x02 \x01(\tB\x1c\xbaH\x19r\x17\x10\x01\x18@2\x11^[a-z][a-z0-9-]*$R\x04name\x12!\n" +
@@ -801,7 +812,9 @@ const file_wippy_api_hub_module_v1_message_proto_rawDesc = "" +
 	"\bhomepage\x18\x13 \x01(\tR\bhomepage\x12\x1c\n" +
 	"\tprotected\x18\x14 \x01(\bR\tprotected\x12?\n" +
 	"\tcontracts\x18\x15 \x03(\v2!.wippy.api.hub.module.v1.ContractR\tcontracts\x12L\n" +
-	"\x0edownload_stats\x18\x16 \x03(\v2%.wippy.api.hub.module.v1.DownloadStatR\rdownloadStats\"\xc9\x02\n" +
+	"\x0edownload_stats\x18\x16 \x03(\v2%.wippy.api.hub.module.v1.DownloadStatR\rdownloadStats\x12\x1d\n" +
+	"\n" +
+	"owner_name\x18\x17 \x01(\tR\townerName\"\xc9\x02\n" +
 	"\fOrganization\x12\x18\n" +
 	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\x120\n" +
 	"\x04name\x18\x02 \x01(\tB\x1c\xbaH\x19r\x17\x10\x01\x18@2\x11^[a-z][a-z0-9-]*$R\x04name\x12!\n" +

--- a/api/hub/wippy/api/hub/module/v1/modulev1connect/service.connect.go
+++ b/api/hub/wippy/api/hub/module/v1/modulev1connect/service.connect.go
@@ -76,18 +76,31 @@ const (
 
 // ModuleServiceClient is a client for the wippy.api.hub.module.v1.ModuleService service.
 type ModuleServiceClient interface {
+	// CreateModule registers a new module within an organization.
 	CreateModule(context.Context, *connect.Request[v1.CreateModuleRequest]) (*connect.Response[v1.CreateModuleResponse], error)
+	// GetModule returns a single module by ID or org/name.
 	GetModule(context.Context, *connect.Request[v1.GetModuleRequest]) (*connect.Response[v1.GetModuleResponse], error)
+	// ListModules returns a paginated list of modules, optionally filtered by organization.
 	ListModules(context.Context, *connect.Request[v1.ListModulesRequest]) (*connect.Response[v1.ListModulesResponse], error)
+	// UpdateModule updates mutable fields of an existing module.
 	UpdateModule(context.Context, *connect.Request[v1.UpdateModuleRequest]) (*connect.Response[v1.UpdateModuleResponse], error)
+	// DeleteModule permanently removes a module and all its versions.
 	DeleteModule(context.Context, *connect.Request[v1.DeleteModuleRequest]) (*connect.Response[v1.DeleteModuleResponse], error)
+	// DeprecateModule marks a module as deprecated with an optional alternative.
 	DeprecateModule(context.Context, *connect.Request[v1.DeprecateModuleRequest]) (*connect.Response[v1.DeprecateModuleResponse], error)
+	// SearchModules performs a full-text search across public modules.
 	SearchModules(context.Context, *connect.Request[v1.SearchModulesRequest]) (*connect.Response[v1.SearchModulesResponse], error)
+	// ListVersions returns a paginated list of versions for a module.
 	ListVersions(context.Context, *connect.Request[v1.ListVersionsRequest]) (*connect.Response[v1.ListVersionsResponse], error)
+	// GetVersion returns a single version by ID, semver string, or label.
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
+	// ListVersionFiles returns the file listing for a specific module version.
 	ListVersionFiles(context.Context, *connect.Request[v1.ListVersionFilesRequest]) (*connect.Response[v1.ListVersionFilesResponse], error)
+	// GetDependencies returns the declared dependencies of a module version.
 	GetDependencies(context.Context, *connect.Request[v1.GetDependenciesRequest]) (*connect.Response[v1.GetDependenciesResponse], error)
+	// GetDependents returns modules that depend on the specified module.
 	GetDependents(context.Context, *connect.Request[v1.GetDependentsRequest]) (*connect.Response[v1.GetDependentsResponse], error)
+	// GetReadme returns the README content for a module version.
 	GetReadme(context.Context, *connect.Request[v1.GetReadmeRequest]) (*connect.Response[v1.GetReadmeResponse], error)
 }
 
@@ -276,18 +289,31 @@ func (c *moduleServiceClient) GetReadme(ctx context.Context, req *connect.Reques
 
 // ModuleServiceHandler is an implementation of the wippy.api.hub.module.v1.ModuleService service.
 type ModuleServiceHandler interface {
+	// CreateModule registers a new module within an organization.
 	CreateModule(context.Context, *connect.Request[v1.CreateModuleRequest]) (*connect.Response[v1.CreateModuleResponse], error)
+	// GetModule returns a single module by ID or org/name.
 	GetModule(context.Context, *connect.Request[v1.GetModuleRequest]) (*connect.Response[v1.GetModuleResponse], error)
+	// ListModules returns a paginated list of modules, optionally filtered by organization.
 	ListModules(context.Context, *connect.Request[v1.ListModulesRequest]) (*connect.Response[v1.ListModulesResponse], error)
+	// UpdateModule updates mutable fields of an existing module.
 	UpdateModule(context.Context, *connect.Request[v1.UpdateModuleRequest]) (*connect.Response[v1.UpdateModuleResponse], error)
+	// DeleteModule permanently removes a module and all its versions.
 	DeleteModule(context.Context, *connect.Request[v1.DeleteModuleRequest]) (*connect.Response[v1.DeleteModuleResponse], error)
+	// DeprecateModule marks a module as deprecated with an optional alternative.
 	DeprecateModule(context.Context, *connect.Request[v1.DeprecateModuleRequest]) (*connect.Response[v1.DeprecateModuleResponse], error)
+	// SearchModules performs a full-text search across public modules.
 	SearchModules(context.Context, *connect.Request[v1.SearchModulesRequest]) (*connect.Response[v1.SearchModulesResponse], error)
+	// ListVersions returns a paginated list of versions for a module.
 	ListVersions(context.Context, *connect.Request[v1.ListVersionsRequest]) (*connect.Response[v1.ListVersionsResponse], error)
+	// GetVersion returns a single version by ID, semver string, or label.
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
+	// ListVersionFiles returns the file listing for a specific module version.
 	ListVersionFiles(context.Context, *connect.Request[v1.ListVersionFilesRequest]) (*connect.Response[v1.ListVersionFilesResponse], error)
+	// GetDependencies returns the declared dependencies of a module version.
 	GetDependencies(context.Context, *connect.Request[v1.GetDependenciesRequest]) (*connect.Response[v1.GetDependenciesResponse], error)
+	// GetDependents returns modules that depend on the specified module.
 	GetDependents(context.Context, *connect.Request[v1.GetDependentsRequest]) (*connect.Response[v1.GetDependentsResponse], error)
+	// GetReadme returns the README content for a module version.
 	GetReadme(context.Context, *connect.Request[v1.GetReadmeRequest]) (*connect.Response[v1.GetReadmeResponse], error)
 }
 

--- a/api/hub/wippy/api/hub/module/v1/service.pb.go
+++ b/api/hub/wippy/api/hub/module/v1/service.pb.go
@@ -25,6 +25,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// ModuleSortOrder defines the ordering options for module listings.
 type ModuleSortOrder int32
 
 const (
@@ -83,6 +84,7 @@ func (ModuleSortOrder) EnumDescriptor() ([]byte, []int) {
 	return file_wippy_api_hub_module_v1_service_proto_rawDescGZIP(), []int{0}
 }
 
+// CreateModuleRequest is the request for CreateModule.
 type CreateModuleRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	OrganizationId string                 `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
@@ -159,6 +161,7 @@ func (x *CreateModuleRequest) GetType() ModuleType {
 	return ModuleType_MODULE_TYPE_UNSPECIFIED
 }
 
+// CreateModuleResponse is the response for CreateModule.
 type CreateModuleResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *Module                `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -203,6 +206,7 @@ func (x *CreateModuleResponse) GetModule() *Module {
 	return nil
 }
 
+// GetModuleRequest is the request for GetModule.
 type GetModuleRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -247,6 +251,7 @@ func (x *GetModuleRequest) GetModule() *ModuleRef {
 	return nil
 }
 
+// GetModuleResponse is the response for GetModule.
 type GetModuleResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *Module                `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -291,6 +296,7 @@ func (x *GetModuleResponse) GetModule() *Module {
 	return nil
 }
 
+// ListModulesRequest is the request for ListModules.
 type ListModulesRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	OrganizationId string                 `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
@@ -375,6 +381,7 @@ func (x *ListModulesRequest) GetSortOrder() ModuleSortOrder {
 	return ModuleSortOrder_MODULE_SORT_ORDER_UNSPECIFIED
 }
 
+// ListModulesResponse is the response for ListModules.
 type ListModulesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Modules       []*Module              `protobuf:"bytes,1,rep,name=modules,proto3" json:"modules,omitempty"`
@@ -443,6 +450,7 @@ func (x *ListModulesResponse) GetPageSize() int32 {
 	return 0
 }
 
+// UpdateModuleRequest is the request for UpdateModule.
 type UpdateModuleRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ModuleId      string                 `protobuf:"bytes,1,opt,name=module_id,json=moduleId,proto3" json:"module_id,omitempty"`
@@ -503,6 +511,7 @@ func (x *UpdateModuleRequest) GetVisibility() Visibility {
 	return Visibility_VISIBILITY_UNSPECIFIED
 }
 
+// UpdateModuleResponse is the response for UpdateModule.
 type UpdateModuleResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *Module                `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -547,6 +556,7 @@ func (x *UpdateModuleResponse) GetModule() *Module {
 	return nil
 }
 
+// DeleteModuleRequest is the request for DeleteModule.
 type DeleteModuleRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ModuleId      string                 `protobuf:"bytes,1,opt,name=module_id,json=moduleId,proto3" json:"module_id,omitempty"`
@@ -591,6 +601,7 @@ func (x *DeleteModuleRequest) GetModuleId() string {
 	return ""
 }
 
+// DeleteModuleResponse is the response for DeleteModule.
 type DeleteModuleResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -627,6 +638,7 @@ func (*DeleteModuleResponse) Descriptor() ([]byte, []int) {
 	return file_wippy_api_hub_module_v1_service_proto_rawDescGZIP(), []int{9}
 }
 
+// DeprecateModuleRequest is the request for DeprecateModule.
 type DeprecateModuleRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ModuleId      string                 `protobuf:"bytes,1,opt,name=module_id,json=moduleId,proto3" json:"module_id,omitempty"`
@@ -687,6 +699,7 @@ func (x *DeprecateModuleRequest) GetAlternative() *ModuleRef {
 	return nil
 }
 
+// DeprecateModuleResponse is the response for DeprecateModule.
 type DeprecateModuleResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *Module                `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -731,6 +744,7 @@ func (x *DeprecateModuleResponse) GetModule() *Module {
 	return nil
 }
 
+// SearchModulesRequest is the request for SearchModules.
 type SearchModulesRequest struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Query             string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
@@ -815,6 +829,7 @@ func (x *SearchModulesRequest) GetIncludeDeprecated() bool {
 	return false
 }
 
+// SearchModulesResponse is the response for SearchModules.
 type SearchModulesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Modules       []*Module              `protobuf:"bytes,1,rep,name=modules,proto3" json:"modules,omitempty"`
@@ -883,6 +898,7 @@ func (x *SearchModulesResponse) GetPageSize() int32 {
 	return 0
 }
 
+// ListVersionsRequest is the request for ListVersions.
 type ListVersionsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -951,6 +967,7 @@ func (x *ListVersionsRequest) GetIncludeYanked() bool {
 	return false
 }
 
+// ListVersionsResponse is the response for ListVersions.
 type ListVersionsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Versions      []*v1.Version          `protobuf:"bytes,1,rep,name=versions,proto3" json:"versions,omitempty"`
@@ -1019,6 +1036,7 @@ func (x *ListVersionsResponse) GetPageSize() int32 {
 	return 0
 }
 
+// GetVersionRequest is the request for GetVersion.
 type GetVersionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -1071,6 +1089,7 @@ func (x *GetVersionRequest) GetVersion() *v1.VersionRef {
 	return nil
 }
 
+// GetVersionResponse is the response for GetVersion.
 type GetVersionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Version       *v1.Version            `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
@@ -1115,6 +1134,7 @@ func (x *GetVersionResponse) GetVersion() *v1.Version {
 	return nil
 }
 
+// ListVersionFilesRequest is the request for ListVersionFiles.
 type ListVersionFilesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -1183,6 +1203,7 @@ func (x *ListVersionFilesRequest) GetPageSize() int32 {
 	return 0
 }
 
+// ListVersionFilesResponse is the response for ListVersionFiles.
 type ListVersionFilesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Files         []*v1.VersionFile      `protobuf:"bytes,1,rep,name=files,proto3" json:"files,omitempty"`
@@ -1251,6 +1272,7 @@ func (x *ListVersionFilesResponse) GetPageSize() int32 {
 	return 0
 }
 
+// GetDependenciesRequest is the request for GetDependencies.
 type GetDependenciesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -1303,6 +1325,7 @@ func (x *GetDependenciesRequest) GetVersion() *v1.VersionRef {
 	return nil
 }
 
+// GetDependenciesResponse is the response for GetDependencies.
 type GetDependenciesResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Dependencies  []*v1.Dependency       `protobuf:"bytes,1,rep,name=dependencies,proto3" json:"dependencies,omitempty"`
@@ -1347,6 +1370,7 @@ func (x *GetDependenciesResponse) GetDependencies() []*v1.Dependency {
 	return nil
 }
 
+// GetDependentsRequest is the request for GetDependents.
 type GetDependentsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -1407,6 +1431,7 @@ func (x *GetDependentsRequest) GetPageSize() int32 {
 	return 0
 }
 
+// GetDependentsResponse is the response for GetDependents.
 type GetDependentsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Dependents    []*DependentModule     `protobuf:"bytes,1,rep,name=dependents,proto3" json:"dependents,omitempty"`
@@ -1475,6 +1500,7 @@ func (x *GetDependentsResponse) GetPageSize() int32 {
 	return 0
 }
 
+// DependentModule represents a module that depends on the queried module.
 type DependentModule struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Org           string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`
@@ -1543,6 +1569,7 @@ func (x *DependentModule) GetConstraint() string {
 	return ""
 }
 
+// GetReadmeRequest is the request for GetReadme.
 type GetReadmeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *ModuleRef             `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -1595,6 +1622,7 @@ func (x *GetReadmeRequest) GetVersion() *v1.VersionRef {
 	return nil
 }
 
+// GetReadmeResponse is the response for GetReadme.
 type GetReadmeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Content       string                 `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`

--- a/api/hub/wippy/api/hub/publish/v1/publishv1connect/service.connect.go
+++ b/api/hub/wippy/api/hub/publish/v1/publishv1connect/service.connect.go
@@ -54,10 +54,15 @@ const (
 
 // PublishServiceClient is a client for the wippy.api.hub.publish.v1.PublishService service.
 type PublishServiceClient interface {
+	// InitiatePublish starts a new publish operation and returns a presigned upload URL.
 	InitiatePublish(context.Context, *connect.Request[v1.InitiatePublishRequest]) (*connect.Response[v1.InitiatePublishResponse], error)
+	// ConfirmPublish confirms the upload is complete and triggers validation and processing.
 	ConfirmPublish(context.Context, *connect.Request[v1.ConfirmPublishRequest]) (*connect.Response[v1.ConfirmPublishResponse], error)
+	// GetPublishStatus returns the current status and details of a publish operation.
 	GetPublishStatus(context.Context, *connect.Request[v1.GetPublishStatusRequest]) (*connect.Response[v1.GetPublishStatusResponse], error)
+	// CancelPublish cancels a pending publish operation.
 	CancelPublish(context.Context, *connect.Request[v1.CancelPublishRequest]) (*connect.Response[v1.CancelPublishResponse], error)
+	// YankVersion marks a published version as yanked, hiding it from resolution.
 	YankVersion(context.Context, *connect.Request[v1.YankVersionRequest]) (*connect.Response[v1.YankVersionResponse], error)
 }
 
@@ -143,10 +148,15 @@ func (c *publishServiceClient) YankVersion(ctx context.Context, req *connect.Req
 // PublishServiceHandler is an implementation of the wippy.api.hub.publish.v1.PublishService
 // service.
 type PublishServiceHandler interface {
+	// InitiatePublish starts a new publish operation and returns a presigned upload URL.
 	InitiatePublish(context.Context, *connect.Request[v1.InitiatePublishRequest]) (*connect.Response[v1.InitiatePublishResponse], error)
+	// ConfirmPublish confirms the upload is complete and triggers validation and processing.
 	ConfirmPublish(context.Context, *connect.Request[v1.ConfirmPublishRequest]) (*connect.Response[v1.ConfirmPublishResponse], error)
+	// GetPublishStatus returns the current status and details of a publish operation.
 	GetPublishStatus(context.Context, *connect.Request[v1.GetPublishStatusRequest]) (*connect.Response[v1.GetPublishStatusResponse], error)
+	// CancelPublish cancels a pending publish operation.
 	CancelPublish(context.Context, *connect.Request[v1.CancelPublishRequest]) (*connect.Response[v1.CancelPublishResponse], error)
+	// YankVersion marks a published version as yanked, hiding it from resolution.
 	YankVersion(context.Context, *connect.Request[v1.YankVersionRequest]) (*connect.Response[v1.YankVersionResponse], error)
 }
 

--- a/api/hub/wippy/api/hub/publish/v1/service.pb.go
+++ b/api/hub/wippy/api/hub/publish/v1/service.pb.go
@@ -27,6 +27,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// InitiatePublishRequest is the request for InitiatePublish.
 type InitiatePublishRequest struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Module *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -39,8 +40,13 @@ type InitiatePublishRequest struct {
 	Digest            string                          `protobuf:"bytes,5,opt,name=digest,proto3" json:"digest,omitempty"`
 	Protected         bool                            `protobuf:"varint,6,opt,name=protected,proto3" json:"protected,omitempty"`
 	ReleaseNotes      string                          `protobuf:"bytes,7,opt,name=release_notes,json=releaseNotes,proto3" json:"release_notes,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Declares the module's kind. Consulted when the module does not exist yet
+	// (publish creates it) or when it differs from the stored value, in which
+	// case the declared type wins. UNSPECIFIED means the publisher declared no
+	// type; creating a module that way is rejected.
+	ModuleType    v1.ModuleType `protobuf:"varint,8,opt,name=module_type,json=moduleType,proto3,enum=wippy.api.hub.module.v1.ModuleType" json:"module_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *InitiatePublishRequest) Reset() {
@@ -133,6 +139,13 @@ func (x *InitiatePublishRequest) GetReleaseNotes() string {
 	return ""
 }
 
+func (x *InitiatePublishRequest) GetModuleType() v1.ModuleType {
+	if x != nil {
+		return x.ModuleType
+	}
+	return v1.ModuleType(0)
+}
+
 type isInitiatePublishRequest_Target interface {
 	isInitiatePublishRequest_Target()
 }
@@ -149,6 +162,7 @@ func (*InitiatePublishRequest_Version) isInitiatePublishRequest_Target() {}
 
 func (*InitiatePublishRequest_Label) isInitiatePublishRequest_Target() {}
 
+// InitiatePublishResponse is the response for InitiatePublish.
 type InitiatePublishResponse struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	PublishId       string                 `protobuf:"bytes,1,opt,name=publish_id,json=publishId,proto3" json:"publish_id,omitempty"`
@@ -209,6 +223,7 @@ func (x *InitiatePublishResponse) GetUploadExpiresAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// ConfirmPublishRequest is the request for ConfirmPublish.
 type ConfirmPublishRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PublishId     string                 `protobuf:"bytes,1,opt,name=publish_id,json=publishId,proto3" json:"publish_id,omitempty"`
@@ -253,6 +268,7 @@ func (x *ConfirmPublishRequest) GetPublishId() string {
 	return ""
 }
 
+// ConfirmPublishResponse is the response for ConfirmPublish.
 type ConfirmPublishResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Status        PublishStatus          `protobuf:"varint,1,opt,name=status,proto3,enum=wippy.api.hub.publish.v1.PublishStatus" json:"status,omitempty"`
@@ -297,6 +313,7 @@ func (x *ConfirmPublishResponse) GetStatus() PublishStatus {
 	return PublishStatus_PUBLISH_STATUS_UNSPECIFIED
 }
 
+// GetPublishStatusRequest is the request for GetPublishStatus.
 type GetPublishStatusRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PublishId     string                 `protobuf:"bytes,1,opt,name=publish_id,json=publishId,proto3" json:"publish_id,omitempty"`
@@ -341,6 +358,7 @@ func (x *GetPublishStatusRequest) GetPublishId() string {
 	return ""
 }
 
+// GetPublishStatusResponse is the response for GetPublishStatus.
 type GetPublishStatusResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Status        PublishStatus          `protobuf:"varint,1,opt,name=status,proto3,enum=wippy.api.hub.publish.v1.PublishStatus" json:"status,omitempty"`
@@ -393,6 +411,7 @@ func (x *GetPublishStatusResponse) GetDetails() *PublishStatusDetails {
 	return nil
 }
 
+// CancelPublishRequest is the request for CancelPublish.
 type CancelPublishRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	PublishId     string                 `protobuf:"bytes,1,opt,name=publish_id,json=publishId,proto3" json:"publish_id,omitempty"`
@@ -437,6 +456,7 @@ func (x *CancelPublishRequest) GetPublishId() string {
 	return ""
 }
 
+// CancelPublishResponse is the response for CancelPublish.
 type CancelPublishResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Cancelled     bool                   `protobuf:"varint,1,opt,name=cancelled,proto3" json:"cancelled,omitempty"`
@@ -481,6 +501,7 @@ func (x *CancelPublishResponse) GetCancelled() bool {
 	return false
 }
 
+// YankVersionRequest is the request for YankVersion.
 type YankVersionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Module        *v1.ModuleRef          `protobuf:"bytes,1,opt,name=module,proto3" json:"module,omitempty"`
@@ -541,6 +562,7 @@ func (x *YankVersionRequest) GetReason() string {
 	return ""
 }
 
+// YankVersionResponse is the response for YankVersion.
 type YankVersionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Version       *v11.Version           `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
@@ -589,7 +611,7 @@ var File_wippy_api_hub_publish_v1_service_proto protoreflect.FileDescriptor
 
 const file_wippy_api_hub_publish_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"&wippy/api/hub/publish/v1/service.proto\x12\x18wippy.api.hub.publish.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%wippy/api/hub/module/v1/message.proto\x1a&wippy/api/hub/publish/v1/message.proto\x1a&wippy/api/hub/version/v1/message.proto\"\xd4\x02\n" +
+	"&wippy/api/hub/publish/v1/service.proto\x12\x18wippy.api.hub.publish.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%wippy/api/hub/module/v1/message.proto\x1a&wippy/api/hub/publish/v1/message.proto\x1a&wippy/api/hub/version/v1/message.proto\"\x9a\x03\n" +
 	"\x16InitiatePublishRequest\x12B\n" +
 	"\x06module\x18\x01 \x01(\v2\".wippy.api.hub.module.v1.ModuleRefB\x06\xbaH\x03\xc8\x01\x01R\x06module\x12#\n" +
 	"\aversion\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x18@H\x00R\aversion\x122\n" +
@@ -597,7 +619,9 @@ const file_wippy_api_hub_publish_v1_service_proto_rawDesc = "" +
 	"\x13expected_size_bytes\x18\x04 \x01(\x04R\x11expectedSizeBytes\x12 \n" +
 	"\x06digest\x18\x05 \x01(\tB\b\xbaH\x05r\x03\x98\x01@R\x06digest\x12\x1c\n" +
 	"\tprotected\x18\x06 \x01(\bR\tprotected\x12#\n" +
-	"\rrelease_notes\x18\a \x01(\tR\freleaseNotesB\b\n" +
+	"\rrelease_notes\x18\a \x01(\tR\freleaseNotes\x12D\n" +
+	"\vmodule_type\x18\b \x01(\x0e2#.wippy.api.hub.module.v1.ModuleTypeR\n" +
+	"moduleTypeB\b\n" +
 	"\x06target\"\x9f\x01\n" +
 	"\x17InitiatePublishResponse\x12\x1d\n" +
 	"\n" +
@@ -660,34 +684,36 @@ var file_wippy_api_hub_publish_v1_service_proto_goTypes = []any{
 	(*YankVersionRequest)(nil),       // 8: wippy.api.hub.publish.v1.YankVersionRequest
 	(*YankVersionResponse)(nil),      // 9: wippy.api.hub.publish.v1.YankVersionResponse
 	(*v1.ModuleRef)(nil),             // 10: wippy.api.hub.module.v1.ModuleRef
-	(*timestamppb.Timestamp)(nil),    // 11: google.protobuf.Timestamp
-	(PublishStatus)(0),               // 12: wippy.api.hub.publish.v1.PublishStatus
-	(*PublishStatusDetails)(nil),     // 13: wippy.api.hub.publish.v1.PublishStatusDetails
-	(*v11.Version)(nil),              // 14: wippy.api.hub.version.v1.Version
+	(v1.ModuleType)(0),               // 11: wippy.api.hub.module.v1.ModuleType
+	(*timestamppb.Timestamp)(nil),    // 12: google.protobuf.Timestamp
+	(PublishStatus)(0),               // 13: wippy.api.hub.publish.v1.PublishStatus
+	(*PublishStatusDetails)(nil),     // 14: wippy.api.hub.publish.v1.PublishStatusDetails
+	(*v11.Version)(nil),              // 15: wippy.api.hub.version.v1.Version
 }
 var file_wippy_api_hub_publish_v1_service_proto_depIdxs = []int32{
 	10, // 0: wippy.api.hub.publish.v1.InitiatePublishRequest.module:type_name -> wippy.api.hub.module.v1.ModuleRef
-	11, // 1: wippy.api.hub.publish.v1.InitiatePublishResponse.upload_expires_at:type_name -> google.protobuf.Timestamp
-	12, // 2: wippy.api.hub.publish.v1.ConfirmPublishResponse.status:type_name -> wippy.api.hub.publish.v1.PublishStatus
-	12, // 3: wippy.api.hub.publish.v1.GetPublishStatusResponse.status:type_name -> wippy.api.hub.publish.v1.PublishStatus
-	13, // 4: wippy.api.hub.publish.v1.GetPublishStatusResponse.details:type_name -> wippy.api.hub.publish.v1.PublishStatusDetails
-	10, // 5: wippy.api.hub.publish.v1.YankVersionRequest.module:type_name -> wippy.api.hub.module.v1.ModuleRef
-	14, // 6: wippy.api.hub.publish.v1.YankVersionResponse.version:type_name -> wippy.api.hub.version.v1.Version
-	0,  // 7: wippy.api.hub.publish.v1.PublishService.InitiatePublish:input_type -> wippy.api.hub.publish.v1.InitiatePublishRequest
-	2,  // 8: wippy.api.hub.publish.v1.PublishService.ConfirmPublish:input_type -> wippy.api.hub.publish.v1.ConfirmPublishRequest
-	4,  // 9: wippy.api.hub.publish.v1.PublishService.GetPublishStatus:input_type -> wippy.api.hub.publish.v1.GetPublishStatusRequest
-	6,  // 10: wippy.api.hub.publish.v1.PublishService.CancelPublish:input_type -> wippy.api.hub.publish.v1.CancelPublishRequest
-	8,  // 11: wippy.api.hub.publish.v1.PublishService.YankVersion:input_type -> wippy.api.hub.publish.v1.YankVersionRequest
-	1,  // 12: wippy.api.hub.publish.v1.PublishService.InitiatePublish:output_type -> wippy.api.hub.publish.v1.InitiatePublishResponse
-	3,  // 13: wippy.api.hub.publish.v1.PublishService.ConfirmPublish:output_type -> wippy.api.hub.publish.v1.ConfirmPublishResponse
-	5,  // 14: wippy.api.hub.publish.v1.PublishService.GetPublishStatus:output_type -> wippy.api.hub.publish.v1.GetPublishStatusResponse
-	7,  // 15: wippy.api.hub.publish.v1.PublishService.CancelPublish:output_type -> wippy.api.hub.publish.v1.CancelPublishResponse
-	9,  // 16: wippy.api.hub.publish.v1.PublishService.YankVersion:output_type -> wippy.api.hub.publish.v1.YankVersionResponse
-	12, // [12:17] is the sub-list for method output_type
-	7,  // [7:12] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	11, // 1: wippy.api.hub.publish.v1.InitiatePublishRequest.module_type:type_name -> wippy.api.hub.module.v1.ModuleType
+	12, // 2: wippy.api.hub.publish.v1.InitiatePublishResponse.upload_expires_at:type_name -> google.protobuf.Timestamp
+	13, // 3: wippy.api.hub.publish.v1.ConfirmPublishResponse.status:type_name -> wippy.api.hub.publish.v1.PublishStatus
+	13, // 4: wippy.api.hub.publish.v1.GetPublishStatusResponse.status:type_name -> wippy.api.hub.publish.v1.PublishStatus
+	14, // 5: wippy.api.hub.publish.v1.GetPublishStatusResponse.details:type_name -> wippy.api.hub.publish.v1.PublishStatusDetails
+	10, // 6: wippy.api.hub.publish.v1.YankVersionRequest.module:type_name -> wippy.api.hub.module.v1.ModuleRef
+	15, // 7: wippy.api.hub.publish.v1.YankVersionResponse.version:type_name -> wippy.api.hub.version.v1.Version
+	0,  // 8: wippy.api.hub.publish.v1.PublishService.InitiatePublish:input_type -> wippy.api.hub.publish.v1.InitiatePublishRequest
+	2,  // 9: wippy.api.hub.publish.v1.PublishService.ConfirmPublish:input_type -> wippy.api.hub.publish.v1.ConfirmPublishRequest
+	4,  // 10: wippy.api.hub.publish.v1.PublishService.GetPublishStatus:input_type -> wippy.api.hub.publish.v1.GetPublishStatusRequest
+	6,  // 11: wippy.api.hub.publish.v1.PublishService.CancelPublish:input_type -> wippy.api.hub.publish.v1.CancelPublishRequest
+	8,  // 12: wippy.api.hub.publish.v1.PublishService.YankVersion:input_type -> wippy.api.hub.publish.v1.YankVersionRequest
+	1,  // 13: wippy.api.hub.publish.v1.PublishService.InitiatePublish:output_type -> wippy.api.hub.publish.v1.InitiatePublishResponse
+	3,  // 14: wippy.api.hub.publish.v1.PublishService.ConfirmPublish:output_type -> wippy.api.hub.publish.v1.ConfirmPublishResponse
+	5,  // 15: wippy.api.hub.publish.v1.PublishService.GetPublishStatus:output_type -> wippy.api.hub.publish.v1.GetPublishStatusResponse
+	7,  // 16: wippy.api.hub.publish.v1.PublishService.CancelPublish:output_type -> wippy.api.hub.publish.v1.CancelPublishResponse
+	9,  // 17: wippy.api.hub.publish.v1.PublishService.YankVersion:output_type -> wippy.api.hub.publish.v1.YankVersionResponse
+	13, // [13:18] is the sub-list for method output_type
+	8,  // [8:13] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_wippy_api_hub_publish_v1_service_proto_init() }

--- a/api/hub/wippy/api/hub/version/v1/message.pb.go
+++ b/api/hub/wippy/api/hub/version/v1/message.pb.go
@@ -25,6 +25,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// ProtectionType indicates the protection level applied to a version's archive.
 type ProtectionType int32
 
 const (

--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -27,11 +28,17 @@ type ModuleConfig struct {
 	Homepage     string              `yaml:"homepage,omitempty"`
 	ModuleName   string              `yaml:"module"`
 	Organization string              `yaml:"organization"`
-	Keywords     []string            `yaml:"keywords,omitempty"`
-	Authors      []string            `yaml:"authors,omitempty"`
-	Include      []string            `yaml:"include,omitempty"`
-	Exclude      []string            `yaml:"exclude,omitempty"`
-	Embed        []string            `yaml:"embed,omitempty"`
+	// Type is the module's kind on the hub: library, application, agent or
+	// plugin. Declaring it here makes the manifest the source of truth — hub
+	// requires it to create a module, and reclassifies the module when it
+	// changes. Empty means "not declared", which only works for a module that
+	// already exists.
+	Type     string   `yaml:"type,omitempty"`
+	Keywords []string `yaml:"keywords,omitempty"`
+	Authors  []string `yaml:"authors,omitempty"`
+	Include  []string `yaml:"include,omitempty"`
+	Exclude  []string `yaml:"exclude,omitempty"`
+	Embed    []string `yaml:"embed,omitempty"`
 }
 
 type PublishConfig struct {
@@ -65,6 +72,24 @@ func LoadFrom(path string) (*ModuleConfig, error) {
 	return &cfg, nil
 }
 
+// ModuleTypes are the module kinds hub accepts. Mirrors hub's
+// domain.ModuleType constants and the modules.module_type CHECK constraint.
+var ModuleTypes = []string{"library", "application", "agent", "plugin"}
+
+// ValidateModuleType accepts the empty string ("not declared") and any of
+// ModuleTypes. Anything else is a typo worth catching before the publish
+// round-trips to hub — notably "app", which is what the badge shows for
+// "application".
+func ValidateModuleType(t string) error {
+	if t == "" {
+		return nil
+	}
+	if slices.Contains(ModuleTypes, t) {
+		return nil
+	}
+	return fmt.Errorf("type must be one of %s (got %q)", strings.Join(ModuleTypes, ", "), t)
+}
+
 func (c *ModuleConfig) Validate() error {
 	if c.Organization == "" {
 		return fmt.Errorf("organization is required in wippy.yaml")
@@ -86,6 +111,10 @@ func (c *ModuleConfig) Validate() error {
 		if _, err := semver.NewVersion(c.Version); err != nil {
 			return fmt.Errorf("version must be valid semver: %w", err)
 		}
+	}
+
+	if err := ValidateModuleType(c.Type); err != nil {
+		return err
 	}
 
 	return nil
@@ -118,6 +147,10 @@ func (c *ModuleConfig) ValidateForLabel() error {
 
 	if !isValidIdentifier(c.ModuleName) {
 		return fmt.Errorf("module must be lowercase alphanumeric with hyphens")
+	}
+
+	if err := ValidateModuleType(c.Type); err != nil {
+		return err
 	}
 
 	return nil

--- a/boot/deps/config/config_test.go
+++ b/boot/deps/config/config_test.go
@@ -334,3 +334,79 @@ func TestEntryExcludes(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateModuleType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty means not declared", input: "", wantErr: false},
+		{name: "library", input: "library", wantErr: false},
+		{name: "application", input: "application", wantErr: false},
+		{name: "agent", input: "agent", wantErr: false},
+		{name: "plugin", input: "plugin", wantErr: false},
+		// "app" is the badge label for "application" — an easy thing to write
+		// in wippy.yaml and exactly what the CHECK constraint would reject.
+		{name: "app is not application", input: "app", wantErr: true},
+		{name: "unknown", input: "widget", wantErr: true},
+		{name: "case sensitive", input: "Library", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateModuleType(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateModuleType(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestModuleConfig_ParsesType proves the new key actually round-trips through
+// the YAML decoder — the whole feature depends on it reaching hub.
+func TestModuleConfig_ParsesType(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultConfigFile)
+	body := "organization: acme\nmodule: widgets\nversion: 1.0.0\ntype: plugin\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom(): %v", err)
+	}
+	if cfg.Type != "plugin" {
+		t.Errorf("cfg.Type = %q, want %q", cfg.Type, "plugin")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate(): %v", err)
+	}
+}
+
+// TestModuleConfig_RejectsBadType: a typo in wippy.yaml must fail before the
+// publish leaves the machine.
+func TestModuleConfig_RejectsBadType(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultConfigFile)
+	body := "organization: acme\nmodule: widgets\nversion: 1.0.0\ntype: app\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom(): %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() must reject type: app")
+	}
+}

--- a/boot/deps/hub/hub_io.go
+++ b/boot/deps/hub/hub_io.go
@@ -27,11 +27,11 @@ type UploadInput struct {
 	Label        string
 	ReleaseNotes string
 	FilePath     string
-	Protected    bool
 	// ModuleType is the kind declared in wippy.yaml (or --module-type). Hub
 	// requires it when the publish creates the module, and reclassifies an
 	// existing module when it differs. Empty means "not declared".
 	ModuleType string
+	Protected  bool
 }
 
 // UploadOutput is the publish workflow id the caller polls on.

--- a/boot/deps/hub/hub_io.go
+++ b/boot/deps/hub/hub_io.go
@@ -28,6 +28,10 @@ type UploadInput struct {
 	ReleaseNotes string
 	FilePath     string
 	Protected    bool
+	// ModuleType is the kind declared in wippy.yaml (or --module-type). Hub
+	// requires it when the publish creates the module, and reclassifies an
+	// existing module when it differs. Empty means "not declared".
+	ModuleType string
 }
 
 // UploadOutput is the publish workflow id the caller polls on.
@@ -86,6 +90,9 @@ func (c *Client) PublishViaHub(ctx context.Context, in UploadInput) (*UploadOutp
 		}
 		if in.ReleaseNotes != "" {
 			req.Header.Set("X-Wippy-Release-Notes", in.ReleaseNotes)
+		}
+		if in.ModuleType != "" {
+			req.Header.Set("X-Wippy-Module-Type", in.ModuleType)
 		}
 
 		resp, err := c.httpClient.Do(req)

--- a/boot/deps/hub/hub_io_module_type_test.go
+++ b/boot/deps/hub/hub_io_module_type_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	modulev1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1"
+)
+
+// wappFixture writes a throwaway .wapp payload and returns its path.
+func wappFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "demo.wapp")
+	if err := os.WriteFile(path, []byte("wapp-bytes"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// publishViaHubCapturingHeaders runs PublishViaHub against a stub hub and
+// returns the headers the client actually put on the wire.
+func publishViaHubCapturingHeaders(t *testing.T, in UploadInput) http.Header {
+	t.Helper()
+
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"publish_id":"wf-1"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(Options{BaseURL: srv.URL, Token: "tok"})
+	if err != nil {
+		t.Fatalf("NewClient(): %v", err)
+	}
+
+	in.FilePath = wappFixture(t)
+	if _, err := client.PublishViaHub(t.Context(), in); err != nil {
+		t.Fatalf("PublishViaHub(): %v", err)
+	}
+	return got
+}
+
+// TestPublishViaHub_SendsModuleTypeHeader proves the declared type actually
+// leaves the CLI. This is the hub-mediated path, which is the one `wippy
+// publish` prefers — if the header is dropped here, hub can never learn the
+// type and every new module silently falls back to the old behavior.
+func TestPublishViaHub_SendsModuleTypeHeader(t *testing.T) {
+	t.Parallel()
+
+	got := publishViaHubCapturingHeaders(t, UploadInput{
+		Org:        "acme",
+		Module:     "widgets",
+		Version:    "1.0.0",
+		ModuleType: "plugin",
+	})
+
+	if h := got.Get("X-Wippy-Module-Type"); h != "plugin" {
+		t.Errorf("X-Wippy-Module-Type = %q, want %q", h, "plugin")
+	}
+}
+
+// TestPublishViaHub_OmitsModuleTypeHeaderWhenUndeclared: no declared type means
+// no header at all, so hub keeps the module's existing type rather than being
+// told to reclassify it to "".
+func TestPublishViaHub_OmitsModuleTypeHeaderWhenUndeclared(t *testing.T) {
+	t.Parallel()
+
+	got := publishViaHubCapturingHeaders(t, UploadInput{
+		Org:     "acme",
+		Module:  "widgets",
+		Version: "1.0.0",
+	})
+
+	if _, present := got["X-Wippy-Module-Type"]; present {
+		t.Errorf("X-Wippy-Module-Type must be absent when no type is declared, got %q",
+			got.Get("X-Wippy-Module-Type"))
+	}
+}
+
+// TestModuleTypeToProto covers the legacy Connect path's mapping. The empty ->
+// UNSPECIFIED case is the contract: hub distinguishes "not declared" from
+// "library", and collapsing them here would reclassify every module published
+// by a client that declares no type.
+func TestModuleTypeToProto(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]modulev1.ModuleType{
+		"":            modulev1.ModuleType_MODULE_TYPE_UNSPECIFIED,
+		"library":     modulev1.ModuleType_MODULE_TYPE_LIBRARY,
+		"application": modulev1.ModuleType_MODULE_TYPE_APPLICATION,
+		"agent":       modulev1.ModuleType_MODULE_TYPE_AGENT,
+		"plugin":      modulev1.ModuleType_MODULE_TYPE_PLUGIN,
+		// "app" is the badge label, not a type — must not smuggle through.
+		"app": modulev1.ModuleType_MODULE_TYPE_UNSPECIFIED,
+	}
+	for in, want := range cases {
+		if got := moduleTypeToProto(in); got != want {
+			t.Errorf("moduleTypeToProto(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/boot/deps/hub/publish.go
+++ b/boot/deps/hub/publish.go
@@ -33,6 +33,27 @@ type PublishParams struct {
 	Digest       string
 	Size         int64
 	Protected    bool
+	// ModuleType is the kind declared in wippy.yaml (or --module-type).
+	// Empty means "not declared" and maps to MODULE_TYPE_UNSPECIFIED.
+	ModuleType string
+}
+
+// moduleTypeToProto maps the declared wippy.yaml type onto the wire enum.
+// An unrecognized or empty value becomes UNSPECIFIED — hub then decides
+// whether "not declared" is acceptable (it is, except when creating).
+func moduleTypeToProto(t string) modulev1.ModuleType {
+	switch t {
+	case "library":
+		return modulev1.ModuleType_MODULE_TYPE_LIBRARY
+	case "application":
+		return modulev1.ModuleType_MODULE_TYPE_APPLICATION
+	case "agent":
+		return modulev1.ModuleType_MODULE_TYPE_AGENT
+	case "plugin":
+		return modulev1.ModuleType_MODULE_TYPE_PLUGIN
+	default:
+		return modulev1.ModuleType_MODULE_TYPE_UNSPECIFIED
+	}
 }
 
 type PublishResult struct {
@@ -89,6 +110,7 @@ func (c *Client) InitiatePublish(ctx context.Context, params *PublishParams) (*P
 		Digest:            params.Digest,
 		Protected:         params.Protected,
 		ReleaseNotes:      params.ReleaseNotes,
+		ModuleType:        moduleTypeToProto(params.ModuleType),
 	}
 
 	if params.Version != "" {

--- a/boot/deps/hub/publish.go
+++ b/boot/deps/hub/publish.go
@@ -31,11 +31,11 @@ type PublishParams struct {
 	Label        string
 	ReleaseNotes string
 	Digest       string
-	Size         int64
-	Protected    bool
 	// ModuleType is the kind declared in wippy.yaml (or --module-type).
 	// Empty means "not declared" and maps to MODULE_TYPE_UNSPECIFIED.
 	ModuleType string
+	Size       int64
+	Protected  bool
 }
 
 // moduleTypeToProto maps the declared wippy.yaml type onto the wire enum.

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -63,7 +63,7 @@ func init() {
 	publishCmd.Flags().StringSlice("embed", nil, "embed fs.directory entries by id or name (default: none)")
 	publishCmd.Flags().Bool("create", false, "create the module on the registry if it does not yet exist")
 	publishCmd.Flags().String("module-visibility", "private", "visibility for newly created modules (--create only): public or private")
-	publishCmd.Flags().String("module-type", "application", "module type for newly created modules (--create only): library, application, agent or plugin")
+	publishCmd.Flags().String("module-type", "", "module type: library, application, agent or plugin (overrides `type:` in wippy.yaml)")
 	publishCmd.Flags().String("module-display-name", "", "display name for newly created modules (--create only)")
 }
 
@@ -91,6 +91,16 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 
 	if versionFlag != "" {
 		cfg.Version = versionFlag
+	}
+
+	// --module-type overrides the manifest, mirroring --version. Empty leaves
+	// wippy.yaml's `type:` in place; empty in both is "not declared", which
+	// hub accepts only for a module that already exists.
+	if moduleType != "" {
+		cfg.Type = moduleType
+	}
+	if err := config.ValidateModuleType(cfg.Type); err != nil {
+		return NewPublishConfigError(err)
 	}
 
 	if label != "" {
@@ -181,7 +191,7 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 
 	registeredThisRun := false
 	if createIfMissing {
-		if err := ensureModuleRegistered(cmd.Context(), client, registryURL, cfg, moduleDisplayName, moduleType, moduleVisibility); err != nil {
+		if err := ensureModuleRegistered(cmd.Context(), client, registryURL, cfg, moduleDisplayName, cfg.Type, moduleVisibility); err != nil {
 			return err
 		}
 		registeredThisRun = true
@@ -202,7 +212,7 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		// A user without create permission gets the real 403 here — that
 		// is the honest failure, not something to paper over.
 		printStatus(fmt.Sprintf("Module %s/%s not registered yet — creating it", cfg.Organization, cfg.ModuleName))
-		if regErr := ensureModuleRegistered(cmd.Context(), client, registryURL, cfg, moduleDisplayName, moduleType, moduleVisibility); regErr != nil {
+		if regErr := ensureModuleRegistered(cmd.Context(), client, registryURL, cfg, moduleDisplayName, cfg.Type, moduleVisibility); regErr != nil {
 			return regErr
 		}
 		publishID, err = publishViaHubOrLegacy(ctx, client, registryURL, cfg, outputFile, label, releaseNotes, protected)
@@ -263,6 +273,7 @@ func publishViaHubOrLegacy(
 		ReleaseNotes: releaseNotes,
 		FilePath:     outputFile,
 		Protected:    protected,
+		ModuleType:   cfg.Type,
 	}
 	out, err := client.PublishViaHub(ctx, in)
 	if err == nil {
@@ -285,6 +296,7 @@ func publishViaHubOrLegacy(
 		Digest:       "", // hub fills in from the upload body it sees
 		ReleaseNotes: releaseNotes,
 		Protected:    protected,
+		ModuleType:   cfg.Type,
 	}
 	if label != "" {
 		params.Label = label
@@ -687,6 +699,20 @@ func ensureModuleRegistered(ctx context.Context, client *hub.Client, registryURL
 	if keywords == nil {
 		keywords = []string{}
 	}
+	// Hub still accepts an undeclared type when creating a module (it defaults to
+	// "application" and warns) so that older clients keep working. Match that
+	// here rather than hard-failing: upgrading the CLI must not break a pipeline
+	// that publishes a brand-new module. The warning is how the user learns to
+	// declare it before enforcement lands.
+	if moduleType == "" {
+		moduleType = "application"
+		printStatus(fmt.Sprintf(
+			"WARNING: %s/%s has no module type declared; defaulting to 'application'. "+
+				"Add `type: library|application|agent|plugin` to wippy.yaml (or pass --module-type) — "+
+				"this default is deprecated and will become an error.",
+			cfg.Organization, cfg.ModuleName))
+	}
+
 	regCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	regResult, regErr := client.RegisterModule(regCtx, &hub.RegisterModuleParams{

--- a/cmd/wippy/cmd/publish_module_type_test.go
+++ b/cmd/wippy/cmd/publish_module_type_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wippyai/runtime/boot/deps/config"
+	"github.com/wippyai/runtime/boot/deps/hub"
+)
+
+// TestPublishModuleTypeFlagDefaultsEmpty guards the highest-blast-radius line in
+// this change. The flag used to default to "application", which is why every
+// module the CLI created was cataloged as an app. It must now default to empty
+// so "not declared" is a state hub can see and reject, and so wippy.yaml's
+// `type:` is not silently overridden by a flag the user never passed.
+func TestPublishModuleTypeFlagDefaultsEmpty(t *testing.T) {
+	t.Parallel()
+
+	flag := publishCmd.Flags().Lookup("module-type")
+	if flag == nil {
+		t.Fatal("publish is missing the --module-type flag")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("--module-type default = %q, want \"\" — a non-empty default silently types every new module",
+			flag.DefValue)
+	}
+}
+
+// TestEnsureModuleRegistered_DefaultsAndWarnsWhenTypeUndeclared: during the
+// grace period an undeclared type must not fail the publish — upgrading the CLI
+// cannot break a pipeline that creates a new module. It defaults to
+// "application" (what hub does too) and tells the user to declare it.
+func TestEnsureModuleRegistered_DefaultsAndWarnsWhenTypeUndeclared(t *testing.T) {
+	cfg := &config.ModuleConfig{Organization: "acme", ModuleName: "widgets"}
+
+	var gotType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ModuleType string `json:"module_type"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotType = body.ModuleType
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"org_name": "acme", "name": "widgets", "visibility": "private", "module_type": body.ModuleType,
+		})
+	}))
+	defer srv.Close()
+
+	client, err := hub.NewClient(hub.Options{BaseURL: srv.URL, Token: "tok"})
+	if err != nil {
+		t.Fatalf("NewClient(): %v", err)
+	}
+
+	if err := ensureModuleRegistered(t.Context(), client, srv.URL, cfg, "Widgets", "", "private"); err != nil {
+		t.Fatalf("ensureModuleRegistered() must not fail on an undeclared type during grace: %v", err)
+	}
+	if gotType != "application" {
+		t.Errorf("module_type sent = %q, want %q (grace-period default)", gotType, "application")
+	}
+}


### PR DESCRIPTION
Pairs with wippy/hub!45 and wippy/proto!3 (GitLab).

## Why

A module's type on the hub was decided by a CLI flag that defaulted to `application` and only applied with `--create`. In practice every module the CLI created was catalogued as an app, with no way to correct it — and the manifest could not express the type at all.

## What

- `ModuleConfig` gains an optional **`type:`** key (`library|application|agent|plugin`), validated on load. Parsing is non-strict, so the new key is backward compatible and older CLIs simply ignore it.
- `--module-type` now defaults to **empty** and overrides the manifest, mirroring how `--version` overrides `cfg.Version`. This is what makes "not declared" a state the CLI can actually detect — the old `application` default is the reason everything became an app.
- The resolved type is sent on **both** publish paths: the `X-Wippy-Module-Type` header on the hub-mediated upload, and the new `module_type` field on the legacy `InitiatePublish` RPC (empty → `MODULE_TYPE_UNSPECIFIED`, which hub keeps distinct from `library`).
- Syncs runtime's hand-relocated copy of the hub protos, which had drifted a revision behind upstream. **Note for the reviewer:** that regen also absorbs an unrelated upstream field (`Module.OwnerName`) — additive and wire-safe, but it is in the diff.

### Compatibility (deliberate)

An undeclared type still creates the module as `application` and prints a **deprecation warning** rather than failing. Upgrading the CLI must not break a pipeline that publishes a brand-new module; hub does the same thing on its side. Enforcement flips on in a follow-up.

## Testing

- `make build-wippy` — binary builds; `wippy publish --help` shows the new flag default
- `go test ./boot/... ./cmd/...` — green
- `golangci-lint run` — **0 new issues**
- Wire tests prove the CLI actually puts `X-Wippy-Module-Type` on the wire, and omits it entirely when no type is declared (so hub preserves the stored type rather than being told to set `""`)
- `moduleTypeToProto` covered, including `"" → UNSPECIFIED` and rejecting `"app"` (the badge label, not a type)
