### PR TITLE
fix(registry): resolve baseline dependencies during boot

### DIFF
--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	registryimpl "github.com/wippyai/runtime/system/registry"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+type bootRecordingRunner struct {
+	transitions []regapi.ChangeSet
+}
+
+type bootDirectiveFunc func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error)
+
+func (f bootDirectiveFunc) Expand(ctx context.Context, op regapi.Operation, state regapi.State) (regapi.DirectiveResult, error) {
+	return f(ctx, op, state)
+}
+
+func (r *bootRecordingRunner) Transition(_ context.Context, state regapi.State, changes regapi.ChangeSet) (regapi.State, error) {
+	r.transitions = append(r.transitions, append(regapi.ChangeSet(nil), changes...))
+	stateMap := topology.NewStateMap(state)
+	for _, op := range changes {
+		switch op.Kind {
+		case regapi.EntryCreate, regapi.EntryUpdate:
+			stateMap[op.Entry.ID] = op.Entry
+		case regapi.EntryDelete:
+			delete(stateMap, op.Entry.ID)
+		}
+	}
+	return topology.StateMapToSlice(stateMap), nil
+}
+
+func TestDependencyHandler_BootExpandsSourceRootBeforeUnrelatedInstall(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, "vendor")
+
+	artifacts := map[string][]byte{
+		"analysis": buildWappBytes(t, []wapp.Entry{{
+			ID:   wapp.NewID("acme.analysis", "runtime"),
+			Kind: "process.host",
+			Data: map[string]any{"runtime": "wasm"},
+		}}),
+		"crm": buildWappBytes(t, []wapp.Entry{{
+			ID:   wapp.NewID("acme.crm", "service"),
+			Kind: "service",
+			Data: map[string]any{"enabled": true},
+		}}),
+	}
+	downloads := map[string]int{}
+
+	hubClient := &fakeHub{
+		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			if _, ok := artifacts[module]; !ok {
+				return nil, fmt.Errorf("unknown module %s/%s", org, module)
+			}
+			return &ModuleManifest{
+				Org: org, Name: module, Version: "v1.0.0", URL: "memory://" + module,
+			}, nil
+		},
+		downloadFile: func(_ context.Context, url, destPath string) error {
+			module := url[len("memory://"):]
+			artifact, ok := artifacts[module]
+			if !ok {
+				return fmt.Errorf("unknown artifact %q", url)
+			}
+			downloads[module]++
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(destPath, artifact, 0o600)
+		},
+	}
+
+	resolver := topology.NewResolver()
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       hubClient,
+		Logger:    zap.NewNop(),
+		Resolver:  resolver,
+		LockPath:  filepath.Join(tmpDir, "wippy.lock"),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	runner := &bootRecordingRunner{}
+	reg := registryimpl.NewRegistry(
+		historymem.New(),
+		runner,
+		topology.NewStateBuilder(zap.NewNop(), resolver),
+		resolver,
+		zap.NewNop(),
+		registryimpl.WithKindDirective(regapi.NamespaceDependency, bootDirectiveFunc(handler.Expand)),
+	)
+
+	analysisRoot := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "analysis"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/analysis","version":"v1.0.0"}`, payload.JSON),
+	}
+	require.NoError(t, reg.LoadState(ctx, regapi.State{analysisRoot}, version.FromParent(nil, 0)))
+
+	_, err = reg.GetEntry(regapi.NewID("acme.analysis", "runtime"))
+	require.NoError(t, err, "boot must not publish a dependency root without its module entries")
+	require.Equal(t, 1, downloads["analysis"], "the declared module must be installed during boot")
+
+	runner.transitions = nil
+	crmRoot := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "crm"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/crm","version":"v1.0.0"}`, payload.JSON),
+	}
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: crmRoot}})
+	require.NoError(t, err)
+	require.Equal(t, 1, downloads["analysis"], "installing CRM must not materialize or reinstall Analysis")
+	require.Equal(t, 1, downloads["crm"])
+
+	for _, transition := range runner.transitions {
+		for _, op := range transition {
+			require.NotEqual(t, regapi.NewID("acme.analysis", "runtime"), op.Entry.ID,
+				"an unrelated install must not mutate the module established at boot")
+		}
+	}
+}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -162,6 +162,14 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
 	}
 
+	satisfied, err := h.unchangedRootDependencySatisfied(ctx, transcoder, op, entry, snapshot)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	if satisfied {
+		return regapi.DirectiveResult{Applied: true}, nil
+	}
+
 	lockedVersions, err := h.installedModuleVersions(ctx, transcoder, snapshot)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
@@ -267,6 +275,45 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		Additional: scoped,
 		Effects:    effects,
 	}, nil
+}
+
+func (h *DependencyHandler) unchangedRootDependencySatisfied(
+	ctx context.Context,
+	transcoder payload.Transcoder,
+	op regapi.Operation,
+	entry regapi.Entry,
+	snapshot regapi.State,
+) (bool, error) {
+	if op.Kind != regapi.EntryUpdate {
+		return false, nil
+	}
+
+	var current regapi.Entry
+	found := false
+	for _, candidate := range snapshot {
+		if idsEqual(candidate.ID, entry.ID) {
+			current = candidate
+			found = true
+			break
+		}
+	}
+	if !found || !entriesEqual(current, entry) {
+		return false, nil
+	}
+
+	definition, err := decodeDependency(ctx, transcoder, entry)
+	if err != nil {
+		return false, err
+	}
+	if definition.Component == "" {
+		return false, nil
+	}
+
+	installedVersion := snapshotModuleVersions(snapshot)[definition.Component]
+	if installedVersion == "" {
+		installedVersion = h.replacementModuleVersion(definition.Component)
+	}
+	return lockedVersionSatisfies(installedVersion, definition.Version), nil
 }
 
 func (h *DependencyHandler) collectSnapshotDependencies(

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -98,6 +98,84 @@ func TestDependencyHandler_ResolveErrors(t *testing.T) {
 	}
 }
 
+func TestDependencyHandler_UnchangedLoadedRootIsIdempotent(t *testing.T) {
+	ctx := newTestContext()
+	manifestCalls := 0
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(context.Context, string, string, string) (*ModuleManifest, error) {
+				manifestCalls++
+				return nil, assert.AnError
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  filepath.Join(t.TempDir(), "wippy.lock"),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	depEntry := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "http"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/http","version":">=v1.0.0 <v2.0.0"}`, payload.JSON),
+	}
+	moduleEntry := regapi.Entry{
+		ID:   regapi.NewID("acme.http", "service"),
+		Kind: "service",
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        "acme/http",
+			metaModuleVersionKey: "v1.4.2",
+		}),
+	}
+
+	result, err := handler.Expand(ctx, regapi.Operation{
+		Kind: regapi.EntryUpdate, Entry: depEntry,
+	}, regapi.State{depEntry, moduleEntry})
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	require.Empty(t, result.Additional)
+	require.Empty(t, result.Effects)
+	require.Zero(t, manifestCalls, "a compatible module already assembled at boot must not be resolved again")
+}
+
+func TestDependencyHandler_UnchangedRootWithIncompatibleLoadedVersionResolves(t *testing.T) {
+	ctx := newTestContext()
+	manifestCalls := 0
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(context.Context, string, string, string) (*ModuleManifest, error) {
+				manifestCalls++
+				return nil, assert.AnError
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  filepath.Join(t.TempDir(), "wippy.lock"),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	depEntry := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "http"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/http","version":"v2.0.0"}`, payload.JSON),
+	}
+	moduleEntry := regapi.Entry{
+		ID:   regapi.NewID("acme.http", "service"),
+		Kind: "service",
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        "acme/http",
+			metaModuleVersionKey: "v1.4.2",
+		}),
+	}
+
+	_, err = handler.Expand(ctx, regapi.Operation{
+		Kind: regapi.EntryUpdate, Entry: depEntry,
+	}, regapi.State{depEntry, moduleEntry})
+	require.Error(t, err)
+	require.ErrorContains(t, err, assert.AnError.Error())
+	require.Equal(t, 1, manifestCalls, "an incompatible loaded version must be resolved instead of accepted")
+}
+
 func TestDependencyHandler_EntryConflict(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()

--- a/system/registry/load_state_test.go
+++ b/system/registry/load_state_test.go
@@ -80,6 +80,103 @@ func TestRegistry_LoadState_V0(t *testing.T) {
 	assert.Len(t, reg.state, 2)
 }
 
+func TestRegistry_LoadState_V0ExpandsBaselineDirectives(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	hist := history.NewMemory()
+	resolver := topology.NewResolver()
+
+	depEntry := registry.Entry{
+		ID:   registry.NewID("app.deps", "analysis"),
+		Kind: registry.NamespaceDependency,
+		Data: payload.New("dependency"),
+	}
+	expandedEntry := registry.Entry{
+		ID:   registry.NewID("analysis", "runtime"),
+		Kind: "process.host",
+		Data: payload.New("expanded"),
+	}
+
+	expander := directiveFunc(func(_ context.Context, op registry.Operation, snapshot registry.State) (registry.DirectiveResult, error) {
+		require.Equal(t, registry.EntryUpdate, op.Kind)
+		require.Equal(t, depEntry.ID, op.Entry.ID)
+		require.Contains(t, snapshot, depEntry)
+		return registry.DirectiveResult{
+			Applied: true,
+			Additional: []registry.ScopedOperation{{
+				Operation: registry.Operation{Kind: registry.EntryCreate, Entry: expandedEntry},
+				Scope:     registry.ScopeBaseline,
+			}},
+		}, nil
+	})
+
+	runner := NewMockRunner()
+	runner.RunFunc = func(state registry.State, changes registry.ChangeSet) (registry.State, error) {
+		stateMap := topology.NewStateMap(state)
+		for _, op := range changes {
+			switch op.Kind {
+			case registry.EntryCreate, registry.EntryUpdate:
+				stateMap[op.Entry.ID] = op.Entry
+			case registry.EntryDelete:
+				delete(stateMap, op.Entry.ID)
+			}
+		}
+		return topology.StateMapToSlice(stateMap), nil
+	}
+
+	reg := NewRegistry(
+		hist,
+		runner,
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+		WithKindDirective(registry.NamespaceDependency, expander),
+	)
+
+	head, err := reg.Current()
+	require.NoError(t, err)
+	require.NoError(t, reg.LoadState(ctx, registry.State{depEntry}, head))
+
+	_, err = reg.GetEntry(depEntry.ID)
+	require.NoError(t, err)
+	_, err = reg.GetEntry(expandedEntry.ID)
+	require.NoError(t, err)
+}
+
+func TestRegistry_LoadState_V0RejectsBaselineDirectiveExpansionFailure(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	resolver := topology.NewResolver()
+	depEntry := registry.Entry{
+		ID:   registry.NewID("app.deps", "missing"),
+		Kind: registry.NamespaceDependency,
+	}
+
+	runner := NewMockRunner()
+	runner.RunFunc = func(state registry.State, _ registry.ChangeSet) (registry.State, error) {
+		return state, nil
+	}
+	reg := NewRegistry(
+		history.NewMemory(),
+		runner,
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+		WithKindDirective(registry.NamespaceDependency, directiveFunc(
+			func(context.Context, registry.Operation, registry.State) (registry.DirectiveResult, error) {
+				return registry.DirectiveResult{}, assert.AnError
+			},
+		)),
+	)
+
+	head, err := reg.Current()
+	require.NoError(t, err)
+	err = reg.LoadState(ctx, registry.State{depEntry}, head)
+	require.ErrorIs(t, err, assert.AnError)
+	_, err = reg.GetEntry(depEntry.ID)
+	require.Error(t, err, "a failed declaration must not be published as a partial root")
+}
+
 func TestRegistry_LoadState_WithHistory(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.NewNop()

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -527,6 +527,55 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
 	}
 
+	// Baseline entries are declarations just like entries restored from history.
+	// Expand them before replay so every history operation observes a complete
+	// state rather than causing an unrelated declaration to materialize later.
+	if planner != nil {
+		baselineEntries := topology.StateMapToSlice(stateMap)
+		for _, entry := range baselineEntries {
+			if len(r.directivesByKind[entry.Kind]) == 0 {
+				continue
+			}
+
+			snapshot := topology.StateMapToSlice(stateMap)
+			plan, err := planner.Expand(ctx, registry.ChangeSet{{
+				Kind:  registry.EntryUpdate,
+				Entry: entry,
+			}}, snapshot)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewExpandChangesError(err)
+			}
+			if !plan.Expanded {
+				continue
+			}
+
+			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewSortChangesError(err)
+			}
+			ops, _ := plan.SplitScopes()
+
+			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				planner.RollbackEffects(ctx, prepared)
+				return NewPrepareEffectsError(err)
+			}
+			preparedEff = append(preparedEff, prepared...)
+
+			for _, op := range ops {
+				switch op.Kind {
+				case registry.EntryCreate, registry.EntryUpdate:
+					stateMap[op.Entry.ID] = op.Entry
+				case registry.EntryDelete:
+					delete(stateMap, op.Entry.ID)
+				}
+			}
+		}
+	}
+
 	if targetVersion.ID() > 0 {
 		current := targetVersion
 		var versions []registry.Version


### PR DESCRIPTION
## Root cause

`LoadState` expanded dependency directives only while replaying history. Source declarations in the v0 baseline were published without expansion, so a dependency absent from `wippy.lock` stayed incomplete until a later unrelated dependency changeset re-expanded the full root set.

## Fix

- expand baseline directives before replaying history or publishing registry state
- fail boot when a declared dependency cannot be resolved instead of accepting a partial root
- make unchanged baseline dependency expansion idempotent when the compatible module is already loaded
- retain normal resolution for missing or incompatible modules

## Proof

- regression test: a v0 baseline dependency creates its module entries during `LoadState`
- failure test: baseline expansion failure leaves no published root
- integration test: Analysis installs during boot; a later CRM install emits no Analysis operation or download
- `go test ./... -count=1`
- `make lint` (`0 issues`)
- combined local binary with the pending runtime and WASM fixes: clean app boot with R declared in source but absent from lock and vendor downloaded and initialized `wippy-langs/r@0.2.6`; authenticated Webscout update completed at registry version 1 without changing or reinitializing R

Review only. This PR has not been merged.