### PR TITLE
feat(registry): persist exact dependency resolutions in history

### DIFF
--- a/api/hub/wippy/api/hub/manifest/v1/message.pb.go
+++ b/api/hub/wippy/api/hub/manifest/v1/message.pb.go
@@ -202,15 +202,19 @@ func (x *ModuleManifest) GetProtected() bool {
 
 // Resolved dependency with download info.
 type ResolvedDependency struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Org           string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Version       string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
-	VersionId     string                 `protobuf:"bytes,4,opt,name=version_id,json=versionId,proto3" json:"version_id,omitempty"`
-	Digest        string                 `protobuf:"bytes,5,opt,name=digest,proto3" json:"digest,omitempty"`
-	SizeBytes     uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
-	Download      *v11.DownloadInfo      `protobuf:"bytes,7,opt,name=download,proto3" json:"download,omitempty"`
-	Protected     bool                   `protobuf:"varint,8,opt,name=protected,proto3" json:"protected,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Org       string                 `protobuf:"bytes,1,opt,name=org,proto3" json:"org,omitempty"`
+	Name      string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Version   string                 `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+	VersionId string                 `protobuf:"bytes,4,opt,name=version_id,json=versionId,proto3" json:"version_id,omitempty"`
+	Digest    string                 `protobuf:"bytes,5,opt,name=digest,proto3" json:"digest,omitempty"`
+	SizeBytes uint64                 `protobuf:"varint,6,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	Download  *v11.DownloadInfo      `protobuf:"bytes,7,opt,name=download,proto3" json:"download,omitempty"`
+	Protected bool                   `protobuf:"varint,8,opt,name=protected,proto3" json:"protected,omitempty"`
+	// Version range the parent module declared for this dependency, verbatim
+	// (e.g. ">=v0.4.10"). Consumers resolve and lock against this range; version
+	// above is only the release it resolved to at request time.
+	Constraint    string `protobuf:"bytes,9,opt,name=constraint,proto3" json:"constraint,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -299,6 +303,13 @@ func (x *ResolvedDependency) GetProtected() bool {
 		return x.Protected
 	}
 	return false
+}
+
+func (x *ResolvedDependency) GetConstraint() string {
+	if x != nil {
+		return x.Constraint
+	}
+	return ""
 }
 
 // Dependency specification for resolution.
@@ -713,7 +724,7 @@ const file_wippy_api_hub_manifest_v1_message_proto_rawDesc = "" +
 	"\fdependencies\x18\t \x03(\v2-.wippy.api.hub.manifest.v1.ResolvedDependencyR\fdependencies\x12A\n" +
 	"\bdownload\x18\n" +
 	" \x01(\v2%.wippy.api.hub.common.v1.DownloadInfoR\bdownload\x12\x1c\n" +
-	"\tprotected\x18\v \x01(\bR\tprotected\"\x8b\x02\n" +
+	"\tprotected\x18\v \x01(\bR\tprotected\"\xab\x02\n" +
 	"\x12ResolvedDependency\x12\x10\n" +
 	"\x03org\x18\x01 \x01(\tR\x03org\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -724,7 +735,10 @@ const file_wippy_api_hub_manifest_v1_message_proto_rawDesc = "" +
 	"\n" +
 	"size_bytes\x18\x06 \x01(\x04R\tsizeBytes\x12A\n" +
 	"\bdownload\x18\a \x01(\v2%.wippy.api.hub.common.v1.DownloadInfoR\bdownload\x12\x1c\n" +
-	"\tprotected\x18\b \x01(\bR\tprotected\"V\n" +
+	"\tprotected\x18\b \x01(\bR\tprotected\x12\x1e\n" +
+	"\n" +
+	"constraint\x18\t \x01(\tR\n" +
+	"constraint\"V\n" +
 	"\x0eDependencySpec\x12\x10\n" +
 	"\x03org\x18\x01 \x01(\tR\x03org\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1e\n" +

--- a/api/modules/source_roots.go
+++ b/api/modules/source_roots.go
@@ -49,6 +49,46 @@ func (r *SourceRootRegistry) SetAll(roots SourceRoots) {
 	}
 }
 
+// SwapSubset atomically replaces the roots for modules with desired and
+// returns the roots that existed before the replacement. Empty module names,
+// roots, and desired entries outside modules are ignored.
+func (r *SourceRootRegistry) SwapSubset(desired SourceRoots, modules ...string) SourceRoots {
+	if r == nil || len(modules) == 0 {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	previous := make(SourceRoots)
+	controlled := make(map[string]struct{}, len(modules))
+	for _, module := range modules {
+		if module == "" {
+			continue
+		}
+		if _, seen := controlled[module]; seen {
+			continue
+		}
+		controlled[module] = struct{}{}
+		if root := r.roots[module]; root != "" {
+			previous[module] = root
+		}
+		delete(r.roots, module)
+	}
+	if r.roots == nil {
+		r.roots = SourceRoots{}
+	}
+	for module, root := range desired {
+		if root == "" {
+			continue
+		}
+		if _, ok := controlled[module]; ok {
+			r.roots[module] = root
+		}
+	}
+	return previous
+}
+
 // Get returns a module root.
 func (r *SourceRootRegistry) Get(module string) (string, bool) {
 	if r == nil || module == "" {
@@ -95,6 +135,21 @@ func WithSourceRoots(ctx context.Context, roots SourceRoots) context.Context {
 	reg.SetAll(roots)
 
 	return ctx
+}
+
+// SwapSourceRoots atomically replaces the controlled module roots and returns
+// the roots that existed before the replacement. It is a no-op when ctx has no
+// source-root registry.
+func SwapSourceRoots(ctx context.Context, desired SourceRoots, modules ...string) SourceRoots {
+	ac := ctxapi.AppFromContext(ctx)
+	if ac == nil {
+		return nil
+	}
+	reg, _ := ac.Get(sourceRootsKey).(*SourceRootRegistry)
+	if reg == nil {
+		return nil
+	}
+	return reg.SwapSubset(desired, modules...)
 }
 
 // SourceRoot returns the local load root for a module, when one is available.

--- a/api/modules/source_roots_test.go
+++ b/api/modules/source_roots_test.go
@@ -83,3 +83,45 @@ func TestSourceRootsNoPanicWhenSealedWithoutRegistry(t *testing.T) {
 		t.Fatal("source root should not be registered when sealed registry is absent")
 	}
 }
+
+func TestSwapSourceRootsReplacesOnlyControlledSubset(t *testing.T) {
+	ctx := WithSourceRootRegistry(ctxapi.NewRootContext())
+	WithSourceRoots(ctx, SourceRoots{
+		"acme/old":       "/repo/old",
+		"acme/updated":   "/repo/updated-v1",
+		"acme/unrelated": "/repo/unrelated",
+	})
+
+	previous := SwapSourceRoots(ctx, SourceRoots{
+		"acme/updated":   "/repo/updated-v2",
+		"acme/new":       "/repo/new",
+		"acme/unrelated": "/must-not-apply",
+	}, "acme/old", "acme/updated", "acme/new")
+
+	if len(previous) != 2 || previous["acme/old"] != "/repo/old" || previous["acme/updated"] != "/repo/updated-v1" {
+		t.Fatalf("previous roots = %#v", previous)
+	}
+	if _, ok := SourceRoot(ctx, "acme/old"); ok {
+		t.Fatal("controlled root omitted from desired must be removed")
+	}
+	if root, ok := SourceRoot(ctx, "acme/updated"); !ok || root != "/repo/updated-v2" {
+		t.Fatalf("updated root = %q, %v", root, ok)
+	}
+	if root, ok := SourceRoot(ctx, "acme/new"); !ok || root != "/repo/new" {
+		t.Fatalf("new root = %q, %v", root, ok)
+	}
+	if root, ok := SourceRoot(ctx, "acme/unrelated"); !ok || root != "/repo/unrelated" {
+		t.Fatalf("unrelated root = %q, %v", root, ok)
+	}
+
+	SwapSourceRoots(ctx, previous, "acme/old", "acme/updated", "acme/new")
+	if root, ok := SourceRoot(ctx, "acme/old"); !ok || root != "/repo/old" {
+		t.Fatalf("restored old root = %q, %v", root, ok)
+	}
+	if root, ok := SourceRoot(ctx, "acme/updated"); !ok || root != "/repo/updated-v1" {
+		t.Fatalf("restored updated root = %q, %v", root, ok)
+	}
+	if _, ok := SourceRoot(ctx, "acme/new"); ok {
+		t.Fatal("new root must be removed during restore")
+	}
+}

--- a/api/registry/expansion.go
+++ b/api/registry/expansion.go
@@ -58,3 +58,12 @@ type Effect interface {
 	Commit(context.Context) error
 	Rollback(context.Context) error
 }
+
+// FinalizingEffect performs irreversible cleanup only after the registry state
+// and its history head are durably committed. Finalize must not be required for
+// correctness: a failure may leak temporary resources, but must not invalidate
+// the committed registry state.
+type FinalizingEffect interface {
+	Effect
+	Finalize(context.Context) error
+}

--- a/api/registry/expansion.go
+++ b/api/registry/expansion.go
@@ -23,9 +23,23 @@ type ScopedOperation struct {
 // DirectiveResult is returned by a Directive to augment a registry operation.
 type DirectiveResult struct {
 	OriginalScope *Scope
+	Resolution    *DependencyResolution
 	Additional    []ScopedOperation
 	Effects       []Effect
 	Applied       bool
+}
+
+// ResolutionDirective restores derived state from the exact dependency graph
+// stored for a registry version. It is used once after declarative history has
+// been reconstructed, never once per historical changeset.
+type ResolutionDirective interface {
+	ReconcileResolution(context.Context, State, *DependencyResolution) (DirectiveResult, error)
+}
+
+// ChangesDirective expands all same-kind operations in one resolution pass.
+// It prevents a multi-root transaction from staging intermediate graphs.
+type ChangesDirective interface {
+	ExpandChanges(context.Context, ChangeSet, State) (DirectiveResult, error)
 }
 
 // Directive can augment a registry operation with additional operations or effects.

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -199,6 +199,20 @@ type (
 		SetHead(Version) error
 	}
 
+	// ChangeSetReplayer is an optional history capability for streaming the
+	// ordered ancestry of one target version. Database histories use it to avoid
+	// one query and one retained decoded changeset per historical version.
+	ChangeSetReplayer interface {
+		ReplayChanges(Version, func(ChangeSet) error) error
+	}
+
+	// HeadCASHistory atomically moves the history head only when it still
+	// matches the caller's source version. It prevents rollback/redo in one
+	// runtime instance from overwriting a concurrent writer's head.
+	HeadCASHistory interface {
+		CompareAndSetHead(expected, target Version) error
+	}
+
 	// Runner defines how ChangeSets are applied to a State to produce a new State
 	Runner interface {
 		// Transition applies a given ChangeSet to a State and returns the resulting modified State

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -203,7 +203,19 @@ type (
 	// ordered ancestry of one target version. Database histories use it to avoid
 	// one query and one retained decoded changeset per historical version.
 	ChangeSetReplayer interface {
-		ReplayChanges(Version, func(ChangeSet) error) error
+		ReplayChanges(context.Context, Version, func(ChangeSet) error) error
+	}
+
+	// VersionIDBounds avoids enumerating an entire long history merely to seed
+	// the monotonic version allocator during boot.
+	VersionIDBounds interface {
+		MaxVersionID() (uint, error)
+	}
+
+	// VersionLookup loads one canonical root-to-version lineage without
+	// enumerating unrelated historical branches.
+	VersionLookup interface {
+		GetVersion(id uint) (Version, error)
 	}
 
 	// HeadCASHistory atomically moves the history head only when it still

--- a/api/registry/resolution.go
+++ b/api/registry/resolution.go
@@ -15,6 +15,10 @@ import (
 // checkpoint the result, but must not treat any other storage error as legacy.
 var ErrDependencyResolutionNotFound = errors.New("dependency resolution not found")
 
+// ErrInvalidDependencyResolution means a caller supplied a graph that cannot
+// be made into a durable snapshot without losing dependency semantics.
+var ErrInvalidDependencyResolution = errors.New("invalid dependency resolution")
+
 // ResolvedModule is an immutable module selection stored with a registry
 // version. Download URLs are intentionally excluded because they expire; a
 // missing artifact is fetched again by exact version/digest.
@@ -22,6 +26,7 @@ type ResolvedModule struct {
 	Name      string `json:"name"`
 	Version   string `json:"version"`
 	VersionID string `json:"version_id,omitempty"`
+	Source    string `json:"source,omitempty"`
 	Digest    string `json:"digest,omitempty"`
 	SizeBytes uint64 `json:"size_bytes,omitempty"`
 	Protected bool   `json:"protected,omitempty"`
@@ -94,6 +99,31 @@ func (r *DependencyResolution) Valid() bool {
 	if r == nil || r.Digest == "" {
 		return false
 	}
+	rootIDs := make(map[string]struct{}, len(r.Roots))
+	components := make(map[string]struct{}, len(r.Roots))
+	for _, root := range r.Roots {
+		if root.ID == "" || root.Component == "" || root.Version == "" {
+			return false
+		}
+		if _, duplicate := rootIDs[root.ID]; duplicate {
+			return false
+		}
+		if _, duplicate := components[root.Component]; duplicate {
+			return false
+		}
+		rootIDs[root.ID] = struct{}{}
+		components[root.Component] = struct{}{}
+	}
+	modules := make(map[string]struct{}, len(r.Modules))
+	for _, module := range r.Modules {
+		if module.Name == "" || module.Version == "" || module.Digest == "" {
+			return false
+		}
+		if _, duplicate := modules[module.Name]; duplicate {
+			return false
+		}
+		modules[module.Name] = struct{}{}
+	}
 	return r.Digest == r.Canonical().Digest
 }
 
@@ -120,4 +150,12 @@ type ResolutionHistory interface {
 	GetDependencyResolution(Version) (*DependencyResolution, error)
 	SaveWithDependencyResolution(Version, ChangeSet, *DependencyResolution, bool) error
 	CheckpointDependencyResolution(Version, *DependencyResolution) error
+}
+
+// ResolutionHeadCASHistory attaches an exact graph and moves head in one
+// atomic operation. A failed head comparison must leave the target version
+// unmodified, so a losing rollback cannot freeze a graph that was never live.
+type ResolutionHeadCASHistory interface {
+	ResolutionHistory
+	CompareAndSetHeadWithDependencyResolution(expected, target Version, resolution *DependencyResolution) error
 }

--- a/api/registry/resolution.go
+++ b/api/registry/resolution.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+)
+
+// ErrDependencyResolutionNotFound means a history version predates durable
+// dependency resolutions. Callers may use the legacy resolver once and
+// checkpoint the result, but must not treat any other storage error as legacy.
+var ErrDependencyResolutionNotFound = errors.New("dependency resolution not found")
+
+// ResolvedModule is an immutable module selection stored with a registry
+// version. Download URLs are intentionally excluded because they expire; a
+// missing artifact is fetched again by exact version/digest.
+type ResolvedModule struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	VersionID string `json:"version_id,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	SizeBytes uint64 `json:"size_bytes,omitempty"`
+	Protected bool   `json:"protected,omitempty"`
+}
+
+// DependencyRoot records one authored dependency declaration used as a solver
+// input. Parameters remain in the ordinary registry changeset because they
+// configure linking rather than version selection.
+type DependencyRoot struct {
+	ID        string `json:"id"`
+	Component string `json:"component"`
+	Version   string `json:"version"`
+}
+
+// DependencyResolution is the exact graph selected for a registry version.
+// InputDigest identifies the declared root set; Digest identifies the complete
+// immutable selection independently of mutable download URLs.
+type DependencyResolution struct {
+	Digest      string           `json:"digest"`
+	InputDigest string           `json:"input_digest"`
+	Roots       []DependencyRoot `json:"roots"`
+	Modules     []ResolvedModule `json:"modules"`
+}
+
+// Canonical returns a detached, deterministically ordered resolution and
+// recomputes its content digest.
+func (r *DependencyResolution) Canonical() *DependencyResolution {
+	if r == nil {
+		return nil
+	}
+	out := &DependencyResolution{
+		InputDigest: r.InputDigest,
+		Roots:       append([]DependencyRoot(nil), r.Roots...),
+		Modules:     append([]ResolvedModule(nil), r.Modules...),
+	}
+	sort.Slice(out.Roots, func(i, j int) bool {
+		if out.Roots[i].ID != out.Roots[j].ID {
+			return out.Roots[i].ID < out.Roots[j].ID
+		}
+		if out.Roots[i].Component != out.Roots[j].Component {
+			return out.Roots[i].Component < out.Roots[j].Component
+		}
+		return out.Roots[i].Version < out.Roots[j].Version
+	})
+	sort.Slice(out.Modules, func(i, j int) bool {
+		left, right := out.Modules[i], out.Modules[j]
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		if left.Version != right.Version {
+			return left.Version < right.Version
+		}
+		if left.VersionID != right.VersionID {
+			return left.VersionID < right.VersionID
+		}
+		if left.Digest != right.Digest {
+			return left.Digest < right.Digest
+		}
+		if left.SizeBytes != right.SizeBytes {
+			return left.SizeBytes < right.SizeBytes
+		}
+		return !left.Protected && right.Protected
+	})
+	out.Digest = out.computeDigest()
+	return out
+}
+
+// Valid reports whether the stored digest matches the canonical resolution.
+func (r *DependencyResolution) Valid() bool {
+	if r == nil || r.Digest == "" {
+		return false
+	}
+	return r.Digest == r.Canonical().Digest
+}
+
+func (r *DependencyResolution) computeDigest() string {
+	payload := struct {
+		InputDigest string           `json:"input_digest"`
+		Roots       []DependencyRoot `json:"roots"`
+		Modules     []ResolvedModule `json:"modules"`
+	}{
+		InputDigest: r.InputDigest,
+		Roots:       r.Roots,
+		Modules:     r.Modules,
+	}
+	data, _ := json.Marshal(payload) // Struct contains only JSON-safe primitives.
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// ResolutionHistory atomically stores a changeset and the exact dependency
+// graph selected while applying it. Implementations must write the version,
+// changeset, resolution reference, and head update in one transaction.
+type ResolutionHistory interface {
+	History
+	GetDependencyResolution(Version) (*DependencyResolution, error)
+	SaveWithDependencyResolution(Version, ChangeSet, *DependencyResolution, bool) error
+	CheckpointDependencyResolution(Version, *DependencyResolution) error
+}

--- a/api/registry/resolution_test.go
+++ b/api/registry/resolution_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencyResolutionCanonicalDigestIsOrderIndependent(t *testing.T) {
+	left := (&DependencyResolution{
+		InputDigest: "roots",
+		Modules: []ResolvedModule{
+			{Name: "acme/z", Version: "v2", Digest: "sha256:z"},
+			{Name: "acme/a", Version: "v1", Digest: "sha256:a"},
+		},
+	}).Canonical()
+	right := (&DependencyResolution{
+		InputDigest: "roots",
+		Modules: []ResolvedModule{
+			{Name: "acme/a", Version: "v1", Digest: "sha256:a"},
+			{Name: "acme/z", Version: "v2", Digest: "sha256:z"},
+		},
+	}).Canonical()
+
+	require.Equal(t, left.Digest, right.Digest)
+	require.True(t, left.Valid())
+	require.True(t, right.Valid())
+}
+
+func TestDependencyResolutionDigestCoversInputsAndArtifacts(t *testing.T) {
+	base := (&DependencyResolution{
+		InputDigest: "roots-a",
+		Modules:     []ResolvedModule{{Name: "acme/a", Version: "v1", Digest: "sha256:a"}},
+	}).Canonical()
+	changedInput := (&DependencyResolution{
+		InputDigest: "roots-b",
+		Modules:     base.Modules,
+	}).Canonical()
+	changedArtifact := (&DependencyResolution{
+		InputDigest: "roots-a",
+		Modules:     []ResolvedModule{{Name: "acme/a", Version: "v1", Digest: "sha256:b"}},
+	}).Canonical()
+
+	require.NotEqual(t, base.Digest, changedInput.Digest)
+	require.NotEqual(t, base.Digest, changedArtifact.Digest)
+}

--- a/api/registry/resolution_test.go
+++ b/api/registry/resolution_test.go
@@ -42,7 +42,31 @@ func TestDependencyResolutionDigestCoversInputsAndArtifacts(t *testing.T) {
 		InputDigest: "roots-a",
 		Modules:     []ResolvedModule{{Name: "acme/a", Version: "v1", Digest: "sha256:b"}},
 	}).Canonical()
+	changedSource := (&DependencyResolution{
+		InputDigest: "roots-a",
+		Modules:     []ResolvedModule{{Name: "acme/a", Version: "v1", Source: "replacement-tree-v1", Digest: "sha256:a"}},
+	}).Canonical()
 
 	require.NotEqual(t, base.Digest, changedInput.Digest)
 	require.NotEqual(t, base.Digest, changedArtifact.Digest)
+	require.NotEqual(t, base.Digest, changedSource.Digest)
+}
+
+func TestDependencyResolutionValidRejectsSemanticDuplicates(t *testing.T) {
+	duplicate := (&DependencyResolution{
+		InputDigest: "roots",
+		Modules: []ResolvedModule{
+			{Name: "acme/a", Version: "v1"},
+			{Name: "acme/a", Version: "v2"},
+		},
+	}).Canonical()
+	require.False(t, duplicate.Valid())
+}
+
+func TestDependencyResolutionValidRequiresArtifactIdentity(t *testing.T) {
+	missingDigest := (&DependencyResolution{
+		InputDigest: "roots",
+		Modules:     []ResolvedModule{{Name: "acme/a", Version: "v1"}},
+	}).Canonical()
+	require.False(t, missingDigest.Valid())
 }

--- a/boot/components/core/registry.go
+++ b/boot/components/core/registry.go
@@ -122,7 +122,7 @@ func Registry() boot.Component {
 				logger.Warn("dependency handler disabled", zap.Error(err))
 			} else if depHandler != nil {
 				registryOpts = append(registryOpts,
-					registry.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(depHandler.Expand)),
+					registry.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(depHandler.Expand, depHandler.ReconcileResolution).WithChangesExpansion(depHandler.ExpandChanges)),
 				)
 			}
 

--- a/boot/deps/hub/artifact_cache.go
+++ b/boot/deps/hub/artifact_cache.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wippyai/runtime/boot/deps/graph"
+)
+
+func immutableWappRelativePath(name graph.Name, version, digest string) (string, error) {
+	algorithm, value, err := parseExpectedDigest(digest)
+	if err != nil || algorithm != "sha256" || len(value) != 64 {
+		return "", fmt.Errorf("immutable artifact path requires a sha256 digest")
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return "", fmt.Errorf("immutable artifact path requires a sha256 digest")
+	}
+	return filepath.Join(
+		name.Organization,
+		name.Module+"-"+version+".sha256-"+strings.ToLower(value)+".wapp",
+	), nil
+}
+
+// publishVerifiedArtifact publishes an already-downloaded private candidate at
+// an immutable digest-addressed path. Concurrent publishers may race, but every
+// accepted winner is verified against the same identity before it is returned.
+// Existing invalid immutable paths are never removed or overwritten.
+func publishVerifiedArtifact(candidate, destination, digest string, size uint64) error {
+	if err := verifyDownloadedArtifact(candidate, digest, size); err != nil {
+		return fmt.Errorf("verify private artifact: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return fmt.Errorf("create artifact cache directory: %w", err)
+	}
+
+	if err := verifyExistingImmutableArtifact(destination, digest, size); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := os.Link(candidate, destination); err == nil {
+		return syncDirectory(filepath.Dir(destination))
+	}
+	// A concurrent publisher may have won between the existence check and Link.
+	if err := verifyExistingImmutableArtifact(destination, digest, size); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	// The candidate can be on another filesystem, where the first hard-link
+	// attempt cannot succeed. Copy it to a private file in the destination
+	// directory, sync and verify it, then hard-link that file into place. Link is
+	// the portable create-if-absent primitive: unlike Rename on Unix, it never
+	// replaces an existing cache entry.
+	stagedPath, err := copyArtifactToPrivateFile(candidate, filepath.Dir(destination), ".artifact-publish-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(stagedPath)
+	if err := verifyDownloadedArtifact(stagedPath, digest, size); err != nil {
+		return fmt.Errorf("verify private publish file: %w", err)
+	}
+
+	if err := verifyExistingImmutableArtifact(destination, digest, size); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Link(stagedPath, destination); err != nil {
+		winnerErr := verifyExistingImmutableArtifact(destination, digest, size)
+		if winnerErr == nil {
+			return nil
+		}
+		if !errors.Is(winnerErr, os.ErrNotExist) {
+			return winnerErr
+		}
+		return fmt.Errorf("publish immutable artifact without replacement: %w", err)
+	}
+	return syncDirectory(filepath.Dir(destination))
+}
+
+// copyArtifactToPrivateFile creates a fully written, synced private candidate.
+// No partially copied bytes are ever exposed at the eventual cache path.
+func copyArtifactToPrivateFile(sourcePath, destinationDir, pattern string) (path string, err error) {
+	destination, err := os.CreateTemp(destinationDir, pattern)
+	if err != nil {
+		return "", fmt.Errorf("create private artifact file: %w", err)
+	}
+	path = destination.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = destination.Close()
+			_ = os.Remove(path)
+		}
+	}()
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("open artifact source: %w", err)
+	}
+	_, copyErr := io.Copy(destination, source)
+	sourceCloseErr := source.Close()
+	syncErr := destination.Sync()
+	destinationCloseErr := destination.Close()
+	if err := errors.Join(copyErr, sourceCloseErr, syncErr, destinationCloseErr); err != nil {
+		return "", fmt.Errorf("copy private artifact: %w", err)
+	}
+	committed = true
+	return path, nil
+}
+
+func verifyExistingImmutableArtifact(path, digest string, size uint64) error {
+	err := verifyDownloadedArtifact(path, digest, size)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return fmt.Errorf("immutable artifact cache entry %q has invalid content: %w", path, err)
+}

--- a/boot/deps/hub/artifact_cache_sync_unix.go
+++ b/boot/deps/hub/artifact_cache_sync_unix.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+//go:build !windows
+
+package hub
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open artifact cache directory for sync: %w", err)
+	}
+	syncErr := dir.Sync()
+	closeErr := dir.Close()
+	if syncErr != nil {
+		return fmt.Errorf("sync artifact cache directory: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close artifact cache directory: %w", closeErr)
+	}
+	return nil
+}

--- a/boot/deps/hub/artifact_cache_sync_windows.go
+++ b/boot/deps/hub/artifact_cache_sync_windows.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+//go:build windows
+
+package hub
+
+// Windows does not support opening and syncing a directory through os.File.
+// The artifact file itself is synced before publication.
+func syncDirectory(string) error {
+	return nil
+}

--- a/boot/deps/hub/artifact_cache_test.go
+++ b/boot/deps/hub/artifact_cache_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
+)
+
+func TestImmutableWappRelativePathSeparatesDigestsForSameVersion(t *testing.T) {
+	t.Parallel()
+
+	name := graph.MustParseName("acme/widget")
+	one := "sha256:" + strings.Repeat("1", 64)
+	two := "sha256:" + strings.Repeat("2", 64)
+
+	onePath, err := immutableWappRelativePath(name, "1.2.3", one)
+	if err != nil {
+		t.Fatalf("first path: %v", err)
+	}
+	twoPath, err := immutableWappRelativePath(name, "1.2.3", two)
+	if err != nil {
+		t.Fatalf("second path: %v", err)
+	}
+	if onePath == twoPath {
+		t.Fatalf("different digests mapped to the same path %q", onePath)
+	}
+	if !strings.Contains(onePath, "widget-1.2.3.sha256-"+strings.Repeat("1", 64)+".wapp") {
+		t.Fatalf("unexpected digest-addressed path %q", onePath)
+	}
+}
+
+func TestImmutableWappRelativePathRejectsNonHexDigest(t *testing.T) {
+	t.Parallel()
+
+	_, err := immutableWappRelativePath(
+		graph.MustParseName("acme/widget"),
+		"1.2.3",
+		"sha256:"+strings.Repeat("z", 64),
+	)
+	if err == nil {
+		t.Fatal("expected a non-hex digest to be rejected")
+	}
+}
+
+func TestPublishVerifiedArtifactConcurrentPublishers(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	destination := filepath.Join(cacheDir, "acme", "widget-1.2.3.sha256-content.wapp")
+	content := []byte("same immutable module bytes")
+	sum := sha256.Sum256(content)
+	digest := fmt.Sprintf("sha256:%x", sum)
+
+	const publishers = 16
+	start := make(chan struct{})
+	errs := make(chan error, publishers)
+	var wg sync.WaitGroup
+	for i := 0; i < publishers; i++ {
+		candidate := filepath.Join(t.TempDir(), fmt.Sprintf("candidate-%d.wapp", i))
+		if err := os.WriteFile(candidate, content, 0o600); err != nil {
+			t.Fatalf("write candidate: %v", err)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- publishVerifiedArtifact(candidate, destination, digest, uint64(len(content)))
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("publish: %v", err)
+		}
+	}
+	if err := verifyDownloadedArtifact(destination, digest, uint64(len(content))); err != nil {
+		t.Fatalf("verify published artifact: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(destination), ".artifact-publish-*"))
+	if err != nil {
+		t.Fatalf("glob private publish files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("private publish files leaked: %v", matches)
+	}
+}
+
+func TestPublishVerifiedArtifactPreservesInvalidExistingDestination(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	candidate := filepath.Join(dir, "candidate.wapp")
+	destination := filepath.Join(dir, "cache", "immutable.wapp")
+	content := []byte("verified module")
+	sum := sha256.Sum256(content)
+	digest := fmt.Sprintf("sha256:%x", sum)
+	if err := os.WriteFile(candidate, content, 0o600); err != nil {
+		t.Fatalf("write candidate: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		t.Fatalf("create destination directory: %v", err)
+	}
+	const existing = "do not overwrite me"
+	if err := os.WriteFile(destination, []byte(existing), 0o600); err != nil {
+		t.Fatalf("write existing destination: %v", err)
+	}
+
+	if err := publishVerifiedArtifact(candidate, destination, digest, uint64(len(content))); err == nil {
+		t.Fatal("expected invalid immutable destination to fail publication")
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read existing destination: %v", err)
+	}
+	if string(got) != existing {
+		t.Fatalf("existing destination changed: got %q", got)
+	}
+}
+
+func TestPublishVerifiedArtifactSameVersionDifferentDigestsCoexist(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	name := graph.MustParseName("acme/widget")
+	for i, content := range [][]byte{[]byte("first build"), []byte("second build")} {
+		sum := sha256.Sum256(content)
+		digest := fmt.Sprintf("sha256:%x", sum)
+		relative, err := immutableWappRelativePath(name, "1.2.3", digest)
+		if err != nil {
+			t.Fatalf("artifact %d path: %v", i, err)
+		}
+		candidate := filepath.Join(t.TempDir(), "candidate.wapp")
+		if err := os.WriteFile(candidate, content, 0o600); err != nil {
+			t.Fatalf("artifact %d candidate: %v", i, err)
+		}
+		if err := publishVerifiedArtifact(candidate, filepath.Join(dir, relative), digest, uint64(len(content))); err != nil {
+			t.Fatalf("artifact %d publish: %v", i, err)
+		}
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "acme", "widget-1.2.3.sha256-*.wapp"))
+	if err != nil {
+		t.Fatalf("glob immutable artifacts: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("got %d immutable artifacts, want 2: %v", len(matches), matches)
+	}
+}
+
+func TestEnsureModuleAvailableMigratesLegacyArtifactThroughPrivateCopy(t *testing.T) {
+	t.Parallel()
+
+	vendorDir := t.TempDir()
+	name := graph.MustParseName("acme/widget")
+	legacyPath := filepath.Join(vendorDir, lock.WappPath(name, "1.2.3"))
+	content := []byte("legacy verified module")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("create legacy directory: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, content, 0o600); err != nil {
+		t.Fatalf("write legacy artifact: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	digest := fmt.Sprintf("sha256:%x", sum)
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+			t.Fatal("verified legacy artifact must not be downloaded again")
+			return nil, nil
+		}},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+
+	gotPath, err := handler.ensureModuleAvailable(context.Background(), ResolvedModule{
+		Org: "acme", Name: "widget", Version: "1.2.3", Digest: digest, SizeBytes: uint64(len(content)),
+	})
+	if err != nil {
+		t.Fatalf("ensure module: %v", err)
+	}
+	wantRelative, err := immutableWappRelativePath(name, "1.2.3", digest)
+	if err != nil {
+		t.Fatalf("immutable path: %v", err)
+	}
+	if want := filepath.Join(vendorDir, wantRelative); gotPath != want {
+		t.Fatalf("path = %q, want %q", gotPath, want)
+	}
+	if err := verifyDownloadedArtifact(gotPath, digest, uint64(len(content))); err != nil {
+		t.Fatalf("verify immutable artifact: %v", err)
+	}
+	legacyInfo, err := os.Stat(legacyPath)
+	if err != nil {
+		t.Fatalf("legacy artifact was removed: %v", err)
+	}
+	immutableInfo, err := os.Stat(gotPath)
+	if err != nil {
+		t.Fatalf("stat immutable artifact: %v", err)
+	}
+	if os.SameFile(legacyInfo, immutableInfo) {
+		t.Fatal("immutable artifact aliases mutable legacy inode")
+	}
+}
+
+func TestEnsureModuleAvailableIgnoresNonRegularLegacyPath(t *testing.T) {
+	t.Parallel()
+
+	vendorDir := t.TempDir()
+	name := graph.MustParseName("acme/widget")
+	legacyPath := filepath.Join(vendorDir, lock.WappPath(name, "1.2.3"))
+	if err := os.MkdirAll(legacyPath, 0o755); err != nil {
+		t.Fatalf("create corrupt legacy directory: %v", err)
+	}
+	content := []byte("downloaded module")
+	sum := sha256.Sum256(content)
+	digest := fmt.Sprintf("sha256:%x", sum)
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{downloadFile: func(_ context.Context, _ string, destination string) error {
+			return os.WriteFile(destination, content, 0o600)
+		}},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+
+	gotPath, err := handler.ensureModuleAvailable(context.Background(), ResolvedModule{
+		Org: "acme", Name: "widget", Version: "1.2.3", URL: "memory://widget",
+		Digest: digest, SizeBytes: uint64(len(content)),
+	})
+	if err != nil {
+		t.Fatalf("ensure module: %v", err)
+	}
+	if err := verifyDownloadedArtifact(gotPath, digest, uint64(len(content))); err != nil {
+		t.Fatalf("verify immutable artifact: %v", err)
+	}
+	if info, err := os.Stat(legacyPath); err != nil || !info.IsDir() {
+		t.Fatalf("nonregular legacy path was mutated: info=%v err=%v", info, err)
+	}
+}
+
+func TestEnsureModuleAvailableConcurrentPublishers(t *testing.T) {
+	t.Parallel()
+
+	vendorDir := t.TempDir()
+	content := []byte("concurrently downloaded module")
+	sum := sha256.Sum256(content)
+	digest := fmt.Sprintf("sha256:%x", sum)
+	var downloads atomic.Int32
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{downloadFile: func(_ context.Context, _ string, destination string) error {
+			downloads.Add(1)
+			return os.WriteFile(destination, content, 0o600)
+		}},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+	mod := ResolvedModule{
+		Org: "acme", Name: "widget", Version: "1.2.3", URL: "memory://widget",
+		Digest: digest, SizeBytes: uint64(len(content)),
+	}
+
+	const callers = 16
+	start := make(chan struct{})
+	paths := make(chan string, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			path, err := handler.ensureModuleAvailable(context.Background(), mod)
+			paths <- path
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(paths)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("ensure module: %v", err)
+		}
+	}
+	var expectedPath string
+	for path := range paths {
+		if expectedPath == "" {
+			expectedPath = path
+		} else if path != expectedPath {
+			t.Errorf("publisher returned %q, want %q", path, expectedPath)
+		}
+	}
+	if err := verifyDownloadedArtifact(expectedPath, digest, uint64(len(content))); err != nil {
+		t.Fatalf("verify immutable artifact: %v", err)
+	}
+	if downloads.Load() == 0 {
+		t.Fatal("expected at least one download")
+	}
+}
+
+func TestEnsureModuleAvailableRollbackSelectsExactDigestAtSameVersion(t *testing.T) {
+	t.Parallel()
+
+	vendorDir := t.TempDir()
+	artifacts := map[string][]byte{
+		"memory://first":  []byte("first published build"),
+		"memory://second": []byte("republished build at same version"),
+	}
+	var downloads atomic.Int32
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{downloadFile: func(_ context.Context, url, destination string) error {
+			downloads.Add(1)
+			return os.WriteFile(destination, artifacts[url], 0o600)
+		}},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+	module := func(url string) ResolvedModule {
+		content := artifacts[url]
+		sum := sha256.Sum256(content)
+		return ResolvedModule{
+			Org: "acme", Name: "widget", Version: "1.2.3", URL: url,
+			Digest: fmt.Sprintf("sha256:%x", sum), SizeBytes: uint64(len(content)),
+		}
+	}
+	first, second := module("memory://first"), module("memory://second")
+	firstPath, err := handler.ensureModuleAvailable(context.Background(), first)
+	if err != nil {
+		t.Fatalf("ensure first build: %v", err)
+	}
+	secondPath, err := handler.ensureModuleAvailable(context.Background(), second)
+	if err != nil {
+		t.Fatalf("ensure second build: %v", err)
+	}
+	if firstPath == secondPath {
+		t.Fatalf("same-version builds share path %q", firstPath)
+	}
+
+	rollbackPath, err := handler.ensureModuleAvailable(context.Background(), first)
+	if err != nil {
+		t.Fatalf("select first build for rollback: %v", err)
+	}
+	if rollbackPath != firstPath {
+		t.Fatalf("rollback selected %q, want %q", rollbackPath, firstPath)
+	}
+	if got := downloads.Load(); got != 2 {
+		t.Fatalf("downloads = %d, want 2; rollback should reuse its exact digest", got)
+	}
+}

--- a/boot/deps/hub/artifact_download_test.go
+++ b/boot/deps/hub/artifact_download_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestDownloadToFileInterruptedBodyPreservesExistingDestination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "module.wapp")
+	require.NoError(t, os.WriteFile(dest, []byte("known-good"), 0o600))
+	client := &Client{httpClient: server.Client()}
+
+	err := client.DownloadToFile(context.Background(), server.URL, dest)
+	require.ErrorContains(t, err, "write file")
+	data, readErr := os.ReadFile(dest)
+	require.NoError(t, readErr)
+	require.Equal(t, "known-good", string(data))
+	parts, globErr := filepath.Glob(filepath.Join(dir, "module.wapp.part-*"))
+	require.NoError(t, globErr)
+	require.Empty(t, parts, "failed downloads must not leak private partial files")
+}
+
+func TestCompleteResolvedModuleIdentitiesNormalizesHubDigest(t *testing.T) {
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       &fakeHub{},
+		Logger:    zap.NewNop(),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	modules := []ResolvedModule{{
+		Org:     "acme",
+		Name:    "module",
+		Version: "v1.2.3",
+		Digest:  "SHA256:" + strings.Repeat("AB", 32),
+	}}
+	require.NoError(t, handler.completeResolvedModuleIdentities(context.Background(), modules))
+	require.Equal(t, moduleSourceHub, modules[0].Source)
+	require.Equal(t, "sha256:"+strings.Repeat("ab", 32), modules[0].Digest)
+}

--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	registryimpl "github.com/wippyai/runtime/system/registry"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+type bootRecordingRunner struct {
+	transitions []regapi.ChangeSet
+}
+
+type bootDirectiveFunc func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error)
+
+func (f bootDirectiveFunc) Expand(ctx context.Context, op regapi.Operation, state regapi.State) (regapi.DirectiveResult, error) {
+	return f(ctx, op, state)
+}
+
+func (r *bootRecordingRunner) Transition(_ context.Context, state regapi.State, changes regapi.ChangeSet) (regapi.State, error) {
+	r.transitions = append(r.transitions, append(regapi.ChangeSet(nil), changes...))
+	stateMap := topology.NewStateMap(state)
+	for _, op := range changes {
+		switch op.Kind {
+		case regapi.EntryCreate, regapi.EntryUpdate:
+			stateMap[op.Entry.ID] = op.Entry
+		case regapi.EntryDelete:
+			delete(stateMap, op.Entry.ID)
+		}
+	}
+	return topology.StateMapToSlice(stateMap), nil
+}
+
+func TestDependencyHandler_BootExpandsSourceRootBeforeUnrelatedInstall(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, "vendor")
+
+	artifacts := map[string][]byte{
+		"analysis": buildWappBytes(t, []wapp.Entry{{
+			ID:   wapp.NewID("acme.analysis", "runtime"),
+			Kind: "process.host",
+			Data: map[string]any{"runtime": "wasm"},
+		}}),
+		"crm": buildWappBytes(t, []wapp.Entry{{
+			ID:   wapp.NewID("acme.crm", "service"),
+			Kind: "service",
+			Data: map[string]any{"enabled": true},
+		}}),
+	}
+	downloads := map[string]int{}
+
+	hubClient := &fakeHub{
+		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			if _, ok := artifacts[module]; !ok {
+				return nil, fmt.Errorf("unknown module %s/%s", org, module)
+			}
+			return &ModuleManifest{
+				Org: org, Name: module, Version: "v1.0.0", URL: "memory://" + module,
+			}, nil
+		},
+		downloadFile: func(_ context.Context, url, destPath string) error {
+			module := url[len("memory://"):]
+			artifact, ok := artifacts[module]
+			if !ok {
+				return fmt.Errorf("unknown artifact %q", url)
+			}
+			downloads[module]++
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(destPath, artifact, 0o600)
+		},
+	}
+
+	resolver := topology.NewResolver()
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       hubClient,
+		Logger:    zap.NewNop(),
+		Resolver:  resolver,
+		LockPath:  filepath.Join(tmpDir, "wippy.lock"),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	runner := &bootRecordingRunner{}
+	reg := registryimpl.NewRegistry(
+		historymem.New(),
+		runner,
+		topology.NewStateBuilder(zap.NewNop(), resolver),
+		resolver,
+		zap.NewNop(),
+		registryimpl.WithKindDirective(regapi.NamespaceDependency, bootDirectiveFunc(handler.Expand)),
+	)
+
+	analysisRoot := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "analysis"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/analysis","version":"v1.0.0"}`, payload.JSON),
+	}
+	require.NoError(t, reg.LoadState(ctx, regapi.State{analysisRoot}, version.FromParent(nil, 0)))
+
+	_, err = reg.GetEntry(regapi.NewID("acme.analysis", "runtime"))
+	require.NoError(t, err, "boot must not publish a dependency root without its module entries")
+	require.Equal(t, 1, downloads["analysis"], "the declared module must be installed during boot")
+
+	runner.transitions = nil
+	crmRoot := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "crm"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/crm","version":"v1.0.0"}`, payload.JSON),
+	}
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: crmRoot}})
+	require.NoError(t, err)
+	require.Equal(t, 1, downloads["analysis"], "installing CRM must not materialize or reinstall Analysis")
+	require.Equal(t, 1, downloads["crm"])
+
+	for _, transition := range runner.transitions {
+		for _, op := range transition {
+			require.NotEqual(t, regapi.NewID("acme.analysis", "runtime"), op.Entry.ID,
+				"an unrelated install must not mutate the module established at boot")
+		}
+	}
+}

--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -4,9 +4,13 @@ package hub
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,7 +18,9 @@ import (
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/internal/version"
 	registryimpl "github.com/wippyai/runtime/system/registry"
+	regexp "github.com/wippyai/runtime/system/registry/expansion"
 	historymem "github.com/wippyai/runtime/system/registry/history/memory"
+	historysqlite "github.com/wippyai/runtime/system/registry/history/sqlite"
 	"github.com/wippyai/runtime/system/registry/topology"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
@@ -22,6 +28,127 @@ import (
 
 type bootRecordingRunner struct {
 	transitions []regapi.ChangeSet
+}
+
+func TestDependencyHandler_PersistedResolutionBootRollbackRedoAndLongHistory(t *testing.T) {
+	ctx := newTestContext()
+	vendorDir := filepath.Join(t.TempDir(), "vendor")
+	artifacts := map[string][]byte{
+		"v1.0.0": buildWappBytes(t, []wapp.Entry{{
+			ID: wapp.NewID("acme.crm", "service"), Kind: "service", Data: map[string]any{"version": "v1"},
+		}}),
+		"v2.0.0": buildWappBytes(t, []wapp.Entry{{
+			ID: wapp.NewID("acme.crm", "service"), Kind: "service", Data: map[string]any{"version": "v2"},
+		}}),
+	}
+	downloads := 0
+	online := &fakeHub{
+		getManifest: func(_ context.Context, org, module, constraint string) (*ModuleManifest, error) {
+			artifact, ok := artifacts[constraint]
+			if !ok {
+				return nil, fmt.Errorf("unexpected constraint %q", constraint)
+			}
+			sum := sha256.Sum256(artifact)
+			return &ModuleManifest{
+				Org: org, Name: module, Version: constraint, VersionID: constraint,
+				Digest: hex.EncodeToString(sum[:]), SizeBytes: uint64(len(artifact)), URL: "memory://" + constraint,
+			}, nil
+		},
+		downloadFile: func(_ context.Context, url, destPath string) error {
+			version := strings.TrimPrefix(url, "memory://")
+			downloads++
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(destPath, artifacts[version], 0o600)
+		},
+	}
+	newHandler := func(client HubClient) *DependencyHandler {
+		handler, err := NewDependencyHandler(DependencyHandlerOptions{
+			Hub: client, Logger: zap.NewNop(), LockPath: filepath.Join(filepath.Dir(vendorDir), "wippy.lock"), VendorDir: vendorDir,
+		})
+		require.NoError(t, err)
+		return handler
+	}
+	newRegistry := func(hist regapi.History, handler *DependencyHandler) *registryimpl.Reg {
+		resolver := topology.NewResolver()
+		handler.resolver = resolver
+		return registryimpl.NewRegistry(
+			hist, &bootRecordingRunner{}, topology.NewStateBuilder(zap.NewNop(), resolver), resolver, zap.NewNop(),
+			registryimpl.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(handler.Expand, handler.ReconcileResolution)),
+		)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "registry.db")
+	history, err := historysqlite.NewSQLite(dbPath, zap.NewNop())
+	require.NoError(t, err)
+	reg := newRegistry(history, newHandler(online))
+	v1Root := regapi.Entry{
+		ID: regapi.NewID("app.deps", "crm"), Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/crm","version":"v1.0.0"}`, payload.JSON),
+	}
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: v1Root}})
+	require.NoError(t, err)
+	require.Equal(t, 1, downloads)
+	v1Resolution, err := history.GetDependencyResolution(v1)
+	require.NoError(t, err)
+	require.Equal(t, "v1.0.0", v1Resolution.Modules[0].Version)
+
+	// A long tail of unrelated versions inherits one content-addressed graph.
+	for i := 0; i < 250; i++ {
+		_, err = reg.Apply(ctx, regapi.ChangeSet{{
+			Kind:  regapi.EntryCreate,
+			Entry: regapi.Entry{ID: regapi.NewID("app.settings", fmt.Sprintf("entry_%03d", i)), Kind: regapi.EntryKind, Data: payload.New(i)},
+		}})
+		require.NoError(t, err)
+	}
+
+	v2Root := v1Root
+	v2Root.Data = payload.NewPayload(`{"component":"acme/crm","version":"v2.0.0"}`, payload.JSON)
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: v2Root}})
+	require.NoError(t, err)
+	require.Equal(t, 2, downloads)
+	require.NoError(t, history.Close())
+
+	// Reopen the actual history database so the restore cannot accidentally
+	// depend on in-memory registry or resolution state.
+	history, err = historysqlite.NewSQLite(dbPath, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = history.Close() })
+	v2, err := history.Head()
+	require.NoError(t, err)
+	versions, err := history.Versions()
+	require.NoError(t, err)
+	require.Greater(t, len(versions), 1)
+	v1 = versions[1]
+
+	manifestCalls := 0
+	offline := &fakeHub{
+		getManifest: func(context.Context, string, string, string) (*ModuleManifest, error) {
+			manifestCalls++
+			return nil, errors.New("resolver must not run while restoring an exact graph")
+		},
+		getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+			return nil, errors.New("cached exact artifacts should be used")
+		},
+	}
+	restored := newRegistry(history, newHandler(offline))
+	require.NoError(t, restored.LoadState(ctx, nil, v2))
+	require.Zero(t, manifestCalls)
+	entry, err := restored.GetEntry(regapi.NewID("acme.crm", "service"))
+	require.NoError(t, err)
+	require.Equal(t, "v2.0.0", moduleVersion(entry))
+
+	// Undo and redo select stored graphs and never resolve them again.
+	require.NoError(t, restored.ApplyVersion(ctx, v1))
+	entry, err = restored.GetEntry(regapi.NewID("acme.crm", "service"))
+	require.NoError(t, err)
+	require.Equal(t, "v1.0.0", moduleVersion(entry))
+	require.NoError(t, restored.ApplyVersion(ctx, v2))
+	entry, err = restored.GetEntry(regapi.NewID("acme.crm", "service"))
+	require.NoError(t, err)
+	require.Equal(t, "v2.0.0", moduleVersion(entry))
+	require.Zero(t, manifestCalls)
 }
 
 type bootDirectiveFunc func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error)

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -254,7 +254,7 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 	}
 
 	var effects []regapi.Effect
-	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, snapshot)
+	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, snapshot, controlledModules)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/boot"
 	apierror "github.com/wippyai/runtime/api/error"
-	moduleapi "github.com/wippyai/runtime/api/modules"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/boot/build"
@@ -43,7 +42,11 @@ import (
 const (
 	metaModuleKey        = "module"
 	metaModuleVersionKey = "module_version"
-	extractedModuleMeta  = ".wippy-module.yaml"
+	metaModuleDigestKey  = "module_digest"
+
+	moduleSourceHub               = "hub"
+	moduleSourceReplacementTreeV1 = "replacement-tree-v1"
+	extractedModuleMeta           = ".wippy-module.yaml"
 )
 
 type DependencyHandlerOptions struct {
@@ -206,6 +209,9 @@ func (h *DependencyHandler) expand(
 		if err != nil {
 			return regapi.DirectiveResult{}, err
 		}
+		if err = h.completeResolvedModuleIdentities(ctx, resolved); err != nil {
+			return regapi.DirectiveResult{}, err
+		}
 	}
 
 	opComponent := ""
@@ -215,7 +221,12 @@ func (h *DependencyHandler) expand(
 			break
 		}
 	}
-	strictModules := touchedModuleNames(resolved, lockedVersions, opComponent)
+	strictModules := touchedModuleIdentities(
+		resolved,
+		lockedVersions,
+		snapshotModuleDigests(snapshot),
+		opComponent,
+	)
 	strictSet := stringSet(strictModules)
 	resolvedSet := resolvedModuleSet(resolved)
 	for module := range extraMutable {
@@ -241,10 +252,11 @@ func (h *DependencyHandler) expand(
 	}
 	desiredModules := resolvedModuleSet(resolved)
 
-	moduleEntries, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touchedModules), resolved, snapshot, transcoder)
+	moduleEntries, unpackPlan, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touchedModules), resolved, snapshot, transcoder)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
+	defer func() { _ = unpackPlan.cleanup() }()
 	linkDeps := mergeLinkDependencies(desiredDepEntries, moduleEntries)
 
 	combined := make([]regapi.Entry, 0, len(snapshot)+len(moduleEntries))
@@ -289,6 +301,13 @@ func (h *DependencyHandler) expand(
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
+	filesystemEffect, err := h.buildModuleFilesystemEffect(resolved, controlledModules, unpackPlan)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	if filesystemEffect != nil {
+		effects = append(effects, filesystemEffect)
+	}
 	if packEffect != nil {
 		effects = append(effects, packEffect)
 	}
@@ -309,9 +328,6 @@ func (h *DependencyHandler) ExpandChanges(ctx context.Context, changes regapi.Ch
 	if len(changes) == 0 {
 		return regapi.DirectiveResult{}, nil
 	}
-	if len(changes) == 1 {
-		return h.Expand(ctx, changes[0], snapshot)
-	}
 	if h == nil || h.hub == nil {
 		return regapi.DirectiveResult{}, ErrDependencyHandlerNotConfigured
 	}
@@ -319,6 +335,43 @@ func (h *DependencyHandler) ExpandChanges(ctx context.Context, changes regapi.Ch
 	if transcoder == nil {
 		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
 	}
+	// Planner batches every ns.dependency operation, including dependencies
+	// owned by module manifests. Only authored roots drive whole-graph solving.
+	// Filter against a rolling state so a delete is recognized from its old
+	// entry and a create/update from its new entry.
+	rollingMap := make(regapi.StateMap, len(snapshot)+len(changes))
+	for _, entry := range snapshot {
+		rollingMap[entry.ID] = entry
+	}
+	rootChanges := make(regapi.ChangeSet, 0, len(changes))
+	for _, op := range changes {
+		old, hadOld := rollingMap[op.Entry.ID]
+		rolling := make(regapi.State, 0, len(rollingMap))
+		for _, entry := range rollingMap {
+			rolling = append(rolling, entry)
+		}
+		resolved, hasResolved := resolveOperationEntry(op, rolling)
+		if (hadOld && isRootDependency(old)) || (hasResolved && isRootDependency(resolved)) {
+			rootChanges = append(rootChanges, op)
+		}
+		switch op.Kind {
+		case regapi.EntryCreate, regapi.EntryUpdate:
+			rollingMap[op.Entry.ID] = op.Entry
+		case regapi.EntryDelete:
+			delete(rollingMap, op.Entry.ID)
+		}
+	}
+	if len(rootChanges) == 0 {
+		return regapi.DirectiveResult{}, nil
+	}
+	if len(rootChanges) == 1 {
+		driver, ok := rootExpansionDriver(rootChanges[0], snapshot)
+		if !ok {
+			return regapi.DirectiveResult{}, nil
+		}
+		return h.Expand(ctx, driver, snapshot)
+	}
+	changes = rootChanges
 	// Preserve ownership from both sides of the batch. Looking only at the
 	// folded state loses modules owned by an earlier delete or retarget, leaving
 	// their entries and embedded packs live after the root has gone away.
@@ -354,8 +407,26 @@ func (h *DependencyHandler) ExpandChanges(ctx context.Context, changes regapi.Ch
 	for _, entry := range stateMap {
 		working = append(working, entry)
 	}
-	// A final no-op must not suppress earlier operations in the same batch.
-	return h.expand(ctx, changes[len(changes)-1], working, extraControlled, extraMutable)
+	// A root retagged as module-owned is declaratively a root deletion. Drive
+	// expansion with that deletion so cleanup cannot be skipped merely because
+	// the final form is still an ns.dependency entry.
+	driver, ok := rootExpansionDriver(changes[len(changes)-1], working)
+	if !ok {
+		return regapi.DirectiveResult{}, nil
+	}
+	return h.expand(ctx, driver, working, extraControlled, extraMutable)
+}
+
+func rootExpansionDriver(op regapi.Operation, snapshot regapi.State) (regapi.Operation, bool) {
+	if entry, ok := resolveOperationEntry(op, snapshot); ok && isRootDependency(entry) {
+		return op, true
+	}
+	for _, entry := range snapshot {
+		if idsEqual(entry.ID, op.Entry.ID) && isRootDependency(entry) {
+			return regapi.Operation{Kind: regapi.EntryDelete, Entry: entry}, true
+		}
+	}
+	return regapi.Operation{}, false
 }
 
 // ReconcileResolution materializes a previously selected graph without asking
@@ -395,7 +466,7 @@ func (h *DependencyHandler) ReconcileResolution(
 		if parseErr != nil || mod.Version == "" {
 			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf("invalid stored module %q@%s", mod.Name, mod.Version))
 		}
-		if identityErr := validateModuleArtifactIdentity(name, mod.Version, mod.Digest); identityErr != nil {
+		if identityErr := validateStoredModuleArtifactIdentity(name, mod.Version, mod.Source, mod.Digest); identityErr != nil {
 			return regapi.DirectiveResult{}, NewDependencyResolutionError(identityErr)
 		}
 		if _, duplicate := seen[mod.Name]; duplicate {
@@ -407,6 +478,7 @@ func (h *DependencyHandler) ReconcileResolution(
 			Name:      name.Module,
 			Version:   mod.Version,
 			VersionID: mod.VersionID,
+			Source:    mod.Source,
 			Digest:    mod.Digest,
 			SizeBytes: mod.SizeBytes,
 			Protected: mod.Protected,
@@ -422,21 +494,33 @@ func (h *DependencyHandler) ReconcileResolution(
 		}
 	}
 
-	installed := snapshotModuleVersions(snapshot)
-	touched := stringSet(touchedModuleNames(resolved, installed, ""))
 	desiredModules := resolvedModuleSet(resolved)
-	controlled := make(map[string]struct{}, len(installed)+len(desiredModules))
-	for module := range installed {
-		controlled[module] = struct{}{}
+	// A stored graph is authoritative by content identity, not merely version.
+	// Reload modules whose entries do not carry the exact stored digest. Entries
+	// written before module_digest existed are deliberately reloaded once.
+	installedDigests := snapshotModuleDigests(snapshot)
+	touched := make(map[string]struct{}, len(desiredModules))
+	for _, mod := range resolved {
+		module := mod.Org + "/" + mod.Name
+		if installedDigests[module] != mod.Digest || !h.hasCurrentUnpackedModule(mod) {
+			touched[module] = struct{}{}
+		}
+	}
+	controlled := make(map[string]struct{}, len(snapshot)+len(desiredModules))
+	for _, entry := range snapshot {
+		if module := entryModule(entry); module != "" {
+			controlled[module] = struct{}{}
+		}
 	}
 	for module := range desiredModules {
 		controlled[module] = struct{}{}
 	}
 
-	moduleEntries, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touched), resolved, snapshot, transcoder)
+	moduleEntries, unpackPlan, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touched), resolved, snapshot, transcoder)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
+	defer func() { _ = unpackPlan.cleanup() }()
 	desiredDepEntries := make([]regapi.Entry, 0, len(desiredDeps))
 	for _, dep := range desiredDeps {
 		desiredDepEntries = append(desiredDepEntries, dep.entry)
@@ -458,7 +542,7 @@ func (h *DependencyHandler) ReconcileResolution(
 	pipeline := build.New(
 		stages.Override(stages.WithMissingOverrideEntriesIgnored()),
 		stages.Disable(),
-		stages.Link(stages.WithDependencies(mergeLinkDependencies(desiredDepEntries, moduleEntries)), stages.WithStrictRequirementModules(touchedModuleNames(resolved, installed, ""))),
+		stages.Link(stages.WithDependencies(mergeLinkDependencies(desiredDepEntries, moduleEntries)), stages.WithStrictRequirementModules(sortedSetKeys(touched))),
 		stages.Override(stages.WithMissingOverrideEntriesIgnored()),
 	)
 	if err := pipeline.Execute(ctx, &combined); err != nil {
@@ -478,6 +562,13 @@ func (h *DependencyHandler) ReconcileResolution(
 		return regapi.DirectiveResult{}, err
 	}
 	var effects []regapi.Effect
+	filesystemEffect, err := h.buildModuleFilesystemEffect(resolved, controlled, unpackPlan)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	if filesystemEffect != nil {
+		effects = append(effects, filesystemEffect)
+	}
 	if packEffect != nil {
 		effects = append(effects, packEffect)
 	}
@@ -523,6 +614,7 @@ func dependencyResolution(roots []desiredDependency, modules []ResolvedModule) *
 			Name:      mod.Org + "/" + mod.Name,
 			Version:   mod.Version,
 			VersionID: mod.VersionID,
+			Source:    mod.Source,
 			Digest:    mod.Digest,
 			SizeBytes: mod.SizeBytes,
 			Protected: mod.Protected,
@@ -910,6 +1002,158 @@ func validateModuleArtifactIdentity(name graph.Name, version, digest string) err
 	return nil
 }
 
+func validateStoredModuleArtifactIdentity(name graph.Name, version, source, digest string) error {
+	if err := validateModuleArtifactIdentity(name, version, ""); err != nil {
+		return err
+	}
+	if digest == "" {
+		return fmt.Errorf("stored module %s@%s has no content digest", name.String(), version)
+	}
+	algorithm, value, err := parseExpectedDigest(digest)
+	wantAlgorithm := "sha256"
+	if source == moduleSourceReplacementTreeV1 {
+		wantAlgorithm = "sha256-tree-v1"
+	} else if source != "" && source != moduleSourceHub {
+		return fmt.Errorf("stored module %s@%s has unsupported source %q", name.String(), version, source)
+	}
+	if err != nil || algorithm != wantAlgorithm || len(value) != sha256.Size*2 {
+		return fmt.Errorf("invalid %s digest for %s@%s", wantAlgorithm, name.String(), version)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("invalid %s digest for %s@%s", wantAlgorithm, name.String(), version)
+	}
+	return nil
+}
+
+// completeResolvedModuleIdentities upgrades legacy Hub responses and local
+// replacements to a content-pinned graph before that graph is persisted.
+func (h *DependencyHandler) completeResolvedModuleIdentities(ctx context.Context, modules []ResolvedModule) error {
+	for i := range modules {
+		mod := &modules[i]
+		name := graph.Name{Organization: mod.Org, Module: mod.Name}
+		if replacement, ok := h.replacementPath(name.String()); ok {
+			digest, size, err := digestDirectoryTree(replacement)
+			if err != nil {
+				return NewDependencyIntegrityError(modKey(*mod), err, mod.Digest, mod.SizeBytes)
+			}
+			mod.Digest = digest
+			mod.Source = moduleSourceReplacementTreeV1
+			mod.SizeBytes = size
+			mod.URL = ""
+		} else if mod.Digest == "" {
+			// Older manifest APIs omitted artifact identity. Prefer metadata from
+			// the exact download endpoint, then fall back to hashing the cached or
+			// freshly downloaded artifact itself.
+			if info, err := h.freshDownloadInfo(ctx, *mod); err == nil && info != nil {
+				if err := validateDownloadInfo(*mod, info); err != nil {
+					return NewDependencyIntegrityError(modKey(*mod), err, mod.Digest, mod.SizeBytes)
+				}
+				mod.Digest = info.Digest
+				if mod.SizeBytes == 0 {
+					mod.SizeBytes = info.Size
+				}
+			}
+			if mod.Digest == "" {
+				path, ok, err := h.cachedModuleArtifact(*mod)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					path, err = h.ensureModuleAvailable(ctx, *mod)
+					if err != nil {
+						return err
+					}
+				}
+				digest, size, err := artifactIdentityFromPath(path)
+				if err != nil {
+					return NewDependencyIntegrityError(modKey(*mod), err, mod.Digest, mod.SizeBytes)
+				}
+				mod.Digest = digest
+				if mod.SizeBytes == 0 {
+					mod.SizeBytes = size
+				}
+			}
+		}
+		if mod.Source == "" {
+			mod.Source = moduleSourceHub
+		}
+		if err := validateStoredModuleArtifactIdentity(name, mod.Version, mod.Source, mod.Digest); err != nil {
+			return NewDependencyIntegrityError(modKey(*mod), err, mod.Digest, mod.SizeBytes)
+		}
+		algorithm, value, _ := parseExpectedDigest(mod.Digest)
+		mod.Digest = algorithm + ":" + strings.ToLower(value)
+	}
+	return nil
+}
+
+// cachedModuleArtifact returns the packed cache entry without extracting it.
+// Identity completion must not rewrite an untouched sibling merely because the
+// runtime is configured to use unpacked modules.
+func (h *DependencyHandler) cachedModuleArtifact(mod ResolvedModule) (string, bool, error) {
+	name, err := graph.ParseName(mod.Org + "/" + mod.Name)
+	if err != nil {
+		return "", false, err
+	}
+	if mod.Digest != "" {
+		path, err := h.immutableArtifactPath(name, mod.Version, mod.Digest)
+		if err != nil {
+			return "", false, err
+		}
+		if err := verifyExistingImmutableArtifact(path, mod.Digest, mod.SizeBytes); err == nil {
+			return path, true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", false, err
+		}
+	} else if path, _, _, ok, err := h.soleImmutableArtifact(name, mod.Version); err != nil {
+		return "", false, err
+	} else if ok {
+		return path, true, nil
+	}
+	// The version-only path is legacy migration input. Callers must establish
+	// its identity before publishing it into the immutable cache.
+	path, err := containedPath(h.vendorDir, lock.WappPath(name, mod.Version))
+	if err != nil {
+		return "", false, err
+	}
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, nil
+	}
+	return path, true, nil
+}
+
+func artifactIdentityFromPath(path string) (string, uint64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, err
+	}
+	if info.IsDir() {
+		data, err := os.ReadFile(filepath.Join(path, extractedModuleMeta))
+		if err != nil {
+			return "", 0, err
+		}
+		var meta extractedModuleMetadata
+		if err := yaml.Unmarshal(data, &meta); err != nil {
+			return "", 0, err
+		}
+		if meta.Digest == "" {
+			return "", 0, fmt.Errorf("extracted module has no content digest")
+		}
+		return meta.Digest, meta.Size, nil
+	}
+	digest, err := sha256FileHex(path)
+	if err != nil {
+		return "", 0, err
+	}
+	return "sha256:" + digest, uint64(info.Size()), nil
+}
+
 func validModuleIdentifier(value string) bool {
 	if value == "" || value[0] < 'a' || value[0] > 'z' {
 		return false
@@ -1060,22 +1304,28 @@ func (p *replacementManifestProvider) ListAllVersions(ctx context.Context, org, 
 	return p.base.ListAllVersions(ctx, org, module)
 }
 
-// touchedModuleNames returns the resolved modules this operation actually
+// touchedModuleIdentities returns the resolved modules this operation actually
 // affects: those new or version-changed relative to the snapshot, plus the
 // module of the dependency entry being changed in this operation. Modules
 // already installed at the same version that this operation does not target are
 // trusted — they were validated when installed — and are excluded from strict
 // requirement enforcement, so a partial update does not re-validate
 // dependencies it did not touch.
-func touchedModuleNames(modules []ResolvedModule, installed map[string]string, opComponent string) []string {
+func touchedModuleIdentities(
+	modules []ResolvedModule,
+	installedVersions map[string]string,
+	installedDigests map[string]string,
+	opComponent string,
+) []string {
 	names := make([]string, 0, len(modules))
 	for _, mod := range modules {
 		if mod.Org == "" || mod.Name == "" {
 			continue
 		}
 		name := mod.Org + "/" + mod.Name
-		version, known := installed[name]
-		if !known || version != mod.Version || name == opComponent {
+		version, known := installedVersions[name]
+		digestMatches := mod.Digest == "" || strings.EqualFold(installedDigests[name], mod.Digest)
+		if !known || version != mod.Version || !digestMatches || name == opComponent {
 			names = append(names, name)
 		}
 	}
@@ -1090,6 +1340,15 @@ func stringSet(values []string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func sortedSetKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for value := range values {
+		keys = append(keys, value)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func resolvedModuleSet(modules []ResolvedModule) map[string]struct{} {
@@ -1119,33 +1378,36 @@ func filterResolvedModules(modules []ResolvedModule, keep map[string]struct{}) [
 	return out
 }
 
-func (h *DependencyHandler) loadModuleEntries(ctx context.Context, modules []ResolvedModule, ownerModules []ResolvedModule, snapshot regapi.State, transcoder payload.Transcoder) ([]regapi.Entry, error) {
+func (h *DependencyHandler) loadModuleEntries(ctx context.Context, modules []ResolvedModule, ownerModules []ResolvedModule, snapshot regapi.State, transcoder payload.Transcoder) ([]regapi.Entry, *unpackPlan, error) {
 	entries := make([]regapi.Entry, 0)
+	plan := &unpackPlan{}
 	owners := moduleOwnersByNamespace(ownerModules)
 	snapshotOwners := moduleOwnersByEntryID(snapshot)
 	snapshotByID := entriesByID(snapshot)
 	installedRoots, err := rootDependencyModules(ctx, transcoder, snapshot)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, mod := range modules {
 		moduleName := mod.Org + "/" + mod.Name
-		moduleEntries, err := h.loadEntriesForModule(ctx, transcoder, mod)
+		moduleEntries, staged, err := h.loadEntriesForModulePlan(ctx, transcoder, mod)
 		if err != nil {
-			return nil, err
+			_ = plan.cleanup()
+			return nil, nil, err
 		}
+		plan.add(staged)
 		for i := range moduleEntries {
 			if keep, ok := preserveHostSnapshotEntry(moduleEntries[i], moduleName, snapshotByID, installedRoots); ok {
 				moduleEntries[i] = keep
 				continue
 			}
-			moduleEntries[i] = markModuleMetaForGraph(moduleEntries[i], moduleName, mod.Version, owners, snapshotOwners)
+			moduleEntries[i] = markModuleIdentityForGraph(moduleEntries[i], moduleName, mod.Version, mod.Digest, owners, snapshotOwners)
 		}
 		entries = append(entries, moduleEntries...)
 	}
 
-	return entries, nil
+	return entries, plan, nil
 }
 
 func entriesByID(entries regapi.State) map[string]regapi.Entry {
@@ -1190,6 +1452,7 @@ func preserveHostSnapshotEntry(entry regapi.Entry, moduleName string, snapshot m
 type moduleOwner struct {
 	name    string
 	version string
+	digest  string
 }
 
 func moduleOwnersByNamespace(modules []ResolvedModule) map[string]moduleOwner {
@@ -1202,6 +1465,7 @@ func moduleOwnersByNamespace(modules []ResolvedModule) map[string]moduleOwner {
 		owners[namespace] = moduleOwner{
 			name:    mod.Org + "/" + mod.Name,
 			version: mod.Version,
+			digest:  mod.Digest,
 		}
 	}
 	return owners
@@ -1217,22 +1481,49 @@ func moduleOwnersByEntryID(entries regapi.State) map[string]moduleOwner {
 		owners[idKey(entry.ID)] = moduleOwner{
 			name:    module,
 			version: moduleVersion(entry),
+			digest:  moduleDigest(entry),
 		}
 	}
 	return owners
 }
 
 func (h *DependencyHandler) loadEntriesForModule(ctx context.Context, transcoder payload.Transcoder, mod ResolvedModule) ([]regapi.Entry, error) {
-	modulePath, err := h.ensureModuleAvailable(ctx, mod)
-	if err != nil {
-		return nil, err
+	entries, staged, err := h.loadEntriesForModulePlan(ctx, transcoder, mod)
+	if staged != nil {
+		_ = os.RemoveAll(staged.stagingDir)
 	}
-	registerResolvedModuleSourceRoot(ctx, mod.Org+"/"+mod.Name, modulePath)
+	return entries, err
+}
+
+func (h *DependencyHandler) loadEntriesForModulePlan(ctx context.Context, transcoder payload.Transcoder, mod ResolvedModule) ([]regapi.Entry, *stagedModuleDirectory, error) {
+	modulePath, staged, err := h.materializeModuleForLoad(ctx, mod)
+	if err != nil {
+		return nil, nil, err
+	}
 	entries, err := loadRawEntriesFromPaths(ctx, []string{modulePath}, h.logger, transcoder)
 	if err != nil {
-		return nil, err
+		if staged != nil {
+			_ = os.RemoveAll(staged.stagingDir)
+		}
+		return nil, nil, err
 	}
-	return h.applyModuleConfigFilters(ctx, modulePath, entries)
+	entries, err = h.applyModuleConfigFilters(ctx, modulePath, entries)
+	if err != nil {
+		if staged != nil {
+			_ = os.RemoveAll(staged.stagingDir)
+		}
+		return nil, nil, err
+	}
+	if mod.Source == moduleSourceReplacementTreeV1 {
+		digest, size, digestErr := digestDirectoryTree(modulePath)
+		if digestErr != nil {
+			return nil, nil, NewDependencyIntegrityError(modKey(mod), digestErr, mod.Digest, mod.SizeBytes)
+		}
+		if !strings.EqualFold(digest, mod.Digest) || (mod.SizeBytes > 0 && size != mod.SizeBytes) {
+			return nil, nil, NewDependencyIntegrityError(modKey(mod), fmt.Errorf("replacement changed while it was being loaded"), mod.Digest, mod.SizeBytes)
+		}
+	}
+	return entries, staged, nil
 }
 
 // applyModuleConfigFilters drops entries the module's wippy.yaml excludes
@@ -1264,19 +1555,81 @@ func (h *DependencyHandler) applyModuleConfigFilters(ctx context.Context, module
 	return filtered, nil
 }
 
-func registerResolvedModuleSourceRoot(ctx context.Context, moduleName, modulePath string) {
-	if moduleName == "" || filepath.Ext(modulePath) == ".wapp" {
-		return
+func (h *DependencyHandler) materializeModuleForLoad(ctx context.Context, mod ResolvedModule) (string, *stagedModuleDirectory, error) {
+	moduleName := mod.Org + "/" + mod.Name
+	if _, replaced := h.replacementPath(moduleName); replaced || !h.shouldUnpackModules() {
+		path, err := h.ensureModuleAvailable(ctx, mod)
+		return path, nil, err
 	}
-	stat, err := os.Stat(modulePath)
-	if err != nil || !stat.IsDir() {
-		return
-	}
-	root, err := filepath.Abs(modulePath)
+
+	name, err := graph.ParseName(moduleName)
 	if err != nil {
-		return
+		return "", nil, NewDependencyEntryInvalidError("", "invalid component", moduleName)
 	}
-	moduleapi.WithSourceRoots(ctx, moduleapi.SourceRoots{moduleName: root})
+	targetDir, err := containedPath(h.vendorDir, lock.ModulePath(name))
+	if err != nil {
+		return "", nil, NewDependencyDownloadError(modKey(mod), err)
+	}
+	if info, statErr := os.Stat(targetDir); statErr == nil && info.IsDir() {
+		if verifyErr := verifyExtractedModule(targetDir, mod.Digest, mod.SizeBytes); verifyErr == nil {
+			return targetDir, nil, nil
+		}
+	}
+
+	wappPath, err := h.ensureModuleAvailable(ctx, mod)
+	if err != nil {
+		return "", nil, err
+	}
+	digest, size := mod.Digest, mod.SizeBytes
+	if digest == "" || size == 0 {
+		actualDigest, actualSize, identityErr := artifactIdentityFromPath(wappPath)
+		if identityErr != nil {
+			return "", nil, NewDependencyIntegrityError(modKey(mod), identityErr, mod.Digest, mod.SizeBytes)
+		}
+		if digest == "" {
+			digest = actualDigest
+		}
+		if size == 0 {
+			size = actualSize
+		}
+	}
+	if err := verifyDownloadedArtifact(wappPath, digest, size); err != nil {
+		return "", nil, NewDependencyIntegrityError(modKey(mod), err, mod.Digest, mod.SizeBytes)
+	}
+	stagingDir, err := h.stageWappModule(wappPath, targetDir, digest, size)
+	if err != nil {
+		return "", nil, err
+	}
+	return stagingDir, &stagedModuleDirectory{
+		module:     moduleName,
+		stagingDir: stagingDir,
+		targetDir:  targetDir,
+	}, nil
+}
+
+func (h *DependencyHandler) stageWappModule(wappPath, targetDir, digest string, size uint64) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(targetDir), 0755); err != nil {
+		return "", NewDependencyLoadError(targetDir, err)
+	}
+	stagingDir, err := os.MkdirTemp(filepath.Dir(targetDir), "."+filepath.Base(targetDir)+".stage-*")
+	if err != nil {
+		return "", NewDependencyLoadError(targetDir, err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+
+	if err := wappextract.ExtractWappToDirKeepSource(wappPath, stagingDir); err != nil {
+		return "", NewDependencyLoadError(wappPath, err)
+	}
+	if err := writeExtractedModuleMeta(stagingDir, digest, size); err != nil {
+		return "", NewDependencyLoadError(stagingDir, err)
+	}
+	cleanup = false
+	return stagingDir, nil
 }
 
 func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod ResolvedModule) (string, error) {
@@ -1290,7 +1643,7 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 	}
 	moduleName := name.String()
 
-	if replacementPath, ok := h.replacementPath(moduleName); ok {
+	if replacementPath, ok := h.replacementPath(moduleName); ok && (mod.Source == "" || mod.Source == moduleSourceReplacementTreeV1) {
 		stat, err := os.Stat(replacementPath)
 		if err != nil {
 			return "", NewDependencyLoadError(replacementPath, err)
@@ -1298,58 +1651,178 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 		if !stat.IsDir() {
 			return "", NewDependencyLoadError(replacementPath, fmt.Errorf("replacement path is not a directory"))
 		}
+		digest, size, err := digestDirectoryTree(replacementPath)
+		if err != nil {
+			return "", NewDependencyIntegrityError(modKey(mod), err, mod.Digest, mod.SizeBytes)
+		}
+		if mod.Digest != "" && !strings.EqualFold(mod.Digest, digest) {
+			return "", NewDependencyIntegrityError(modKey(mod), fmt.Errorf("replacement content digest mismatch"), mod.Digest, mod.SizeBytes)
+		}
+		if mod.SizeBytes > 0 && mod.SizeBytes != size {
+			return "", NewDependencyIntegrityError(modKey(mod), fmt.Errorf("replacement content size mismatch"), mod.Digest, mod.SizeBytes)
+		}
 		return replacementPath, nil
 	}
+	if mod.Source == moduleSourceReplacementTreeV1 {
+		return "", NewDependencyLoadError(moduleName, fmt.Errorf("stored local replacement is not configured"))
+	}
 
-	shouldUnpack := h.shouldUnpackModules()
-	dirPath, err := containedPath(h.vendorDir, lock.ModulePath(name))
+	expectedDigest, expectedSize := mod.Digest, mod.SizeBytes
+	if expectedDigest != "" {
+		immutablePath, pathErr := h.immutableArtifactPath(name, mod.Version, expectedDigest)
+		if pathErr != nil {
+			return "", NewDependencyIntegrityError(modKey(mod), pathErr, expectedDigest, expectedSize)
+		}
+		if verifyErr := verifyExistingImmutableArtifact(immutablePath, expectedDigest, expectedSize); verifyErr == nil {
+			return immutablePath, nil
+		} else if !errors.Is(verifyErr, os.ErrNotExist) {
+			return "", NewDependencyIntegrityError(modKey(mod), verifyErr, expectedDigest, expectedSize)
+		}
+	} else if immutablePath, _, _, ok, cacheErr := h.soleImmutableArtifact(name, mod.Version); cacheErr != nil {
+		return "", NewDependencyDownloadError(modKey(mod), cacheErr)
+	} else if ok {
+		return immutablePath, nil
+	}
+
+	// A version-only artifact may have been written by an older runtime. Treat
+	// it strictly as migration input: establish its identity, publish a verified
+	// immutable copy, and never mutate or remove the conventional path.
+	legacyPath, err := containedPath(h.vendorDir, lock.WappPath(name, mod.Version))
 	if err != nil {
 		return "", NewDependencyDownloadError(modKey(mod), err)
 	}
+	if legacyInfo, statErr := os.Stat(legacyPath); statErr == nil && legacyInfo.Mode().IsRegular() {
+		legacyDigest, legacySize := expectedDigest, expectedSize
+		if legacyDigest == "" {
+			legacyDigest, legacySize, err = artifactIdentityFromPath(legacyPath)
+		} else {
+			err = verifyDownloadedArtifact(legacyPath, legacyDigest, legacySize)
+		}
+		if err == nil {
+			privatePath, copyErr := copyArtifactToPrivateFile(legacyPath, h.vendorDir, ".artifact-migrate-*")
+			if copyErr == nil {
+				defer os.Remove(privatePath)
+				immutablePath, pathErr := h.immutableArtifactPath(name, mod.Version, legacyDigest)
+				if pathErr != nil {
+					return "", NewDependencyIntegrityError(modKey(mod), pathErr, legacyDigest, legacySize)
+				}
+				publishErr := publishVerifiedArtifact(privatePath, immutablePath, legacyDigest, legacySize)
+				if publishErr == nil {
+					return immutablePath, nil
+				}
+				err = publishErr
+			} else {
+				err = copyErr
+			}
+		}
+		if h.logger != nil {
+			h.logger.Warn("legacy dependency artifact failed integrity check; ignoring migration input",
+				zap.String("module", modKey(mod)),
+				zap.String("path", legacyPath),
+				zap.Error(err))
+		}
+	} else if statErr == nil {
+		if h.logger != nil {
+			h.logger.Warn("legacy dependency artifact is not a regular file; ignoring migration input",
+				zap.String("module", modKey(mod)),
+				zap.String("path", legacyPath))
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return "", NewDependencyDownloadError(modKey(mod), statErr)
+	}
+
+	privateDir, err := os.MkdirTemp(h.vendorDir, ".artifact-download-*")
+	if err != nil {
+		return "", NewDependencyDownloadError(modKey(mod), err)
+	}
+	defer os.RemoveAll(privateDir)
+	privatePath := filepath.Join(privateDir, "artifact.wapp")
+	digest, size, err := h.downloadModuleArtifact(ctx, mod, privatePath)
+	if err != nil {
+		return "", err
+	}
+	immutablePath, err := h.immutableArtifactPath(name, mod.Version, digest)
+	if err != nil {
+		return "", NewDependencyIntegrityError(modKey(mod), err, digest, size)
+	}
+	if err := publishVerifiedArtifact(privatePath, immutablePath, digest, size); err != nil {
+		return "", NewDependencyIntegrityError(modKey(mod), err, digest, size)
+	}
+	return immutablePath, nil
+}
+
+func (h *DependencyHandler) immutableArtifactPath(name graph.Name, version, digest string) (string, error) {
+	relative, err := immutableWappRelativePath(name, version, digest)
+	if err != nil {
+		return "", err
+	}
+	return containedPath(h.vendorDir, relative)
+}
+
+// soleImmutableArtifact supports legacy Hub responses that identify an exact
+// version but omit its digest. Reuse is unambiguous only while one verified
+// digest exists for that version. If multiple republished builds coexist, the
+// caller must ask the Hub which content is current instead of guessing.
+func (h *DependencyHandler) soleImmutableArtifact(name graph.Name, version string) (string, string, uint64, bool, error) {
+	dir, err := containedPath(h.vendorDir, name.Organization)
+	if err != nil {
+		return "", "", 0, false, err
+	}
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", "", 0, false, nil
+	}
+	if err != nil {
+		return "", "", 0, false, err
+	}
+	prefix := name.Module + "-" + version + ".sha256-"
+	const suffix = ".wapp"
+	var foundPath, foundDigest string
+	var foundSize uint64
+	for _, entry := range entries {
+		filename := entry.Name()
+		if !strings.HasPrefix(filename, prefix) || !strings.HasSuffix(filename, suffix) {
+			continue
+		}
+		hexDigest := strings.TrimSuffix(strings.TrimPrefix(filename, prefix), suffix)
+		if len(hexDigest) != sha256.Size*2 {
+			continue
+		}
+		if _, decodeErr := hex.DecodeString(hexDigest); decodeErr != nil {
+			continue
+		}
+		path, pathErr := containedPath(h.vendorDir, filepath.Join(name.Organization, filename))
+		if pathErr != nil {
+			return "", "", 0, false, pathErr
+		}
+		digest := "sha256:" + strings.ToLower(hexDigest)
+		if verifyErr := verifyExistingImmutableArtifact(path, digest, 0); verifyErr != nil {
+			continue
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			continue
+		}
+		if foundPath != "" {
+			return "", "", 0, false, nil
+		}
+		foundPath, foundDigest, foundSize = path, digest, uint64(info.Size())
+	}
+	return foundPath, foundDigest, foundSize, foundPath != "", nil
+}
+
+func (h *DependencyHandler) downloadModuleArtifact(ctx context.Context, mod ResolvedModule, destination string) (string, uint64, error) {
 	expectedDigest := mod.Digest
 	expectedSize := mod.SizeBytes
-	wappPath, err := containedPath(h.vendorDir, lock.WappPath(name, mod.Version))
-	if err != nil {
-		return "", NewDependencyDownloadError(modKey(mod), err)
-	}
-	if exists(wappPath) {
-		if err := verifyDownloadedArtifact(wappPath, expectedDigest, expectedSize); err == nil {
-			if shouldUnpack {
-				if err := h.extractWappModule(wappPath, dirPath, expectedDigest, expectedSize); err != nil {
-					return "", err
-				}
-				return dirPath, nil
-			}
-			return wappPath, nil
-		}
-		h.logger.Warn("cached dependency artifact failed integrity check; redownloading",
-			zap.String("module", modKey(mod)),
-			zap.String("path", wappPath))
-		_ = os.Remove(wappPath)
-	}
-
-	if exists(dirPath) {
-		if installed, ok := h.installedVersion(name.String()); ok && installed == mod.Version {
-			if err := verifyExtractedModule(dirPath, expectedDigest, expectedSize); err == nil {
-				return dirPath, nil
-			} else if expectedDigest != "" || expectedSize > 0 {
-				h.logger.Warn("unpacked dependency failed integrity check; redownloading",
-					zap.String("module", modKey(mod)),
-					zap.String("path", dirPath),
-					zap.Error(err))
-			}
-		}
-	}
-
 	url := mod.URL
 	urlIsFresh := false
 	if url == "" {
 		info, infoErr := h.freshDownloadInfo(ctx, mod)
 		if infoErr != nil {
-			return "", NewDependencyDownloadError(modKey(mod), infoErr)
+			return "", 0, NewDependencyDownloadError(modKey(mod), infoErr)
 		}
 		if infoErr = validateDownloadInfo(mod, info); infoErr != nil {
-			return "", NewDependencyIntegrityError(modKey(mod), infoErr, expectedDigest, expectedSize)
+			return "", 0, NewDependencyIntegrityError(modKey(mod), infoErr, expectedDigest, expectedSize)
 		}
 		url = info.URL
 		urlIsFresh = true
@@ -1361,20 +1834,20 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 		}
 	}
 	if url == "" {
-		return "", NewDependencyDownloadError(modKey(mod), ErrDependencyNoContent)
+		return "", 0, NewDependencyDownloadError(modKey(mod), ErrDependencyNoContent)
 	}
 
 	downloadCtx, cancel := withOptionalTimeout(ctx, h.downloadTimeout)
 	defer cancel()
 
-	downloadErr := h.hub.DownloadToFile(downloadCtx, url, wappPath)
+	downloadErr := h.hub.DownloadToFile(downloadCtx, url, destination)
 	if downloadErr != nil && !urlIsFresh {
 		// mod.URL is a presigned URL captured at resolve time; on a long-lived
 		// process it can expire (15-min TTL) before download. Fetch a fresh URL
 		// and retry once before giving up.
 		if info, infoErr := h.freshDownloadInfo(ctx, mod); infoErr == nil && info != nil && info.URL != "" {
 			if infoErr = validateDownloadInfo(mod, info); infoErr != nil {
-				return "", NewDependencyIntegrityError(modKey(mod), infoErr, expectedDigest, expectedSize)
+				return "", 0, NewDependencyIntegrityError(modKey(mod), infoErr, expectedDigest, expectedSize)
 			}
 			if expectedDigest == "" {
 				expectedDigest = info.Digest
@@ -1384,25 +1857,28 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 			}
 			retryCtx, retryCancel := withOptionalTimeout(ctx, h.downloadTimeout)
 			defer retryCancel()
-			downloadErr = h.hub.DownloadToFile(retryCtx, info.URL, wappPath)
+			downloadErr = h.hub.DownloadToFile(retryCtx, info.URL, destination)
 		}
 	}
 	if downloadErr != nil {
-		return "", NewDependencyDownloadError(modKey(mod), downloadErr)
+		return "", 0, NewDependencyDownloadError(modKey(mod), downloadErr)
 	}
-	if err := verifyDownloadedArtifact(wappPath, expectedDigest, expectedSize); err != nil {
-		_ = os.Remove(wappPath)
-		return "", NewDependencyIntegrityError(modKey(mod), err, expectedDigest, expectedSize)
-	}
-
-	if shouldUnpack {
-		if err := h.extractWappModule(wappPath, dirPath, expectedDigest, expectedSize); err != nil {
-			return "", err
+	if expectedDigest == "" {
+		digest, size, identityErr := artifactIdentityFromPath(destination)
+		if identityErr != nil {
+			_ = os.Remove(destination)
+			return "", 0, NewDependencyIntegrityError(modKey(mod), identityErr, expectedDigest, expectedSize)
 		}
-		return dirPath, nil
+		expectedDigest = digest
+		if expectedSize == 0 {
+			expectedSize = size
+		}
 	}
-
-	return wappPath, nil
+	if err := verifyDownloadedArtifact(destination, expectedDigest, expectedSize); err != nil {
+		_ = os.Remove(destination)
+		return "", 0, NewDependencyIntegrityError(modKey(mod), err, expectedDigest, expectedSize)
+	}
+	return expectedDigest, expectedSize, nil
 }
 
 func containedPath(root, relative string) (string, error) {
@@ -1420,6 +1896,23 @@ func containedPath(root, relative string) (string, error) {
 	rel, err := filepath.Rel(rootAbs, targetAbs)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("artifact path %q escapes vendor directory", relative)
+	}
+	cursor := rootAbs
+	for _, component := range strings.Split(rel, string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		cursor = filepath.Join(cursor, component)
+		info, statErr := os.Lstat(cursor)
+		if errors.Is(statErr, os.ErrNotExist) {
+			break
+		}
+		if statErr != nil {
+			return "", fmt.Errorf("inspect artifact path %q: %w", relative, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("artifact path %q traverses symlink %q", relative, cursor)
+		}
 	}
 	return targetAbs, nil
 }
@@ -1461,70 +1954,6 @@ func (h *DependencyHandler) freshDownloadInfo(ctx context.Context, mod ResolvedM
 		Version:   mod.Version,
 		VersionID: mod.VersionID,
 	})
-}
-
-func (h *DependencyHandler) extractWappModule(wappPath, dirPath string, digest string, size uint64) error {
-	tmpDir, err := os.MkdirTemp(filepath.Dir(dirPath), "."+filepath.Base(dirPath)+".extract-*")
-	if err != nil {
-		return NewDependencyLoadError(dirPath, err)
-	}
-	cleanupTmp := true
-	defer func() {
-		if cleanupTmp {
-			_ = os.RemoveAll(tmpDir)
-		}
-	}()
-
-	if err := wappextract.ExtractWappToDirKeepSource(wappPath, tmpDir); err != nil {
-		return NewDependencyLoadError(wappPath, err)
-	}
-	if err := writeExtractedModuleMeta(tmpDir, digest, size); err != nil {
-		return NewDependencyLoadError(tmpDir, err)
-	}
-	if err := replaceDirectory(dirPath, tmpDir); err != nil {
-		return NewDependencyLoadError(dirPath, err)
-	}
-	if err := os.Remove(wappPath); err != nil {
-		h.logger.Warn("failed to remove unpacked module artifact",
-			zap.String("path", wappPath),
-			zap.Error(err))
-	}
-	cleanupTmp = false
-	return nil
-}
-
-func replaceDirectory(targetDir, replacementDir string) error {
-	parent := filepath.Dir(targetDir)
-	base := filepath.Base(targetDir)
-	var backupDir string
-
-	if exists(targetDir) {
-		var err error
-		backupDir, err = os.MkdirTemp(parent, "."+base+".backup-*")
-		if err != nil {
-			return fmt.Errorf("create backup directory: %w", err)
-		}
-		if err := os.Remove(backupDir); err != nil {
-			_ = os.RemoveAll(backupDir)
-			return fmt.Errorf("prepare backup directory: %w", err)
-		}
-		if err := os.Rename(targetDir, backupDir); err != nil {
-			_ = os.RemoveAll(backupDir)
-			return fmt.Errorf("move existing directory aside: %w", err)
-		}
-	}
-
-	if err := os.Rename(replacementDir, targetDir); err != nil {
-		if backupDir != "" {
-			_ = os.Rename(backupDir, targetDir)
-		}
-		return fmt.Errorf("activate extracted directory: %w", err)
-	}
-
-	if backupDir != "" {
-		_ = os.RemoveAll(backupDir)
-	}
-	return nil
 }
 
 func (h *DependencyHandler) replacementPath(moduleName string) (string, bool) {
@@ -1658,15 +2087,20 @@ func verifyDownloadedArtifact(path, expectedDigest string, expectedSize uint64) 
 }
 
 type extractedModuleMetadata struct {
-	Digest string `yaml:"digest,omitempty"`
-	Size   uint64 `yaml:"size,omitempty"`
+	Digest     string `yaml:"digest,omitempty"`
+	TreeDigest string `yaml:"tree_digest,omitempty"`
+	Size       uint64 `yaml:"size,omitempty"`
 }
 
 func writeExtractedModuleMeta(dirPath, digest string, size uint64) error {
 	if digest == "" && size == 0 {
 		return nil
 	}
-	data, err := yaml.Marshal(extractedModuleMetadata{Digest: digest, Size: size})
+	treeDigest, _, err := digestDirectoryTree(dirPath)
+	if err != nil {
+		return fmt.Errorf("hash extracted module: %w", err)
+	}
+	data, err := yaml.Marshal(extractedModuleMetadata{Digest: digest, Size: size, TreeDigest: treeDigest})
 	if err != nil {
 		return fmt.Errorf("marshal extracted module metadata: %w", err)
 	}
@@ -1690,6 +2124,16 @@ func verifyExtractedModule(dirPath, expectedDigest string, expectedSize uint64) 
 	}
 	if expectedSize > 0 && meta.Size != expectedSize {
 		return fmt.Errorf("size mismatch: expected %d bytes, got %d bytes", expectedSize, meta.Size)
+	}
+	if meta.TreeDigest == "" {
+		return fmt.Errorf("extracted module has no tree digest")
+	}
+	treeDigest, _, err := digestDirectoryTree(dirPath)
+	if err != nil {
+		return fmt.Errorf("hash extracted module: %w", err)
+	}
+	if !strings.EqualFold(meta.TreeDigest, treeDigest) {
+		return fmt.Errorf("extracted module tree digest mismatch: expected %s, got %s", meta.TreeDigest, treeDigest)
 	}
 	return nil
 }
@@ -1724,21 +2168,6 @@ func sha256FileHex(path string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-func (h *DependencyHandler) installedVersion(moduleName string) (string, bool) {
-	if h.lockPath == "" {
-		return "", false
-	}
-	lockObj, err := lock.New(h.lockPath)
-	if err != nil {
-		return "", false
-	}
-	mod, ok := lockObj.GetModule(moduleName)
-	if !ok {
-		return "", false
-	}
-	return mod.Version, true
 }
 
 func (h *DependencyHandler) lockedModuleDigests() map[string]string {
@@ -2123,6 +2552,40 @@ func moduleVersion(entry regapi.Entry) string {
 	return ""
 }
 
+func moduleDigest(entry regapi.Entry) string {
+	if entry.Meta == nil {
+		return ""
+	}
+	if v, ok := entry.Meta[metaModuleDigestKey]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func snapshotModuleDigests(snapshot regapi.State) map[string]string {
+	digests := make(map[string]string)
+	ambiguous := make(map[string]struct{})
+	for _, entry := range snapshot {
+		module := entryModule(entry)
+		digest := moduleDigest(entry)
+		if module == "" || digest == "" {
+			continue
+		}
+		if _, bad := ambiguous[module]; bad {
+			continue
+		}
+		if existing, seen := digests[module]; seen && !strings.EqualFold(existing, digest) {
+			delete(digests, module)
+			ambiguous[module] = struct{}{}
+			continue
+		}
+		digests[module] = digest
+	}
+	return digests
+}
+
 func isRootDependency(entry regapi.Entry) bool {
 	return entry.Kind == regapi.NamespaceDependency && entryModule(entry) == ""
 }
@@ -2145,6 +2608,40 @@ func markModuleMeta(entry regapi.Entry, moduleName, moduleVersion string) regapi
 	}
 	entry.Meta = meta
 	return entry
+}
+
+func markModuleIdentity(entry regapi.Entry, moduleName, moduleVersion, digest string) regapi.Entry {
+	entry = markModuleMeta(entry, moduleName, moduleVersion)
+	if entryModule(entry) != moduleName || digest == "" {
+		return entry
+	}
+	meta := attrs.NewBagFrom(entry.Meta)
+	meta.Set(metaModuleDigestKey, digest)
+	entry.Meta = meta
+	return entry
+}
+
+func markModuleIdentityForGraph(
+	entry regapi.Entry,
+	moduleName string,
+	moduleVersion string,
+	digest string,
+	namespaceOwners map[string]moduleOwner,
+	entryOwners map[string]moduleOwner,
+) regapi.Entry {
+	if entryModule(entry) != "" {
+		return markModuleIdentity(entry, moduleName, moduleVersion, digest)
+	}
+	if owner, ok := entryOwners[idKey(entry.ID)]; ok && owner.name != "" {
+		if owner.name == moduleName {
+			return markModuleIdentity(entry, moduleName, moduleVersion, digest)
+		}
+		return markModuleIdentity(entry, owner.name, owner.version, owner.digest)
+	}
+	if owner, ok := namespaceOwners[entry.ID.NS]; ok && owner.name != "" {
+		return markModuleIdentity(entry, owner.name, owner.version, owner.digest)
+	}
+	return markModuleIdentity(entry, moduleName, moduleVersion, digest)
 }
 
 func markModuleMetaForGraph(

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -162,6 +162,14 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
 	}
 
+	satisfied, err := h.unchangedRootDependencySatisfied(ctx, transcoder, op, entry, snapshot)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	if satisfied {
+		return regapi.DirectiveResult{Applied: true}, nil
+	}
+
 	lockedVersions, err := h.installedModuleVersions(ctx, transcoder, snapshot)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
@@ -267,6 +275,45 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		Additional: scoped,
 		Effects:    effects,
 	}, nil
+}
+
+func (h *DependencyHandler) unchangedRootDependencySatisfied(
+	ctx context.Context,
+	transcoder payload.Transcoder,
+	op regapi.Operation,
+	entry regapi.Entry,
+	snapshot regapi.State,
+) (bool, error) {
+	if op.Kind != regapi.EntryUpdate {
+		return false, nil
+	}
+
+	var current regapi.Entry
+	found := false
+	for _, candidate := range snapshot {
+		if idsEqual(candidate.ID, entry.ID) {
+			current = candidate
+			found = true
+			break
+		}
+	}
+	if !found || !entriesEqual(current, entry) {
+		return false, nil
+	}
+
+	definition, err := decodeDependency(ctx, transcoder, entry)
+	if err != nil {
+		return false, err
+	}
+	if definition.Component == "" {
+		return false, nil
+	}
+
+	installedVersion := snapshotModuleVersions(snapshot)[definition.Component]
+	if installedVersion == "" {
+		installedVersion = h.replacementModuleVersion(definition.Component)
+	}
+	return lockedVersionSatisfies(installedVersion, definition.Version), nil
 }
 
 func (h *DependencyHandler) collectSnapshotDependencies(

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -272,9 +274,248 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 
 	return regapi.DirectiveResult{
 		Applied:    true,
+		Resolution: dependencyResolution(desiredDeps, resolved),
 		Additional: scoped,
 		Effects:    effects,
 	}, nil
+}
+
+// ExpandChanges resolves the final declarative root set for one registry
+// transaction. Earlier operations are folded into a temporary snapshot and
+// the last operation drives the existing expansion path, so agents retain the
+// same simple entry-update surface for both single and multi-root updates.
+func (h *DependencyHandler) ExpandChanges(ctx context.Context, changes regapi.ChangeSet, snapshot regapi.State) (regapi.DirectiveResult, error) {
+	if len(changes) == 0 {
+		return regapi.DirectiveResult{}, nil
+	}
+	if len(changes) == 1 {
+		return h.Expand(ctx, changes[0], snapshot)
+	}
+	stateMap := make(regapi.StateMap, len(snapshot)+len(changes)-1)
+	for _, entry := range snapshot {
+		stateMap[entry.ID] = entry
+	}
+	for _, op := range changes[:len(changes)-1] {
+		switch op.Kind {
+		case regapi.EntryCreate, regapi.EntryUpdate:
+			stateMap[op.Entry.ID] = op.Entry
+		case regapi.EntryDelete:
+			delete(stateMap, op.Entry.ID)
+		}
+	}
+	working := make(regapi.State, 0, len(stateMap))
+	for _, entry := range stateMap {
+		working = append(working, entry)
+	}
+	return h.Expand(ctx, changes[len(changes)-1], working)
+}
+
+// ReconcileResolution materializes a previously selected graph without asking
+// the Hub to choose versions again. It is intentionally a whole-graph operation:
+// history is first reduced to its final declarative state, then reconciled once.
+func (h *DependencyHandler) ReconcileResolution(
+	ctx context.Context,
+	snapshot regapi.State,
+	resolution *regapi.DependencyResolution,
+) (regapi.DirectiveResult, error) {
+	if h == nil || h.hub == nil {
+		return regapi.DirectiveResult{}, ErrDependencyHandlerNotConfigured
+	}
+	if resolution == nil || !resolution.Valid() {
+		return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf("stored dependency resolution is invalid"))
+	}
+	transcoder := payload.GetTranscoder(ctx)
+	if transcoder == nil {
+		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
+	}
+
+	desiredDeps, err := h.collectResolutionDependencies(ctx, snapshot, transcoder, resolution.Roots)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	if got := dependencyInputDigest(desiredDeps); got != resolution.InputDigest {
+		return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf(
+			"stored dependency input digest does not match declarations: stored %s, current %s",
+			resolution.InputDigest, got,
+		))
+	}
+
+	resolved := make([]ResolvedModule, 0, len(resolution.Modules))
+	seen := make(map[string]struct{}, len(resolution.Modules))
+	for _, mod := range resolution.Modules {
+		name, parseErr := graph.ParseName(mod.Name)
+		if parseErr != nil || mod.Version == "" {
+			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf("invalid stored module %q@%s", mod.Name, mod.Version))
+		}
+		if _, duplicate := seen[mod.Name]; duplicate {
+			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf("duplicate stored module %q", mod.Name))
+		}
+		seen[mod.Name] = struct{}{}
+		resolved = append(resolved, ResolvedModule{
+			Org:       name.Organization,
+			Name:      name.Module,
+			Version:   mod.Version,
+			VersionID: mod.VersionID,
+			Digest:    mod.Digest,
+			SizeBytes: mod.SizeBytes,
+			Protected: mod.Protected,
+		})
+	}
+	for _, root := range desiredDeps {
+		selected, ok := selectedModuleVersion(resolved, root.definition.Component)
+		if !ok || !lockedVersionSatisfies(selected, root.definition.Version) {
+			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf(
+				"stored module %s@%s does not satisfy %s",
+				root.definition.Component, selected, root.definition.Version,
+			))
+		}
+	}
+
+	installed := snapshotModuleVersions(snapshot)
+	touched := stringSet(touchedModuleNames(resolved, installed, ""))
+	desiredModules := resolvedModuleSet(resolved)
+	controlled := make(map[string]struct{}, len(installed)+len(desiredModules))
+	for module := range installed {
+		controlled[module] = struct{}{}
+	}
+	for module := range desiredModules {
+		controlled[module] = struct{}{}
+	}
+
+	moduleEntries, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touched), resolved, snapshot, transcoder)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	desiredDepEntries := make([]regapi.Entry, 0, len(desiredDeps))
+	for _, dep := range desiredDeps {
+		desiredDepEntries = append(desiredDepEntries, dep.entry)
+	}
+	combined := make([]regapi.Entry, 0, len(snapshot)+len(moduleEntries))
+	for _, entry := range snapshot {
+		if module := entryModule(entry); module != "" {
+			if _, desired := desiredModules[module]; !desired {
+				continue
+			}
+			if _, changed := touched[module]; changed {
+				continue
+			}
+		}
+		combined = append(combined, entry)
+	}
+	combined = append(combined, moduleEntries...)
+
+	pipeline := build.New(
+		stages.Override(stages.WithMissingOverrideEntriesIgnored()),
+		stages.Disable(),
+		stages.Link(stages.WithDependencies(mergeLinkDependencies(desiredDepEntries, moduleEntries)), stages.WithStrictRequirementModules(touchedModuleNames(resolved, installed, ""))),
+		stages.Override(stages.WithMissingOverrideEntriesIgnored()),
+	)
+	if err := pipeline.Execute(ctx, &combined); err != nil {
+		return regapi.DirectiveResult{}, NewDependencyPipelineError(err)
+	}
+
+	additional, err := h.buildOperations(snapshot, combined, regapi.ID{}, controlled, controlled)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	scoped := make([]regapi.ScopedOperation, 0, len(additional))
+	for _, op := range additional {
+		scoped = append(scoped, regapi.ScopedOperation{Operation: op, Scope: regapi.ScopeBaseline})
+	}
+	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, snapshot, controlled)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	var effects []regapi.Effect
+	if packEffect != nil {
+		effects = append(effects, packEffect)
+	}
+	return regapi.DirectiveResult{
+		Applied:    true,
+		Resolution: resolution.Canonical(),
+		Additional: scoped,
+		Effects:    effects,
+	}, nil
+}
+
+func selectedModuleVersion(modules []ResolvedModule, component string) (string, bool) {
+	for _, mod := range modules {
+		if mod.Org+"/"+mod.Name == component {
+			return mod.Version, true
+		}
+	}
+	return "", false
+}
+
+func dependencyResolution(roots []desiredDependency, modules []ResolvedModule) *regapi.DependencyResolution {
+	resolved := &regapi.DependencyResolution{
+		InputDigest: dependencyInputDigest(roots),
+		Roots:       dependencyRoots(roots),
+		Modules:     make([]regapi.ResolvedModule, 0, len(modules)),
+	}
+	for _, mod := range modules {
+		if mod.Org == "" || mod.Name == "" || mod.Version == "" {
+			continue
+		}
+		resolved.Modules = append(resolved.Modules, regapi.ResolvedModule{
+			Name:      mod.Org + "/" + mod.Name,
+			Version:   mod.Version,
+			VersionID: mod.VersionID,
+			Digest:    mod.Digest,
+			SizeBytes: mod.SizeBytes,
+			Protected: mod.Protected,
+		})
+	}
+	return resolved.Canonical()
+}
+
+func dependencyRoots(roots []desiredDependency) []regapi.DependencyRoot {
+	result := make([]regapi.DependencyRoot, 0, len(roots))
+	for _, root := range roots {
+		result = append(result, regapi.DependencyRoot{
+			ID: root.entry.ID.String(), Component: root.definition.Component, Version: root.definition.Version,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+func dependencyInputDigest(roots []desiredDependency) string {
+	canonical := dependencyRoots(roots)
+	data, _ := json.Marshal(canonical)
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (h *DependencyHandler) collectResolutionDependencies(
+	ctx context.Context,
+	snapshot regapi.State,
+	transcoder payload.Transcoder,
+	roots []regapi.DependencyRoot,
+) ([]desiredDependency, error) {
+	byID := make(map[string]regapi.Entry, len(snapshot))
+	for _, entry := range snapshot {
+		byID[entry.ID.String()] = entry
+	}
+	deps := make([]desiredDependency, 0, len(roots))
+	for _, root := range roots {
+		entry, ok := byID[root.ID]
+		if !ok || entry.Kind != regapi.NamespaceDependency {
+			return nil, NewDependencyResolutionError(fmt.Errorf("stored dependency root %s is missing", root.ID))
+		}
+		definition, err := decodeDependency(ctx, transcoder, entry)
+		if err != nil {
+			return nil, err
+		}
+		if definition.Component != root.Component || definition.Version != root.Version {
+			return nil, NewDependencyResolutionError(fmt.Errorf(
+				"stored dependency root %s expected %s@%s, got %s@%s",
+				root.ID, root.Component, root.Version, definition.Component, definition.Version,
+			))
+		}
+		deps = append(deps, desiredDependency{entry: entry, definition: definition})
+	}
+	return deps, nil
 }
 
 func (h *DependencyHandler) unchangedRootDependencySatisfied(

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -355,10 +355,6 @@ func (h *DependencyHandler) collectDesiredDependencies(
 	transcoder payload.Transcoder,
 ) ([]desiredDependency, error) {
 	deps := make(map[string]desiredDependency)
-	lockedVersions, err := h.installedModuleVersions(ctx, transcoder, snapshot)
-	if err != nil {
-		return nil, err
-	}
 	operationID := op.Entry.ID
 
 	current, err := h.collectSnapshotDependencies(ctx, snapshot, transcoder)
@@ -366,9 +362,6 @@ func (h *DependencyHandler) collectDesiredDependencies(
 		return nil, err
 	}
 	for _, dep := range current {
-		if !idsEqual(dep.entry.ID, operationID) {
-			dep.definition = pinExistingDependencyVersion(dep.definition, lockedVersions)
-		}
 		deps[idKey(dep.entry.ID)] = dep
 	}
 
@@ -475,16 +468,6 @@ func snapshotModuleVersions(snapshot regapi.State) map[string]string {
 		versions[module] = version
 	}
 	return versions
-}
-
-func pinExistingDependencyVersion(def DependencyDefinition, moduleVersions map[string]string) DependencyDefinition {
-	if def.Component == "" {
-		return def
-	}
-	if version := moduleVersions[def.Component]; version != "" {
-		def.Version = version
-	}
-	return def
 }
 
 func mergeLinkDependencies(explicitDeps, moduleEntries []regapi.Entry) []regapi.Entry {

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/wippyai/runtime/boot/deps/auth"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/graph"
+	hubsemver "github.com/wippyai/runtime/boot/deps/hub/semver"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	"github.com/wippyai/runtime/boot/deps/wappextract"
 	"github.com/wippyai/runtime/boot/loader"
@@ -141,6 +142,16 @@ func NewDependencyHandler(opts DependencyHandlerOptions) (*DependencyHandler, er
 }
 
 func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, snapshot regapi.State) (regapi.DirectiveResult, error) {
+	return h.expand(ctx, op, snapshot, nil, nil)
+}
+
+func (h *DependencyHandler) expand(
+	ctx context.Context,
+	op regapi.Operation,
+	snapshot regapi.State,
+	extraControlled map[string]struct{},
+	extraMutable map[string]struct{},
+) (regapi.DirectiveResult, error) {
 	if h == nil || h.hub == nil {
 		return regapi.DirectiveResult{}, ErrDependencyHandlerNotConfigured
 	}
@@ -164,14 +175,6 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
 	}
 
-	satisfied, err := h.unchangedRootDependencySatisfied(ctx, transcoder, op, entry, snapshot)
-	if err != nil {
-		return regapi.DirectiveResult{}, err
-	}
-	if satisfied {
-		return regapi.DirectiveResult{Applied: true}, nil
-	}
-
 	lockedVersions, err := h.installedModuleVersions(ctx, transcoder, snapshot)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
@@ -180,6 +183,9 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 	controlledModules, err := h.collectControlledModules(ctx, snapshot, transcoder)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
+	}
+	for module := range extraControlled {
+		controlledModules[module] = struct{}{}
 	}
 
 	desiredDeps, err := h.collectDesiredDependencies(ctx, op, snapshot, transcoder)
@@ -210,9 +216,24 @@ func (h *DependencyHandler) Expand(ctx context.Context, op regapi.Operation, sna
 		}
 	}
 	strictModules := touchedModuleNames(resolved, lockedVersions, opComponent)
+	strictSet := stringSet(strictModules)
+	resolvedSet := resolvedModuleSet(resolved)
+	for module := range extraMutable {
+		if _, desired := resolvedSet[module]; desired {
+			strictSet[module] = struct{}{}
+		}
+	}
+	strictModules = make([]string, 0, len(strictSet))
+	for module := range strictSet {
+		strictModules = append(strictModules, module)
+	}
+	sort.Strings(strictModules)
 	mutableModules, err := h.operationModules(ctx, op, snapshot, transcoder)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
+	}
+	for module := range extraMutable {
+		mutableModules[module] = struct{}{}
 	}
 	touchedModules := stringSet(strictModules)
 	for module := range mutableModules {
@@ -291,11 +312,37 @@ func (h *DependencyHandler) ExpandChanges(ctx context.Context, changes regapi.Ch
 	if len(changes) == 1 {
 		return h.Expand(ctx, changes[0], snapshot)
 	}
+	if h == nil || h.hub == nil {
+		return regapi.DirectiveResult{}, ErrDependencyHandlerNotConfigured
+	}
+	transcoder := payload.GetTranscoder(ctx)
+	if transcoder == nil {
+		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
+	}
+	// Preserve ownership from both sides of the batch. Looking only at the
+	// folded state loses modules owned by an earlier delete or retarget, leaving
+	// their entries and embedded packs live after the root has gone away.
+	extraControlled, err := h.collectControlledModules(ctx, snapshot, transcoder)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	extraMutable := make(map[string]struct{})
 	stateMap := make(regapi.StateMap, len(snapshot)+len(changes)-1)
 	for _, entry := range snapshot {
 		stateMap[entry.ID] = entry
 	}
 	for _, op := range changes[:len(changes)-1] {
+		rolling := make(regapi.State, 0, len(stateMap))
+		for _, entry := range stateMap {
+			rolling = append(rolling, entry)
+		}
+		affected, opErr := h.operationModules(ctx, op, rolling, transcoder)
+		if opErr != nil {
+			return regapi.DirectiveResult{}, opErr
+		}
+		for module := range affected {
+			extraMutable[module] = struct{}{}
+		}
 		switch op.Kind {
 		case regapi.EntryCreate, regapi.EntryUpdate:
 			stateMap[op.Entry.ID] = op.Entry
@@ -307,7 +354,8 @@ func (h *DependencyHandler) ExpandChanges(ctx context.Context, changes regapi.Ch
 	for _, entry := range stateMap {
 		working = append(working, entry)
 	}
-	return h.Expand(ctx, changes[len(changes)-1], working)
+	// A final no-op must not suppress earlier operations in the same batch.
+	return h.expand(ctx, changes[len(changes)-1], working, extraControlled, extraMutable)
 }
 
 // ReconcileResolution materializes a previously selected graph without asking
@@ -347,6 +395,9 @@ func (h *DependencyHandler) ReconcileResolution(
 		if parseErr != nil || mod.Version == "" {
 			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf("invalid stored module %q@%s", mod.Name, mod.Version))
 		}
+		if identityErr := validateModuleArtifactIdentity(name, mod.Version, mod.Digest); identityErr != nil {
+			return regapi.DirectiveResult{}, NewDependencyResolutionError(identityErr)
+		}
 		if _, duplicate := seen[mod.Name]; duplicate {
 			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf("duplicate stored module %q", mod.Name))
 		}
@@ -363,7 +414,7 @@ func (h *DependencyHandler) ReconcileResolution(
 	}
 	for _, root := range desiredDeps {
 		selected, ok := selectedModuleVersion(resolved, root.definition.Component)
-		if !ok || !lockedVersionSatisfies(selected, root.definition.Version) {
+		if !ok || !storedVersionSatisfies(selected, root.definition.Version) {
 			return regapi.DirectiveResult{}, NewDependencyResolutionError(fmt.Errorf(
 				"stored module %s@%s does not satisfy %s",
 				root.definition.Component, selected, root.definition.Version,
@@ -438,6 +489,17 @@ func (h *DependencyHandler) ReconcileResolution(
 	}, nil
 }
 
+// storedVersionSatisfies validates selectors that can be checked without the
+// resolver. A label is intentionally accepted here: the graph digest binds the
+// authored label to the exact version selected when the graph was created, and
+// resolving the moving label again would defeat deterministic offline restore.
+func storedVersionSatisfies(version, constraint string) bool {
+	if strings.HasPrefix(strings.TrimSpace(constraint), "@") {
+		return strings.TrimSpace(version) != ""
+	}
+	return lockedVersionSatisfies(version, constraint)
+}
+
 func selectedModuleVersion(modules []ResolvedModule, component string) (string, bool) {
 	for _, mod := range modules {
 		if mod.Org+"/"+mod.Name == component {
@@ -495,12 +557,29 @@ func (h *DependencyHandler) collectResolutionDependencies(
 ) ([]desiredDependency, error) {
 	byID := make(map[string]regapi.Entry, len(snapshot))
 	for _, entry := range snapshot {
-		byID[entry.ID.String()] = entry
+		if isRootDependency(entry) {
+			byID[idKey(entry.ID)] = entry
+		}
+	}
+	if len(byID) != len(roots) {
+		return nil, NewDependencyResolutionError(fmt.Errorf(
+			"stored dependency root set has %d entries, current declarations have %d", len(roots), len(byID),
+		))
 	}
 	deps := make([]desiredDependency, 0, len(roots))
+	seenIDs := make(map[string]struct{}, len(roots))
+	seenComponents := make(map[string]string, len(roots))
 	for _, root := range roots {
-		entry, ok := byID[root.ID]
-		if !ok || entry.Kind != regapi.NamespaceDependency {
+		rootKey := idKey(regapi.ParseID(root.ID))
+		if rootKey == ":" {
+			return nil, NewDependencyResolutionError(fmt.Errorf("stored dependency root has an empty id"))
+		}
+		if _, duplicate := seenIDs[rootKey]; duplicate {
+			return nil, NewDependencyResolutionError(fmt.Errorf("duplicate stored dependency root %s", root.ID))
+		}
+		seenIDs[rootKey] = struct{}{}
+		entry, ok := byID[rootKey]
+		if !ok {
 			return nil, NewDependencyResolutionError(fmt.Errorf("stored dependency root %s is missing", root.ID))
 		}
 		definition, err := decodeDependency(ctx, transcoder, entry)
@@ -513,48 +592,15 @@ func (h *DependencyHandler) collectResolutionDependencies(
 				root.ID, root.Component, root.Version, definition.Component, definition.Version,
 			))
 		}
+		if previousID, duplicate := seenComponents[definition.Component]; duplicate {
+			return nil, NewDependencyResolutionError(fmt.Errorf(
+				"duplicate stored dependency component %s in roots %s and %s", definition.Component, previousID, root.ID,
+			))
+		}
+		seenComponents[definition.Component] = root.ID
 		deps = append(deps, desiredDependency{entry: entry, definition: definition})
 	}
 	return deps, nil
-}
-
-func (h *DependencyHandler) unchangedRootDependencySatisfied(
-	ctx context.Context,
-	transcoder payload.Transcoder,
-	op regapi.Operation,
-	entry regapi.Entry,
-	snapshot regapi.State,
-) (bool, error) {
-	if op.Kind != regapi.EntryUpdate {
-		return false, nil
-	}
-
-	var current regapi.Entry
-	found := false
-	for _, candidate := range snapshot {
-		if idsEqual(candidate.ID, entry.ID) {
-			current = candidate
-			found = true
-			break
-		}
-	}
-	if !found || !entriesEqual(current, entry) {
-		return false, nil
-	}
-
-	definition, err := decodeDependency(ctx, transcoder, entry)
-	if err != nil {
-		return false, err
-	}
-	if definition.Component == "" {
-		return false, nil
-	}
-
-	installedVersion := snapshotModuleVersions(snapshot)[definition.Component]
-	if installedVersion == "" {
-		installedVersion = h.replacementModuleVersion(definition.Component)
-	}
-	return lockedVersionSatisfies(installedVersion, definition.Version), nil
 }
 
 func (h *DependencyHandler) collectSnapshotDependencies(
@@ -828,8 +874,53 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 		}
 		return nil, NewDependencyResolutionErrors(result.Errors)
 	}
+	for _, mod := range result.Modules {
+		name := graph.Name{Organization: mod.Org, Module: mod.Name}
+		if err := validateModuleArtifactIdentity(name, mod.Version, mod.Digest); err != nil {
+			return nil, NewDependencyIntegrityError(modKey(mod), err, mod.Digest, mod.SizeBytes)
+		}
+		if mod.VersionID == "" && mod.Digest == "" {
+			if _, replaced := h.replacementPath(name.String()); !replaced && h.logger != nil {
+				h.logger.Warn("resolved module has legacy identity without version id or digest",
+					zap.String("module", name.String()), zap.String("version", mod.Version))
+			}
+		}
+	}
 
 	return result.Modules, nil
+}
+
+func validateModuleArtifactIdentity(name graph.Name, version, digest string) error {
+	if !validModuleIdentifier(name.Organization) || !validModuleIdentifier(name.Module) {
+		return fmt.Errorf("invalid module name %q: organization and module must be lowercase alphanumeric with hyphens", name.String())
+	}
+	if _, err := hubsemver.ParseVersion(strings.TrimSpace(version)); err != nil {
+		return fmt.Errorf("invalid exact module version %q for %s", version, name.String())
+	}
+	if digest == "" {
+		return nil // Older hubs and local replacements did not always provide one.
+	}
+	algorithm, value, err := parseExpectedDigest(digest)
+	if err != nil || algorithm != "sha256" || len(value) != sha256.Size*2 {
+		return fmt.Errorf("invalid sha256 digest for %s@%s", name.String(), version)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("invalid sha256 digest for %s@%s", name.String(), version)
+	}
+	return nil
+}
+
+func validModuleIdentifier(value string) bool {
+	if value == "" || value[0] < 'a' || value[0] > 'z' {
+		return false
+	}
+	for i := 1; i < len(value); i++ {
+		c := value[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' {
+			return false
+		}
+	}
+	return true
 }
 
 // replacementManifestProvider resolves locally-replaced modules from their lock
@@ -1211,10 +1302,16 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 	}
 
 	shouldUnpack := h.shouldUnpackModules()
-	dirPath := filepath.Join(h.vendorDir, lock.ModulePath(name))
+	dirPath, err := containedPath(h.vendorDir, lock.ModulePath(name))
+	if err != nil {
+		return "", NewDependencyDownloadError(modKey(mod), err)
+	}
 	expectedDigest := mod.Digest
 	expectedSize := mod.SizeBytes
-	wappPath := filepath.Join(h.vendorDir, lock.WappPath(name, mod.Version))
+	wappPath, err := containedPath(h.vendorDir, lock.WappPath(name, mod.Version))
+	if err != nil {
+		return "", NewDependencyDownloadError(modKey(mod), err)
+	}
 	if exists(wappPath) {
 		if err := verifyDownloadedArtifact(wappPath, expectedDigest, expectedSize); err == nil {
 			if shouldUnpack {
@@ -1251,6 +1348,9 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 		if infoErr != nil {
 			return "", NewDependencyDownloadError(modKey(mod), infoErr)
 		}
+		if infoErr = validateDownloadInfo(mod, info); infoErr != nil {
+			return "", NewDependencyIntegrityError(modKey(mod), infoErr, expectedDigest, expectedSize)
+		}
 		url = info.URL
 		urlIsFresh = true
 		if expectedDigest == "" {
@@ -1273,6 +1373,9 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 		// process it can expire (15-min TTL) before download. Fetch a fresh URL
 		// and retry once before giving up.
 		if info, infoErr := h.freshDownloadInfo(ctx, mod); infoErr == nil && info != nil && info.URL != "" {
+			if infoErr = validateDownloadInfo(mod, info); infoErr != nil {
+				return "", NewDependencyIntegrityError(modKey(mod), infoErr, expectedDigest, expectedSize)
+			}
 			if expectedDigest == "" {
 				expectedDigest = info.Digest
 			}
@@ -1300,6 +1403,49 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 	}
 
 	return wappPath, nil
+}
+
+func containedPath(root, relative string) (string, error) {
+	if filepath.IsAbs(relative) {
+		return "", fmt.Errorf("artifact path %q is absolute", relative)
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve vendor directory: %w", err)
+	}
+	targetAbs, err := filepath.Abs(filepath.Join(rootAbs, relative))
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact path: %w", err)
+	}
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("artifact path %q escapes vendor directory", relative)
+	}
+	return targetAbs, nil
+}
+
+func validateDownloadInfo(mod ResolvedModule, info *DownloadInfo) error {
+	if info == nil {
+		return ErrDependencyNoContent
+	}
+	if info.Version != "" {
+		got := strings.TrimPrefix(strings.TrimSpace(info.Version), "v")
+		want := strings.TrimPrefix(strings.TrimSpace(mod.Version), "v")
+		if got != want {
+			return fmt.Errorf("download version mismatch: expected %s, got %s", mod.Version, info.Version)
+		}
+	}
+	if mod.Digest != "" && info.Digest != "" {
+		wantAlgorithm, want, wantErr := parseExpectedDigest(mod.Digest)
+		gotAlgorithm, got, gotErr := parseExpectedDigest(info.Digest)
+		if wantErr != nil || gotErr != nil || wantAlgorithm != gotAlgorithm || !strings.EqualFold(want, got) {
+			return fmt.Errorf("download digest mismatch: expected %s, got %s", mod.Digest, info.Digest)
+		}
+	}
+	if mod.SizeBytes > 0 && info.Size > 0 && mod.SizeBytes != info.Size {
+		return fmt.Errorf("download size mismatch: expected %d bytes, got %d bytes", mod.SizeBytes, info.Size)
+	}
+	return nil
 }
 
 // freshDownloadInfo fetches a current presigned download URL for a module.

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -2212,7 +2212,7 @@ func TestDependencyHandler_CollectDesiredDependencies_IgnoresModuleOwnedDependen
 	assert.Equal(t, "acme/root", deps[0].definition.Component)
 }
 
-func TestDependencyHandler_CollectDesiredDependencies_PinsExistingInstalledVersions(t *testing.T) {
+func TestDependencyHandler_CollectDesiredDependencies_PreservesExistingDeclaredVersions(t *testing.T) {
 	ctx := newTestContext()
 	transcoder := payload.GetTranscoder(ctx)
 	require.NotNil(t, transcoder)
@@ -2258,7 +2258,7 @@ func TestDependencyHandler_CollectDesiredDependencies_PinsExistingInstalledVersi
 	for _, dep := range deps {
 		versions[dep.definition.Component] = dep.definition.Version
 	}
-	assert.Equal(t, "0.5.39", versions["wippy/facade"])
+	assert.Equal(t, ">=v0.5.16", versions["wippy/facade"])
 	assert.Equal(t, ">=v0.0.0", versions["wippy/dummy"])
 }
 

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -98,19 +98,25 @@ func TestDependencyHandler_ResolveErrors(t *testing.T) {
 	}
 }
 
-func TestDependencyHandler_UnchangedLoadedRootIsIdempotent(t *testing.T) {
+func TestDependencyHandler_UnchangedLoadedRootProducesCheckpointResolution(t *testing.T) {
 	ctx := newTestContext()
 	manifestCalls := 0
+	vendorDir := t.TempDir()
+	artifact := buildWappBytes(t, []wapp.Entry{{ID: wapp.NewID("acme.http", "service"), Kind: "service"}})
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
-			getManifest: func(context.Context, string, string, string) (*ModuleManifest, error) {
+			getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
 				manifestCalls++
-				return nil, assert.AnError
+				return &ModuleManifest{Org: org, Name: module, Version: "v1.4.2", URL: "memory://http"}, nil
+			},
+			downloadFile: func(_ context.Context, _ string, dest string) error {
+				require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+				return os.WriteFile(dest, artifact, 0o600)
 			},
 		},
 		Logger:    zap.NewNop(),
 		LockPath:  filepath.Join(t.TempDir(), "wippy.lock"),
-		VendorDir: t.TempDir(),
+		VendorDir: vendorDir,
 	})
 	require.NoError(t, err)
 
@@ -133,9 +139,8 @@ func TestDependencyHandler_UnchangedLoadedRootIsIdempotent(t *testing.T) {
 	}, regapi.State{depEntry, moduleEntry})
 	require.NoError(t, err)
 	require.True(t, result.Applied)
-	require.Empty(t, result.Additional)
-	require.Empty(t, result.Effects)
-	require.Zero(t, manifestCalls, "a compatible module already assembled at boot must not be resolved again")
+	require.NotNil(t, result.Resolution, "legacy boot must have an exact graph to checkpoint")
+	require.Equal(t, 1, manifestCalls)
 }
 
 func TestDependencyHandler_UnchangedRootWithIncompatibleLoadedVersionResolves(t *testing.T) {
@@ -2416,7 +2421,7 @@ modules:
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
 			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
-				return &ModuleManifest{Org: org, Name: module, Version: version, Digest: "sha256:v2digest"}, nil
+				return &ModuleManifest{Org: org, Name: module, Version: version, Digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222"}, nil
 			},
 		},
 		Logger:    zap.NewNop(),

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -21,6 +21,7 @@ import (
 	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/lock"
 	syspayload "github.com/wippyai/runtime/system/payload"
 	jsonpayload "github.com/wippyai/runtime/system/payload/json"
 	yamlpayload "github.com/wippyai/runtime/system/payload/yaml"
@@ -403,19 +404,29 @@ modules:
 	require.NoError(t, os.MkdirAll(legacyDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "_index.yaml"), []byte("version: \"1.0\"\nnamespace: acme.legacy\nentries: []\n"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "sentinel.txt"), []byte("keep"), 0600))
-	writeWapp(t, filepath.Join(vendorDir, "acme", "legacy-v1.0.0.wapp"), []wapp.Entry{
+	legacyWapp := filepath.Join(vendorDir, "acme", "legacy-v1.0.0.wapp")
+	writeWapp(t, legacyWapp, []wapp.Entry{
 		{ID: wapp.NewID("acme.legacy", "rewritten"), Kind: "service", Data: map[string]any{"ok": true}},
 	})
+	legacyDigest, err := sha256FileHex(legacyWapp)
+	require.NoError(t, err)
 	before := mustReadFile(t, filepath.Join(legacyDir, "_index.yaml"))
 
-	writeWapp(t, filepath.Join(vendorDir, "acme", "fresh-v1.0.0.wapp"), []wapp.Entry{
+	freshWapp := filepath.Join(vendorDir, "acme", "fresh-v1.0.0.wapp")
+	writeWapp(t, freshWapp, []wapp.Entry{
 		{ID: wapp.NewID("acme.fresh", "svc"), Kind: "service", Data: map[string]any{"ok": true}},
 	})
+	freshDigest, err := sha256FileHex(freshWapp)
+	require.NoError(t, err)
+	digests := map[string]string{
+		"legacy": "sha256:" + legacyDigest,
+		"fresh":  "sha256:" + freshDigest,
+	}
 
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
 			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
-				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+				return &ModuleManifest{Org: org, Name: module, Version: version, Digest: digests[module]}, nil
 			},
 		},
 		Logger:    zap.NewNop(),
@@ -432,7 +443,11 @@ modules:
 	legacySvc := regapi.Entry{
 		ID:   regapi.NewID("acme.legacy", "svc"),
 		Kind: "service",
-		Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: "acme/legacy", metaModuleVersionKey: "v1.0.0"}),
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        "acme/legacy",
+			metaModuleVersionKey: "v1.0.0",
+			metaModuleDigestKey:  digests["legacy"],
+		}),
 		Data: payload.NewPayload(`{"ok":true}`, payload.JSON),
 	}
 	freshRoot := regapi.Entry{
@@ -511,6 +526,13 @@ modules:
 	require.NoError(t, err)
 	require.True(t, result.Applied)
 	assert.Equal(t, int32(1), downloadCalls.Load())
+	assert.FileExists(t, filepath.Join(staleDir, "stale.lua"), "planning must not replace the live tree")
+	require.Len(t, result.Effects, 1)
+	require.NoError(t, result.Effects[0].Prepare(ctx))
+	require.NoError(t, result.Effects[0].Commit(ctx))
+	finalizer, ok := result.Effects[0].(regapi.FinalizingEffect)
+	require.True(t, ok)
+	require.NoError(t, finalizer.Finalize(ctx))
 	assert.FileExists(t, filepath.Join(staleDir, "_index.yaml"))
 
 	entries, err := handler.loadEntriesForModule(ctx, payload.GetTranscoder(ctx), ResolvedModule{
@@ -1547,7 +1569,8 @@ func TestDependencyHandler_Expand_InfersPackedEntryModuleOwnershipFromResolvedGr
 	tmpDir := t.TempDir()
 	vendorDir := filepath.Join(tmpDir, "vendor")
 
-	writeWapp(t, filepath.Join(vendorDir, "kickside", "uploads-v1.0.0.wapp"), []wapp.Entry{
+	uploadsWapp := filepath.Join(vendorDir, "kickside", "uploads-v1.0.0.wapp")
+	writeWapp(t, uploadsWapp, []wapp.Entry{
 		{
 			ID:   wapp.NewID("wippy.session", "dep.wippy.llm"),
 			Kind: regapi.NamespaceDependency,
@@ -1557,14 +1580,24 @@ func TestDependencyHandler_Expand_InfersPackedEntryModuleOwnershipFromResolvedGr
 			},
 		},
 	})
-	writeWapp(t, filepath.Join(vendorDir, "kickside", "sessions-v1.0.0.wapp"), []wapp.Entry{
+	sessionsWapp := filepath.Join(vendorDir, "kickside", "sessions-v1.0.0.wapp")
+	writeWapp(t, sessionsWapp, []wapp.Entry{
 		{ID: wapp.NewID("kickside.sessions", "component"), Kind: "registry.entry", Data: map[string]any{}},
 	})
+	uploadsDigest, err := sha256FileHex(uploadsWapp)
+	require.NoError(t, err)
+	sessionsDigest, err := sha256FileHex(sessionsWapp)
+	require.NoError(t, err)
+	digests := map[string]string{
+		"kickside/uploads":  "sha256:" + uploadsDigest,
+		"kickside/sessions": "sha256:" + sessionsDigest,
+		"wippy/session":     "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	}
 
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
 			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
-				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+				return &ModuleManifest{Org: org, Name: module, Version: version, Digest: digests[org+"/"+module]}, nil
 			},
 		},
 		Logger:    zap.NewNop(),
@@ -1578,6 +1611,7 @@ func TestDependencyHandler_Expand_InfersPackedEntryModuleOwnershipFromResolvedGr
 		Meta: attrs.NewBagFrom(map[string]any{
 			metaModuleKey:        "wippy/session",
 			metaModuleVersionKey: "v1.0.0",
+			metaModuleDigestKey:  digests["wippy/session"],
 		}),
 		Data: payload.NewPayload(`{"component":"wippy/llm","version":"v1.0.0"}`, payload.JSON),
 	}
@@ -1849,6 +1883,13 @@ func TestDependencyHandler_Expand_FailsBeforeRegistryApplyWhenRequirementTargetI
 	ctx := newTestContext()
 	tmpDir := t.TempDir()
 	vendorDir := filepath.Join(tmpDir, "vendor")
+	lockPath := filepath.Join(tmpDir, lock.DefaultFilename)
+	lockObj, err := lock.New(lockPath)
+	require.NoError(t, err)
+	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "."})
+	lockObj.SetOptions(lock.Options{UnpackModules: true})
+	lockObj.SetModule(lock.Module{Name: "butschster/telegram", Version: "0.3.0"})
+	require.NoError(t, lockObj.Write())
 
 	writeWapp(t, filepath.Join(vendorDir, "butschster", "telegram-0.3.0.wapp"), []wapp.Entry{
 		{
@@ -1879,6 +1920,7 @@ func TestDependencyHandler_Expand_FailsBeforeRegistryApplyWhenRequirementTargetI
 			},
 		},
 		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
 		VendorDir: vendorDir,
 	})
 	require.NoError(t, err)
@@ -1898,6 +1940,9 @@ func TestDependencyHandler_Expand_FailsBeforeRegistryApplyWhenRequirementTargetI
 	require.ErrorContains(t, err, "telegram.handler:webhook_endpoint")
 	assert.False(t, result.Applied)
 	assert.Empty(t, result.Additional)
+	staging, globErr := filepath.Glob(filepath.Join(vendorDir, "butschster", ".telegram.stage-*"))
+	require.NoError(t, globErr)
+	assert.Empty(t, staging, "planning errors must remove private extracted trees")
 }
 
 func TestDependencyHandler_Expand_DoesNotFailOnUnrelatedSnapshotRequirement(t *testing.T) {
@@ -1965,7 +2010,8 @@ func TestDependencyHandler_Expand_DoesNotReValidateUntouchedInstalledModule(t *t
 	vendorDir := filepath.Join(tmpDir, "vendor")
 
 	// Newly installed module (the op); no requirements.
-	writeWapp(t, filepath.Join(vendorDir, "acme", "fresh-v1.0.0.wapp"), []wapp.Entry{
+	freshWapp := filepath.Join(vendorDir, "acme", "fresh-v1.0.0.wapp")
+	writeWapp(t, freshWapp, []wapp.Entry{
 		{
 			ID:   wapp.NewID("acme.fresh", "service"),
 			Kind: "process.lua",
@@ -1973,7 +2019,8 @@ func TestDependencyHandler_Expand_DoesNotReValidateUntouchedInstalledModule(t *t
 		},
 	})
 	// Already installed sibling module with an unprovided, no-default requirement.
-	writeWapp(t, filepath.Join(vendorDir, "acme", "legacy-v1.0.0.wapp"), []wapp.Entry{
+	legacyWapp := filepath.Join(vendorDir, "acme", "legacy-v1.0.0.wapp")
+	writeWapp(t, legacyWapp, []wapp.Entry{
 		{
 			ID:   wapp.NewID("acme.legacy", "needs_value"),
 			Kind: regapi.NamespaceRequirement,
@@ -1989,11 +2036,19 @@ func TestDependencyHandler_Expand_DoesNotReValidateUntouchedInstalledModule(t *t
 			Data: map[string]any{},
 		},
 	})
+	freshDigest, err := sha256FileHex(freshWapp)
+	require.NoError(t, err)
+	legacyDigest, err := sha256FileHex(legacyWapp)
+	require.NoError(t, err)
+	digests := map[string]string{
+		"fresh":  "sha256:" + freshDigest,
+		"legacy": "sha256:" + legacyDigest,
+	}
 
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
 			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
-				return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+				return &ModuleManifest{Org: org, Name: module, Version: version, Digest: digests[module]}, nil
 			},
 		},
 		Logger:    zap.NewNop(),
@@ -2008,11 +2063,11 @@ func TestDependencyHandler_Expand_DoesNotReValidateUntouchedInstalledModule(t *t
 			Data: payload.NewPayload(`{"component":"acme/legacy","version":"v1.0.0"}`, payload.JSON),
 		},
 		// Module-owned entry stamping legacy's installed version into the snapshot.
-		markModuleMeta(regapi.Entry{
+		markModuleIdentity(regapi.Entry{
 			ID:   regapi.NewID("acme.legacy", "target"),
 			Kind: "process.lua",
 			Data: payload.NewPayload(`{}`, payload.JSON),
-		}, "acme/legacy", "v1.0.0"),
+		}, "acme/legacy", "v1.0.0", digests["legacy"]),
 	}
 
 	rootDep := regapi.Entry{

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -98,6 +98,84 @@ func TestDependencyHandler_ResolveErrors(t *testing.T) {
 	}
 }
 
+func TestDependencyHandler_UnchangedLoadedRootIsIdempotent(t *testing.T) {
+	ctx := newTestContext()
+	manifestCalls := 0
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(context.Context, string, string, string) (*ModuleManifest, error) {
+				manifestCalls++
+				return nil, assert.AnError
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  filepath.Join(t.TempDir(), "wippy.lock"),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	depEntry := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "http"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/http","version":">=v1.0.0 <v2.0.0"}`, payload.JSON),
+	}
+	moduleEntry := regapi.Entry{
+		ID:   regapi.NewID("acme.http", "service"),
+		Kind: "service",
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        "acme/http",
+			metaModuleVersionKey: "v1.4.2",
+		}),
+	}
+
+	result, err := handler.Expand(ctx, regapi.Operation{
+		Kind: regapi.EntryUpdate, Entry: depEntry,
+	}, regapi.State{depEntry, moduleEntry})
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	require.Empty(t, result.Additional)
+	require.Empty(t, result.Effects)
+	require.Zero(t, manifestCalls, "a compatible module already assembled at boot must not be resolved again")
+}
+
+func TestDependencyHandler_UnchangedRootWithIncompatibleLoadedVersionResolves(t *testing.T) {
+	ctx := newTestContext()
+	manifestCalls := 0
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getManifest: func(context.Context, string, string, string) (*ModuleManifest, error) {
+				manifestCalls++
+				return nil, assert.AnError
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  filepath.Join(t.TempDir(), "wippy.lock"),
+		VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	depEntry := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "http"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.NewPayload(`{"component":"acme/http","version":"v2.0.0"}`, payload.JSON),
+	}
+	moduleEntry := regapi.Entry{
+		ID:   regapi.NewID("acme.http", "service"),
+		Kind: "service",
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        "acme/http",
+			metaModuleVersionKey: "v1.4.2",
+		}),
+	}
+
+	_, err = handler.Expand(ctx, regapi.Operation{
+		Kind: regapi.EntryUpdate, Entry: depEntry,
+	}, regapi.State{depEntry, moduleEntry})
+	require.Error(t, err)
+	require.ErrorContains(t, err, assert.AnError.Error())
+	require.Equal(t, 1, manifestCalls, "an incompatible loaded version must be resolved instead of accepted")
+}
+
 func TestDependencyHandler_EntryConflict(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -2435,6 +2435,24 @@ modules:
 	assert.Equal(t, "2.0.0", modules[0].Version)
 }
 
+func TestDependencyInputDigestCoversSolverInputsNotLinkParameters(t *testing.T) {
+	root := desiredDependency{
+		entry: regapi.Entry{ID: regapi.NewID("app.deps", "agent")},
+		definition: DependencyDefinition{
+			Component:  "wippy/agent",
+			Version:    "^0.4.0",
+			Parameters: []Parameter{{Name: "target", Value: regapi.NewID("app", "processes")}},
+		},
+	}
+	changedParameters := root
+	changedParameters.definition.Parameters = []Parameter{{Name: "target", Value: "app:processes"}}
+	changedRange := root
+	changedRange.definition.Version = "^0.5.0"
+
+	require.Equal(t, dependencyInputDigest([]desiredDependency{root}), dependencyInputDigest([]desiredDependency{changedParameters}))
+	require.NotEqual(t, dependencyInputDigest([]desiredDependency{root}), dependencyInputDigest([]desiredDependency{changedRange}))
+}
+
 func TestDependencyHandler_ExpandUpdateRootDependencyReplacesSameIDModuleEntries(t *testing.T) {
 	ctx := newTestContext()
 	vendorDir := t.TempDir()

--- a/boot/deps/hub/download.go
+++ b/boot/deps/hub/download.go
@@ -161,24 +161,35 @@ func (c *Client) downloadToFileOnce(ctx context.Context, url, destPath string) e
 		}
 	}
 
-	f, err := os.Create(destPath)
+	f, err := os.CreateTemp(filepath.Dir(destPath), filepath.Base(destPath)+".part-*")
 	if err != nil {
-		return fmt.Errorf("create file: %w", err)
+		return fmt.Errorf("create temp file: %w", err)
 	}
+	tmpPath := f.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
 		f.Close()
-		os.Remove(destPath)
 		return fmt.Errorf("write file: %w", err)
 	}
 
 	if err := f.Sync(); err != nil {
 		f.Close()
-		os.Remove(destPath)
 		return fmt.Errorf("sync file: %w", err)
 	}
-
-	return f.Close()
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close file: %w", err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return fmt.Errorf("activate downloaded file: %w", err)
+	}
+	committed = true
+	return syncDirectory(filepath.Dir(destPath))
 }
 
 type downloadRequestError struct {

--- a/boot/deps/hub/download_test.go
+++ b/boot/deps/hub/download_test.go
@@ -32,6 +32,8 @@ func TestDownloadToFileRetriesTransientStatus(t *testing.T) {
 	}
 
 	dest := filepath.Join(t.TempDir(), "cache", "module.wapp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o600))
 	err := client.DownloadToFile(context.Background(), server.URL, dest)
 	require.NoError(t, err)
 	require.Equal(t, 3, attempts)
@@ -55,8 +57,13 @@ func TestDownloadToFileDoesNotRetryForbidden(t *testing.T) {
 	}
 
 	dest := filepath.Join(t.TempDir(), "cache", "module.wapp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o600))
 	err := client.DownloadToFile(context.Background(), server.URL, dest)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status 403")
 	require.Equal(t, 1, attempts)
+	data, readErr := os.ReadFile(dest)
+	require.NoError(t, readErr)
+	require.Equal(t, "existing", string(data))
 }

--- a/boot/deps/hub/embed_effect.go
+++ b/boot/deps/hub/embed_effect.go
@@ -4,8 +4,11 @@ package hub
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/wippyai/runtime/api/attrs"
 	apierror "github.com/wippyai/runtime/api/error"
@@ -32,7 +35,7 @@ type stagedPack struct {
 	version  string
 }
 
-// obsoletePack identifies a module pack to unregister (and close) on Commit
+// obsoletePack identifies a module pack to unregister (and close) on Finalize
 // because the module was removed or replaced by a newer version.
 type obsoletePack struct {
 	module  string
@@ -97,22 +100,24 @@ func (e *embedPackEffect) Commit(_ context.Context) error {
 }
 
 func (e *embedPackEffect) Finalize(_ context.Context) error {
+	var errs []error
 	for _, op := range e.obsolete {
 		if err := e.reg.UnregisterModule(op.module, op.version); err != nil {
-			// Logged, not fatal: the changeset already committed and the old
-			// pack is no longer referenced by any live entry. Failing here
-			// would only leak a file handle for the rest of the process life.
+			// The changeset is already durable, so callers only report this as a
+			// cleanup warning. Return it for observability instead of pretending
+			// the obsolete handle was released.
 			e.logger.Warn("failed to unregister obsolete embedded pack",
 				zap.String("module", op.module),
 				zap.String("version", op.version),
 				zap.Error(err))
+			errs = append(errs, fmt.Errorf("unregister embedded pack %s@%s: %w", op.module, op.version, err))
 			continue
 		}
 		e.logger.Debug("released obsolete embedded pack",
 			zap.String("module", op.module),
 			zap.String("version", op.version))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *embedPackEffect) Rollback(_ context.Context) error {
@@ -153,11 +158,29 @@ func (h *DependencyHandler) buildEmbedPackEffect(
 
 	desired := make(map[string]string, len(resolved))
 	installed := snapshotModuleVersions(snapshot)
+	installedDigests := snapshotModuleDigests(snapshot)
 	staged := make([]stagedPack, 0, len(resolved))
 	for _, mod := range resolved {
 		name := mod.Org + "/" + mod.Name
+		if h.moduleUsesDirectoryMode(name) {
+			continue
+		}
 
-		if installed[name] == mod.Version && reg.HasModulePack(name, mod.Version) && !h.moduleUsesDirectoryMode(name) {
+		if installed[name] == mod.Version && reg.HasModulePack(name, mod.Version) {
+			// The embed registry addresses packs by module and version. Replacing a
+			// pack with different bytes at the same identity would close the old
+			// handle during Prepare, so Rollback could not restore it. Fail closed
+			// when both generations have durable identities; legacy snapshots that
+			// predate module digests retain the existing behavior.
+			if installedDigest := installedDigests[name]; installedDigest != "" && mod.Digest != "" &&
+				!strings.EqualFold(installedDigest, mod.Digest) {
+				return nil, NewDependencyIntegrityError(
+					modKey(mod),
+					errors.New("cannot replace an active embedded pack at the same module version"),
+					mod.Digest,
+					mod.SizeBytes,
+				)
+			}
 			desired[name] = mod.Version
 			continue
 		}
@@ -223,6 +246,9 @@ func obsoletePacksFor(snapshot regapi.State, desired map[string]string, controll
 // and whether that path is a .wapp pack. Replacement (local source) and
 // unpacked modules are directories and are reported as non-pack.
 func (h *DependencyHandler) modulePackPath(ctx context.Context, mod ResolvedModule) (string, bool, error) {
+	if h.moduleUsesDirectoryMode(mod.Org + "/" + mod.Name) {
+		return "", false, nil
+	}
 	path, err := h.ensureModuleAvailable(ctx, mod)
 	if err != nil {
 		return "", false, err

--- a/boot/deps/hub/embed_effect.go
+++ b/boot/deps/hub/embed_effect.go
@@ -47,12 +47,12 @@ type obsoletePack struct {
 //     the same changeset resolve during apply. New packs are keyed by their own
 //     .wapp path, so a version update stages the new pack without disturbing the
 //     pack still serving the old version.
-//   - Commit unregisters and closes packs made obsolete by the operation
-//     (removed modules on uninstall, prior versions on update). The new packs
-//     stay registered.
+//   - Commit activates the staged set but remains reversible.
+//   - Finalize unregisters and closes obsolete packs only after the registry
+//     history/head is durable. The new packs stay registered.
 //   - Rollback unregisters and closes the packs staged in Prepare, restoring the
 //     pre-operation set. Obsolete packs are left untouched because they are only
-//     dropped on a successful Commit.
+//     dropped during Finalize after a successful durable commit.
 type embedPackEffect struct {
 	reg      embedPackRegistry
 	staged   []stagedPack
@@ -93,6 +93,10 @@ func (e *embedPackEffect) Prepare(_ context.Context) error {
 }
 
 func (e *embedPackEffect) Commit(_ context.Context) error {
+	return nil
+}
+
+func (e *embedPackEffect) Finalize(_ context.Context) error {
 	for _, op := range e.obsolete {
 		if err := e.reg.UnregisterModule(op.module, op.version); err != nil {
 			// Logged, not fatal: the changeset already committed and the old

--- a/boot/deps/hub/embed_effect.go
+++ b/boot/deps/hub/embed_effect.go
@@ -129,9 +129,10 @@ func (e *embedPackEffect) rollbackPrepared() {
 
 // buildEmbedPackEffect computes the pack-lifecycle effect for a module
 // operation. resolved are the desired modules after the operation; snapshot is
-// the registry state before it. staged packs are the resolved modules backed by
-// a .wapp on disk; obsolete packs are modules present in the snapshot whose
-// version is no longer desired (removed) or has changed (updated).
+// the registry state before it. controlled limits removals to modules owned by
+// dependency roots participating in this operation. staged packs are the
+// resolved modules backed by a .wapp on disk; obsolete packs are controlled
+// modules whose version is no longer desired (removed) or changed (updated).
 //
 // Returns nil when there is no embed registry in the context, or when neither
 // staged nor obsolete packs exist, so callers can append it unconditionally.
@@ -139,6 +140,7 @@ func (h *DependencyHandler) buildEmbedPackEffect(
 	ctx context.Context,
 	resolved []ResolvedModule,
 	snapshot regapi.State,
+	controlled map[string]struct{},
 ) (*embedPackEffect, error) {
 	reg := embedpkg.GetRegistryFromContext(ctx)
 	if reg == nil {
@@ -171,7 +173,7 @@ func (h *DependencyHandler) buildEmbedPackEffect(
 		})
 	}
 
-	obsolete := obsoletePacksFor(snapshot, desired)
+	obsolete := obsoletePacksFor(snapshot, desired, controlled)
 
 	if len(staged) == 0 && len(obsolete) == 0 {
 		return nil, nil
@@ -190,14 +192,18 @@ func (h *DependencyHandler) buildEmbedPackEffect(
 	}, nil
 }
 
-// obsoletePacksFor returns the snapshot modules whose version is not the desired
-// version (changed) or which are no longer desired at all (removed). A staged
-// pack for the new version is keyed by its own path, so unregistering the old
-// version by (module, version) never affects the new pack.
-func obsoletePacksFor(snapshot regapi.State, desired map[string]string) []obsoletePack {
+// obsoletePacksFor returns controlled snapshot modules whose version is not the
+// desired version (changed) or which are no longer desired at all (removed).
+// Packs outside controlled are unrelated to this dependency operation and must
+// remain live. A staged pack for the new version is keyed by its own path, so
+// unregistering the old version never affects the new pack.
+func obsoletePacksFor(snapshot regapi.State, desired map[string]string, controlled map[string]struct{}) []obsoletePack {
 	current := snapshotModuleVersions(snapshot)
 	obsolete := make([]obsoletePack, 0)
 	for module, version := range current {
+		if _, ok := controlled[module]; !ok {
+			continue
+		}
 		if version == "" {
 			continue
 		}

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -131,6 +131,7 @@ func TestEmbedPackEffect_PrepareCommit(t *testing.T) {
 	require.Len(t, eff.prepared, 1)
 
 	require.NoError(t, eff.Commit(context.Background()))
+	require.NoError(t, eff.Finalize(context.Background()))
 	// Commit must not unregister the staged pack on a fresh install.
 	assert.Empty(t, reg.unregistered)
 	assert.Empty(t, reg.modulesDropped)
@@ -168,7 +169,8 @@ func TestEmbedPackEffect_Update(t *testing.T) {
 	assert.Contains(t, reg.registered, newPack)
 
 	require.NoError(t, eff.Commit(context.Background()))
-	// Old version dropped on commit; new pack remains registered.
+	require.NoError(t, eff.Finalize(context.Background()))
+	// Old version is dropped only after durable finalization; new pack remains registered.
 	require.Len(t, reg.modulesDropped, 1)
 	assert.Equal(t, droppedModule{module: "org/mod", version: "1.0.0"}, reg.modulesDropped[0])
 	assert.Contains(t, reg.registered, newPack)
@@ -186,9 +188,11 @@ func TestEmbedPackEffect_UpdateRollbackKeepsOld(t *testing.T) {
 	)
 
 	require.NoError(t, eff.Prepare(context.Background()))
+	require.NoError(t, eff.Commit(context.Background()))
 	require.NoError(t, eff.Rollback(context.Background()))
 
-	// New pack removed; old version never dropped because Commit did not run.
+	// Commit remains reversible: the new pack is removed and the old version is
+	// not dropped until the separate durable Finalize phase.
 	assert.Contains(t, reg.unregistered, newPack)
 	assert.Empty(t, reg.modulesDropped)
 }
@@ -201,6 +205,7 @@ func TestEmbedPackEffect_Uninstall(t *testing.T) {
 	assert.Empty(t, reg.registered)
 
 	require.NoError(t, eff.Commit(context.Background()))
+	require.NoError(t, eff.Finalize(context.Background()))
 	require.Len(t, reg.modulesDropped, 1)
 	assert.Equal(t, droppedModule{module: "org/mod", version: "1.0.0"}, reg.modulesDropped[0])
 }
@@ -385,6 +390,7 @@ func TestBuildEmbedPackEffect_DropsPackWhenResolvedModuleIsDirectory(t *testing.
 	assert.Equal(t, []obsoletePack{{module: "org/mod", version: "1.0.0"}}, eff.obsolete)
 
 	require.NoError(t, eff.Commit(context.Background()))
+	require.NoError(t, eff.Finalize(context.Background()))
 	_, err = reg.GetFSForEntry(moduleEntry("ui", "app", "org/mod", "1.0.0"))
 	require.Error(t, err)
 }
@@ -432,6 +438,7 @@ func TestBuildEmbedPackEffect_DropsPackWhenUnpackModulesEnabled(t *testing.T) {
 	assert.Equal(t, []obsoletePack{{module: "org/mod", version: "1.0.0"}}, eff.obsolete)
 
 	require.NoError(t, eff.Commit(context.Background()))
+	require.NoError(t, eff.Finalize(context.Background()))
 	_, err = reg.GetFSForEntry(moduleEntry("ui", "app", "org/mod", "1.0.0"))
 	require.Error(t, err)
 }
@@ -491,6 +498,9 @@ func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
 	assert.Equal(t, "stable", readHubResource(t, reg, moduleEntry("ui", "stable", "org/stable", "1.0.0"), "v.txt"))
 
 	require.NoError(t, eff.Commit(context.Background()))
+	// Commit is still reversible; obsolete packs remain until history/head is durable.
+	assert.Equal(t, "1", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "1.0.0"), "v.txt"))
+	require.NoError(t, eff.Finalize(context.Background()))
 	assert.Equal(t, "2", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "2.0.0"), "v.txt"))
 	assert.Equal(t, "stable", readHubResource(t, reg, moduleEntry("ui", "stable", "org/stable", "1.0.0"), "v.txt"))
 	_, err = reg.GetFS(regapi.NewID("ui", "removed"))

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
+	"github.com/wippyai/runtime/boot/deps/graph"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	embedpkg "github.com/wippyai/runtime/service/fs/embed"
 	yamlpayload "github.com/wippyai/runtime/system/payload/yaml"
@@ -322,6 +323,41 @@ func TestBuildEmbedPackEffect_SkipsUnchangedResolvedPack(t *testing.T) {
 	assert.Nil(t, eff)
 }
 
+func TestBuildEmbedPackEffect_RejectsSameVersionDifferentDigest(t *testing.T) {
+	reg := embedpkg.NewRegistry()
+	defer func() { require.NoError(t, reg.Close()) }()
+	ctx := embedapi.WithRegistry(newTestContext(), reg)
+	vendorDir := t.TempDir()
+	packPath := filepath.Join(vendorDir, "org", "mod-1.0.0.wapp")
+	writeResourceWapp(t, packPath, "ui", "app", map[string]string{"v.txt": "old"})
+	require.NoError(t, reg.RegisterPack(packPath, "org/mod", "1.0.0",
+		createHubResourceReader(t, "ui", "app", map[string]string{"v.txt": "old"}), nil))
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+				t.Fatal("unsafe same-version replacement must fail before materialization")
+				return nil, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	const oldDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	const newDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	snapshotEntry := markModuleIdentity(moduleEntry("ui", "app", "org/mod", "1.0.0"), "org/mod", "1.0.0", oldDigest)
+	resolved := []ResolvedModule{{
+		Org: "org", Name: "mod", Version: "1.0.0", Source: moduleSourceHub, Digest: newDigest,
+	}}
+
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, regapi.State{snapshotEntry}, map[string]struct{}{"org/mod": {}})
+	require.Error(t, err)
+	assert.Nil(t, eff)
+	assert.Equal(t, "old", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "1.0.0"), "v.txt"))
+}
+
 func TestBuildEmbedPackEffect_StagesUnchangedPackWhenRegistryMissing(t *testing.T) {
 	reg := embedpkg.NewRegistry()
 	defer func() { require.NoError(t, reg.Close()) }()
@@ -329,6 +365,11 @@ func TestBuildEmbedPackEffect_StagesUnchangedPackWhenRegistryMissing(t *testing.
 	vendorDir := t.TempDir()
 	packPath := filepath.Join(vendorDir, "org", "mod-1.0.0.wapp")
 	writeResourceWapp(t, packPath, "ui", "app", map[string]string{"v.txt": "1"})
+	digest, _, err := artifactIdentityFromPath(packPath)
+	require.NoError(t, err)
+	immutableRelative, err := immutableWappRelativePath(graph.MustParseName("org/mod"), "1.0.0", digest)
+	require.NoError(t, err)
+	immutablePackPath := filepath.Join(vendorDir, immutableRelative)
 
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
@@ -348,7 +389,7 @@ func TestBuildEmbedPackEffect_StagesUnchangedPackWhenRegistryMissing(t *testing.
 	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{"org/mod": {}})
 	require.NoError(t, err)
 	require.NotNil(t, eff)
-	assert.Equal(t, []stagedPack{{packPath: packPath, module: "org/mod", version: "1.0.0"}}, eff.staged)
+	assert.Equal(t, []stagedPack{{packPath: immutablePackPath, module: "org/mod", version: "1.0.0"}}, eff.staged)
 	assert.Empty(t, eff.obsolete)
 }
 
@@ -404,6 +445,8 @@ func TestBuildEmbedPackEffect_DropsPackWhenUnpackModulesEnabled(t *testing.T) {
 	lockPath := filepath.Join(projectDir, lock.DefaultFilename)
 	dirPath := filepath.Join(vendorDir, "org", "mod")
 	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	digest := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	require.NoError(t, writeExtractedModuleMeta(dirPath, digest, 0))
 
 	lockObj, err := lock.New(lockPath)
 	require.NoError(t, err)
@@ -428,7 +471,7 @@ func TestBuildEmbedPackEffect_DropsPackWhenUnpackModulesEnabled(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0"}}
+	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0", Source: moduleSourceHub, Digest: digest}}
 	snapshot := regapi.State{moduleEntry("ui", "app", "org/mod", "1.0.0")}
 
 	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{"org/mod": {}})
@@ -458,6 +501,11 @@ func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
 
 	newPack := filepath.Join(vendorDir, "org", "mod-2.0.0.wapp")
 	writeResourceWapp(t, newPack, "ui", "app", map[string]string{"v.txt": "2"})
+	newDigest, _, err := artifactIdentityFromPath(newPack)
+	require.NoError(t, err)
+	newImmutableRelative, err := immutableWappRelativePath(graph.MustParseName("org/mod"), "2.0.0", newDigest)
+	require.NoError(t, err)
+	newImmutablePack := filepath.Join(vendorDir, newImmutableRelative)
 
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
@@ -486,7 +534,7 @@ func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, eff)
-	assert.Equal(t, []stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}}, eff.staged)
+	assert.Equal(t, []stagedPack{{packPath: newImmutablePack, module: "org/mod", version: "2.0.0"}}, eff.staged)
 	assert.ElementsMatch(t, []obsoletePack{
 		{module: "org/mod", version: "1.0.0"},
 		{module: "org/removed", version: "3.0.0"},
@@ -574,7 +622,7 @@ func TestEmbedPackEffect_UpdateRollbackKeepsLiveOldVersion(t *testing.T) {
 	assert.Equal(t, "1", readHubResource(t, reg, moduleEntry("ui", "app", "org/mod", "1.0.0"), "v.txt"))
 }
 
-func TestEnsureModuleAvailable_UnpackModulesExtractsCachedWapp(t *testing.T) {
+func TestMaterializeModuleForLoad_StagesCachedWappUntilPrepare(t *testing.T) {
 	projectDir := t.TempDir()
 	vendorDir := filepath.Join(projectDir, ".wippy", "vendor")
 	lockPath := filepath.Join(projectDir, lock.DefaultFilename)
@@ -603,23 +651,33 @@ func TestEnsureModuleAvailable_UnpackModulesExtractsCachedWapp(t *testing.T) {
 		VendorDir: vendorDir,
 	})
 	require.NoError(t, err)
+	digest, size, err := artifactIdentityFromPath(packPath)
+	require.NoError(t, err)
 
-	gotPath, err := handler.ensureModuleAvailable(
+	gotPath, staged, err := handler.materializeModuleForLoad(
 		context.Background(),
-		ResolvedModule{Org: "org", Name: "mod", Version: "1.0.0"},
+		ResolvedModule{Org: "org", Name: "mod", Version: "1.0.0", Digest: digest, SizeBytes: size},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, dirPath, gotPath)
-	assert.NoFileExists(t, packPath)
+	require.NotNil(t, staged)
+	assert.Equal(t, staged.stagingDir, gotPath)
+	assert.FileExists(t, packPath)
+	assert.FileExists(t, filepath.Join(dirPath, "stale.txt"), "planning must leave the active tree untouched")
+	assert.FileExists(t, filepath.Join(gotPath, "app", "asset.txt"))
+
+	effect := &moduleFilesystemEffect{staged: []stagedModuleDirectory{*staged}}
+	require.NoError(t, effect.Prepare(context.Background()))
 	assert.NoFileExists(t, filepath.Join(dirPath, "stale.txt"))
 	assert.FileExists(t, filepath.Join(dirPath, "app", "asset.txt"))
+	require.NoError(t, effect.Commit(context.Background()))
+	require.NoError(t, effect.Finalize(context.Background()))
 
 	indexData, err := os.ReadFile(filepath.Join(dirPath, "_index.yaml"))
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(string(indexData), "kind: fs.directory"), string(indexData))
 }
 
-func TestEnsureModuleAvailable_UnpackModulesDownloadsWhenDirectoryVersionStale(t *testing.T) {
+func TestMaterializeModuleForLoad_DownloadsPrivatelyUntilPrepare(t *testing.T) {
 	projectDir := t.TempDir()
 	vendorDir := filepath.Join(projectDir, ".wippy", "vendor")
 	lockPath := filepath.Join(projectDir, lock.DefaultFilename)
@@ -634,6 +692,12 @@ func TestEnsureModuleAvailable_UnpackModulesDownloadsWhenDirectoryVersionStale(t
 	lockObj.SetModule(lock.Module{Name: "org/mod", Version: "1.0.0"})
 	require.NoError(t, lockObj.Write())
 
+	sourcePack := filepath.Join(t.TempDir(), "mod-2.0.0.wapp")
+	writeEmbeddedFSWapp(t, sourcePack, "ui", "app", map[string]string{"asset.txt": "new"})
+	downloadBytes, err := os.ReadFile(sourcePack)
+	require.NoError(t, err)
+	digest, size, err := artifactIdentityFromPath(sourcePack)
+	require.NoError(t, err)
 	downloaded := false
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
@@ -642,8 +706,10 @@ func TestEnsureModuleAvailable_UnpackModulesDownloadsWhenDirectoryVersionStale(t
 			},
 			downloadFile: func(_ context.Context, _ string, destPath string) error {
 				downloaded = true
-				writeEmbeddedFSWapp(t, destPath, "ui", "app", map[string]string{"asset.txt": "new"})
-				return nil
+				if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(destPath, downloadBytes, 0600)
 			},
 		},
 		Logger:    zap.NewNop(),
@@ -652,42 +718,27 @@ func TestEnsureModuleAvailable_UnpackModulesDownloadsWhenDirectoryVersionStale(t
 	})
 	require.NoError(t, err)
 
-	gotPath, err := handler.ensureModuleAvailable(
+	gotPath, staged, err := handler.materializeModuleForLoad(
 		context.Background(),
-		ResolvedModule{Org: "org", Name: "mod", Version: "2.0.0"},
+		ResolvedModule{Org: "org", Name: "mod", Version: "2.0.0", Digest: digest, SizeBytes: size},
 	)
 	require.NoError(t, err)
 	assert.True(t, downloaded)
-	assert.Equal(t, dirPath, gotPath)
+	require.NotNil(t, staged)
+	assert.Equal(t, staged.stagingDir, gotPath)
+	assert.FileExists(t, filepath.Join(dirPath, "stale.txt"), "planning must leave the active tree untouched")
+	assert.FileExists(t, filepath.Join(gotPath, "app", "asset.txt"))
+	assert.NoFileExists(t, filepath.Join(vendorDir, "org", "mod-2.0.0.wapp"))
+
+	effect := &moduleFilesystemEffect{staged: []stagedModuleDirectory{*staged}}
+	require.NoError(t, effect.Prepare(context.Background()))
 	assert.NoFileExists(t, filepath.Join(dirPath, "stale.txt"))
 	assert.FileExists(t, filepath.Join(dirPath, "app", "asset.txt"))
-	assert.NoFileExists(t, filepath.Join(vendorDir, "org", "mod-2.0.0.wapp"))
+	require.NoError(t, effect.Rollback(context.Background()))
+	assert.FileExists(t, filepath.Join(dirPath, "stale.txt"), "history failure must restore the old tree")
 }
 
-func TestExtractWappModule_FailurePreservesExistingDirectory(t *testing.T) {
-	projectDir := t.TempDir()
-	vendorDir := filepath.Join(projectDir, ".wippy", "vendor")
-	wappPath := filepath.Join(vendorDir, "org", "mod-2.0.0.wapp")
-	dirPath := filepath.Join(vendorDir, "org", "mod")
-	require.NoError(t, os.MkdirAll(filepath.Dir(wappPath), 0755))
-	require.NoError(t, os.MkdirAll(dirPath, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dirPath, "live.txt"), []byte("old"), 0644))
-	require.NoError(t, os.WriteFile(wappPath, []byte("not a wapp"), 0644))
-
-	handler, err := NewDependencyHandler(DependencyHandlerOptions{
-		Hub:       &fakeHub{},
-		Logger:    zap.NewNop(),
-		VendorDir: vendorDir,
-	})
-	require.NoError(t, err)
-
-	err = handler.extractWappModule(wappPath, dirPath, "", 0)
-	require.Error(t, err)
-	assert.FileExists(t, filepath.Join(dirPath, "live.txt"))
-	assert.FileExists(t, wappPath)
-}
-
-func TestLoadEntriesForModule_UnpackModulesRegistersRuntimeSourceRoot(t *testing.T) {
+func TestSourceRootEffect_UnpackedModulePrepareAndRollback(t *testing.T) {
 	projectDir := t.TempDir()
 	vendorDir := filepath.Join(projectDir, ".wippy", "vendor")
 	lockPath := filepath.Join(projectDir, lock.DefaultFilename)
@@ -723,20 +774,58 @@ func TestLoadEntriesForModule_UnpackModulesRegistersRuntimeSourceRoot(t *testing
 	ac := ctxapi.AppFromContext(ctx)
 	require.NotNil(t, ac)
 	ac.Seal()
+	moduleapi.WithSourceRoots(ctx, moduleapi.SourceRoots{
+		"org/removed":   "/old/removed",
+		"org/unrelated": "/old/unrelated",
+	})
 
+	resolved := ResolvedModule{Org: "org", Name: "mod", Version: "1.0.0"}
 	entries, err := handler.loadEntriesForModule(
 		ctx,
 		transcoder,
-		ResolvedModule{Org: "org", Name: "mod", Version: "1.0.0"},
+		resolved,
 	)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	assert.Equal(t, regapi.NewID("ui", "app"), entries[0].ID)
 	assert.Equal(t, regapi.Kind("fs.directory"), entries[0].Kind)
+	_, ok = moduleapi.SourceRoot(ctx, "org/mod")
+	require.False(t, ok, "planning must not publish a source root before effect preparation")
+
+	effect, err := handler.buildSourceRootEffect(
+		[]ResolvedModule{resolved},
+		map[string]struct{}{"org/mod": {}, "org/removed": {}},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, effect)
+	require.NoError(t, effect.Prepare(ctx))
 
 	root, ok := moduleapi.SourceRoot(ctx, "org/mod")
 	require.True(t, ok)
 	assert.Equal(t, dirPath, root)
+	_, ok = moduleapi.SourceRoot(ctx, "org/removed")
+	require.False(t, ok)
+	root, ok = moduleapi.SourceRoot(ctx, "org/unrelated")
+	require.True(t, ok)
+	assert.Equal(t, "/old/unrelated", root)
+
+	require.NoError(t, effect.Commit(ctx))
+	require.NoError(t, effect.Rollback(ctx))
+	_, ok = moduleapi.SourceRoot(ctx, "org/mod")
+	require.False(t, ok)
+	root, ok = moduleapi.SourceRoot(ctx, "org/removed")
+	require.True(t, ok)
+	assert.Equal(t, "/old/removed", root)
+	root, ok = moduleapi.SourceRoot(ctx, "org/unrelated")
+	require.True(t, ok)
+	assert.Equal(t, "/old/unrelated", root)
+
+	// Lifecycle cleanup is idempotent; a duplicate rollback must not remove the
+	// restored roots.
+	require.NoError(t, effect.Rollback(ctx))
+	root, ok = moduleapi.SourceRoot(ctx, "org/removed")
+	require.True(t, ok)
+	assert.Equal(t, "/old/removed", root)
 }
 
 func moduleEntry(ns, name, module, version string) regapi.Entry {

--- a/boot/deps/hub/embed_effect_test.go
+++ b/boot/deps/hub/embed_effect_test.go
@@ -243,22 +243,33 @@ func TestObsoletePacksFor(t *testing.T) {
 
 	t.Run("update marks changed version obsolete", func(t *testing.T) {
 		desired := map[string]string{"org/mod": "2.0.0", "org/other": "3.0.0"}
-		obs := obsoletePacksFor(snapshot, desired)
+		controlled := map[string]struct{}{"org/mod": {}, "org/other": {}}
+		obs := obsoletePacksFor(snapshot, desired, controlled)
 		require.Len(t, obs, 1)
 		assert.Equal(t, obsoletePack{module: "org/mod", version: "1.0.0"}, obs[0])
 	})
 
 	t.Run("removal marks dropped module obsolete", func(t *testing.T) {
 		desired := map[string]string{"org/other": "3.0.0"}
-		obs := obsoletePacksFor(snapshot, desired)
+		controlled := map[string]struct{}{"org/mod": {}, "org/other": {}}
+		obs := obsoletePacksFor(snapshot, desired, controlled)
 		require.Len(t, obs, 1)
 		assert.Equal(t, obsoletePack{module: "org/mod", version: "1.0.0"}, obs[0])
 	})
 
 	t.Run("unchanged versions are not obsolete", func(t *testing.T) {
 		desired := map[string]string{"org/mod": "1.0.0", "org/other": "3.0.0"}
-		obs := obsoletePacksFor(snapshot, desired)
+		controlled := map[string]struct{}{"org/mod": {}, "org/other": {}}
+		obs := obsoletePacksFor(snapshot, desired, controlled)
 		assert.Empty(t, obs)
+	})
+
+	t.Run("unrelated modules remain live", func(t *testing.T) {
+		desired := map[string]string{"org/mod": "2.0.0"}
+		controlled := map[string]struct{}{"org/mod": {}}
+		obs := obsoletePacksFor(snapshot, desired, controlled)
+		require.Len(t, obs, 1)
+		assert.Equal(t, obsoletePack{module: "org/mod", version: "1.0.0"}, obs[0])
 	})
 }
 
@@ -271,7 +282,7 @@ func TestBuildEmbedPackEffect_NoRegistry(t *testing.T) {
 	require.NoError(t, err)
 
 	// No embed registry installed in context: effect is skipped.
-	eff, err := handler.buildEmbedPackEffect(newTestContext(), nil, nil)
+	eff, err := handler.buildEmbedPackEffect(newTestContext(), nil, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, eff)
 }
@@ -301,7 +312,7 @@ func TestBuildEmbedPackEffect_SkipsUnchangedResolvedPack(t *testing.T) {
 	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0"}}
 	snapshot := regapi.State{moduleEntry("ui", "app", "org/mod", "1.0.0")}
 
-	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{"org/mod": {}})
 	require.NoError(t, err)
 	assert.Nil(t, eff)
 }
@@ -329,7 +340,7 @@ func TestBuildEmbedPackEffect_StagesUnchangedPackWhenRegistryMissing(t *testing.
 	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0"}}
 	snapshot := regapi.State{moduleEntry("ui", "app", "org/mod", "1.0.0")}
 
-	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{"org/mod": {}})
 	require.NoError(t, err)
 	require.NotNil(t, eff)
 	assert.Equal(t, []stagedPack{{packPath: packPath, module: "org/mod", version: "1.0.0"}}, eff.staged)
@@ -367,7 +378,7 @@ func TestBuildEmbedPackEffect_DropsPackWhenResolvedModuleIsDirectory(t *testing.
 	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0"}}
 	snapshot := regapi.State{moduleEntry("ui", "app", "org/mod", "1.0.0")}
 
-	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{"org/mod": {}})
 	require.NoError(t, err)
 	require.NotNil(t, eff)
 	assert.Empty(t, eff.staged)
@@ -414,7 +425,7 @@ func TestBuildEmbedPackEffect_DropsPackWhenUnpackModulesEnabled(t *testing.T) {
 	resolved := []ResolvedModule{{Org: "org", Name: "mod", Version: "1.0.0"}}
 	snapshot := regapi.State{moduleEntry("ui", "app", "org/mod", "1.0.0")}
 
-	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{"org/mod": {}})
 	require.NoError(t, err)
 	require.NotNil(t, eff)
 	assert.Empty(t, eff.staged)
@@ -463,7 +474,9 @@ func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
 		moduleEntry("ui", "removed", "org/removed", "3.0.0"),
 	}
 
-	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot)
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, map[string]struct{}{
+		"org/mod": {}, "org/stable": {}, "org/removed": {},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, eff)
 	assert.Equal(t, []stagedPack{{packPath: newPack, module: "org/mod", version: "2.0.0"}}, eff.staged)
@@ -482,6 +495,52 @@ func TestBuildEmbedPackEffect_StagesOnlyChangedPacks(t *testing.T) {
 	assert.Equal(t, "stable", readHubResource(t, reg, moduleEntry("ui", "stable", "org/stable", "1.0.0"), "v.txt"))
 	_, err = reg.GetFS(regapi.NewID("ui", "removed"))
 	require.Error(t, err)
+}
+
+func TestBuildEmbedPackEffect_InstallPreservesUnrelatedApplicationPack(t *testing.T) {
+	reg := embedpkg.NewRegistry()
+	defer func() { require.NoError(t, reg.Close()) }()
+	ctx := embedapi.WithRegistry(newTestContext(), reg)
+	vendorDir := t.TempDir()
+
+	appPack := filepath.Join(t.TempDir(), "kickside-0.1.63.wapp")
+	writeResourceWapp(t, appPack, "app", "app_fs", map[string]string{"index.js": "app"})
+	appFile, err := os.Open(appPack)
+	require.NoError(t, err)
+	appReader, err := wapp.NewReader(appFile)
+	require.NoError(t, err)
+	require.NoError(t, reg.RegisterPack(appPack, "kickside/kickside", "0.1.63", appReader, appFile))
+
+	crmPack := filepath.Join(vendorDir, "spiralscout", "crm-0.1.18.wapp")
+	writeResourceWapp(t, crmPack, "crm", "ui_fs", map[string]string{"index.js": "crm"})
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+				t.Fatal("test pack already exists in the vendor cache")
+				return nil, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	resolved := []ResolvedModule{{Org: "spiralscout", Name: "crm", Version: "0.1.18"}}
+	snapshot := regapi.State{moduleEntry("app", "app_fs", "kickside/kickside", "0.1.63")}
+	controlled := map[string]struct{}{"spiralscout/crm": {}}
+
+	eff, err := handler.buildEmbedPackEffect(ctx, resolved, snapshot, controlled)
+	require.NoError(t, err)
+	require.NotNil(t, eff)
+	assert.Empty(t, eff.obsolete)
+
+	require.NoError(t, eff.Prepare(context.Background()))
+	require.NoError(t, eff.Commit(context.Background()))
+	assert.Equal(t, "app", readHubResource(t, reg,
+		moduleEntry("app", "app_fs", "kickside/kickside", "0.1.63"), "index.js"))
+	assert.Equal(t, "crm", readHubResource(t, reg,
+		moduleEntry("crm", "ui_fs", "spiralscout/crm", "0.1.18"), "index.js"))
 }
 
 func TestEmbedPackEffect_UpdateRollbackKeepsLiveOldVersion(t *testing.T) {

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -66,14 +66,18 @@ type ModuleManifest struct {
 
 // ManifestDep represents a dependency declared by a resolved manifest.
 type ManifestDep struct {
-	Org       string
-	Name      string
-	Version   string
-	VersionID string
-	Digest    string
-	URL       string
-	SizeBytes uint64
-	Protected bool
+	Org     string
+	Name    string
+	Version string
+	// Constraint is the range the parent module declared, verbatim (e.g.
+	// ">=v0.4.10"). Version is only what the server resolved it to; resolving or
+	// locking against Version would collapse the range into a pin.
+	Constraint string
+	VersionID  string
+	Digest     string
+	URL        string
+	SizeBytes  uint64
+	Protected  bool
 }
 
 // GetManifest retrieves the manifest for a single module version. The
@@ -130,13 +134,14 @@ func (c *Client) GetManifest(ctx context.Context, org, module, constraint string
 
 	for _, dep := range m.Dependencies {
 		md := ManifestDep{
-			Org:       dep.Org,
-			Name:      dep.Name,
-			Version:   dep.Version,
-			VersionID: dep.VersionId,
-			Digest:    dep.Digest,
-			SizeBytes: dep.SizeBytes,
-			Protected: dep.Protected,
+			Org:        dep.Org,
+			Name:       dep.Name,
+			Version:    dep.Version,
+			VersionID:  dep.VersionId,
+			Digest:     dep.Digest,
+			SizeBytes:  dep.SizeBytes,
+			Protected:  dep.Protected,
+			Constraint: dep.Constraint,
 		}
 		if dep.Download != nil {
 			md.URL = dep.Download.Url

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -18,6 +18,7 @@ type ResolvedModule struct {
 	Name      string
 	Version   string
 	VersionID string
+	Source    string
 	Digest    string
 	URL       string
 	SizeBytes uint64

--- a/boot/deps/hub/manifest_cache.go
+++ b/boot/deps/hub/manifest_cache.go
@@ -4,6 +4,7 @@ package hub
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	lru "github.com/wippyai/runtime/internal/cache"
@@ -75,14 +76,16 @@ func NewManifestCacheWithOptions(provider ManifestProvider, capacity int, ttl, g
 	}
 }
 
-// GetManifest serves from the LRU when the (org, name, constraint)
-// triple is cached; otherwise it falls through to the wrapped provider
-// and stores the result. Both the constraint key and the resolved
-// version key are populated so subsequent calls with either form hit.
+// GetManifest caches exact versions. Mutable selectors (the empty selector and
+// labels such as @latest) always reach the provider; their resolved exact
+// version is cached for later immutable lookups.
 func (c *ManifestCache) GetManifest(ctx context.Context, org, module, constraint string) (*ModuleManifest, error) {
 	key := manifestCacheKey(org, module, constraint)
-	if cached, hit := c.store.Get(key); hit {
-		return cached, nil
+	mutable := constraint == "" || strings.HasPrefix(strings.TrimSpace(constraint), "@")
+	if !mutable {
+		if cached, hit := c.store.Get(key); hit {
+			return cached, nil
+		}
 	}
 
 	manifest, err := c.inner.GetManifest(ctx, org, module, constraint)
@@ -93,7 +96,9 @@ func (c *ManifestCache) GetManifest(ctx context.Context, org, module, constraint
 		return nil, nil
 	}
 
-	_ = c.store.Set(key, manifest)
+	if !mutable {
+		_ = c.store.Set(key, manifest)
+	}
 	if resolved := manifestCacheKey(org, module, manifest.Version); resolved != key {
 		_ = c.store.Set(resolved, manifest)
 	}
@@ -124,7 +129,11 @@ func (c *ManifestCache) Refresh(ctx context.Context, org, module, constraint str
 	}
 
 	key := manifestCacheKey(org, module, constraint)
-	_ = c.store.Set(key, manifest)
+	if constraint != "" && !strings.HasPrefix(strings.TrimSpace(constraint), "@") {
+		_ = c.store.Set(key, manifest)
+	} else {
+		c.store.Delete(key)
+	}
 	if resolved := manifestCacheKey(org, module, manifest.Version); resolved != key {
 		_ = c.store.Set(resolved, manifest)
 	}

--- a/boot/deps/hub/manifest_test.go
+++ b/boot/deps/hub/manifest_test.go
@@ -3,9 +3,16 @@
 package hub
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	manifestv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/manifest/v1"
+	manifestv1connect "github.com/wippyai/runtime/api/hub/wippy/api/hub/manifest/v1/manifestv1connect"
 )
 
 func TestResolutionError_String_WithConstraint(t *testing.T) {
@@ -25,4 +32,49 @@ func TestResolutionError_String_WithoutConstraint(t *testing.T) {
 		Message: "module not found",
 	}
 	assert.Equal(t, "wippyai/stdlib: module not found", e.String())
+}
+
+type constraintManifestService struct {
+	manifestv1connect.UnimplementedManifestServiceHandler
+}
+
+func (s *constraintManifestService) GetManifest(
+	_ context.Context,
+	_ *connect.Request[manifestv1.GetManifestRequest],
+) (*connect.Response[manifestv1.GetManifestResponse], error) {
+	return connect.NewResponse(&manifestv1.GetManifestResponse{
+		Manifest: &manifestv1.ModuleManifest{
+			Org:     "keeper",
+			Name:    "keeper",
+			Version: "0.5.57",
+			Dependencies: []*manifestv1.ResolvedDependency{{
+				Org:        "wippy",
+				Name:       "dataflow",
+				Version:    "0.5.2",
+				Constraint: ">=v0.4.10",
+			}},
+		},
+	}), nil
+}
+
+// The declared constraint must survive the wire: hub sends the range it was
+// published with, and the client must decode it rather than seeing only the
+// version hub resolved that range to.
+func TestGetManifest_DecodesDeclaredConstraintFromWire(t *testing.T) {
+	mux := http.NewServeMux()
+	path, handler := manifestv1connect.NewManifestServiceHandler(&constraintManifestService{})
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(Options{BaseURL: server.URL})
+	require.NoError(t, err)
+
+	manifest, err := client.GetManifest(context.Background(), "keeper", "keeper", "0.5.57")
+	require.NoError(t, err)
+	require.Len(t, manifest.Dependencies, 1)
+
+	assert.Equal(t, ">=v0.4.10", manifest.Dependencies[0].Constraint)
+	assert.Equal(t, "0.5.2", manifest.Dependencies[0].Version)
 }

--- a/boot/deps/hub/resolution_hardening_test.go
+++ b/boot/deps/hub/resolution_hardening_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+func hardeningRoot(id, component, version string) regapi.Entry {
+	return regapi.Entry{
+		ID:   regapi.ParseID(id),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.New(map[string]any{"component": component, "version": version}),
+	}
+}
+
+func hardeningModuleEntry(id, module, version string) regapi.Entry {
+	return regapi.Entry{
+		ID:   regapi.ParseID(id),
+		Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: module, metaModuleVersionKey: version}),
+		Data: payload.New(map[string]any{"module": module}),
+	}
+}
+
+func hardeningResolution(roots ...regapi.Entry) *regapi.DependencyResolution {
+	desired := make([]desiredDependency, 0, len(roots))
+	modules := make([]ResolvedModule, 0, len(roots))
+	seen := make(map[string]struct{})
+	for _, root := range roots {
+		def, _ := root.Data.Data().(map[string]any)
+		component, _ := def["component"].(string)
+		version, _ := def["version"].(string)
+		desired = append(desired, desiredDependency{entry: root, definition: DependencyDefinition{Component: component, Version: version}})
+		if _, ok := seen[component]; ok {
+			continue
+		}
+		seen[component] = struct{}{}
+		name, _ := graph.ParseName(component)
+		modules = append(modules, ResolvedModule{Org: name.Organization, Name: name.Module, Version: "v1.0.0"})
+	}
+	return dependencyResolution(desired, modules)
+}
+
+func TestDependencyHandler_ExpandChangesDeletesEarlierRootModulesAndReturnsResolution(t *testing.T) {
+	ctx := newTestContext()
+	vendorDir := t.TempDir()
+	artifact := buildWappBytes(t, []wapp.Entry{{
+		ID: wapp.NewID("acme.b", "entry"), Kind: regapi.EntryKind, Data: map[string]any{"module": "b"},
+	}})
+	manifestCalls := 0
+	hub := &fakeHub{
+		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			manifestCalls++
+			return &ModuleManifest{Org: org, Name: module, Version: "v1.0.0", URL: "memory://b"}, nil
+		},
+		downloadFile: func(_ context.Context, _ string, dest string) error {
+			require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+			return os.WriteFile(dest, artifact, 0o600)
+		},
+	}
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: hub, Logger: zap.NewNop(), VendorDir: vendorDir})
+	require.NoError(t, err)
+
+	rootA := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
+	rootB := hardeningRoot("app.deps:b", "acme/b", "v1.0.0")
+	moduleA := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
+	moduleB := hardeningModuleEntry("acme.b:entry", "acme/b", "v1.0.0")
+	result, err := handler.ExpandChanges(ctx, regapi.ChangeSet{
+		{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: rootA.ID}},
+		{Kind: regapi.EntryUpdate, Entry: rootB}, // deliberately unchanged and last
+	}, regapi.State{rootA, rootB, moduleA, moduleB})
+	require.NoError(t, err)
+	require.NotNil(t, result.Resolution, "the final no-op must not inherit the pre-batch graph")
+	require.Len(t, result.Resolution.Roots, 1)
+	require.Equal(t, rootB.ID.String(), result.Resolution.Roots[0].ID)
+	require.Equal(t, 1, manifestCalls)
+	require.Contains(t, result.Additional, regapi.ScopedOperation{
+		Operation: regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: moduleA.ID}},
+		Scope:     regapi.ScopeBaseline,
+	})
+}
+
+func TestDependencyHandler_ExpandChangesRetargetsEarlierRootWithoutLeavingOldModule(t *testing.T) {
+	ctx := newTestContext()
+	vendorDir := t.TempDir()
+	artifacts := map[string][]byte{
+		"b": buildWappBytes(t, []wapp.Entry{{ID: wapp.NewID("acme.b", "entry"), Kind: regapi.EntryKind}}),
+		"c": buildWappBytes(t, []wapp.Entry{{ID: wapp.NewID("acme.c", "entry"), Kind: regapi.EntryKind}}),
+	}
+	hub := &fakeHub{
+		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			return &ModuleManifest{Org: org, Name: module, Version: "v1.0.0", URL: "memory://" + module}, nil
+		},
+		downloadFile: func(_ context.Context, url, dest string) error {
+			require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+			return os.WriteFile(dest, artifacts[url[len("memory://"):]], 0o600)
+		},
+	}
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: hub, Logger: zap.NewNop(), VendorDir: vendorDir})
+	require.NoError(t, err)
+	rootA := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
+	rootC := hardeningRoot("app.deps:a", "acme/c", "v1.0.0")
+	rootB := hardeningRoot("app.deps:b", "acme/b", "v1.0.0")
+	moduleA := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
+	moduleB := hardeningModuleEntry("acme.b:entry", "acme/b", "v1.0.0")
+	result, err := handler.ExpandChanges(ctx, regapi.ChangeSet{
+		{Kind: regapi.EntryUpdate, Entry: rootC},
+		{Kind: regapi.EntryUpdate, Entry: rootB},
+	}, regapi.State{rootA, rootB, moduleA, moduleB})
+	require.NoError(t, err)
+	require.Equal(t, "acme/c", result.Resolution.Roots[0].Component)
+	require.Contains(t, result.Additional, regapi.ScopedOperation{
+		Operation: regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: moduleA.ID}},
+		Scope:     regapi.ScopeBaseline,
+	})
+}
+
+func TestDependencyHandler_ExpandUnchangedRootStillReturnsLegacyCheckpointGraph(t *testing.T) {
+	ctx := newTestContext()
+	root := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
+	module := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
+	artifact := buildWappBytes(t, []wapp.Entry{{ID: wapp.NewID("acme.a", "entry"), Kind: regapi.EntryKind}})
+	hub := &fakeHub{
+		getManifest: func(_ context.Context, org, name, _ string) (*ModuleManifest, error) {
+			return &ModuleManifest{Org: org, Name: name, Version: "v1.0.0", URL: "memory://a"}, nil
+		},
+		downloadFile: func(_ context.Context, _ string, dest string) error {
+			require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+			return os.WriteFile(dest, artifact, 0o600)
+		},
+	}
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: hub, Logger: zap.NewNop(), VendorDir: t.TempDir()})
+	require.NoError(t, err)
+	result, err := handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryUpdate, Entry: root}, regapi.State{root, module})
+	require.NoError(t, err)
+	require.NotNil(t, result.Resolution)
+	require.Len(t, result.Resolution.Modules, 1)
+}
+
+func TestDependencyHandler_ReconcileRejectsRootSetDriftAndDuplicates(t *testing.T) {
+	ctx := newTestContext()
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir()})
+	require.NoError(t, err)
+	rootA := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
+	rootB := hardeningRoot("app.deps:b", "acme/b", "v1.0.0")
+
+	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, hardeningResolution(rootA))
+	require.ErrorContains(t, err, "root set")
+
+	duplicate := hardeningResolution(rootA, rootB)
+	duplicate.Roots[1] = duplicate.Roots[0]
+	duplicate = duplicate.Canonical()
+	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, duplicate)
+	require.ErrorContains(t, err, "duplicate stored dependency root")
+
+	rootBDuplicateComponent := hardeningRoot("app.deps:b", "acme/a", "v1.0.0")
+	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootBDuplicateComponent}, hardeningResolution(rootA, rootBDuplicateComponent))
+	require.ErrorContains(t, err, "duplicate stored dependency component")
+}
+
+func TestDependencyHandler_ReconcileAcceptsStoredLabelSelectionOffline(t *testing.T) {
+	ctx := newTestContext()
+	root := hardeningRoot("app.deps:a", "acme/a", "@latest")
+	module := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir()})
+	require.NoError(t, err)
+	resolution := hardeningResolution(root)
+	result, err := handler.ReconcileResolution(ctx, regapi.State{root, module}, resolution)
+	require.NoError(t, err)
+	require.Equal(t, resolution.Digest, result.Resolution.Digest)
+}
+
+func TestDependencyHandler_ReconcileRejectsUnsafeStoredArtifactIdentity(t *testing.T) {
+	ctx := newTestContext()
+	root := hardeningRoot("app.deps:a", "../escape", "v1.0.0")
+	resolution := hardeningResolution(root)
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir()})
+	require.NoError(t, err)
+	_, err = handler.ReconcileResolution(ctx, regapi.State{root}, resolution)
+	require.ErrorContains(t, err, "invalid module name")
+
+	safeRoot := hardeningRoot("app.deps:safe", "acme/safe", "v1.0.0")
+	badDigest := hardeningResolution(safeRoot)
+	badDigest.Modules[0].Digest = "sha256:deadbeef"
+	badDigest = badDigest.Canonical()
+	_, err = handler.ReconcileResolution(ctx, regapi.State{safeRoot}, badDigest)
+	require.ErrorContains(t, err, "invalid sha256 digest")
+
+	require.Error(t, validateModuleArtifactIdentity(graph.Name{Organization: "acme", Module: "safe"}, "1.0.0/../../escape", ""))
+	_, err = containedPath(t.TempDir(), filepath.Join("..", "escape.wapp"))
+	require.ErrorContains(t, err, "escapes vendor")
+}
+
+func TestValidateDownloadInfoRejectsStoredIdentityDrift(t *testing.T) {
+	mod := ResolvedModule{Org: "acme", Name: "safe", Version: "v1.0.0", Digest: "sha256:" + string(make([]byte, 64)), SizeBytes: 10}
+	require.ErrorContains(t, validateDownloadInfo(mod, &DownloadInfo{Version: "v2.0.0"}), "version mismatch")
+	require.ErrorContains(t, validateDownloadInfo(mod, &DownloadInfo{Version: "v1.0.0", Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}), "digest mismatch")
+	require.ErrorContains(t, validateDownloadInfo(mod, &DownloadInfo{Version: "v1.0.0", Size: 11}), "size mismatch")
+}

--- a/boot/deps/hub/resolution_hardening_test.go
+++ b/boot/deps/hub/resolution_hardening_test.go
@@ -29,7 +29,11 @@ func hardeningModuleEntry(id, module, version string) regapi.Entry {
 	return regapi.Entry{
 		ID:   regapi.ParseID(id),
 		Kind: regapi.EntryKind,
-		Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: module, metaModuleVersionKey: version}),
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        module,
+			metaModuleVersionKey: version,
+			metaModuleDigestKey:  hardeningDigest,
+		}),
 		Data: payload.New(map[string]any{"module": module}),
 	}
 }
@@ -48,10 +52,14 @@ func hardeningResolution(roots ...regapi.Entry) *regapi.DependencyResolution {
 		}
 		seen[component] = struct{}{}
 		name, _ := graph.ParseName(component)
-		modules = append(modules, ResolvedModule{Org: name.Organization, Name: name.Module, Version: "v1.0.0"})
+		modules = append(modules, ResolvedModule{
+			Org: name.Organization, Name: name.Module, Version: "v1.0.0", Digest: hardeningDigest,
+		})
 	}
 	return dependencyResolution(desired, modules)
 }
+
+const hardeningDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
 func TestDependencyHandler_ExpandChangesDeletesEarlierRootModulesAndReturnsResolution(t *testing.T) {
 	ctx := newTestContext()
@@ -127,6 +135,31 @@ func TestDependencyHandler_ExpandChangesRetargetsEarlierRootWithoutLeavingOldMod
 	})
 }
 
+func TestDependencyHandler_ExpandChangesRetaggingRootStillRemovesOwnedModule(t *testing.T) {
+	ctx := newTestContext()
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	root := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
+	owned := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
+	retagged := root
+	retagged.Meta = attrs.NewBagFrom(map[string]any{
+		metaModuleKey: "host/owner",
+	})
+
+	result, err := handler.ExpandChanges(ctx, regapi.ChangeSet{{
+		Kind: regapi.EntryUpdate, Entry: retagged,
+	}}, regapi.State{root, owned})
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	require.Contains(t, result.Additional, regapi.ScopedOperation{
+		Operation: regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: owned.ID}},
+		Scope:     regapi.ScopeBaseline,
+	})
+}
+
 func TestDependencyHandler_ExpandUnchangedRootStillReturnsLegacyCheckpointGraph(t *testing.T) {
 	ctx := newTestContext()
 	root := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
@@ -163,11 +196,11 @@ func TestDependencyHandler_ReconcileRejectsRootSetDriftAndDuplicates(t *testing.
 	duplicate.Roots[1] = duplicate.Roots[0]
 	duplicate = duplicate.Canonical()
 	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, duplicate)
-	require.ErrorContains(t, err, "duplicate stored dependency root")
+	require.ErrorContains(t, err, "stored dependency resolution is invalid")
 
 	rootBDuplicateComponent := hardeningRoot("app.deps:b", "acme/a", "v1.0.0")
 	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootBDuplicateComponent}, hardeningResolution(rootA, rootBDuplicateComponent))
-	require.ErrorContains(t, err, "duplicate stored dependency component")
+	require.ErrorContains(t, err, "stored dependency resolution is invalid")
 }
 
 func TestDependencyHandler_ReconcileAcceptsStoredLabelSelectionOffline(t *testing.T) {
@@ -201,6 +234,10 @@ func TestDependencyHandler_ReconcileRejectsUnsafeStoredArtifactIdentity(t *testi
 	require.Error(t, validateModuleArtifactIdentity(graph.Name{Organization: "acme", Module: "safe"}, "1.0.0/../../escape", ""))
 	_, err = containedPath(t.TempDir(), filepath.Join("..", "escape.wapp"))
 	require.ErrorContains(t, err, "escapes vendor")
+	vendor := t.TempDir()
+	require.NoError(t, os.Symlink(t.TempDir(), filepath.Join(vendor, "linked")))
+	_, err = containedPath(vendor, filepath.Join("linked", "module.wapp"))
+	require.ErrorContains(t, err, "traverses symlink")
 }
 
 func TestValidateDownloadInfoRejectsStoredIdentityDrift(t *testing.T) {
@@ -208,4 +245,16 @@ func TestValidateDownloadInfoRejectsStoredIdentityDrift(t *testing.T) {
 	require.ErrorContains(t, validateDownloadInfo(mod, &DownloadInfo{Version: "v2.0.0"}), "version mismatch")
 	require.ErrorContains(t, validateDownloadInfo(mod, &DownloadInfo{Version: "v1.0.0", Digest: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}), "digest mismatch")
 	require.ErrorContains(t, validateDownloadInfo(mod, &DownloadInfo{Version: "v1.0.0", Size: 11}), "size mismatch")
+}
+
+func TestVerifyExtractedModuleRejectsContentTampering(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "module.yaml")
+	require.NoError(t, os.WriteFile(file, []byte("value: original\n"), 0o600))
+	digest := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	require.NoError(t, writeExtractedModuleMeta(dir, digest, 10))
+	require.NoError(t, verifyExtractedModule(dir, digest, 10))
+
+	require.NoError(t, os.WriteFile(file, []byte("value: tampered\n"), 0o600))
+	require.ErrorContains(t, verifyExtractedModule(dir, digest, 10), "tree digest mismatch")
 }

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -600,6 +600,19 @@ func (r *resolver) fetchManifest(ctx context.Context, org, name, version string)
 	if manifest == nil {
 		return nil, fmt.Errorf("hub returned no manifest for %s/%s@%s", org, name, version)
 	}
+	if manifest.Org != org || manifest.Name != name {
+		return nil, fmt.Errorf(
+			"manifest identity mismatch: requested %s/%s@%s, hub returned %s/%s@%s",
+			org, name, version, manifest.Org, manifest.Name, manifest.Version,
+		)
+	}
+	if version != "" && !strings.HasPrefix(version, "@") &&
+		strings.TrimPrefix(manifest.Version, "v") != strings.TrimPrefix(version, "v") {
+		return nil, fmt.Errorf(
+			"manifest version mismatch for %s/%s: requested %s, hub returned %s",
+			org, name, version, manifest.Version,
+		)
+	}
 
 	expected := r.lockedDigests[org+"/"+name+"@"+version]
 	if expected == "" || manifest.Digest == expected {

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -266,8 +266,20 @@ func (r *resolver) process(ctx context.Context, key string) {
 
 	source := moduleSource(key, version)
 	for _, dep := range manifest.Dependencies {
-		r.addConstraint(dep.Org+"/"+dep.Name, source, dep.Version)
+		r.addConstraint(dep.Org+"/"+dep.Name, source, declaredConstraint(dep))
 	}
+}
+
+// declaredConstraint returns the range the parent module declared for a
+// dependency. A hub that predates the constraint field sends only the version it
+// resolved to; fall back to it so an older server still yields a usable graph.
+// Grafting a resolved version in place of a real range would pin the dependency,
+// discarding any lock that satisfies the range and defeating intersection.
+func declaredConstraint(dep ManifestDep) string {
+	if dep.Constraint != "" {
+		return dep.Constraint
+	}
+	return dep.Version
 }
 
 // orphan removes a module that no live constraint demands and retracts its subtree.
@@ -383,6 +395,12 @@ func (r *resolver) resolveVersion(ctx context.Context, org, name string, live []
 
 // resolveIntersection selects the highest available version satisfying every
 // constraint, or errConstraintsIncompatible when none does.
+//
+// The constraints are matched individually rather than concatenated into one
+// string and reparsed: the parser caps a constraint at maxConstraintParts, a
+// budget sized for a single authored range, and a handful of parents each
+// declaring a two-sided range exceeds it. Concatenating would turn a perfectly
+// satisfiable set into a parse failure reported as a version conflict.
 func (r *resolver) resolveIntersection(ctx context.Context, org, name string, constraints []string) (string, error) {
 	key := org + "/" + name
 
@@ -390,9 +408,13 @@ func (r *resolver) resolveIntersection(ctx context.Context, org, name string, co
 		return locked, nil
 	}
 
-	merged, err := semver.ParseConstraint(strings.Join(constraints, " "))
-	if err != nil {
-		return "", errConstraintsIncompatible
+	parsed := make([]semver.Constraint, 0, len(constraints))
+	for _, c := range constraints {
+		p, err := semver.ParseConstraint(c)
+		if err != nil {
+			return "", fmt.Errorf("invalid constraint %q: %w", c, err)
+		}
+		parsed = append(parsed, p)
 	}
 
 	versions, err := r.provider.ListAllVersions(ctx, org, name)
@@ -400,34 +422,42 @@ func (r *resolver) resolveIntersection(ctx context.Context, org, name string, co
 		return "", fmt.Errorf("list versions: %w", err)
 	}
 
-	type indexedVersion struct {
-		original string
-		parsed   semver.Version
-	}
+	var best, bestStable *VersionInfo
+	var bestSem, bestStableSem semver.Version
 
-	indexed := make([]indexedVersion, 0, len(versions))
-	semverVersions := make([]semver.Version, 0, len(versions))
-	for _, v := range versions {
+	for i := range versions {
+		v := &versions[i]
 		sv, err := semver.ParseVersion(v.Version)
-		if err != nil {
+		if err != nil || !matchesAll(parsed, sv) {
 			continue
 		}
-		indexed = append(indexed, indexedVersion{parsed: sv, original: v.Version})
-		semverVersions = append(semverVersions, sv)
-	}
-
-	best, err := merged.FindBestMatch(semverVersions)
-	if err != nil {
-		return "", errConstraintsIncompatible
-	}
-
-	for _, iv := range indexed {
-		if iv.parsed.Equal(best) {
-			return iv.original, nil
+		if best == nil || sv.GreaterThan(bestSem) {
+			best, bestSem = v, sv
+		}
+		if !sv.IsPrerelease() && (bestStable == nil || sv.GreaterThan(bestStableSem)) {
+			bestStable, bestStableSem = v, sv
 		}
 	}
 
-	return best.String(), nil
+	// Mirror FindBestMatch: a stable release always wins over a prerelease.
+	if bestStable != nil {
+		return bestStable.Version, nil
+	}
+	if best != nil {
+		return best.Version, nil
+	}
+
+	return "", errConstraintsIncompatible
+}
+
+// matchesAll reports whether a version satisfies every constraint.
+func matchesAll(constraints []semver.Constraint, v semver.Version) bool {
+	for _, c := range constraints {
+		if !c.Match(v) {
+			return false
+		}
+	}
+	return true
 }
 
 // lockedSatisfiesAll reports whether a locked version satisfies every constraint.

--- a/boot/deps/hub/resolve_test.go
+++ b/boot/deps/hub/resolve_test.go
@@ -990,3 +990,146 @@ func TestManifestCache_TTLExpiry(t *testing.T) {
 	_, hit := cache.store.Get("acme/http@1.0.0")
 	assert.False(t, hit, "expired entry must not be served after TTL")
 }
+
+// dataflowProvider mirrors the real keeper/dataflow graph: keeper declares
+// ">=v0.4.10" for dataflow, and the hub resolved that range to 0.5.2 at request
+// time. dataflow ships 0.4.x releases and a breaking 0.5.x line.
+func dataflowProvider(constraint string) *fakeManifestProvider {
+	p := newFakeProvider()
+	p.addModule("keeper", "keeper", "0.5.57", ManifestDep{
+		Org:        "wippy",
+		Name:       "dataflow",
+		Version:    "0.5.2",
+		Constraint: constraint,
+	})
+	for _, v := range []string{"0.4.10", "0.4.31", "0.5.0", "0.5.2"} {
+		p.addModule("wippy", "dataflow", v)
+	}
+	return p
+}
+
+func resolveKeeper(t *testing.T, p *fakeManifestProvider, opts *ResolveOptions) map[string]string {
+	t.Helper()
+
+	result, err := Resolve(context.Background(), p, []DependencySpec{
+		{Org: "keeper", Name: "keeper", Constraint: "0.5.57"},
+	}, opts)
+	require.NoError(t, err)
+	assert.Empty(t, result.Errors)
+
+	got := make(map[string]string, len(result.Modules))
+	for _, m := range result.Modules {
+		got[m.Org+"/"+m.Name] = m.Version
+	}
+	return got
+}
+
+// A lock pinning a version that satisfies the declared range must survive. The
+// hub resolving ">=v0.4.10" to 0.5.2 is not a demand for 0.5.2; treating it as
+// one discards the lock and force-bumps the install to latest.
+func TestResolve_LockedVersionSurvivesDeclaredRange(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider(">=v0.4.10"), &ResolveOptions{
+		LockedVersions: map[string]string{"wippy/dataflow": "0.4.31"},
+	})
+
+	assert.Equal(t, "0.4.31", got["wippy/dataflow"])
+}
+
+// Without a lock the range still selects the newest matching release: preserving
+// the constraint must not change what ">=" means.
+func TestResolve_UnlockedDeclaredRangeTakesNewest(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider(">=v0.4.10"), nil)
+
+	assert.Equal(t, "0.5.2", got["wippy/dataflow"])
+}
+
+// A hub predating the constraint field sends only the resolved version, so the
+// resolver has nothing but that pin to go on. Asserted against a lock the pin
+// does not satisfy: the lock must lose, which is what distinguishes this path
+// from a real range (where the lock would win). Without the lock the assertion
+// would hold either way and prove nothing.
+func TestResolve_MissingConstraintFallsBackToResolvedVersion(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider(""), &ResolveOptions{
+		LockedVersions: map[string]string{"wippy/dataflow": "0.4.31"},
+	})
+
+	assert.Equal(t, "0.5.2", got["wippy/dataflow"])
+}
+
+// An unconstrained dependency accepts any version, so a locked one still holds.
+// Hub reports it as "*"; treating that as a pin would bump it to latest.
+func TestResolve_LockedVersionSurvivesAnyConstraint(t *testing.T) {
+	got := resolveKeeper(t, dataflowProvider("*"), &ResolveOptions{
+		LockedVersions: map[string]string{"wippy/dataflow": "0.4.31"},
+	})
+
+	assert.Equal(t, "0.4.31", got["wippy/dataflow"])
+}
+
+// Many modules depending on one module, each declaring its own compatible
+// two-sided range, is an ordinary graph. Preserving the declared ranges makes
+// those constraints distinct, so the module now resolves through the
+// intersection path -- which must still resolve, not report a conflict.
+func TestResolve_ManyParentsWithCompatibleRanges(t *testing.T) {
+	p := newFakeProvider()
+
+	// Distinct ranges: each parent pins its own floor, all mutually compatible.
+	parents := map[string]string{
+		"alpha":   ">=v0.4.10 <v0.5.0",
+		"bravo":   ">=v0.4.11 <v0.5.0",
+		"charlie": ">=v0.4.12 <v0.5.0",
+		"delta":   ">=v0.4.13 <v0.5.0",
+		"echo":    ">=v0.4.14 <v0.5.0",
+		"foxtrot": ">=v0.4.15 <v0.5.0",
+	}
+	roots := make([]DependencySpec, 0, len(parents))
+	for parent, constraint := range parents {
+		p.addModule("acme", parent, "1.0.0", ManifestDep{
+			Org:        "wippy",
+			Name:       "dataflow",
+			Version:    "0.4.31",
+			Constraint: constraint,
+		})
+		roots = append(roots, DependencySpec{Org: "acme", Name: parent, Constraint: "1.0.0"})
+	}
+	for _, v := range []string{"0.4.10", "0.4.31", "0.5.0"} {
+		p.addModule("wippy", "dataflow", v)
+	}
+
+	result, err := Resolve(context.Background(), p, roots, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Errors, "compatible ranges must not be reported as a conflict")
+
+	for _, m := range result.Modules {
+		if m.Org == "wippy" && m.Name == "dataflow" {
+			assert.Equal(t, "0.4.31", m.Version)
+			return
+		}
+	}
+	t.Fatal("wippy/dataflow was not resolved at all")
+}
+
+// A genuinely unsatisfiable set must still be reported as a conflict: matching
+// each constraint individually must not turn an incompatibility into a resolve.
+func TestResolve_IncompatibleRangesStillConflict(t *testing.T) {
+	p := newFakeProvider()
+	p.addModule("acme", "alpha", "1.0.0", ManifestDep{
+		Org: "wippy", Name: "dataflow", Version: "0.4.31", Constraint: ">=v0.4.10 <v0.5.0",
+	})
+	p.addModule("acme", "bravo", "1.0.0", ManifestDep{
+		Org: "wippy", Name: "dataflow", Version: "0.5.0", Constraint: ">=v0.5.0",
+	})
+	for _, v := range []string{"0.4.31", "0.5.0"} {
+		p.addModule("wippy", "dataflow", v)
+	}
+
+	result, err := Resolve(context.Background(), p, []DependencySpec{
+		{Org: "acme", Name: "alpha", Constraint: "1.0.0"},
+		{Org: "acme", Name: "bravo", Constraint: "1.0.0"},
+	}, nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, result.Errors, "no version satisfies both ranges; this must conflict")
+	assert.Contains(t, result.Errors[0].Message, "conflicting version constraints")
+}

--- a/boot/deps/hub/resolve_test.go
+++ b/boot/deps/hub/resolve_test.go
@@ -974,6 +974,37 @@ func TestManifestCache_RefreshOverwritesStale(t *testing.T) {
 	assert.Equal(t, "sha256:1.0.0", after.Digest, "subsequent Get must see refreshed manifest")
 }
 
+func TestManifestCache_MutableLabelAlwaysRefreshes(t *testing.T) {
+	p := newMutableProvider()
+	p.override("acme", "http", "@latest", "sha256:first")
+	cache := NewManifestCache(p)
+	defer cache.Close()
+
+	first, err := cache.GetManifest(context.Background(), "acme", "http", "@latest")
+	require.NoError(t, err)
+	require.Equal(t, "sha256:first", first.Digest)
+
+	p.override("acme", "http", "@latest", "sha256:second")
+	second, err := cache.GetManifest(context.Background(), "acme", "http", "@latest")
+	require.NoError(t, err)
+	require.Equal(t, "sha256:second", second.Digest)
+}
+
+func TestResolve_RejectsManifestIdentityMismatch(t *testing.T) {
+	p := newMutableProvider()
+	p.overrides["acme/http@1.0.0"] = &ModuleManifest{
+		Org: "other", Name: "module", Version: "1.0.0",
+	}
+
+	result, err := Resolve(context.Background(), p, []DependencySpec{{
+		Org: "acme", Name: "http", Constraint: "1.0.0",
+	}}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Modules)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Message, "manifest identity mismatch")
+}
+
 func TestManifestCache_TTLExpiry(t *testing.T) {
 	p := newFakeProvider()
 	p.addModule("acme", "http", "1.0.0")

--- a/boot/deps/hub/source_root_effect.go
+++ b/boot/deps/hub/source_root_effect.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+
+	moduleapi "github.com/wippyai/runtime/api/modules"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+// sourceRootEffect keeps module-relative directory resolution inside the same
+// prepare/rollback boundary as the registry transition and durable history.
+type sourceRootEffect struct {
+	desired  moduleapi.SourceRoots
+	previous moduleapi.SourceRoots
+	modules  []string
+	prepared bool
+}
+
+func (e *sourceRootEffect) Prepare(ctx context.Context) error {
+	if e.prepared {
+		return nil
+	}
+	e.previous = moduleapi.SwapSourceRoots(ctx, e.desired, e.modules...)
+	e.prepared = true
+	return nil
+}
+
+func (e *sourceRootEffect) Commit(context.Context) error { return nil }
+
+func (e *sourceRootEffect) Rollback(ctx context.Context) error {
+	if !e.prepared {
+		return nil
+	}
+	moduleapi.SwapSourceRoots(ctx, e.previous, e.modules...)
+	e.previous = nil
+	e.prepared = false
+	return nil
+}
+
+func (h *DependencyHandler) buildSourceRootEffect(
+	resolved []ResolvedModule,
+	controlled map[string]struct{},
+) (*sourceRootEffect, error) {
+	desired := make(moduleapi.SourceRoots)
+	for _, mod := range resolved {
+		module := mod.Org + "/" + mod.Name
+		var root string
+		if replacement, ok := h.replacementPath(module); ok && (mod.Source == "" || mod.Source == moduleSourceReplacementTreeV1) {
+			root = replacement
+		} else if h.shouldUnpackModules() {
+			name := graph.Name{Organization: mod.Org, Module: mod.Name}
+			path, err := containedPath(h.vendorDir, lock.ModulePath(name))
+			if err != nil {
+				return nil, err
+			}
+			root = path
+		}
+		if root == "" {
+			continue
+		}
+		absolute, err := filepath.Abs(root)
+		if err != nil {
+			return nil, err
+		}
+		desired[module] = absolute
+	}
+	if len(desired) == 0 && len(controlled) == 0 {
+		return nil, nil
+	}
+	// Detach the caller-owned map because effects outlive planning.
+	controlledCopy := make(map[string]struct{}, len(controlled)+len(resolved))
+	modules := make([]string, 0, len(controlled)+len(resolved))
+	for module := range controlled {
+		controlledCopy[module] = struct{}{}
+		modules = append(modules, module)
+	}
+	for _, mod := range resolved {
+		module := mod.Org + "/" + mod.Name
+		if mod.Org != "" && mod.Name != "" {
+			if _, ok := controlledCopy[module]; !ok {
+				controlledCopy[module] = struct{}{}
+				modules = append(modules, module)
+			}
+		}
+	}
+	sort.Strings(modules)
+	return &sourceRootEffect{desired: desired, modules: modules}, nil
+}

--- a/boot/deps/hub/tree_digest.go
+++ b/boot/deps/hub/tree_digest.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const treeIdentityModeMask = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+
+// digestDirectoryTree identifies the complete loadable tree, not only file
+// bytes. Lexical WalkDir order plus length-framed records makes the digest
+// deterministic and unambiguous. Empty directories and executable/permission
+// changes are significant; unstable or unsupported node types fail closed.
+func digestDirectoryTree(root string) (string, uint64, error) {
+	hash := sha256.New()
+	var total uint64
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if entry.IsDir() && rel != "." && entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if rel == extractedModuleMeta {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		mode := info.Mode()
+		if mode&os.ModeSymlink != 0 {
+			return fmt.Errorf("module tree contains symlink %q", rel)
+		}
+		switch {
+		case mode.IsDir():
+			return writeTreeDigestRecord(hash, 'd', rel, mode, 0)
+		case mode.IsRegular():
+			if err := writeTreeDigestRecord(hash, 'f', rel, mode, info.Size()); err != nil {
+				return err
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(hash, file)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			total += uint64(info.Size())
+			return nil
+		default:
+			return fmt.Errorf("module tree contains unsupported file type %q (%s)", rel, mode.Type())
+		}
+	})
+	if err != nil {
+		return "", 0, err
+	}
+	return "sha256-tree-v1:" + hex.EncodeToString(hash.Sum(nil)), total, nil
+}
+
+func writeTreeDigestRecord(dst io.Writer, kind byte, rel string, mode fs.FileMode, size int64) error {
+	_, err := fmt.Fprintf(dst, "%c:%d:%s:%o:%d:", kind, len(rel), rel, uint32(mode&treeIdentityModeMask), size)
+	return err
+}

--- a/boot/deps/hub/tree_digest_fifo_unix_test.go
+++ b/boot/deps/hub/tree_digest_fifo_unix_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build unix
+
+package hub
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigestDirectoryTree_RejectsFIFO(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, syscall.Mkfifo(filepath.Join(root, "stream"), 0600))
+	_, _, err := digestDirectoryTree(root)
+	require.ErrorContains(t, err, "unsupported file type")
+}

--- a/boot/deps/hub/tree_digest_test.go
+++ b/boot/deps/hub/tree_digest_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigestDirectoryTree_EmptyDirectoryChangesIdentity(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "module.lua"), []byte("return true"), 0644))
+	before, beforeSize, err := digestDirectoryTree(root)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Mkdir(filepath.Join(root, "empty"), 0755))
+	after, afterSize, err := digestDirectoryTree(root)
+	require.NoError(t, err)
+	assert.NotEqual(t, before, after)
+	assert.Equal(t, beforeSize, afterSize, "artifact size remains the sum of regular file bytes")
+}
+
+func TestDigestDirectoryTree_PermissionChangesIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve Unix permission bits")
+	}
+	root := t.TempDir()
+	path := filepath.Join(root, "module.lua")
+	require.NoError(t, os.WriteFile(path, []byte("return true"), 0644))
+	before, _, err := digestDirectoryTree(root)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chmod(path, 0755))
+	after, _, err := digestDirectoryTree(root)
+	require.NoError(t, err)
+	assert.NotEqual(t, before, after)
+}
+
+func TestDigestDirectoryTree_IsDeterministicAcrossCreationOrder(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	writeDigestFixture(t, first, []string{"b", "a"})
+	writeDigestFixture(t, second, []string{"a", "b"})
+
+	firstDigest, firstSize, err := digestDirectoryTree(first)
+	require.NoError(t, err)
+	secondDigest, secondSize, err := digestDirectoryTree(second)
+	require.NoError(t, err)
+	assert.Equal(t, firstDigest, secondDigest)
+	assert.Equal(t, firstSize, secondSize)
+}
+
+func writeDigestFixture(t *testing.T, root string, names []string) {
+	t.Helper()
+	for _, name := range names {
+		dir := filepath.Join(root, name)
+		require.NoError(t, os.Mkdir(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "value"), []byte(name), 0644))
+	}
+}

--- a/boot/deps/hub/unpack_effect.go
+++ b/boot/deps/hub/unpack_effect.go
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+// stagedModuleDirectory is private to one directive expansion. Planning reads
+// entries from stagingDir; targetDir is not changed until Prepare.
+type stagedModuleDirectory struct {
+	module     string
+	stagingDir string
+	targetDir  string
+}
+
+type unpackPlan struct {
+	staged []stagedModuleDirectory
+}
+
+func (p *unpackPlan) add(staged *stagedModuleDirectory) {
+	if p == nil || staged == nil {
+		return
+	}
+	p.staged = append(p.staged, *staged)
+}
+
+func (p *unpackPlan) cleanup() error {
+	if p == nil {
+		return nil
+	}
+	var errs []error
+	for _, staged := range p.staged {
+		if err := os.RemoveAll(staged.stagingDir); err != nil {
+			errs = append(errs, fmt.Errorf("remove staged module %s: %w", staged.module, err))
+		}
+	}
+	p.staged = nil
+	return errors.Join(errs...)
+}
+
+func (p *unpackPlan) take() []stagedModuleDirectory {
+	if p == nil {
+		return nil
+	}
+	staged := p.staged
+	p.staged = nil
+	return staged
+}
+
+type activatedModuleDirectory struct {
+	stagedModuleDirectory
+	backupDir  string
+	discardDir string
+}
+
+type filesystemEffectState uint8
+
+const (
+	filesystemEffectPlanned filesystemEffectState = iota
+	filesystemEffectPrepared
+	filesystemEffectCommitted
+	filesystemEffectRollbackPending
+	filesystemEffectRolledBack
+	filesystemEffectFinalized
+)
+
+type moduleFilesystemOps struct {
+	rename    func(string, string) error
+	removeAll func(string) error
+}
+
+func (ops moduleFilesystemOps) withDefaults() moduleFilesystemOps {
+	if ops.rename == nil {
+		ops.rename = os.Rename
+	}
+	if ops.removeAll == nil {
+		ops.removeAll = os.RemoveAll
+	}
+	return ops
+}
+
+// moduleFilesystemEffect activates unpacked module trees and publishes their
+// source roots as one transaction. Backups are retained until Finalize, after
+// registry history is durable.
+type moduleFilesystemEffect struct {
+	ops       moduleFilesystemOps
+	roots     *sourceRootEffect
+	staged    []stagedModuleDirectory
+	activated []activatedModuleDirectory
+	mu        sync.Mutex
+	state     filesystemEffectState
+}
+
+func (h *DependencyHandler) buildModuleFilesystemEffect(
+	resolved []ResolvedModule,
+	controlled map[string]struct{},
+	plan *unpackPlan,
+) (regapi.Effect, error) {
+	roots, err := h.buildSourceRootEffect(resolved, controlled)
+	if err != nil {
+		return nil, err
+	}
+	if plan == nil || len(plan.staged) == 0 {
+		if roots == nil {
+			return nil, nil
+		}
+		return roots, nil
+	}
+	return &moduleFilesystemEffect{
+		staged: plan.take(),
+		roots:  roots,
+	}, nil
+}
+
+func (h *DependencyHandler) hasCurrentUnpackedModule(mod ResolvedModule) bool {
+	if !h.shouldUnpackModules() || mod.Source == moduleSourceReplacementTreeV1 {
+		return true
+	}
+	name := graph.Name{Organization: mod.Org, Module: mod.Name}
+	targetDir, err := containedPath(h.vendorDir, lock.ModulePath(name))
+	if err != nil {
+		return false
+	}
+	return verifyExtractedModule(targetDir, mod.Digest, mod.SizeBytes) == nil
+}
+
+func (e *moduleFilesystemEffect) Prepare(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.state == filesystemEffectPrepared || e.state == filesystemEffectCommitted {
+		return nil
+	}
+	if e.state != filesystemEffectPlanned {
+		return fmt.Errorf("prepare module filesystem effect in state %d", e.state)
+	}
+
+	ops := e.ops.withDefaults()
+	for i, staged := range e.staged {
+		activated, err := activateModuleDirectory(staged, ops)
+		if err != nil {
+			if activated.backupDir != "" || activated.discardDir != "" {
+				e.activated = append(e.activated, activated)
+			}
+			remaining := e.staged[i:]
+			cleanupErr := cleanupStagedModuleDirectories(remaining, ops.removeAll)
+			if cleanupErr == nil {
+				e.staged = nil
+			} else {
+				e.staged = remaining
+			}
+			rollbackErr := e.restoreActivated(ops)
+			if cleanupErr == nil && rollbackErr == nil {
+				e.state = filesystemEffectRolledBack
+			} else {
+				e.state = filesystemEffectRollbackPending
+			}
+			return errors.Join(err, cleanupErr, rollbackErr)
+		}
+		e.activated = append(e.activated, activated)
+	}
+	e.staged = nil
+
+	if e.roots != nil {
+		if err := e.roots.Prepare(ctx); err != nil {
+			rollbackErr := e.restoreActivated(ops)
+			if rollbackErr == nil {
+				e.state = filesystemEffectRolledBack
+			} else {
+				e.state = filesystemEffectRollbackPending
+			}
+			return errors.Join(err, rollbackErr)
+		}
+	}
+	e.state = filesystemEffectPrepared
+	return nil
+}
+
+func (e *moduleFilesystemEffect) Commit(context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state == filesystemEffectCommitted {
+		return nil
+	}
+	if e.state != filesystemEffectPrepared {
+		return fmt.Errorf("commit module filesystem effect in state %d", e.state)
+	}
+	e.state = filesystemEffectCommitted
+	return nil
+}
+
+func (e *moduleFilesystemEffect) Rollback(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.state == filesystemEffectRolledBack {
+		return nil
+	}
+	if e.state == filesystemEffectFinalized {
+		return fmt.Errorf("rollback finalized module filesystem effect")
+	}
+	var errs []error
+	ops := e.ops.withDefaults()
+	if e.state == filesystemEffectPlanned {
+		if err := cleanupStagedModuleDirectories(e.staged, ops.removeAll); err != nil {
+			errs = append(errs, err)
+		} else {
+			e.staged = nil
+		}
+	} else {
+		errs = append(errs, e.restoreActivated(ops))
+		if len(e.staged) > 0 {
+			if err := cleanupStagedModuleDirectories(e.staged, ops.removeAll); err != nil {
+				errs = append(errs, err)
+			} else {
+				e.staged = nil
+			}
+		}
+	}
+	if e.roots != nil {
+		errs = append(errs, e.roots.Rollback(ctx))
+	}
+	err := errors.Join(errs...)
+	if err == nil {
+		e.state = filesystemEffectRolledBack
+	} else {
+		e.state = filesystemEffectRollbackPending
+	}
+	return err
+}
+
+func (e *moduleFilesystemEffect) Finalize(context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.state == filesystemEffectFinalized {
+		return nil
+	}
+	if e.state != filesystemEffectPrepared && e.state != filesystemEffectCommitted {
+		return fmt.Errorf("finalize module filesystem effect in state %d", e.state)
+	}
+	var errs []error
+	remaining := make([]activatedModuleDirectory, 0, len(e.activated))
+	ops := e.ops.withDefaults()
+	for _, activated := range e.activated {
+		if activated.backupDir == "" {
+			continue
+		}
+		if err := ops.removeAll(activated.backupDir); err != nil {
+			errs = append(errs, fmt.Errorf("remove module backup %s: %w", activated.module, err))
+			remaining = append(remaining, activated)
+		}
+	}
+	e.activated = remaining
+	err := errors.Join(errs...)
+	if err == nil {
+		e.state = filesystemEffectFinalized
+	}
+	return err
+}
+
+func (e *moduleFilesystemEffect) restoreActivated(ops moduleFilesystemOps) error {
+	var errs []error
+	failed := make([]activatedModuleDirectory, 0, len(e.activated))
+	for i := len(e.activated) - 1; i >= 0; i-- {
+		activated := e.activated[i]
+		if err := restoreModuleDirectory(&activated, ops); err != nil {
+			errs = append(errs, err)
+			failed = append(failed, activated)
+		}
+	}
+	for left, right := 0, len(failed)-1; left < right; left, right = left+1, right-1 {
+		failed[left], failed[right] = failed[right], failed[left]
+	}
+	e.activated = failed
+	return errors.Join(errs...)
+}
+
+func activateModuleDirectory(staged stagedModuleDirectory, ops moduleFilesystemOps) (activatedModuleDirectory, error) {
+	activated := activatedModuleDirectory{stagedModuleDirectory: staged}
+	parent := filepath.Dir(staged.targetDir)
+	if filepath.Dir(staged.stagingDir) != parent {
+		return activated, fmt.Errorf("staged module %s is not beside its target", staged.module)
+	}
+	if err := os.MkdirAll(parent, 0755); err != nil {
+		return activated, fmt.Errorf("create module parent %s: %w", staged.module, err)
+	}
+
+	if _, err := os.Lstat(staged.targetDir); err == nil {
+		backupDir, backupErr := reserveSiblingPath(parent, "."+filepath.Base(staged.targetDir)+".backup-*")
+		if backupErr != nil {
+			return activated, fmt.Errorf("reserve module backup %s: %w", staged.module, backupErr)
+		}
+		if err := ops.rename(staged.targetDir, backupDir); err != nil {
+			return activated, fmt.Errorf("move active module %s to backup: %w", staged.module, err)
+		}
+		activated.backupDir = backupDir
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return activated, fmt.Errorf("inspect active module %s: %w", staged.module, err)
+	}
+
+	if err := ops.rename(staged.stagingDir, staged.targetDir); err != nil {
+		if activated.backupDir != "" {
+			if restoreErr := ops.rename(activated.backupDir, staged.targetDir); restoreErr != nil {
+				return activated, errors.Join(
+					fmt.Errorf("activate staged module %s: %w", staged.module, err),
+					fmt.Errorf("restore module %s after activation failure: %w", staged.module, restoreErr),
+				)
+			}
+			activated.backupDir = ""
+		}
+		return activated, fmt.Errorf("activate staged module %s: %w", staged.module, err)
+	}
+	return activated, nil
+}
+
+func restoreModuleDirectory(activated *activatedModuleDirectory, ops moduleFilesystemOps) error {
+	if activated == nil {
+		return nil
+	}
+	if activated.discardDir != "" && activated.backupDir == "" {
+		if err := ops.removeAll(activated.discardDir); err != nil {
+			return fmt.Errorf("remove rolled-back module %s: %w", activated.module, err)
+		}
+		activated.discardDir = ""
+		return nil
+	}
+	if _, err := os.Lstat(activated.targetDir); errors.Is(err, os.ErrNotExist) {
+		if activated.backupDir != "" {
+			if err := ops.rename(activated.backupDir, activated.targetDir); err != nil {
+				return fmt.Errorf("restore missing previous module %s: %w", activated.module, err)
+			}
+			activated.backupDir = ""
+		}
+		if activated.discardDir != "" {
+			if err := ops.removeAll(activated.discardDir); err != nil {
+				return fmt.Errorf("remove rolled-back module %s: %w", activated.module, err)
+			}
+			activated.discardDir = ""
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect active module %s during rollback: %w", activated.module, err)
+	}
+
+	parent := filepath.Dir(activated.targetDir)
+	discard, err := reserveSiblingPath(parent, "."+filepath.Base(activated.targetDir)+".discard-*")
+	if err != nil {
+		return fmt.Errorf("reserve rollback path for %s: %w", activated.module, err)
+	}
+	if err := ops.rename(activated.targetDir, discard); err != nil {
+		return fmt.Errorf("move staged module %s out of service: %w", activated.module, err)
+	}
+	activated.discardDir = discard
+
+	if activated.backupDir != "" {
+		if err := ops.rename(activated.backupDir, activated.targetDir); err != nil {
+			restoreErr := ops.rename(discard, activated.targetDir)
+			if restoreErr == nil {
+				activated.discardDir = ""
+			}
+			return errors.Join(
+				fmt.Errorf("restore previous module %s: %w", activated.module, err),
+				wrapRollbackRestoreError(activated.module, restoreErr),
+			)
+		}
+		activated.backupDir = ""
+	}
+	if err := ops.removeAll(discard); err != nil {
+		return fmt.Errorf("remove rolled-back module %s: %w", activated.module, err)
+	}
+	activated.discardDir = ""
+	return nil
+}
+
+func wrapRollbackRestoreError(module string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("put staged module %s back after restore failure: %w", module, err)
+}
+
+func reserveSiblingPath(parent, pattern string) (string, error) {
+	path, err := os.MkdirTemp(parent, pattern)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		_ = os.RemoveAll(path)
+		return "", err
+	}
+	return path, nil
+}
+
+func cleanupStagedModuleDirectories(staged []stagedModuleDirectory, removeAll func(string) error) error {
+	var errs []error
+	for _, module := range staged {
+		if err := removeAll(module.stagingDir); err != nil {
+			errs = append(errs, fmt.Errorf("remove staged module %s: %w", module.module, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/boot/deps/hub/unpack_effect_test.go
+++ b/boot/deps/hub/unpack_effect_test.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	moduleapi "github.com/wippyai/runtime/api/modules"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
+)
+
+func TestModuleFilesystemEffect_HistoryFailureRestoresDirectoryAndSourceRoots(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "mod")
+	stage := filepath.Join(parent, ".mod.stage-test")
+	writeTreeMarker(t, target, "old")
+	writeTreeMarker(t, stage, "new")
+
+	ctx := newTestContext()
+	moduleapi.WithSourceRoots(ctx, moduleapi.SourceRoots{
+		"org/mod":     "/previous/mod",
+		"org/removed": "/previous/removed",
+	})
+	effect := &moduleFilesystemEffect{
+		staged: []stagedModuleDirectory{{module: "org/mod", stagingDir: stage, targetDir: target}},
+		roots: &sourceRootEffect{
+			desired: moduleapi.SourceRoots{"org/mod": target},
+			modules: []string{"org/mod", "org/removed"},
+		},
+	}
+
+	require.NoError(t, effect.Prepare(ctx))
+	assert.Equal(t, "new", readTreeMarker(t, target))
+	root, ok := moduleapi.SourceRoot(ctx, "org/mod")
+	require.True(t, ok)
+	assert.Equal(t, target, root)
+	require.NoError(t, effect.Commit(ctx))
+
+	// Registry history/CAS failure calls Rollback after Commit.
+	require.NoError(t, effect.Rollback(ctx))
+	assert.Equal(t, "old", readTreeMarker(t, target))
+	root, ok = moduleapi.SourceRoot(ctx, "org/mod")
+	require.True(t, ok)
+	assert.Equal(t, "/previous/mod", root)
+	root, ok = moduleapi.SourceRoot(ctx, "org/removed")
+	require.True(t, ok)
+	assert.Equal(t, "/previous/removed", root)
+}
+
+func TestModuleFilesystemEffect_ActivationFailureRestoresEarlierModules(t *testing.T) {
+	parent := t.TempDir()
+	firstTarget := filepath.Join(parent, "first")
+	secondTarget := filepath.Join(parent, "second")
+	firstStage := filepath.Join(parent, ".first.stage-test")
+	missingSecondStage := filepath.Join(parent, ".second.stage-missing")
+	writeTreeMarker(t, firstTarget, "old-first")
+	writeTreeMarker(t, secondTarget, "old-second")
+	writeTreeMarker(t, firstStage, "new-first")
+
+	effect := &moduleFilesystemEffect{staged: []stagedModuleDirectory{
+		{module: "org/first", stagingDir: firstStage, targetDir: firstTarget},
+		{module: "org/second", stagingDir: missingSecondStage, targetDir: secondTarget},
+	}}
+
+	require.Error(t, effect.Prepare(context.Background()))
+	assert.Equal(t, "old-first", readTreeMarker(t, firstTarget))
+	assert.Equal(t, "old-second", readTreeMarker(t, secondTarget))
+	assertNoLifecycleDirectories(t, parent)
+	require.NoError(t, effect.Rollback(context.Background()), "cleanup after a failed Prepare is idempotent")
+}
+
+func TestModuleFilesystemEffect_FinalizeKeepsAllNewModulesAndRemovesBackups(t *testing.T) {
+	parent := t.TempDir()
+	var staged []stagedModuleDirectory
+	for _, name := range []string{"first", "second"} {
+		target := filepath.Join(parent, name)
+		stage := filepath.Join(parent, "."+name+".stage-test")
+		writeTreeMarker(t, target, "old-"+name)
+		writeTreeMarker(t, stage, "new-"+name)
+		staged = append(staged, stagedModuleDirectory{module: "org/" + name, stagingDir: stage, targetDir: target})
+	}
+	effect := &moduleFilesystemEffect{staged: staged}
+
+	require.NoError(t, effect.Prepare(context.Background()))
+	require.NoError(t, effect.Commit(context.Background()))
+	require.NoError(t, effect.Finalize(context.Background()))
+	assert.Equal(t, "new-first", readTreeMarker(t, filepath.Join(parent, "first")))
+	assert.Equal(t, "new-second", readTreeMarker(t, filepath.Join(parent, "second")))
+	assertNoLifecycleDirectories(t, parent)
+}
+
+func TestModuleFilesystemEffect_ActivationDoubleFailureRestoresThroughBookkeeping(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "mod")
+	stage := filepath.Join(parent, ".mod.stage-test")
+	writeTreeMarker(t, target, "old")
+	writeTreeMarker(t, stage, "new")
+
+	renameCalls := 0
+	effect := &moduleFilesystemEffect{
+		staged: []stagedModuleDirectory{{module: "org/mod", stagingDir: stage, targetDir: target}},
+		ops: moduleFilesystemOps{rename: func(oldPath, newPath string) error {
+			renameCalls++
+			if renameCalls == 2 {
+				return errors.New("injected staged activation failure")
+			}
+			if renameCalls == 3 {
+				return errors.New("injected immediate backup restore failure")
+			}
+			return os.Rename(oldPath, newPath)
+		}},
+	}
+
+	require.Error(t, effect.Prepare(context.Background()))
+	assert.Equal(t, "old", readTreeMarker(t, target), "general rollback must retain and restore the failed activation")
+	assert.Equal(t, filesystemEffectRolledBack, effect.state)
+	assert.Empty(t, effect.activated)
+	assertNoLifecycleDirectories(t, parent)
+}
+
+func TestModuleFilesystemEffect_ActivationRestoreFailureCanRetryRollback(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "mod")
+	stage := filepath.Join(parent, ".mod.stage-test")
+	writeTreeMarker(t, target, "old")
+	writeTreeMarker(t, stage, "new")
+
+	renameCalls := 0
+	effect := &moduleFilesystemEffect{
+		staged: []stagedModuleDirectory{{module: "org/mod", stagingDir: stage, targetDir: target}},
+		ops: moduleFilesystemOps{rename: func(oldPath, newPath string) error {
+			renameCalls++
+			if renameCalls >= 2 && renameCalls <= 4 {
+				return errors.New("injected activation and restore failure")
+			}
+			return os.Rename(oldPath, newPath)
+		}},
+	}
+
+	require.Error(t, effect.Prepare(context.Background()))
+	assert.Equal(t, filesystemEffectRollbackPending, effect.state)
+	require.Len(t, effect.activated, 1, "failed backup restore must remain recoverable")
+	assert.NoDirExists(t, target)
+	require.NoError(t, effect.Rollback(context.Background()))
+	assert.Equal(t, filesystemEffectRolledBack, effect.state)
+	assert.Equal(t, "old", readTreeMarker(t, target))
+	assertNoLifecycleDirectories(t, parent)
+}
+
+func TestModuleFilesystemEffect_RollbackRetainsFailedDiscardCleanup(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "mod")
+	stage := filepath.Join(parent, ".mod.stage-test")
+	writeTreeMarker(t, target, "old")
+	writeTreeMarker(t, stage, "new")
+
+	removeCalls := 0
+	effect := &moduleFilesystemEffect{
+		staged: []stagedModuleDirectory{{module: "org/mod", stagingDir: stage, targetDir: target}},
+		ops: moduleFilesystemOps{removeAll: func(path string) error {
+			removeCalls++
+			if removeCalls == 1 {
+				return errors.New("injected discard cleanup failure")
+			}
+			return os.RemoveAll(path)
+		}},
+	}
+
+	require.NoError(t, effect.Prepare(context.Background()))
+	require.Error(t, effect.Rollback(context.Background()))
+	assert.Equal(t, filesystemEffectRollbackPending, effect.state)
+	require.Len(t, effect.activated, 1)
+	assert.NotEmpty(t, effect.activated[0].discardDir)
+	assert.Equal(t, "old", readTreeMarker(t, target))
+	require.NoError(t, effect.Rollback(context.Background()))
+	assert.Equal(t, filesystemEffectRolledBack, effect.state)
+	assertNoLifecycleDirectories(t, parent)
+}
+
+func TestModuleFilesystemEffect_FinalizeRetainsFailedBackupCleanup(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "mod")
+	stage := filepath.Join(parent, ".mod.stage-test")
+	writeTreeMarker(t, target, "old")
+	writeTreeMarker(t, stage, "new")
+
+	removeCalls := 0
+	effect := &moduleFilesystemEffect{
+		staged: []stagedModuleDirectory{{module: "org/mod", stagingDir: stage, targetDir: target}},
+		ops: moduleFilesystemOps{removeAll: func(path string) error {
+			removeCalls++
+			if removeCalls == 1 {
+				return errors.New("injected backup cleanup failure")
+			}
+			return os.RemoveAll(path)
+		}},
+	}
+
+	require.NoError(t, effect.Prepare(context.Background()))
+	require.NoError(t, effect.Commit(context.Background()))
+	require.Error(t, effect.Finalize(context.Background()))
+	assert.Equal(t, filesystemEffectCommitted, effect.state)
+	require.Len(t, effect.activated, 1, "failed backup cleanup must remain retryable")
+	assert.DirExists(t, effect.activated[0].backupDir)
+	require.NoError(t, effect.Finalize(context.Background()))
+	assert.Equal(t, filesystemEffectFinalized, effect.state)
+	assert.Equal(t, "new", readTreeMarker(t, target))
+	assertNoLifecycleDirectories(t, parent)
+}
+
+func TestModuleFilesystemEffect_PlannedRollbackRetainsFailedStageCleanup(t *testing.T) {
+	parent := t.TempDir()
+	stage := filepath.Join(parent, ".mod.stage-test")
+	writeTreeMarker(t, stage, "new")
+
+	removeCalls := 0
+	effect := &moduleFilesystemEffect{
+		staged: []stagedModuleDirectory{{module: "org/mod", stagingDir: stage, targetDir: filepath.Join(parent, "mod")}},
+		ops: moduleFilesystemOps{removeAll: func(path string) error {
+			removeCalls++
+			if removeCalls == 1 {
+				return errors.New("injected stage cleanup failure")
+			}
+			return os.RemoveAll(path)
+		}},
+	}
+
+	require.Error(t, effect.Rollback(context.Background()))
+	assert.Equal(t, filesystemEffectRollbackPending, effect.state)
+	require.Len(t, effect.staged, 1)
+	assert.DirExists(t, stage)
+	require.NoError(t, effect.Rollback(context.Background()))
+	assert.Equal(t, filesystemEffectRolledBack, effect.state)
+	assert.NoDirExists(t, stage)
+}
+
+func TestMaterializeModuleForLoad_RestartReusesVerifiedDirectory(t *testing.T) {
+	projectDir := t.TempDir()
+	vendorDir := filepath.Join(projectDir, ".wippy", "vendor")
+	lockPath := filepath.Join(projectDir, lock.DefaultFilename)
+	target := filepath.Join(vendorDir, "org", "mod")
+	writeTreeMarker(t, target, "installed")
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	require.NoError(t, writeExtractedModuleMeta(target, digest, 17))
+
+	lockObj, err := lock.New(lockPath)
+	require.NoError(t, err)
+	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "."})
+	lockObj.SetOptions(lock.Options{UnpackModules: true})
+	lockObj.SetModule(lock.Module{Name: "org/mod", Version: "1.0.0"})
+	require.NoError(t, lockObj.Write())
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{
+			getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+				t.Fatal("a verified unpacked module must be reused on restart")
+				return nil, nil
+			},
+		},
+		Logger:    zap.NewNop(),
+		LockPath:  lockPath,
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	path, staged, err := handler.materializeModuleForLoad(context.Background(), ResolvedModule{
+		Org: "org", Name: "mod", Version: "1.0.0", Digest: digest, SizeBytes: 17,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, target, path)
+	assert.Nil(t, staged)
+	assert.Equal(t, "installed", readTreeMarker(t, target))
+}
+
+func writeTreeMarker(t *testing.T, dir, value string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "marker"), []byte(value), 0644))
+}
+
+func readTreeMarker(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "marker"))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func assertNoLifecycleDirectories(t *testing.T, parent string) {
+	t.Helper()
+	for _, pattern := range []string{".*.backup-*", ".*.discard-*", ".*.stage-*"} {
+		matches, err := filepath.Glob(filepath.Join(parent, pattern))
+		require.NoError(t, err)
+		assert.Empty(t, matches, pattern)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,14 +4,18 @@ package version
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/wippyai/runtime/api/registry"
 )
 
-// version represents a version with parent/next pointers
+// version represents a version with an immutable parent and a legacy next
+// pointer. A version can have several children, so next retains only the
+// lowest-ID child for deterministic linear traversal. Branch-aware callers
+// must enumerate history and choose an explicit target version.
 type version struct {
 	previous *version
-	next     *version
+	next     atomic.Pointer[version]
 	id       uint
 }
 
@@ -35,10 +39,11 @@ func (v *version) Previous() registry.Version {
 
 // Next returns the next version.
 func (v *version) Next() registry.Version {
-	if v.next == nil {
+	next := v.next.Load()
+	if next == nil {
 		return nil
 	}
-	return v.next
+	return next
 }
 
 // New creates a new version struct.
@@ -63,6 +68,18 @@ func FromParent(parent registry.Version, id uint) registry.Version {
 		id:       id,
 		previous: parentVersion,
 	}
-	parentVersion.next = child
+	parentVersion.retainFirstChild(child)
 	return child
+}
+
+func (v *version) retainFirstChild(child *version) {
+	for {
+		current := v.next.Load()
+		if current != nil && current.id <= child.id {
+			return
+		}
+		if v.next.CompareAndSwap(current, child) {
+			return
+		}
+	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -3,6 +3,7 @@
 package version
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/wippyai/runtime/api/registry"
@@ -71,5 +72,34 @@ func TestChain(_ *testing.T) {
 	v := v3
 	for i := 3; i > 0; i-- {
 		v = v.Previous()
+	}
+}
+
+func TestNextRetainsLowestIDChild(t *testing.T) {
+	parent := New(1)
+	FromParent(parent, 9)
+	lowest := FromParent(parent, 3)
+	FromParent(parent, 7)
+
+	if next := parent.Next(); next == nil || next.ID() != lowest.ID() {
+		t.Fatalf("expected deterministic lowest-ID child v%d, got %v", lowest.ID(), next)
+	}
+}
+
+func TestNextConcurrentBranches(t *testing.T) {
+	parent := New(1)
+	var wg sync.WaitGroup
+	for id := uint(2); id < 100; id++ {
+		wg.Add(1)
+		go func(id uint) {
+			defer wg.Done()
+			FromParent(parent, id)
+			_ = parent.Next()
+		}(id)
+	}
+	wg.Wait()
+
+	if next := parent.Next(); next == nil || next.ID() != 2 {
+		t.Fatalf("expected lowest concurrent child v2, got %v", next)
 	}
 }

--- a/runtime/lua/modules/registry/history.go
+++ b/runtime/lua/modules/registry/history.go
@@ -63,22 +63,14 @@ func historyGetVersion(l *lua.LState) int {
 		return 2
 	}
 
-	versions, versErr := history.hist.Versions()
-	if versErr != nil {
-		err := lua.WrapErrorWithLua(l, versErr, "get versions").
+	foundVersion, lookupErr := findHistoryVersion(history.hist, uint(vID))
+	if lookupErr != nil {
+		err := lua.WrapErrorWithLua(l, lookupErr, "get version").
 			WithKind(lua.Internal).
 			WithRetryable(false)
 		l.Push(lua.LNil)
 		l.Push(err)
 		return 2
-	}
-
-	var foundVersion regapi.Version
-	for _, ver := range versions {
-		if ver.ID() == uint(vID) {
-			foundVersion = ver
-			break
-		}
 	}
 
 	if foundVersion == nil {
@@ -93,6 +85,22 @@ func historyGetVersion(l *lua.LState) int {
 	value.PushTypedUserData(l, foundVersion, typeVersion)
 	l.Push(lua.LNil)
 	return 2
+}
+
+func findHistoryVersion(history regapi.History, id uint) (regapi.Version, error) {
+	if lookup, ok := history.(regapi.VersionLookup); ok {
+		return lookup.GetVersion(id)
+	}
+	versions, err := history.Versions()
+	if err != nil {
+		return nil, err
+	}
+	for _, stored := range versions {
+		if stored.ID() == id {
+			return stored, nil
+		}
+	}
+	return nil, nil
 }
 
 // historySnapshotAt returns a snapshot of the registry at a specific version

--- a/runtime/lua/modules/registry/history_test.go
+++ b/runtime/lua/modules/registry/history_test.go
@@ -6,8 +6,19 @@ import (
 	"testing"
 
 	lua "github.com/wippyai/go-lua"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
 	"go.uber.org/zap"
 )
+
+type lookupOnlyHistory struct {
+	*historymem.Storage
+}
+
+func (h *lookupOnlyHistory) Versions() ([]regapi.Version, error) {
+	panic("findHistoryVersion enumerated a lookup-capable history")
+}
 
 func TestCheckHistoryValid(t *testing.T) {
 	l := newTestState()
@@ -41,5 +52,21 @@ func TestHistoryToString(t *testing.T) {
 	expected := "registry.History{}"
 	if str != expected {
 		t.Errorf("expected %s, got %s", expected, str)
+	}
+}
+
+func TestFindHistoryVersionUsesDirectLookup(t *testing.T) {
+	storage := historymem.New()
+	v1 := version.FromParent(version.New(regapi.RootVersion), 1)
+	if err := storage.Save(v1, nil, false); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findHistoryVersion(&lookupOnlyHistory{Storage: storage}, v1.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.ID() != v1.ID() {
+		t.Fatalf("direct lookup returned %#v", got)
 	}
 }

--- a/runtime/lua/modules/registry/module.go
+++ b/runtime/lua/modules/registry/module.go
@@ -482,22 +482,14 @@ func makeSnapshotAt(log *zap.Logger) lua.LGoFunc {
 			return 2
 		}
 
-		versions, versErr := hist.Versions()
-		if versErr != nil {
-			err := lua.WrapErrorWithLua(l, versErr, "get versions").
+		foundVersion, lookupErr := findHistoryVersion(hist, uint(versionID))
+		if lookupErr != nil {
+			err := lua.WrapErrorWithLua(l, lookupErr, "get version").
 				WithKind(lua.Internal).
 				WithRetryable(false)
 			l.Push(lua.LNil)
 			l.Push(err)
 			return 2
-		}
-
-		var foundVersion regapi.Version
-		for _, ver := range versions {
-			if ver.ID() == uint(versionID) {
-				foundVersion = ver
-				break
-			}
 		}
 
 		if foundVersion == nil {

--- a/service/http/factory.go
+++ b/service/http/factory.go
@@ -190,40 +190,31 @@ func (f *StaticFactory) CreateHandler(_ context.Context, cfg *config.StaticConfi
 		return nil, NewInvalidStaticConfigError(err)
 	}
 
-	fsys, ok := f.fsReg.GetFS(cfg.FS.String())
-	if !ok {
+	if _, ok := f.fsReg.GetFS(cfg.FS.String()); !ok {
 		return nil, NewFilesystemNotFoundError(cfg.FS.String())
 	}
-
-	// Create base handler
-	var handler http.Handler
-
-	// For SPA mode, use our custom handler
-	if cfg.StaticOptions.SPA {
-		if cfg.StaticOptions.IndexFile == "" {
-			return nil, ErrIndexFileRequired
-		}
-		handler = NewSPAHandler(fsys, cfg.StaticOptions.IndexFile)
-
-		if cfg.StaticOptions.CacheControl != "" {
-			handler = wrapWithCacheControl(handler, cfg.StaticOptions.CacheControl)
-		}
-	} else {
-		handler = http.FileServer(http.FS(fsys))
-
-		// Always strip the path prefix so the file server receives paths relative to the fs root
-		if cfg.Path != "" && cfg.Path != "/" {
-			handler = http.StripPrefix(cfg.Path, handler)
-		}
-
-		if cfg.StaticOptions.CacheControl != "" {
-			handler = wrapWithCacheControl(handler, cfg.StaticOptions.CacheControl)
-		}
+	if cfg.StaticOptions.SPA && cfg.StaticOptions.IndexFile == "" {
+		return nil, ErrIndexFileRequired
 	}
 
-	// Apply middleware if configured
+	// Do not retain a filesystem instance here. fs.directory and fs.embed can
+	// publish a replacement through the filesystem registry while this HTTP
+	// mount remains live. Resolving the current instance per request makes the
+	// mount observe that event instead of serving a closed or stale filesystem.
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fsys, ok := f.fsReg.GetFS(cfg.FS.String())
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		newStaticContentHandler(fsys, cfg).ServeHTTP(w, r)
+	})
+	if cfg.StaticOptions.CacheControl != "" {
+		handler = wrapWithCacheControl(handler, cfg.StaticOptions.CacheControl)
+	}
+
+	// Apply middleware once around the dynamic filesystem resolver.
 	if len(cfg.Middleware) > 0 {
-		// Build middleware chain
 		middlewareHandlers := make([]func(http.Handler) http.Handler, len(cfg.Middleware))
 		for i, name := range cfg.Middleware {
 			mw, err := f.middlewareFactory.CreateMiddleware(name, cfg.Options)
@@ -233,13 +224,28 @@ func (f *StaticFactory) CreateHandler(_ context.Context, cfg *config.StaticConfi
 			middlewareHandlers[i] = mw
 		}
 
-		// Apply middleware chain in reverse order
 		for i := len(middlewareHandlers) - 1; i >= 0; i-- {
 			handler = middlewareHandlers[i](handler)
 		}
 	}
 
 	return handler, nil
+}
+
+// newStaticContentHandler creates a content handler for one filesystem
+// generation. Callers should resolve that generation from the registry at the
+// boundary where a request is served.
+func newStaticContentHandler(fsys fs.FS, cfg *config.StaticConfig) http.Handler {
+	if cfg.StaticOptions.SPA {
+		return NewSPAHandler(fsys, cfg.StaticOptions.IndexFile)
+	}
+
+	handler := http.FileServer(http.FS(fsys))
+	if cfg.Path != "" && cfg.Path != "/" {
+		handler = http.StripPrefix(cfg.Path, handler)
+	}
+
+	return handler
 }
 
 // ServerFactory creates HTTP server instances

--- a/service/http/factory_test.go
+++ b/service/http/factory_test.go
@@ -18,12 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/event"
 	apifsLib "github.com/wippyai/runtime/api/fs"
 	"github.com/wippyai/runtime/api/function"
 	"github.com/wippyai/runtime/api/payload"
 	apiregistry "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/runtime"
 	config "github.com/wippyai/runtime/api/service/http"
+	"github.com/wippyai/runtime/system/eventbus"
+	fsregistry "github.com/wippyai/runtime/system/fs"
 	"go.uber.org/zap"
 )
 
@@ -415,6 +418,63 @@ func TestStaticFactory_CreateHandler(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "index file must be specified for SPA mode")
 	})
+}
+
+func TestStaticFactory_RefreshesMountedFilesAfterFilesystemRegisterEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := eventbus.NewBus()
+	defer bus.Stop()
+	registry := fsregistry.NewRegistry(bus, zap.NewNop())
+	require.NoError(t, registry.Start(ctx))
+	defer func() { require.NoError(t, registry.Stop()) }()
+
+	oldDir, cleanupOld := createFactoryTempDir(t, map[string]string{"app.html": "old bundle"})
+	defer cleanupOld()
+	newDir, cleanupNew := createFactoryTempDir(t, map[string]string{"app.html": "new bundle"})
+	defer cleanupNew()
+
+	oldFS := NewMockFS(oldDir)
+	newFS := NewMockFS(newDir)
+	fsID := "test:bundle"
+
+	bus.Send(ctx, event.Event{System: apifsLib.System, Kind: apifsLib.FsRegister, Path: fsID, Data: oldFS})
+	require.Eventually(t, func() bool {
+		got, ok := registry.GetFS(fsID)
+		return ok && got == oldFS
+	}, time.Second, 10*time.Millisecond)
+
+	factory, err := NewStaticFactory(registry, NewMiddlewareRegistry(nil))
+	require.NoError(t, err)
+	handler, err := factory.CreateHandler(ctx, &config.StaticConfig{
+		Meta: map[string]any{config.ServerID: "test:gateway"},
+		Path: "/app/keeper",
+		FS:   apiregistry.ParseID(fsID),
+	})
+	require.NoError(t, err)
+
+	serve := func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "http://example.com/app/keeper/app.html", nil))
+		return w
+	}
+
+	first := serve()
+	require.Equal(t, http.StatusOK, first.Code)
+	assert.Equal(t, "old bundle", first.Body.String())
+
+	// This is the same event emitted when fs.directory or fs.embed publishes a
+	// new package generation. The mounted HTTP route must now use newFS.
+	bus.Send(ctx, event.Event{System: apifsLib.System, Kind: apifsLib.FsRegister, Path: fsID, Data: newFS})
+	require.Eventually(t, func() bool {
+		got, ok := registry.GetFS(fsID)
+		return ok && got == newFS
+	}, time.Second, 10*time.Millisecond)
+
+	second := serve()
+	require.Equal(t, http.StatusOK, second.Code)
+	assert.Equal(t, "new bundle", second.Body.String())
 }
 
 func TestNewStaticFactory(t *testing.T) {

--- a/system/registry/errors.go
+++ b/system/registry/errors.go
@@ -10,10 +10,11 @@ import (
 
 // Sentinel errors
 var (
-	ErrNoCurrentVersion          = apierror.New(apierror.NotFound, "no current version").WithRetryable(apierror.False)
-	ErrDependencyResolverNotInit = apierror.New(apierror.Internal, "dependency resolver not initialized").WithRetryable(apierror.False)
-	ErrEmptyVersionPath          = apierror.New(apierror.Internal, "empty version path").WithRetryable(apierror.False)
-	ErrNoCommonAncestor          = apierror.New(apierror.Internal, "no common ancestor found in version path").WithRetryable(apierror.False)
+	ErrNoCurrentVersion             = apierror.New(apierror.NotFound, "no current version").WithRetryable(apierror.False)
+	ErrDependencyResolverNotInit    = apierror.New(apierror.Internal, "dependency resolver not initialized").WithRetryable(apierror.False)
+	ErrDurableResolutionUnsupported = apierror.New(apierror.Internal, "history does not support durable dependency resolutions").WithRetryable(apierror.False)
+	ErrEmptyVersionPath             = apierror.New(apierror.Internal, "empty version path").WithRetryable(apierror.False)
+	ErrNoCommonAncestor             = apierror.New(apierror.Internal, "no common ancestor found in version path").WithRetryable(apierror.False)
 )
 
 // NewEntryNotFoundError creates an error when an entry is not found

--- a/system/registry/expansion/dependency_directive.go
+++ b/system/registry/expansion/dependency_directive.go
@@ -11,15 +11,46 @@ import (
 // DependencyDirectiveFunc provides expansion for dependency entries.
 // Implementations should honor the provided context.
 type DependencyDirectiveFunc func(ctx context.Context, op registry.Operation, snapshot registry.State) (registry.DirectiveResult, error)
+type DependencyChangesDirectiveFunc func(ctx context.Context, changes registry.ChangeSet, snapshot registry.State) (registry.DirectiveResult, error)
+type ResolutionDirectiveFunc func(ctx context.Context, snapshot registry.State, resolution *registry.DependencyResolution) (registry.DirectiveResult, error)
 
 // DependencyDirective expands dependency operations using a direct handler.
 type DependencyDirective struct {
-	ExpandFunc DependencyDirectiveFunc
+	ExpandFunc    DependencyDirectiveFunc
+	ChangesFunc   DependencyChangesDirectiveFunc
+	ReconcileFunc ResolutionDirectiveFunc
 }
 
 // NewDependencyDirective constructs a dependency directive backed by the given handler.
-func NewDependencyDirective(expand DependencyDirectiveFunc) *DependencyDirective {
-	return &DependencyDirective{ExpandFunc: expand}
+func NewDependencyDirective(expand DependencyDirectiveFunc, reconcile ...ResolutionDirectiveFunc) *DependencyDirective {
+	directive := &DependencyDirective{ExpandFunc: expand}
+	if len(reconcile) > 0 {
+		directive.ReconcileFunc = reconcile[0]
+	}
+	return directive
+}
+
+// WithChangesExpansion makes a dependency transaction resolve its final root
+// set once instead of resolving each intermediate operation.
+func (d *DependencyDirective) WithChangesExpansion(expand DependencyChangesDirectiveFunc) *DependencyDirective {
+	if d != nil {
+		d.ChangesFunc = expand
+	}
+	return d
+}
+
+func (d *DependencyDirective) ExpandChanges(ctx context.Context, changes registry.ChangeSet, snapshot registry.State) (registry.DirectiveResult, error) {
+	if d == nil || d.ChangesFunc == nil {
+		return registry.DirectiveResult{}, nil
+	}
+	return d.ChangesFunc(ctx, changes, snapshot)
+}
+
+func (d *DependencyDirective) ReconcileResolution(ctx context.Context, snapshot registry.State, resolution *registry.DependencyResolution) (registry.DirectiveResult, error) {
+	if d == nil || d.ReconcileFunc == nil {
+		return registry.DirectiveResult{}, nil
+	}
+	return d.ReconcileFunc(ctx, snapshot, resolution)
 }
 
 // Expand implements registry.Directive.

--- a/system/registry/expansion/expansion.go
+++ b/system/registry/expansion/expansion.go
@@ -4,6 +4,7 @@ package expansion
 
 import (
 	"context"
+	"errors"
 
 	"github.com/wippyai/runtime/api/registry"
 	regtop "github.com/wippyai/runtime/system/registry/topology"
@@ -293,6 +294,23 @@ func (p *Planner) CommitEffects(ctx context.Context, effects []registry.Effect) 
 		}
 	}
 	return nil
+}
+
+// FinalizeEffects runs optional irreversible cleanup after history persistence.
+// Callers deliberately treat failures as cleanup leaks rather than rolling back
+// an already durable registry transition.
+func (p *Planner) FinalizeEffects(ctx context.Context, effects []registry.Effect) error {
+	var errs []error
+	for _, eff := range effects {
+		finalizer, ok := eff.(registry.FinalizingEffect)
+		if !ok {
+			continue
+		}
+		if err := finalizer.Finalize(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // RollbackEffects runs Rollback on each effect in reverse order.

--- a/system/registry/expansion/expansion.go
+++ b/system/registry/expansion/expansion.go
@@ -18,9 +18,10 @@ type ScopedOp struct {
 
 // Plan contains expanded operations and effects.
 type Plan struct {
-	Ops      []ScopedOp
-	Effects  []registry.Effect
-	Expanded bool
+	Resolution *registry.DependencyResolution
+	Ops        []ScopedOp
+	Effects    []registry.Effect
+	Expanded   bool
 }
 
 // SplitScopes separates all operations from history-only operations.
@@ -80,8 +81,58 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 	}
 
 	var effects []registry.Effect
+	var resolution *registry.DependencyResolution
 	expanded := false
 	originalCount := len(scoped)
+	type batchKey struct {
+		kind           registry.Kind
+		directiveIndex int
+	}
+	type batchExpansion struct {
+		result     registry.DirectiveResult
+		firstIndex int
+	}
+	batchExpansions := make(map[batchKey]batchExpansion)
+	for kind, directives := range p.DirectivesByKind {
+		var changes registry.ChangeSet
+		firstIndex := -1
+		for i := 0; i < originalCount; i++ {
+			op := scoped[i].Operation
+			opKind := op.Entry.Kind
+			if opKind == "" {
+				if entry, ok := entryFromSnapshot(snapshot, op.Entry.ID); ok {
+					opKind = entry.Kind
+				}
+			}
+			if opKind != kind {
+				continue
+			}
+			if firstIndex < 0 {
+				firstIndex = i
+			}
+			changes = append(changes, op)
+		}
+		if len(changes) < 2 {
+			continue
+		}
+		for directiveIndex, directive := range directives {
+			batch, ok := directive.(registry.ChangesDirective)
+			if !ok {
+				continue
+			}
+			result, err := batch.ExpandChanges(ctx, changes, snapshot)
+			if err != nil {
+				return nil, err
+			}
+			if !result.Applied && result.OriginalScope == nil && result.Resolution == nil && len(result.Additional) == 0 && len(result.Effects) == 0 {
+				continue // Capability is present but not configured; use per-op expansion.
+			}
+			if result.OriginalScope != nil {
+				return nil, NewDirectiveResultInvalidError(changes[0].Entry.ID, kind)
+			}
+			batchExpansions[batchKey{kind: kind, directiveIndex: directiveIndex}] = batchExpansion{result: result, firstIndex: firstIndex}
+		}
+	}
 
 	for i := 0; i < originalCount; i++ {
 		op := scoped[i].Operation
@@ -97,18 +148,34 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 			continue
 		}
 
-		for _, directive := range directives {
-			res, err := directive.Expand(ctx, op, snapshot)
-			if err != nil {
-				return nil, err
+		for directiveIndex, directive := range directives {
+			var res registry.DirectiveResult
+			if batch, ok := batchExpansions[batchKey{kind: kind, directiveIndex: directiveIndex}]; ok {
+				if i != batch.firstIndex {
+					continue
+				}
+				res = batch.result
+			} else {
+				var err error
+				res, err = directive.Expand(ctx, op, snapshot)
+				if err != nil {
+					return nil, err
+				}
 			}
 			if !res.Applied {
-				if res.OriginalScope != nil || len(res.Additional) > 0 || len(res.Effects) > 0 {
+				if res.OriginalScope != nil || res.Resolution != nil || len(res.Additional) > 0 || len(res.Effects) > 0 {
 					return nil, NewDirectiveResultInvalidError(op.Entry.ID, kind)
 				}
 				continue
 			}
 			expanded = true
+			if res.Resolution != nil {
+				canonical := res.Resolution.Canonical()
+				if resolution != nil && resolution.Digest != canonical.Digest {
+					return nil, NewDirectiveExpansionConflictError(op.Entry.ID)
+				}
+				resolution = canonical
+			}
 			if res.OriginalScope != nil {
 				scoped[i].Scope = *res.OriginalScope
 			}
@@ -131,7 +198,7 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 		}
 	}
 
-	return &Plan{Ops: scoped, Effects: effects, Expanded: expanded}, nil
+	return &Plan{Ops: scoped, Effects: effects, Resolution: resolution, Expanded: expanded}, nil
 }
 
 func recordExpandedOperation(opsByID map[registry.ID]map[string]struct{}, op registry.Operation) bool {

--- a/system/registry/expansion/expansion.go
+++ b/system/registry/expansion/expansion.go
@@ -82,6 +82,13 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 	}
 
 	var effects []registry.Effect
+	var ownedEffects []registry.Effect
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			p.RollbackEffects(ctx, ownedEffects)
+		}
+	}()
 	var resolution *registry.DependencyResolution
 	expanded := false
 	originalCount := len(scoped)
@@ -125,6 +132,7 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 			if err != nil {
 				return nil, err
 			}
+			ownedEffects = append(ownedEffects, result.Effects...)
 			if !result.Applied && result.OriginalScope == nil && result.Resolution == nil && len(result.Additional) == 0 && len(result.Effects) == 0 {
 				continue // Capability is present but not configured; use per-op expansion.
 			}
@@ -162,6 +170,7 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 				if err != nil {
 					return nil, err
 				}
+				ownedEffects = append(ownedEffects, res.Effects...)
 			}
 			if !res.Applied {
 				if res.OriginalScope != nil || res.Resolution != nil || len(res.Additional) > 0 || len(res.Effects) > 0 {
@@ -199,6 +208,7 @@ func (p *Planner) Expand(ctx context.Context, changes registry.ChangeSet, snapsh
 		}
 	}
 
+	succeeded = true
 	return &Plan{Ops: scoped, Effects: effects, Resolution: resolution, Expanded: expanded}, nil
 }
 

--- a/system/registry/expansion/expansion_test.go
+++ b/system/registry/expansion/expansion_test.go
@@ -18,6 +18,15 @@ type stubDirective struct {
 	expandFunc func(context.Context, registry.Operation, registry.State) (registry.DirectiveResult, error)
 }
 
+type stubChangesDirective struct {
+	stubDirective
+	expandChangesFunc func(context.Context, registry.ChangeSet, registry.State) (registry.DirectiveResult, error)
+}
+
+func (s *stubChangesDirective) ExpandChanges(ctx context.Context, changes registry.ChangeSet, state registry.State) (registry.DirectiveResult, error) {
+	return s.expandChangesFunc(ctx, changes, state)
+}
+
 func (s *stubDirective) Expand(ctx context.Context, op registry.Operation, snap registry.State) (registry.DirectiveResult, error) {
 	return s.expandFunc(ctx, op, snap)
 }
@@ -132,6 +141,33 @@ func TestPlanner_Expand_DirectiveApplied_AddsOps(t *testing.T) {
 	assert.Len(t, plan.Ops, 2)
 	assert.True(t, plan.Expanded)
 	assert.Equal(t, registry.ScopeBaseline, plan.Ops[1].Scope)
+}
+
+func TestPlanner_Expand_BatchesSameKindTransactionOnce(t *testing.T) {
+	perOperationCalls := 0
+	batchCalls := 0
+	dir := &stubChangesDirective{
+		stubDirective: stubDirective{expandFunc: func(context.Context, registry.Operation, registry.State) (registry.DirectiveResult, error) {
+			perOperationCalls++
+			return registry.DirectiveResult{Applied: true}, nil
+		}},
+		expandChangesFunc: func(_ context.Context, changes registry.ChangeSet, _ registry.State) (registry.DirectiveResult, error) {
+			batchCalls++
+			require.Len(t, changes, 2)
+			return registry.DirectiveResult{Applied: true}, nil
+		},
+	}
+	p := NewPlanner(map[registry.Kind][]registry.Directive{"dep": {dir}}, nil, zap.NewNop())
+	changes := registry.ChangeSet{
+		newOp(registry.EntryCreate, newEntry("app", "one", "dep")),
+		newOp(registry.EntryCreate, newEntry("app", "two", "dep")),
+	}
+
+	plan, err := p.Expand(context.Background(), changes, nil)
+	require.NoError(t, err)
+	require.Len(t, plan.Ops, 2)
+	require.Equal(t, 1, batchCalls)
+	require.Zero(t, perOperationCalls)
 }
 
 func TestPlanner_Expand_DirectiveError(t *testing.T) {

--- a/system/registry/expansion/expansion_test.go
+++ b/system/registry/expansion/expansion_test.go
@@ -508,6 +508,28 @@ func TestPlanner_RollbackEffects_Empty(t *testing.T) {
 	p.RollbackEffects(context.Background(), nil)
 }
 
+func TestPlanner_ExpandErrorRollsBackEarlierUnpreparedEffects(t *testing.T) {
+	effect := &testEffect{}
+	kind := registry.Kind("test.kind")
+	planner := NewPlanner(map[registry.Kind][]registry.Directive{
+		kind: {
+			&stubDirective{expandFunc: func(context.Context, registry.Operation, registry.State) (registry.DirectiveResult, error) {
+				return registry.DirectiveResult{Applied: true, Effects: []registry.Effect{effect}}, nil
+			}},
+			&stubDirective{expandFunc: func(context.Context, registry.Operation, registry.State) (registry.DirectiveResult, error) {
+				return registry.DirectiveResult{}, errors.New("later planning failure")
+			}},
+		},
+	}, nil, zap.NewNop())
+
+	_, err := planner.Expand(context.Background(), registry.ChangeSet{{
+		Kind:  registry.EntryCreate,
+		Entry: registry.Entry{ID: registry.NewID("test", "entry"), Kind: kind},
+	}}, nil)
+	require.ErrorContains(t, err, "later planning failure")
+	assert.Equal(t, 1, effect.rollbackCall)
+}
+
 // --- helpers ---
 
 type testEffect struct {

--- a/system/registry/history/memory/memory.go
+++ b/system/registry/history/memory/memory.go
@@ -3,7 +3,10 @@
 package memory
 
 import (
+	"context"
 	"fmt"
+	"reflect"
+	"sort"
 	"sync"
 
 	"github.com/wippyai/runtime/api/attrs"
@@ -48,7 +51,30 @@ func (m *Storage) Versions() ([]registry.Version, error) {
 	for _, v := range m.versions {
 		versions = append(versions, v)
 	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i].ID() < versions[j].ID() })
 	return versions, nil
+}
+
+func (m *Storage) MaxVersionID() (uint, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	var maxID uint
+	for id := range m.versions {
+		if id > maxID {
+			maxID = id
+		}
+	}
+	return maxID, nil
+}
+
+func (m *Storage) GetVersion(id uint) (registry.Version, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	stored, ok := m.versions[id]
+	if !ok {
+		return nil, NewVersionNotFoundError(fmt.Sprintf("%d", id))
+	}
+	return stored, nil
 }
 
 // Get returns the ChangeSet associated with a specific version.
@@ -75,29 +101,53 @@ func (m *Storage) Get(version registry.Version) (registry.ChangeSet, error) {
 	return actionsCopy, nil
 }
 
-// ReplayChanges streams root-to-target changesets without retaining decoded
-// history payloads. The root version is structural and is not replayed.
-func (m *Storage) ReplayChanges(target registry.Version, apply func(registry.ChangeSet) error) error {
+// ReplayChanges snapshots root-to-target changesets so callbacks may safely
+// call back into the history. The structural root version is not replayed.
+func (m *Storage) ReplayChanges(ctx context.Context, target registry.Version, apply func(registry.ChangeSet) error) error {
 	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	stored, ok := m.versions[target.ID()]
-	if !ok {
-		return NewVersionNotFoundError(target.String())
+	changesets, err := m.replayChanges(ctx, target)
+	m.mutex.RUnlock()
+	if err != nil {
+		return err
 	}
-	lineage := make([]uint, 0)
-	for current := stored; current != nil && current.ID() > registry.RootVersion; current = current.Previous() {
-		lineage = append(lineage, current.ID())
-	}
-	for i := len(lineage) - 1; i >= 0; i-- {
-		actions, ok := m.actions[lineage[i]]
-		if !ok {
-			return NewVersionNotFoundError(fmt.Sprintf("%d", lineage[i]))
+	for _, changes := range changesets {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		if err := apply(cloneChangeSet(actions)); err != nil {
+		if err := apply(changes); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (m *Storage) replayChanges(ctx context.Context, target registry.Version) ([]registry.ChangeSet, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stored, ok := m.versions[target.ID()]
+	if !ok {
+		return nil, NewVersionNotFoundError(target.String())
+	}
+	lineage := make([]uint, 0)
+	for current := stored; current != nil && current.ID() > registry.RootVersion; current = current.Previous() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		lineage = append(lineage, current.ID())
+	}
+	changesets := make([]registry.ChangeSet, 0, len(lineage))
+	for i := len(lineage) - 1; i >= 0; i-- {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		actions, ok := m.actions[lineage[i]]
+		if !ok {
+			return nil, NewVersionNotFoundError(fmt.Sprintf("%d", lineage[i]))
+		}
+		changesets = append(changesets, cloneChangeSet(actions))
+	}
+	return changesets, nil
 }
 
 func cloneEntry(e registry.Entry) registry.Entry {
@@ -175,9 +225,19 @@ func (m *Storage) Save(newVersion registry.Version, actions registry.ChangeSet, 
 }
 
 func (m *Storage) SaveWithDependencyResolution(newVersion registry.Version, actions registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
+	var canonicalResolution *registry.DependencyResolution
+	if resolution != nil {
+		canonicalResolution = resolution.Canonical()
+		if !canonicalResolution.Valid() {
+			return registry.ErrInvalidDependencyResolution
+		}
+	}
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	if newVersion.ID() != registry.RootVersion && newVersion.Previous() == nil {
+		return fmt.Errorf("non-root version %d has no parent", newVersion.ID())
+	}
 	if _, exists := m.versions[newVersion.ID()]; exists {
 		if newVersion.ID() == registry.RootVersion && len(actions) == 0 && resolution == nil {
 			if head {
@@ -187,19 +247,27 @@ func (m *Storage) SaveWithDependencyResolution(newVersion registry.Version, acti
 		}
 		return fmt.Errorf("version %d already exists", newVersion.ID())
 	}
+	storedVersion := newVersion
 	if previous := newVersion.Previous(); previous != nil {
-		if _, exists := m.versions[previous.ID()]; !exists {
+		storedParent, exists := m.versions[previous.ID()]
+		if !exists {
 			return NewVersionNotFoundError(previous.String())
 		}
 		if head && !memoryHeadMatchesParent(m.head, previous) {
 			return fmt.Errorf("history head changed: expected version %d", previous.ID())
 		}
+		// Preserve the caller's version object when it was constructed directly
+		// from the canonical stored parent. Rebuild foreign or truncated caller
+		// lineages in O(1), keeping sequential saves cheap for long histories.
+		if !sameVersionInstance(previous, storedParent) {
+			storedVersion = version.FromParent(storedParent, newVersion.ID())
+		}
 	}
 
 	m.actions[newVersion.ID()] = cloneChangeSet(actions)
-	m.versions[newVersion.ID()] = newVersion
-	if resolution != nil {
-		m.resolutions[newVersion.ID()] = resolution.Canonical()
+	m.versions[newVersion.ID()] = storedVersion
+	if canonicalResolution != nil {
+		m.resolutions[newVersion.ID()] = canonicalResolution
 	} else if previous := newVersion.Previous(); previous != nil {
 		if inherited, ok := m.resolutions[previous.ID()]; ok {
 			m.resolutions[newVersion.ID()] = inherited.Canonical()
@@ -207,10 +275,18 @@ func (m *Storage) SaveWithDependencyResolution(newVersion registry.Version, acti
 	}
 
 	if head {
-		m.head = newVersion
+		m.head = storedVersion
 	}
 
 	return nil
+}
+
+func sameVersionInstance(left, right registry.Version) bool {
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	return leftValue.IsValid() && rightValue.IsValid() &&
+		leftValue.Kind() == reflect.Pointer && rightValue.Kind() == reflect.Pointer &&
+		leftValue.Type() == rightValue.Type() && leftValue.Pointer() == rightValue.Pointer()
 }
 
 func (m *Storage) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
@@ -227,12 +303,15 @@ func (m *Storage) CheckpointDependencyResolution(v registry.Version, resolution 
 	if resolution == nil {
 		return registry.ErrDependencyResolutionNotFound
 	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	if _, ok := m.versions[v.ID()]; !ok {
 		return NewVersionNotFoundError(v.String())
 	}
-	canonical := resolution.Canonical()
 	if existing, ok := m.resolutions[v.ID()]; ok && existing.Digest != canonical.Digest {
 		return fmt.Errorf("version %d already references dependency resolution %s, refusing %s", v.ID(), existing.Digest, canonical.Digest)
 	}
@@ -264,10 +343,11 @@ func (m *Storage) SetHead(v registry.Version) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if _, ok := m.versions[v.ID()]; !ok {
+	stored, ok := m.versions[v.ID()]
+	if !ok {
 		return NewVersionNotFoundError(v.String())
 	}
-	m.head = v
+	m.head = stored
 	return nil
 }
 
@@ -278,9 +358,34 @@ func (m *Storage) CompareAndSetHead(expected, target registry.Version) error {
 	if !ok {
 		return NewVersionNotFoundError(target.String())
 	}
-	if m.head == nil || m.head.ID() != expected.ID() {
+	if !memoryHeadMatchesParent(m.head, expected) {
 		return fmt.Errorf("history head changed: expected version %d", expected.ID())
 	}
+	m.head = stored
+	return nil
+}
+
+func (m *Storage) CompareAndSetHeadWithDependencyResolution(expected, target registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	stored, ok := m.versions[target.ID()]
+	if !ok {
+		return NewVersionNotFoundError(target.String())
+	}
+	if !memoryHeadMatchesParent(m.head, expected) {
+		return fmt.Errorf("history head changed: expected version %d", expected.ID())
+	}
+	if existing, ok := m.resolutions[target.ID()]; ok && existing.Digest != canonical.Digest {
+		return fmt.Errorf("version %d already references dependency resolution %s, refusing %s", target.ID(), existing.Digest, canonical.Digest)
+	}
+	m.resolutions[target.ID()] = canonical
 	m.head = stored
 	return nil
 }

--- a/system/registry/history/memory/memory.go
+++ b/system/registry/history/memory/memory.go
@@ -3,9 +3,11 @@
 package memory
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/internal/version"
 )
@@ -73,20 +75,98 @@ func (m *Storage) Get(version registry.Version) (registry.ChangeSet, error) {
 	return actionsCopy, nil
 }
 
+// ReplayChanges streams root-to-target changesets without retaining decoded
+// history payloads. The root version is structural and is not replayed.
+func (m *Storage) ReplayChanges(target registry.Version, apply func(registry.ChangeSet) error) error {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	stored, ok := m.versions[target.ID()]
+	if !ok {
+		return NewVersionNotFoundError(target.String())
+	}
+	lineage := make([]uint, 0)
+	for current := stored; current != nil && current.ID() > registry.RootVersion; current = current.Previous() {
+		lineage = append(lineage, current.ID())
+	}
+	for i := len(lineage) - 1; i >= 0; i-- {
+		actions, ok := m.actions[lineage[i]]
+		if !ok {
+			return NewVersionNotFoundError(fmt.Sprintf("%d", lineage[i]))
+		}
+		if err := apply(cloneChangeSet(actions)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func cloneEntry(e registry.Entry) registry.Entry {
 	var meta attrs.Bag
 	if e.Meta != nil {
 		meta = make(attrs.Bag, len(e.Meta))
 		for k, v := range e.Meta {
-			meta[k] = v
+			meta[k] = snapshotValue(v)
 		}
+	}
+	var data payload.Payload
+	if e.Data != nil {
+		data = payload.NewPayload(snapshotValue(e.Data.Data()), e.Data.Format())
 	}
 	return registry.Entry{
 		ID:   e.ID,
 		Kind: e.Kind,
 		Meta: meta,
-		Data: e.Data,
+		Data: data,
 	}
+}
+
+func snapshotValue(value any) any {
+	switch v := value.(type) {
+	case attrs.Bag:
+		cloned := make(attrs.Bag, len(v))
+		for key, item := range v {
+			cloned[key] = snapshotValue(item)
+		}
+		return cloned
+	case map[string]any:
+		cloned := make(map[string]any, len(v))
+		for key, item := range v {
+			cloned[key] = snapshotValue(item)
+		}
+		return cloned
+	case map[any]any:
+		cloned := make(map[any]any, len(v))
+		for key, item := range v {
+			cloned[snapshotValue(key)] = snapshotValue(item)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(v))
+		for i, item := range v {
+			cloned[i] = snapshotValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), v...)
+	case []byte:
+		return append([]byte(nil), v...)
+	case payload.Payload:
+		return payload.NewPayload(snapshotValue(v.Data()), v.Format())
+	default:
+		return value
+	}
+}
+
+func cloneChangeSet(actions registry.ChangeSet) registry.ChangeSet {
+	cloned := make(registry.ChangeSet, len(actions))
+	for i, op := range actions {
+		cloned[i] = registry.Operation{Kind: op.Kind, Entry: cloneEntry(op.Entry)}
+		if op.OriginalEntry != nil {
+			original := cloneEntry(*op.OriginalEntry)
+			cloned[i].OriginalEntry = &original
+		}
+	}
+	return cloned
 }
 
 // Save records a set of actions and creates a new version.
@@ -98,7 +178,25 @@ func (m *Storage) SaveWithDependencyResolution(newVersion registry.Version, acti
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	m.actions[newVersion.ID()] = actions
+	if _, exists := m.versions[newVersion.ID()]; exists {
+		if newVersion.ID() == registry.RootVersion && len(actions) == 0 && resolution == nil {
+			if head {
+				m.head = m.versions[registry.RootVersion]
+			}
+			return nil
+		}
+		return fmt.Errorf("version %d already exists", newVersion.ID())
+	}
+	if previous := newVersion.Previous(); previous != nil {
+		if _, exists := m.versions[previous.ID()]; !exists {
+			return NewVersionNotFoundError(previous.String())
+		}
+		if head && !memoryHeadMatchesParent(m.head, previous) {
+			return fmt.Errorf("history head changed: expected version %d", previous.ID())
+		}
+	}
+
+	m.actions[newVersion.ID()] = cloneChangeSet(actions)
 	m.versions[newVersion.ID()] = newVersion
 	if resolution != nil {
 		m.resolutions[newVersion.ID()] = resolution.Canonical()
@@ -134,8 +232,19 @@ func (m *Storage) CheckpointDependencyResolution(v registry.Version, resolution 
 	if _, ok := m.versions[v.ID()]; !ok {
 		return NewVersionNotFoundError(v.String())
 	}
-	m.resolutions[v.ID()] = resolution.Canonical()
+	canonical := resolution.Canonical()
+	if existing, ok := m.resolutions[v.ID()]; ok && existing.Digest != canonical.Digest {
+		return fmt.Errorf("version %d already references dependency resolution %s, refusing %s", v.ID(), existing.Digest, canonical.Digest)
+	}
+	m.resolutions[v.ID()] = canonical
 	return nil
+}
+
+func memoryHeadMatchesParent(head, parent registry.Version) bool {
+	if head == nil {
+		return parent != nil && parent.ID() == registry.RootVersion
+	}
+	return parent != nil && head.ID() == parent.ID()
 }
 
 // Head returns the current head version of the history.
@@ -159,5 +268,19 @@ func (m *Storage) SetHead(v registry.Version) error {
 		return NewVersionNotFoundError(v.String())
 	}
 	m.head = v
+	return nil
+}
+
+func (m *Storage) CompareAndSetHead(expected, target registry.Version) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	stored, ok := m.versions[target.ID()]
+	if !ok {
+		return NewVersionNotFoundError(target.String())
+	}
+	if m.head == nil || m.head.ID() != expected.ID() {
+		return fmt.Errorf("history head changed: expected version %d", expected.ID())
+	}
+	m.head = stored
 	return nil
 }

--- a/system/registry/history/memory/memory.go
+++ b/system/registry/history/memory/memory.go
@@ -12,10 +12,11 @@ import (
 
 // Storage is an in-memory implementation of the registry.History interface.
 type Storage struct {
-	versions map[uint]registry.Version
-	actions  map[uint]registry.ChangeSet
-	head     registry.Version
-	mutex    sync.RWMutex
+	resolutions map[uint]*registry.DependencyResolution
+	versions    map[uint]registry.Version
+	actions     map[uint]registry.ChangeSet
+	head        registry.Version
+	mutex       sync.RWMutex
 }
 
 // New creates a new Storage.
@@ -24,6 +25,7 @@ func New() *Storage {
 	v0 := version.New(0)
 
 	m := &Storage{
+		resolutions: make(map[uint]*registry.DependencyResolution),
 		versions: map[uint]registry.Version{
 			0: v0,
 		},
@@ -89,16 +91,50 @@ func cloneEntry(e registry.Entry) registry.Entry {
 
 // Save records a set of actions and creates a new version.
 func (m *Storage) Save(newVersion registry.Version, actions registry.ChangeSet, head bool) error {
+	return m.SaveWithDependencyResolution(newVersion, actions, nil, head)
+}
+
+func (m *Storage) SaveWithDependencyResolution(newVersion registry.Version, actions registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	m.actions[newVersion.ID()] = actions
 	m.versions[newVersion.ID()] = newVersion
+	if resolution != nil {
+		m.resolutions[newVersion.ID()] = resolution.Canonical()
+	} else if previous := newVersion.Previous(); previous != nil {
+		if inherited, ok := m.resolutions[previous.ID()]; ok {
+			m.resolutions[newVersion.ID()] = inherited.Canonical()
+		}
+	}
 
 	if head {
 		m.head = newVersion
 	}
 
+	return nil
+}
+
+func (m *Storage) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	resolution, ok := m.resolutions[v.ID()]
+	if !ok {
+		return nil, registry.ErrDependencyResolutionNotFound
+	}
+	return resolution.Canonical(), nil
+}
+
+func (m *Storage) CheckpointDependencyResolution(v registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if _, ok := m.versions[v.ID()]; !ok {
+		return NewVersionNotFoundError(v.String())
+	}
+	m.resolutions[v.ID()] = resolution.Canonical()
 	return nil
 }
 

--- a/system/registry/history/memory/memory_test.go
+++ b/system/registry/history/memory/memory_test.go
@@ -39,6 +39,38 @@ func TestStorage_Versions(t *testing.T) {
 	}
 }
 
+func TestStorage_ReplayChangesFollowsOnlyTargetAncestry(t *testing.T) {
+	storage := New()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	v2 := version.FromParent(v1, 2)
+	v3 := version.FromParent(v1, 3)
+	entry := func(name string) registry.ChangeSet {
+		return registry.ChangeSet{{Kind: registry.EntryCreate, Entry: registry.Entry{ID: registry.NewID("test", name)}}}
+	}
+	if err := storage.Save(v1, entry("one"), false); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Save(v2, entry("branch_a"), false); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Save(v3, entry("branch_b"), false); err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	if err := storage.ReplayChanges(v3, func(cs registry.ChangeSet) error {
+		for _, op := range cs {
+			names = append(names, op.Entry.ID.Name)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"one", "branch_b"}) {
+		t.Fatalf("replayed names = %v", names)
+	}
+}
+
 func TestStorage_Get(t *testing.T) {
 	storage := New()
 	v2 := version.New(2)
@@ -186,5 +218,72 @@ func TestStorage_DependencyResolutionRoundTripAndInheritance(t *testing.T) {
 	}
 	if inherited.Digest != resolution.Digest {
 		t.Fatalf("expected inherited digest %s, got %s", resolution.Digest, inherited.Digest)
+	}
+}
+
+func TestStorage_SaveSnapshotsMutableChangesAndUsesHeadCAS(t *testing.T) {
+	storage := New()
+	v0 := version.New(0)
+	data := map[string]any{"version": "v1", "nested": []any{"original"}}
+	meta := map[string]any{"nested": map[string]any{"enabled": true}}
+	v1 := version.FromParent(v0, 1)
+	if err := storage.Save(v1, registry.ChangeSet{{
+		Kind:  registry.EntryCreate,
+		Entry: registry.Entry{ID: registry.NewID("app", "entry"), Data: payload.New(data), Meta: meta},
+	}}, true); err != nil {
+		t.Fatalf("save v1: %v", err)
+	}
+	data["version"] = "mutated"
+	data["nested"].([]any)[0] = "mutated"
+	meta["nested"].(map[string]any)["enabled"] = false
+
+	got, err := storage.Get(v1)
+	if err != nil {
+		t.Fatalf("get v1: %v", err)
+	}
+	gotData := got[0].Entry.Data.Data().(map[string]any)
+	if gotData["version"] != "v1" || gotData["nested"].([]any)[0] != "original" {
+		t.Fatalf("saved payload was mutated through caller alias: %#v", gotData)
+	}
+	if got[0].Entry.Meta["nested"].(map[string]any)["enabled"] != true {
+		t.Fatalf("saved metadata was mutated through caller alias: %#v", got[0].Entry.Meta)
+	}
+
+	gotData["version"] = "mutated-through-get"
+	again, err := storage.Get(v1)
+	if err != nil || again[0].Entry.Data.Data().(map[string]any)["version"] != "v1" {
+		t.Fatalf("Get returned mutable storage aliases: %#v, %v", again, err)
+	}
+
+	v2 := version.FromParent(v1, 2)
+	if err := storage.Save(v2, nil, true); err != nil {
+		t.Fatalf("save v2: %v", err)
+	}
+	stale := version.FromParent(v1, 3)
+	if err := storage.Save(stale, nil, true); err == nil {
+		t.Fatal("expected stale-parent head CAS failure")
+	}
+	if _, err := storage.Get(stale); err == nil {
+		t.Fatal("failed CAS must not retain a partial version")
+	}
+}
+
+func TestStorage_DependencyResolutionCheckpointIsImmutable(t *testing.T) {
+	storage := New()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	if err := storage.Save(v1, nil, true); err != nil {
+		t.Fatalf("save v1: %v", err)
+	}
+	first := (&registry.DependencyResolution{InputDigest: "first"}).Canonical()
+	second := (&registry.DependencyResolution{InputDigest: "second"}).Canonical()
+	if err := storage.CheckpointDependencyResolution(v1, first); err != nil {
+		t.Fatalf("first checkpoint: %v", err)
+	}
+	if err := storage.CheckpointDependencyResolution(v1, first); err != nil {
+		t.Fatalf("idempotent checkpoint: %v", err)
+	}
+	if err := storage.CheckpointDependencyResolution(v1, second); err == nil {
+		t.Fatal("expected immutable resolution reference conflict")
 	}
 }

--- a/system/registry/history/memory/memory_test.go
+++ b/system/registry/history/memory/memory_test.go
@@ -3,22 +3,51 @@
 package memory
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/internal/version"
 )
 
+func TestStorageCanonicalizesSavedAncestryAndHead(t *testing.T) {
+	storage := New()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	if err := storage.Save(v1, nil, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// The caller supplies the right parent ID with a deliberately truncated
+	// parent chain. Storage must link to its canonical v1, not retain this object.
+	v2 := version.FromParent(version.New(1), 2)
+	if err := storage.Save(v2, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.SetHead(version.New(2)); err != nil {
+		t.Fatal(err)
+	}
+	head, err := storage.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head.Previous() == nil || head.Previous().ID() != 1 || head.Previous().Previous() == nil || head.Previous().Previous().ID() != 0 {
+		t.Fatalf("head ancestry was not canonicalized: %#v", head)
+	}
+}
+
 func TestStorage_Versions(t *testing.T) {
 	storage := New()
 
 	v0 := version.New(0)
-	v1 := version.New(1)
-	v2 := version.New(2)
-	v3 := version.New(3)
+	v1 := version.FromParent(v0, 1)
+	v2 := version.FromParent(v1, 2)
+	v3 := version.FromParent(v2, 3)
 
 	_ = storage.Save(v1, registry.ChangeSet{}, false)
 	_ = storage.Save(v2, registry.ChangeSet{}, false)
@@ -33,9 +62,9 @@ func TestStorage_Versions(t *testing.T) {
 		return versions[i].ID() < versions[j].ID()
 	})
 
-	expectedVersions := []registry.Version{v0, v1, v2, v3}
-	if !reflect.DeepEqual(versions, expectedVersions) {
-		t.Errorf("Expected versions: %v, got: %v", expectedVersions, versions)
+	expectedIDs := []uint{v0.ID(), v1.ID(), v2.ID(), v3.ID()}
+	if got := versionIDs(versions); !reflect.DeepEqual(got, expectedIDs) {
+		t.Errorf("Expected version IDs: %v, got: %v", expectedIDs, got)
 	}
 }
 
@@ -58,7 +87,7 @@ func TestStorage_ReplayChangesFollowsOnlyTargetAncestry(t *testing.T) {
 		t.Fatal(err)
 	}
 	var names []string
-	if err := storage.ReplayChanges(v3, func(cs registry.ChangeSet) error {
+	if err := storage.ReplayChanges(context.Background(), v3, func(cs registry.ChangeSet) error {
 		for _, op := range cs {
 			names = append(names, op.Entry.ID.Name)
 		}
@@ -71,9 +100,61 @@ func TestStorage_ReplayChangesFollowsOnlyTargetAncestry(t *testing.T) {
 	}
 }
 
+func TestStorageReplayHonorsCanceledContextAtRoot(t *testing.T) {
+	storage := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := storage.ReplayChanges(ctx, version.New(registry.RootVersion), func(registry.ChangeSet) error {
+		t.Fatal("root replay must not invoke callback")
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStorageReplayDoesNotHoldLockDuringCallback(t *testing.T) {
+	storage := New()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	require.NoError(t, storage.Save(v1, nil, false))
+	v2 := version.FromParent(v1, 2)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- storage.ReplayChanges(context.Background(), v1, func(registry.ChangeSet) error {
+			return storage.Save(v2, nil, false)
+		})
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("replay callback could not re-enter history")
+	}
+	_, err := storage.Get(v2)
+	require.NoError(t, err)
+}
+
+func TestStorageRejectsMalformedResolutionWithoutMutation(t *testing.T) {
+	storage := New()
+	malformed := (&registry.DependencyResolution{Modules: []registry.ResolvedModule{
+		{Name: "duplicate", Version: "1.0.0"},
+		{Name: "duplicate", Version: "2.0.0"},
+	}}).Canonical()
+	v1 := version.FromParent(version.New(0), 1)
+
+	require.ErrorIs(t, storage.SaveWithDependencyResolution(v1, nil, malformed, true), registry.ErrInvalidDependencyResolution)
+	_, err := storage.GetVersion(v1.ID())
+	require.Error(t, err)
+	_, err = storage.Head()
+	require.Error(t, err)
+}
+
 func TestStorage_Get(t *testing.T) {
 	storage := New()
-	v2 := version.New(2)
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	v2 := version.FromParent(v1, 2)
 
 	actions := registry.ChangeSet{
 		{
@@ -85,6 +166,7 @@ func TestStorage_Get(t *testing.T) {
 		},
 	}
 
+	_ = storage.Save(v1, nil, false)
 	_ = storage.Save(v2, actions, false)
 
 	retrievedActions, err := storage.Get(v2)
@@ -105,8 +187,8 @@ func TestStorage_Get(t *testing.T) {
 func TestStorage_Save(t *testing.T) {
 	storage := New()
 	v0 := version.New(0)
-	v1 := version.New(1)
-	v2 := version.New(2)
+	v1 := version.FromParent(v0, 1)
+	v2 := version.FromParent(v1, 2)
 
 	actions := registry.ChangeSet{
 		{
@@ -133,9 +215,9 @@ func TestStorage_Save(t *testing.T) {
 		return versions[i].ID() < versions[j].ID()
 	})
 
-	expectedVersions := []registry.Version{v0, v1, v2}
-	if !reflect.DeepEqual(versions, expectedVersions) {
-		t.Errorf("Expected versions: %v, got: %v", expectedVersions, versions)
+	expectedIDs := []uint{v0.ID(), v1.ID(), v2.ID()}
+	if got := versionIDs(versions); !reflect.DeepEqual(got, expectedIDs) {
+		t.Errorf("Expected version IDs: %v, got: %v", expectedIDs, got)
 	}
 
 	retrievedActions, _ := storage.Get(v2)
@@ -144,45 +226,69 @@ func TestStorage_Save(t *testing.T) {
 	}
 }
 
+func versionIDs(versions []registry.Version) []uint {
+	ids := make([]uint, len(versions))
+	for i, stored := range versions {
+		ids[i] = stored.ID()
+	}
+	return ids
+}
+
 func TestStorage_Head(t *testing.T) {
 	storage := New()
+	v0 := version.New(0)
 
 	_, err := storage.Head()
 	if err == nil {
 		t.Errorf("Expected error when getting head of empty history, got nil")
 	}
 
-	v1 := version.New(1)
+	v1 := version.FromParent(v0, 1)
 	_ = storage.Save(v1, registry.ChangeSet{}, true)
 
 	head, err := storage.Head()
 	if err != nil {
 		t.Fatalf("Unexpected error getting head: %v", err)
 	}
-	if !reflect.DeepEqual(head, v1) {
+	if head.ID() != v1.ID() {
 		t.Errorf("Expected head to be v1 (%v), got: %v", v1, head)
 	}
 
-	v2 := version.New(2)
+	v2 := version.FromParent(v1, 2)
 	_ = storage.Save(v2, registry.ChangeSet{}, false)
 
 	head, err = storage.Head()
 	if err != nil {
 		t.Fatalf("Unexpected error getting head: %v", err)
 	}
-	if !reflect.DeepEqual(head, v1) {
+	if head.ID() != v1.ID() {
 		t.Errorf("Expected head to remain v1 (%v), got: %v", v1, head)
 	}
 
-	v3 := version.New(3)
+	v3 := version.FromParent(v1, 3)
 	_ = storage.Save(v3, registry.ChangeSet{}, true)
 
 	head, err = storage.Head()
 	if err != nil {
 		t.Fatalf("Unexpected error getting head: %v", err)
 	}
-	if !reflect.DeepEqual(head, v3) {
+	if head.ID() != v3.ID() {
 		t.Errorf("Expected head to be v3 (%v), got: %v", v3, head)
+	}
+}
+
+func TestStorageRejectsParentlessNonRootVersion(t *testing.T) {
+	storage := New()
+	err := storage.Save(version.New(1), nil, false)
+	if err == nil {
+		t.Fatal("expected parentless non-root version to be rejected")
+	}
+	versions, versionsErr := storage.Versions()
+	if versionsErr != nil {
+		t.Fatal(versionsErr)
+	}
+	if len(versions) != 1 || versions[0].ID() != registry.RootVersion {
+		t.Fatalf("rejected version was partially persisted: %v", versions)
 	}
 }
 

--- a/system/registry/history/memory/memory_test.go
+++ b/system/registry/history/memory/memory_test.go
@@ -153,3 +153,38 @@ func TestStorage_Head(t *testing.T) {
 		t.Errorf("Expected head to be v3 (%v), got: %v", v3, head)
 	}
 }
+
+func TestStorage_DependencyResolutionRoundTripAndInheritance(t *testing.T) {
+	storage := New()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	resolution := (&registry.DependencyResolution{
+		InputDigest: "roots",
+		Modules: []registry.ResolvedModule{{
+			Name: "acme/crm", Version: "v1.6.0", Digest: "sha256:crm",
+		}},
+	}).Canonical()
+
+	if err := storage.SaveWithDependencyResolution(v1, nil, resolution, true); err != nil {
+		t.Fatalf("save resolution: %v", err)
+	}
+	got, err := storage.GetDependencyResolution(v1)
+	if err != nil {
+		t.Fatalf("get resolution: %v", err)
+	}
+	if got.Digest != resolution.Digest {
+		t.Fatalf("expected digest %s, got %s", resolution.Digest, got.Digest)
+	}
+
+	v2 := version.FromParent(v1, 2)
+	if err := storage.Save(v2, nil, true); err != nil {
+		t.Fatalf("save inherited version: %v", err)
+	}
+	inherited, err := storage.GetDependencyResolution(v2)
+	if err != nil {
+		t.Fatalf("get inherited resolution: %v", err)
+	}
+	if inherited.Digest != resolution.Digest {
+		t.Fatalf("expected inherited digest %s, got %s", resolution.Digest, inherited.Digest)
+	}
+}

--- a/system/registry/history/nil/nil.go
+++ b/system/registry/history/nil/nil.go
@@ -17,8 +17,10 @@ import (
 //   - When you want to minimize memory overhead
 //   - When you only need forward progression without rollback capability
 type History struct {
-	head registry.Version
-	mu   sync.RWMutex
+	head              registry.Version
+	resolution        *registry.DependencyResolution
+	resolutionVersion uint
+	mu                sync.RWMutex
 }
 
 // New creates a new nil History instance.
@@ -29,24 +31,62 @@ func New() *History {
 // Save accepts a new version and updates the current head version.
 // The changeset is not persisted. Setting head to true updates the current version.
 func (n *History) Save(newVersion registry.Version, _ registry.ChangeSet, head bool) error {
+	return n.SaveWithDependencyResolution(newVersion, nil, nil, head)
+}
+
+func (n *History) SaveWithDependencyResolution(newVersion registry.Version, _ registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
 	if head {
 		n.mu.Lock()
+		defer n.mu.Unlock()
+		if previous := newVersion.Previous(); previous != nil && !nilHeadMatchesParent(n.head, previous) {
+			return ErrRollbackNotSupported
+		}
 		n.head = newVersion
-		n.mu.Unlock()
+		if resolution != nil {
+			n.resolution = resolution.Canonical()
+			n.resolutionVersion = newVersion.ID()
+		} else if n.resolution != nil {
+			n.resolutionVersion = newVersion.ID()
+		}
 	}
 	return nil
 }
 
-func (n *History) SaveWithDependencyResolution(newVersion registry.Version, cs registry.ChangeSet, _ *registry.DependencyResolution, head bool) error {
-	return n.Save(newVersion, cs, head)
+func (n *History) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if n.resolution == nil || n.resolutionVersion != v.ID() {
+		return nil, registry.ErrDependencyResolutionNotFound
+	}
+	return n.resolution.Canonical(), nil
 }
 
-func (n *History) GetDependencyResolution(registry.Version) (*registry.DependencyResolution, error) {
-	return nil, registry.ErrDependencyResolutionNotFound
+func (n *History) CheckpointDependencyResolution(v registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.head != nil && n.head.ID() != v.ID() {
+		return ErrHistoryNotAvailable
+	}
+	if n.head == nil && v.ID() != registry.RootVersion {
+		return ErrHistoryNotAvailable
+	}
+	canonical := resolution.Canonical()
+	if n.resolution != nil && n.resolutionVersion == v.ID() && n.resolution.Digest != canonical.Digest {
+		return ErrHistoryNotAvailable
+	}
+	n.resolution = canonical
+	n.resolutionVersion = v.ID()
+	return nil
 }
 
-func (n *History) CheckpointDependencyResolution(registry.Version, *registry.DependencyResolution) error {
-	return ErrHistoryNotAvailable
+func nilHeadMatchesParent(head, parent registry.Version) bool {
+	if head == nil {
+		return parent != nil && parent.ID() == registry.RootVersion
+	}
+	return parent != nil && head.ID() == parent.ID()
 }
 
 // Get returns an error as version history is not available with nil History.

--- a/system/registry/history/nil/nil.go
+++ b/system/registry/history/nil/nil.go
@@ -35,6 +35,13 @@ func (n *History) Save(newVersion registry.Version, _ registry.ChangeSet, head b
 }
 
 func (n *History) SaveWithDependencyResolution(newVersion registry.Version, _ registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
+	var canonical *registry.DependencyResolution
+	if resolution != nil {
+		canonical = resolution.Canonical()
+		if !canonical.Valid() {
+			return registry.ErrInvalidDependencyResolution
+		}
+	}
 	if head {
 		n.mu.Lock()
 		defer n.mu.Unlock()
@@ -42,8 +49,8 @@ func (n *History) SaveWithDependencyResolution(newVersion registry.Version, _ re
 			return ErrRollbackNotSupported
 		}
 		n.head = newVersion
-		if resolution != nil {
-			n.resolution = resolution.Canonical()
+		if canonical != nil {
+			n.resolution = canonical
 			n.resolutionVersion = newVersion.ID()
 		} else if n.resolution != nil {
 			n.resolutionVersion = newVersion.ID()
@@ -65,6 +72,10 @@ func (n *History) CheckpointDependencyResolution(v registry.Version, resolution 
 	if resolution == nil {
 		return registry.ErrDependencyResolutionNotFound
 	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.head != nil && n.head.ID() != v.ID() {
@@ -73,12 +84,36 @@ func (n *History) CheckpointDependencyResolution(v registry.Version, resolution 
 	if n.head == nil && v.ID() != registry.RootVersion {
 		return ErrHistoryNotAvailable
 	}
-	canonical := resolution.Canonical()
 	if n.resolution != nil && n.resolutionVersion == v.ID() && n.resolution.Digest != canonical.Digest {
 		return ErrHistoryNotAvailable
 	}
 	n.resolution = canonical
 	n.resolutionVersion = v.ID()
+	return nil
+}
+
+func (n *History) CompareAndSetHeadWithDependencyResolution(expected, target registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if !nilHeadMatchesParent(n.head, expected) {
+		return ErrRollbackNotSupported
+	}
+	if target.ID() != expected.ID() {
+		return ErrHistoryNotAvailable
+	}
+	if n.resolution != nil && n.resolutionVersion == target.ID() && n.resolution.Digest != canonical.Digest {
+		return ErrHistoryNotAvailable
+	}
+	n.resolution = canonical
+	n.resolutionVersion = target.ID()
+	n.head = target
 	return nil
 }
 

--- a/system/registry/history/nil/nil.go
+++ b/system/registry/history/nil/nil.go
@@ -37,6 +37,18 @@ func (n *History) Save(newVersion registry.Version, _ registry.ChangeSet, head b
 	return nil
 }
 
+func (n *History) SaveWithDependencyResolution(newVersion registry.Version, cs registry.ChangeSet, _ *registry.DependencyResolution, head bool) error {
+	return n.Save(newVersion, cs, head)
+}
+
+func (n *History) GetDependencyResolution(registry.Version) (*registry.DependencyResolution, error) {
+	return nil, registry.ErrDependencyResolutionNotFound
+}
+
+func (n *History) CheckpointDependencyResolution(registry.Version, *registry.DependencyResolution) error {
+	return ErrHistoryNotAvailable
+}
+
 // Get returns an error as version history is not available with nil History.
 func (n *History) Get(_ registry.Version) (registry.ChangeSet, error) {
 	return nil, ErrHistoryNotAvailable

--- a/system/registry/history/nil/nil_test.go
+++ b/system/registry/history/nil/nil_test.go
@@ -205,3 +205,33 @@ func TestHistory_ConcurrentHeadRead(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestHistory_RetainsCurrentDependencyResolution(t *testing.T) {
+	hist := New()
+	v0 := version.New(registry.RootVersion)
+	first := (&registry.DependencyResolution{InputDigest: "first"}).Canonical()
+	second := (&registry.DependencyResolution{InputDigest: "second"}).Canonical()
+
+	if err := hist.CheckpointDependencyResolution(v0, first); err != nil {
+		t.Fatalf("checkpoint baseline resolution: %v", err)
+	}
+	got, err := hist.GetDependencyResolution(v0)
+	if err != nil || got.Digest != first.Digest {
+		t.Fatalf("get baseline resolution: %#v, %v", got, err)
+	}
+	if err := hist.CheckpointDependencyResolution(v0, second); err == nil {
+		t.Fatal("expected immutable checkpoint conflict")
+	}
+
+	v1 := version.FromParent(v0, 1)
+	if err := hist.SaveWithDependencyResolution(v1, nil, second, true); err != nil {
+		t.Fatalf("save runtime resolution: %v", err)
+	}
+	got, err = hist.GetDependencyResolution(v1)
+	if err != nil || got.Digest != second.Digest {
+		t.Fatalf("get runtime resolution: %#v, %v", got, err)
+	}
+	if _, err := hist.GetDependencyResolution(v0); err == nil {
+		t.Fatal("nil history must expose only the current resolution")
+	}
+}

--- a/system/registry/history/nil/nil_test.go
+++ b/system/registry/history/nil/nil_test.go
@@ -3,6 +3,7 @@
 package nil
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -233,5 +234,39 @@ func TestHistory_RetainsCurrentDependencyResolution(t *testing.T) {
 	}
 	if _, err := hist.GetDependencyResolution(v0); err == nil {
 		t.Fatal("nil history must expose only the current resolution")
+	}
+}
+
+func TestHistory_AtomicResolutionInitializesRootHead(t *testing.T) {
+	hist := New()
+	v0 := version.New(registry.RootVersion)
+	resolution := (&registry.DependencyResolution{InputDigest: "baseline"}).Canonical()
+
+	if err := hist.CompareAndSetHeadWithDependencyResolution(v0, v0, resolution); err != nil {
+		t.Fatalf("initialize root resolution and head: %v", err)
+	}
+	head, err := hist.Head()
+	if err != nil || head.ID() != registry.RootVersion {
+		t.Fatalf("root head was not initialized: %#v, %v", head, err)
+	}
+	stored, err := hist.GetDependencyResolution(v0)
+	if err != nil || stored.Digest != resolution.Digest {
+		t.Fatalf("root resolution was not initialized: %#v, %v", stored, err)
+	}
+}
+
+func TestHistory_RejectsMalformedResolutionWithoutMutation(t *testing.T) {
+	hist := New()
+	malformed := (&registry.DependencyResolution{Roots: []registry.DependencyRoot{
+		{ID: "duplicate", Component: "one", Version: "1"},
+		{ID: "duplicate", Component: "two", Version: "1"},
+	}}).Canonical()
+	v0 := version.New(registry.RootVersion)
+
+	if err := hist.SaveWithDependencyResolution(v0, nil, malformed, true); !errors.Is(err, registry.ErrInvalidDependencyResolution) {
+		t.Fatalf("expected invalid resolution error, got %v", err)
+	}
+	if _, err := hist.Head(); err == nil {
+		t.Fatal("malformed resolution advanced nil history head")
 	}
 }

--- a/system/registry/history/postgres/postgres.go
+++ b/system/registry/history/postgres/postgres.go
@@ -48,7 +48,10 @@ type postgresQueries struct {
 	insertRootVersion    string
 	insertVersion        string
 	queryHead            string
+	queryHeadLineage     string
+	queryVersionLineage  string
 	queryVersions        string
+	queryMaxVersionID    string
 	setHead              string
 	setInitialHead       string
 	updateHeadCAS        string
@@ -145,6 +148,13 @@ func buildQueries(schemaName string) postgresQueries {
 	resolutionGraphs := table("resolution_graphs")
 	versionResolutions := table("version_resolutions")
 	metadata := table("metadata")
+	versionLineage := `WITH RECURSIVE lineage(id, parent_id) AS (
+		SELECT id, parent_id FROM ` + versions + ` WHERE id = $1
+		UNION
+		SELECT v.id, v.parent_id
+		FROM ` + versions + ` v JOIN lineage ON v.id = lineage.parent_id
+	)
+	SELECT id, parent_id FROM lineage`
 
 	return postgresQueries{
 		getResolution:        "SELECT vr.resolution_digest, g.data FROM " + versionResolutions + " vr LEFT JOIN " + resolutionGraphs + " g ON g.digest = vr.resolution_digest WHERE vr.version_id = $1",
@@ -159,19 +169,22 @@ func buildQueries(schemaName string) postgresQueries {
 		insertRootVersion:    "INSERT INTO " + versions + " (id, parent_id) VALUES (0, NULL) ON CONFLICT(id) DO NOTHING",
 		insertVersion:        "INSERT INTO " + versions + " (id, parent_id) VALUES ($1, $2)",
 		queryHead:            "SELECT value FROM " + metadata + " WHERE key = 'head'",
+		queryHeadLineage:     versionLineage,
+		queryVersionLineage:  versionLineage,
 		queryVersions:        "SELECT id, parent_id FROM " + versions + " ORDER BY id ASC",
+		queryMaxVersionID:    "SELECT COALESCE(MAX(id), 0) FROM " + versions,
 		setHead:              "UPDATE " + metadata + " SET value = $1 WHERE key = 'head' AND EXISTS (SELECT 1 FROM " + versions + " WHERE id = $2)",
 		setInitialHead:       "INSERT INTO " + metadata + " (key, value) VALUES ('head', '0') ON CONFLICT(key) DO NOTHING",
 		updateHeadCAS:        "UPDATE " + metadata + " SET value = $1 WHERE key = 'head' AND value = $2 AND EXISTS (SELECT 1 FROM " + versions + " WHERE id = $3)",
 		versionExists:        "SELECT 1 FROM " + versions + " WHERE id = $1",
-		replayChanges: `WITH RECURSIVE lineage(id, parent_id, depth) AS (
-			SELECT id, parent_id, 0 FROM ` + versions + ` WHERE id = $1
-			UNION ALL
-			SELECT v.id, v.parent_id, lineage.depth + 1
+		replayChanges: `WITH RECURSIVE lineage(id, parent_id) AS (
+			SELECT id, parent_id FROM ` + versions + ` WHERE id = $1
+			UNION
+			SELECT v.id, v.parent_id
 			FROM ` + versions + ` v JOIN lineage ON v.id = lineage.parent_id
 		)
-		SELECT c.data FROM lineage JOIN ` + changesets + ` c ON c.version_id = lineage.id
-		WHERE lineage.id <> 0 ORDER BY lineage.depth DESC`,
+		SELECT lineage.id, lineage.parent_id, c.data
+		FROM lineage LEFT JOIN ` + changesets + ` c ON c.version_id = lineage.id`,
 	}
 }
 
@@ -213,6 +226,78 @@ func (h *History) Versions() ([]registry.Version, error) {
 	return h.versions(context.Background())
 }
 
+func (h *History) MaxVersionID() (uint, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	var maxID uint
+	if err := h.db.QueryRowContext(context.Background(), h.queries.queryMaxVersionID).Scan(&maxID); err != nil {
+		return 0, NewGetVersionsError(err)
+	}
+	return maxID, nil
+}
+
+func (h *History) GetVersion(id uint) (registry.Version, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	rows, err := h.db.QueryContext(context.Background(), h.queries.queryVersionLineage, id)
+	if err != nil {
+		return nil, NewQueryVersionsError(err)
+	}
+	parents := make(map[uint]sql.NullInt64)
+	for rows.Next() {
+		var versionID uint
+		var parentID sql.NullInt64
+		if err := rows.Scan(&versionID, &parentID); err != nil {
+			_ = rows.Close()
+			return nil, NewScanVersionError(err)
+		}
+		parents[versionID] = parentID
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, NewIterateVersionsError(err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, NewIterateVersionsError(err)
+	}
+	stored, err := versionFromLineage(id, parents)
+	if err != nil {
+		return nil, NewQueryVersionsError(err)
+	}
+	return stored, nil
+}
+
+func versionFromLineage(targetID uint, parents map[uint]sql.NullInt64) (registry.Version, error) {
+	ids := make([]uint, 0, len(parents))
+	seen := make(map[uint]struct{}, len(parents))
+	currentID := targetID
+	for currentID != registry.RootVersion {
+		if _, duplicate := seen[currentID]; duplicate {
+			return nil, fmt.Errorf("version %d lineage contains a cycle", targetID)
+		}
+		seen[currentID] = struct{}{}
+		parentID, ok := parents[currentID]
+		if !ok {
+			return nil, fmt.Errorf("version %d not found", currentID)
+		}
+		if !parentID.Valid || parentID.Int64 < 0 {
+			return nil, fmt.Errorf("version %d lineage does not terminate at root", targetID)
+		}
+		ids = append(ids, currentID)
+		currentID = uint(parentID.Int64)
+	}
+	rootParent, ok := parents[registry.RootVersion]
+	if !ok || rootParent.Valid {
+		return nil, fmt.Errorf("version %d lineage does not terminate at root", targetID)
+	}
+	current := version.New(registry.RootVersion)
+	for i := len(ids) - 1; i >= 0; i-- {
+		current = version.FromParent(current, ids[i])
+	}
+	return current, nil
+}
+
 func (h *History) versions(ctx context.Context) ([]registry.Version, error) {
 	rows, err := h.db.QueryContext(ctx, h.queries.queryVersions)
 	if err != nil {
@@ -241,8 +326,10 @@ func (h *History) versions(ctx context.Context) ([]registry.Version, error) {
 				return nil, NewParentVersionNotFoundError(uint(parentID.Int64), id)
 			}
 			v = version.FromParent(parent, id)
-		} else {
+		} else if id == registry.RootVersion {
 			v = version.New(id)
+		} else {
+			return nil, NewParentVersionNotFoundError(registry.RootVersion, id)
 		}
 
 		versionMap[id] = v
@@ -322,28 +409,18 @@ func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	return cs, nil
 }
 
-func (h *History) ReplayChanges(target registry.Version, apply func(registry.ChangeSet) error) error {
+func (h *History) ReplayChanges(ctx context.Context, target registry.Version, apply func(registry.ChangeSet) error) error {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-	ctx := context.Background()
-	var exists int
-	if err := h.db.QueryRowContext(ctx, h.queries.versionExists, target.ID()).Scan(&exists); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return NewChangesetNotFoundError(target.ID())
-		}
-		return NewQueryChangesetError(err)
-	}
-	rows, err := h.db.QueryContext(ctx, h.queries.replayChanges, target.ID())
+	encoded, err := h.replayLineage(ctx, target)
+	h.mu.RUnlock()
 	if err != nil {
-		return NewQueryChangesetError(err)
+		return err
 	}
-	defer func() { _ = rows.Close() }()
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return NewQueryChangesetError(err)
+	for _, item := range encoded {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		changes, err := h.decodeChangeSet(data)
+		changes, err := h.decodeChangeSet(item)
 		if err != nil {
 			return err
 		}
@@ -351,10 +428,71 @@ func (h *History) ReplayChanges(target registry.Version, apply func(registry.Cha
 			return err
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return NewIterateVersionsError(err)
-	}
 	return nil
+}
+
+type replayLineageRow struct {
+	data     []byte
+	parentID sql.NullInt64
+}
+
+func (h *History) replayLineage(ctx context.Context, target registry.Version) ([][]byte, error) {
+	var exists int
+	if err := h.db.QueryRowContext(ctx, h.queries.versionExists, target.ID()).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, NewChangesetNotFoundError(target.ID())
+		}
+		return nil, NewQueryChangesetError(err)
+	}
+	rows, err := h.db.QueryContext(ctx, h.queries.replayChanges, target.ID())
+	if err != nil {
+		return nil, NewQueryChangesetError(err)
+	}
+	lineage := make(map[uint]replayLineageRow)
+	for rows.Next() {
+		var versionID uint
+		var parentID sql.NullInt64
+		var data []byte
+		if err := rows.Scan(&versionID, &parentID, &data); err != nil {
+			_ = rows.Close()
+			return nil, NewQueryChangesetError(err)
+		}
+		lineage[versionID] = replayLineageRow{parentID: parentID, data: data}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, NewIterateVersionsError(err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, NewIterateVersionsError(err)
+	}
+
+	encoded := make([][]byte, 0, len(lineage))
+	seen := make(map[uint]struct{}, len(lineage))
+	currentID := target.ID()
+	for currentID != registry.RootVersion {
+		if _, duplicate := seen[currentID]; duplicate {
+			return nil, NewQueryChangesetError(fmt.Errorf("version %d lineage is cyclic", target.ID()))
+		}
+		seen[currentID] = struct{}{}
+		row, ok := lineage[currentID]
+		if !ok || !row.parentID.Valid || row.parentID.Int64 < 0 {
+			return nil, NewQueryChangesetError(fmt.Errorf("version %d lineage does not terminate at root", target.ID()))
+		}
+		if row.data == nil {
+			return nil, NewChangesetNotFoundError(currentID)
+		}
+		encoded = append(encoded, row.data)
+		currentID = uint(row.parentID.Int64)
+	}
+	root, ok := lineage[registry.RootVersion]
+	if !ok || root.parentID.Valid {
+		return nil, NewQueryChangesetError(fmt.Errorf("version %d lineage does not terminate at root", target.ID()))
+	}
+	for left, right := 0, len(encoded)-1; left < right; left, right = left+1, right-1 {
+		encoded[left], encoded[right] = encoded[right], encoded[left]
+	}
+	return encoded, nil
 }
 
 func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) error {
@@ -362,6 +500,16 @@ func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) err
 }
 
 func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
+	if v.ID() != registry.RootVersion && v.Previous() == nil {
+		return NewInsertVersionError(fmt.Errorf("non-root version %d has no parent", v.ID()))
+	}
+	var canonicalResolution *registry.DependencyResolution
+	if resolution != nil {
+		canonicalResolution = resolution.Canonical()
+		if !canonicalResolution.Valid() {
+			return registry.ErrInvalidDependencyResolution
+		}
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -375,8 +523,8 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	var parentID sql.NullInt64
 	if v.Previous() != nil {
 		prevID := v.Previous().ID()
-		const maxInt64 = uint(1<<63 - 1)
-		if prevID > maxInt64 {
+		const maxInt64 = uint64(1<<63 - 1)
+		if uint64(prevID) > maxInt64 {
 			return NewParentVersionIDTooLargeError(prevID)
 		}
 		parentID = sql.NullInt64{Int64: int64(prevID), Valid: true}
@@ -446,19 +594,18 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	if err != nil {
 		return NewInsertChangesetError(err)
 	}
-	if resolution != nil {
-		canonical := resolution.Canonical()
-		data, marshalErr := json.Marshal(canonical)
+	if canonicalResolution != nil {
+		data, marshalErr := json.Marshal(canonicalResolution)
 		if marshalErr != nil {
 			return NewEncodeChangesetError(marshalErr)
 		}
-		if _, err = tx.ExecContext(ctx, h.queries.insertResolution, canonical.Digest, data); err != nil {
+		if _, err = tx.ExecContext(ctx, h.queries.insertResolution, canonicalResolution.Digest, data); err != nil {
 			return NewInsertChangesetError(err)
 		}
-		if err = h.ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+		if err = h.ensureResolutionGraph(ctx, tx, canonicalResolution.Digest); err != nil {
 			return NewDecodeChangesetError(err)
 		}
-		if err = h.setVersionResolution(ctx, tx, v.ID(), canonical.Digest); err != nil {
+		if err = h.setVersionResolution(ctx, tx, v.ID(), canonicalResolution.Digest); err != nil {
 			return NewInsertChangesetError(err)
 		}
 	} else if v.Previous() != nil {
@@ -516,9 +663,12 @@ func (h *History) CheckpointDependencyResolution(v registry.Version, resolution 
 	if resolution == nil {
 		return registry.ErrDependencyResolutionNotFound
 	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	canonical := resolution.Canonical()
 	data, err := json.Marshal(canonical)
 	if err != nil {
 		return NewEncodeChangesetError(err)
@@ -562,18 +712,28 @@ func (h *History) Head() (registry.Version, error) {
 	}
 	headID := uint(head64)
 
-	versions, err := h.versions(ctx)
+	rows, err := h.db.QueryContext(ctx, h.queries.queryHeadLineage, headID)
 	if err != nil {
-		return nil, NewGetVersionsError(err)
+		return nil, NewQueryHeadError(err)
 	}
-
-	for _, v := range versions {
-		if v.ID() == headID {
-			return v, nil
+	defer func() { _ = rows.Close() }()
+	parents := make(map[uint]sql.NullInt64)
+	for rows.Next() {
+		var id uint
+		var parentID sql.NullInt64
+		if err := rows.Scan(&id, &parentID); err != nil {
+			return nil, NewQueryHeadError(err)
 		}
+		parents[id] = parentID
 	}
-
-	return nil, NewHeadVersionNotFoundError(headID)
+	if err := rows.Err(); err != nil {
+		return nil, NewQueryHeadError(err)
+	}
+	stored, err := versionFromLineage(headID, parents)
+	if err != nil {
+		return nil, NewHeadVersionNotFoundError(headID)
+	}
+	return stored, nil
 }
 
 func (h *History) SetHead(v registry.Version) error {
@@ -611,6 +771,53 @@ func (h *History) CompareAndSetHead(expected, target registry.Version) error {
 	}
 	if updated != 1 {
 		return NewSetHeadError(fmt.Errorf("history head changed or target version %d does not exist", target.ID()))
+	}
+	return nil
+}
+
+func (h *History) CompareAndSetHeadWithDependencyResolution(expected, target registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	data, err := json.Marshal(canonical)
+	if err != nil {
+		return NewEncodeChangesetError(err)
+	}
+	ctx := context.Background()
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return NewBeginTransactionError(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(ctx, h.queries.insertResolution, canonical.Digest, data); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	if err = h.ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+		return NewDecodeChangesetError(err)
+	}
+	if err = h.setVersionResolution(ctx, tx, target.ID(), canonical.Digest); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	result, err := tx.ExecContext(ctx, h.queries.updateHeadCAS,
+		strconv.FormatUint(uint64(target.ID()), 10), strconv.FormatUint(uint64(expected.ID()), 10), target.ID())
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	if updated != 1 {
+		return NewSetHeadError(fmt.Errorf("history head changed or target version %d does not exist", target.ID()))
+	}
+	if err = tx.Commit(); err != nil {
+		return NewCommitTransactionError(err)
 	}
 	return nil
 }

--- a/system/registry/history/postgres/postgres.go
+++ b/system/registry/history/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strconv"
@@ -34,16 +35,20 @@ type History struct {
 }
 
 type postgresQueries struct {
-	getChangeset        string
-	insertChangeset     string
-	insertRootChangeset string
-	insertRootVersion   string
-	insertVersion       string
-	queryHead           string
-	queryVersions       string
-	setHead             string
-	setInitialHead      string
-	updateHead          string
+	getResolution        string
+	getChangeset         string
+	inheritResolution    string
+	insertResolution     string
+	setVersionResolution string
+	insertChangeset      string
+	insertRootChangeset  string
+	insertRootVersion    string
+	insertVersion        string
+	queryHead            string
+	queryVersions        string
+	setHead              string
+	setInitialHead       string
+	updateHead           string
 }
 
 type encodedPayload struct {
@@ -132,19 +137,25 @@ func buildQueries(schemaName string) postgresQueries {
 	}
 	versions := table("versions")
 	changesets := table("changesets")
+	resolutionGraphs := table("resolution_graphs")
+	versionResolutions := table("version_resolutions")
 	metadata := table("metadata")
 
 	return postgresQueries{
-		getChangeset:        "SELECT data FROM " + changesets + " WHERE version_id = $1",
-		insertChangeset:     "INSERT INTO " + changesets + " (version_id, data) VALUES ($1, $2) ON CONFLICT(version_id) DO UPDATE SET data = EXCLUDED.data",
-		insertRootChangeset: "INSERT INTO " + changesets + " (version_id, data) VALUES (0, $1) ON CONFLICT(version_id) DO NOTHING",
-		insertRootVersion:   "INSERT INTO " + versions + " (id, parent_id) VALUES (0, NULL) ON CONFLICT(id) DO NOTHING",
-		insertVersion:       "INSERT INTO " + versions + " (id, parent_id) VALUES ($1, $2) ON CONFLICT(id) DO UPDATE SET parent_id = EXCLUDED.parent_id",
-		queryHead:           "SELECT value FROM " + metadata + " WHERE key = 'head'",
-		queryVersions:       "SELECT id, parent_id FROM " + versions + " ORDER BY id ASC",
-		setHead:             "INSERT INTO " + metadata + " (key, value) VALUES ('head', $1) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
-		setInitialHead:      "INSERT INTO " + metadata + " (key, value) VALUES ('head', '0') ON CONFLICT(key) DO NOTHING",
-		updateHead:          "INSERT INTO " + metadata + " (key, value) VALUES ('head', $1) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
+		getResolution:        "SELECT g.data FROM " + versionResolutions + " vr JOIN " + resolutionGraphs + " g ON g.digest = vr.resolution_digest WHERE vr.version_id = $1",
+		getChangeset:         "SELECT data FROM " + changesets + " WHERE version_id = $1",
+		inheritResolution:    "INSERT INTO " + versionResolutions + " (version_id, resolution_digest) SELECT $1, resolution_digest FROM " + versionResolutions + " WHERE version_id = $2 ON CONFLICT(version_id) DO UPDATE SET resolution_digest = EXCLUDED.resolution_digest",
+		insertResolution:     "INSERT INTO " + resolutionGraphs + " (digest, data) VALUES ($1, $2) ON CONFLICT(digest) DO NOTHING",
+		setVersionResolution: "INSERT INTO " + versionResolutions + " (version_id, resolution_digest) VALUES ($1, $2) ON CONFLICT(version_id) DO UPDATE SET resolution_digest = EXCLUDED.resolution_digest",
+		insertChangeset:      "INSERT INTO " + changesets + " (version_id, data) VALUES ($1, $2) ON CONFLICT(version_id) DO UPDATE SET data = EXCLUDED.data",
+		insertRootChangeset:  "INSERT INTO " + changesets + " (version_id, data) VALUES (0, $1) ON CONFLICT(version_id) DO NOTHING",
+		insertRootVersion:    "INSERT INTO " + versions + " (id, parent_id) VALUES (0, NULL) ON CONFLICT(id) DO NOTHING",
+		insertVersion:        "INSERT INTO " + versions + " (id, parent_id) VALUES ($1, $2) ON CONFLICT(id) DO UPDATE SET parent_id = EXCLUDED.parent_id",
+		queryHead:            "SELECT value FROM " + metadata + " WHERE key = 'head'",
+		queryVersions:        "SELECT id, parent_id FROM " + versions + " ORDER BY id ASC",
+		setHead:              "INSERT INTO " + metadata + " (key, value) VALUES ('head', $1) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
+		setInitialHead:       "INSERT INTO " + metadata + " (key, value) VALUES ('head', '0') ON CONFLICT(key) DO NOTHING",
+		updateHead:           "INSERT INTO " + metadata + " (key, value) VALUES ('head', $1) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
 	}
 }
 
@@ -292,6 +303,10 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 }
 
 func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) error {
+	return h.SaveWithDependencyResolution(v, cs, nil, head)
+}
+
+func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -376,6 +391,23 @@ func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) err
 	if err != nil {
 		return NewInsertChangesetError(err)
 	}
+	if resolution != nil {
+		canonical := resolution.Canonical()
+		data, marshalErr := json.Marshal(canonical)
+		if marshalErr != nil {
+			return NewEncodeChangesetError(marshalErr)
+		}
+		if _, err = tx.ExecContext(ctx, h.queries.insertResolution, canonical.Digest, data); err != nil {
+			return NewInsertChangesetError(err)
+		}
+		if _, err = tx.ExecContext(ctx, h.queries.setVersionResolution, v.ID(), canonical.Digest); err != nil {
+			return NewInsertChangesetError(err)
+		}
+	} else if v.Previous() != nil {
+		if _, err = tx.ExecContext(ctx, h.queries.inheritResolution, v.ID(), v.Previous().ID()); err != nil {
+			return NewInsertChangesetError(err)
+		}
+	}
 
 	if head {
 		_, err = tx.ExecContext(ctx, h.queries.updateHead, strconv.FormatUint(uint64(v.ID()), 10))
@@ -388,6 +420,55 @@ func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) err
 		return NewCommitTransactionError(err)
 	}
 
+	return nil
+}
+
+func (h *History) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	var data []byte
+	err := h.db.QueryRowContext(context.Background(), h.queries.getResolution, v.ID()).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, registry.ErrDependencyResolutionNotFound
+	}
+	if err != nil {
+		return nil, NewQueryChangesetError(err)
+	}
+	var resolution registry.DependencyResolution
+	if err := json.Unmarshal(data, &resolution); err != nil {
+		return nil, NewDecodeChangesetError(err)
+	}
+	if !resolution.Valid() {
+		return nil, NewDecodeChangesetError(errors.New("stored dependency resolution digest mismatch"))
+	}
+	return resolution.Canonical(), nil
+}
+
+func (h *History) CheckpointDependencyResolution(v registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	canonical := resolution.Canonical()
+	data, err := json.Marshal(canonical)
+	if err != nil {
+		return NewEncodeChangesetError(err)
+	}
+	tx, err := h.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return NewBeginTransactionError(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(context.Background(), h.queries.insertResolution, canonical.Digest, data); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	if _, err = tx.ExecContext(context.Background(), h.queries.setVersionResolution, v.ID(), canonical.Digest); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	if err = tx.Commit(); err != nil {
+		return NewCommitTransactionError(err)
+	}
 	return nil
 }
 

--- a/system/registry/history/postgres/postgres.go
+++ b/system/registry/history/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -36,6 +37,8 @@ type History struct {
 
 type postgresQueries struct {
 	getResolution        string
+	getResolutionGraph   string
+	getVersionResolution string
 	getChangeset         string
 	inheritResolution    string
 	insertResolution     string
@@ -48,7 +51,9 @@ type postgresQueries struct {
 	queryVersions        string
 	setHead              string
 	setInitialHead       string
-	updateHead           string
+	updateHeadCAS        string
+	versionExists        string
+	replayChanges        string
 }
 
 type encodedPayload struct {
@@ -142,20 +147,31 @@ func buildQueries(schemaName string) postgresQueries {
 	metadata := table("metadata")
 
 	return postgresQueries{
-		getResolution:        "SELECT g.data FROM " + versionResolutions + " vr JOIN " + resolutionGraphs + " g ON g.digest = vr.resolution_digest WHERE vr.version_id = $1",
+		getResolution:        "SELECT vr.resolution_digest, g.data FROM " + versionResolutions + " vr LEFT JOIN " + resolutionGraphs + " g ON g.digest = vr.resolution_digest WHERE vr.version_id = $1",
+		getResolutionGraph:   "SELECT data FROM " + resolutionGraphs + " WHERE digest = $1",
+		getVersionResolution: "SELECT resolution_digest FROM " + versionResolutions + " WHERE version_id = $1",
 		getChangeset:         "SELECT data FROM " + changesets + " WHERE version_id = $1",
-		inheritResolution:    "INSERT INTO " + versionResolutions + " (version_id, resolution_digest) SELECT $1, resolution_digest FROM " + versionResolutions + " WHERE version_id = $2 ON CONFLICT(version_id) DO UPDATE SET resolution_digest = EXCLUDED.resolution_digest",
+		inheritResolution:    "INSERT INTO " + versionResolutions + " (version_id, resolution_digest) SELECT $1, resolution_digest FROM " + versionResolutions + " WHERE version_id = $2 ON CONFLICT(version_id) DO NOTHING",
 		insertResolution:     "INSERT INTO " + resolutionGraphs + " (digest, data) VALUES ($1, $2) ON CONFLICT(digest) DO NOTHING",
-		setVersionResolution: "INSERT INTO " + versionResolutions + " (version_id, resolution_digest) VALUES ($1, $2) ON CONFLICT(version_id) DO UPDATE SET resolution_digest = EXCLUDED.resolution_digest",
-		insertChangeset:      "INSERT INTO " + changesets + " (version_id, data) VALUES ($1, $2) ON CONFLICT(version_id) DO UPDATE SET data = EXCLUDED.data",
+		setVersionResolution: "INSERT INTO " + versionResolutions + " (version_id, resolution_digest) VALUES ($1, $2) ON CONFLICT(version_id) DO NOTHING",
+		insertChangeset:      "INSERT INTO " + changesets + " (version_id, data) VALUES ($1, $2)",
 		insertRootChangeset:  "INSERT INTO " + changesets + " (version_id, data) VALUES (0, $1) ON CONFLICT(version_id) DO NOTHING",
 		insertRootVersion:    "INSERT INTO " + versions + " (id, parent_id) VALUES (0, NULL) ON CONFLICT(id) DO NOTHING",
-		insertVersion:        "INSERT INTO " + versions + " (id, parent_id) VALUES ($1, $2) ON CONFLICT(id) DO UPDATE SET parent_id = EXCLUDED.parent_id",
+		insertVersion:        "INSERT INTO " + versions + " (id, parent_id) VALUES ($1, $2)",
 		queryHead:            "SELECT value FROM " + metadata + " WHERE key = 'head'",
 		queryVersions:        "SELECT id, parent_id FROM " + versions + " ORDER BY id ASC",
-		setHead:              "INSERT INTO " + metadata + " (key, value) VALUES ('head', $1) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
+		setHead:              "UPDATE " + metadata + " SET value = $1 WHERE key = 'head' AND EXISTS (SELECT 1 FROM " + versions + " WHERE id = $2)",
 		setInitialHead:       "INSERT INTO " + metadata + " (key, value) VALUES ('head', '0') ON CONFLICT(key) DO NOTHING",
-		updateHead:           "INSERT INTO " + metadata + " (key, value) VALUES ('head', $1) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
+		updateHeadCAS:        "UPDATE " + metadata + " SET value = $1 WHERE key = 'head' AND value = $2 AND EXISTS (SELECT 1 FROM " + versions + " WHERE id = $3)",
+		versionExists:        "SELECT 1 FROM " + versions + " WHERE id = $1",
+		replayChanges: `WITH RECURSIVE lineage(id, parent_id, depth) AS (
+			SELECT id, parent_id, 0 FROM ` + versions + ` WHERE id = $1
+			UNION ALL
+			SELECT v.id, v.parent_id, lineage.depth + 1
+			FROM ` + versions + ` v JOIN lineage ON v.id = lineage.parent_id
+		)
+		SELECT c.data FROM lineage JOIN ` + changesets + ` c ON c.version_id = lineage.id
+		WHERE lineage.id <> 0 ORDER BY lineage.depth DESC`,
 	}
 }
 
@@ -254,6 +270,10 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 		return nil, NewQueryChangesetError(err)
 	}
 
+	return h.decodeChangeSet(data)
+}
+
+func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	var encodedOps []struct {
 		Entry         encodedEntry
 		OriginalEntry *encodedEntry
@@ -300,6 +320,41 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 	}
 
 	return cs, nil
+}
+
+func (h *History) ReplayChanges(target registry.Version, apply func(registry.ChangeSet) error) error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	ctx := context.Background()
+	var exists int
+	if err := h.db.QueryRowContext(ctx, h.queries.versionExists, target.ID()).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewChangesetNotFoundError(target.ID())
+		}
+		return NewQueryChangesetError(err)
+	}
+	rows, err := h.db.QueryContext(ctx, h.queries.replayChanges, target.ID())
+	if err != nil {
+		return NewQueryChangesetError(err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return NewQueryChangesetError(err)
+		}
+		changes, err := h.decodeChangeSet(data)
+		if err != nil {
+			return err
+		}
+		if err := apply(changes); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return NewIterateVersionsError(err)
+	}
+	return nil
 }
 
 func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) error {
@@ -400,7 +455,10 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 		if _, err = tx.ExecContext(ctx, h.queries.insertResolution, canonical.Digest, data); err != nil {
 			return NewInsertChangesetError(err)
 		}
-		if _, err = tx.ExecContext(ctx, h.queries.setVersionResolution, v.ID(), canonical.Digest); err != nil {
+		if err = h.ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+			return NewDecodeChangesetError(err)
+		}
+		if err = h.setVersionResolution(ctx, tx, v.ID(), canonical.Digest); err != nil {
 			return NewInsertChangesetError(err)
 		}
 	} else if v.Previous() != nil {
@@ -410,9 +468,21 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	}
 
 	if head {
-		_, err = tx.ExecContext(ctx, h.queries.updateHead, strconv.FormatUint(uint64(v.ID()), 10))
+		if v.Previous() == nil {
+			return NewUpdateHeadError(errors.New("head updates require an expected parent version"))
+		}
+		result, updateErr := tx.ExecContext(ctx, h.queries.updateHeadCAS,
+			strconv.FormatUint(uint64(v.ID()), 10), strconv.FormatUint(uint64(v.Previous().ID()), 10), v.ID())
+		err = updateErr
 		if err != nil {
 			return NewUpdateHeadError(err)
+		}
+		updated, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return NewUpdateHeadError(rowsErr)
+		}
+		if updated != 1 {
+			return NewUpdateHeadError(fmt.Errorf("history head changed: expected version %d", v.Previous().ID()))
 		}
 	}
 
@@ -426,22 +496,20 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 func (h *History) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	var digest string
 	var data []byte
-	err := h.db.QueryRowContext(context.Background(), h.queries.getResolution, v.ID()).Scan(&data)
+	err := h.db.QueryRowContext(context.Background(), h.queries.getResolution, v.ID()).Scan(&digest, &data)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, registry.ErrDependencyResolutionNotFound
 	}
 	if err != nil {
 		return nil, NewQueryChangesetError(err)
 	}
-	var resolution registry.DependencyResolution
-	if err := json.Unmarshal(data, &resolution); err != nil {
+	resolution, err := decodeResolutionGraph(digest, data)
+	if err != nil {
 		return nil, NewDecodeChangesetError(err)
 	}
-	if !resolution.Valid() {
-		return nil, NewDecodeChangesetError(errors.New("stored dependency resolution digest mismatch"))
-	}
-	return resolution.Canonical(), nil
+	return resolution, nil
 }
 
 func (h *History) CheckpointDependencyResolution(v registry.Version, resolution *registry.DependencyResolution) error {
@@ -463,7 +531,10 @@ func (h *History) CheckpointDependencyResolution(v registry.Version, resolution 
 	if _, err = tx.ExecContext(context.Background(), h.queries.insertResolution, canonical.Digest, data); err != nil {
 		return NewInsertChangesetError(err)
 	}
-	if _, err = tx.ExecContext(context.Background(), h.queries.setVersionResolution, v.ID(), canonical.Digest); err != nil {
+	if err = h.ensureResolutionGraph(context.Background(), tx, canonical.Digest); err != nil {
+		return NewDecodeChangesetError(err)
+	}
+	if err = h.setVersionResolution(context.Background(), tx, v.ID(), canonical.Digest); err != nil {
 		return NewInsertChangesetError(err)
 	}
 	if err = tx.Commit(); err != nil {
@@ -510,11 +581,88 @@ func (h *History) SetHead(v registry.Version) error {
 	defer h.mu.Unlock()
 
 	ctx := context.Background()
-	_, err := h.db.ExecContext(ctx, h.queries.setHead, strconv.FormatUint(uint64(v.ID()), 10))
+	result, err := h.db.ExecContext(ctx, h.queries.setHead, strconv.FormatUint(uint64(v.ID()), 10), v.ID())
 	if err != nil {
 		return NewSetHeadError(err)
 	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	if updated != 1 {
+		return NewSetHeadError(fmt.Errorf("version %d does not exist", v.ID()))
+	}
 
+	return nil
+}
+
+func (h *History) CompareAndSetHead(expected, target registry.Version) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ctx := context.Background()
+	result, err := h.db.ExecContext(ctx, h.queries.updateHeadCAS,
+		strconv.FormatUint(uint64(target.ID()), 10), strconv.FormatUint(uint64(expected.ID()), 10), target.ID())
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	if updated != 1 {
+		return NewSetHeadError(fmt.Errorf("history head changed or target version %d does not exist", target.ID()))
+	}
+	return nil
+}
+
+func (h *History) ensureResolutionGraph(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, digest string) error {
+	var data []byte
+	if err := q.QueryRowContext(ctx, h.queries.getResolutionGraph, digest).Scan(&data); err != nil {
+		return fmt.Errorf("query stored dependency resolution %s: %w", digest, err)
+	}
+	_, err := decodeResolutionGraph(digest, data)
+	return err
+}
+
+func decodeResolutionGraph(digest string, data []byte) (*registry.DependencyResolution, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("stored dependency resolution %s has no graph payload", digest)
+	}
+	var resolution registry.DependencyResolution
+	if err := json.Unmarshal(data, &resolution); err != nil {
+		return nil, err
+	}
+	if !resolution.Valid() {
+		return nil, errors.New("stored dependency resolution digest mismatch")
+	}
+	canonical := resolution.Canonical()
+	if canonical.Digest != digest {
+		return nil, fmt.Errorf("stored dependency resolution key mismatch: row %s, payload %s", digest, canonical.Digest)
+	}
+	return canonical, nil
+}
+
+func (h *History) setVersionResolution(ctx context.Context, tx *sql.Tx, versionID uint, digest string) error {
+	result, err := tx.ExecContext(ctx, h.queries.setVersionResolution, versionID, digest)
+	if err != nil {
+		return err
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 1 {
+		return nil
+	}
+	var stored string
+	if err := tx.QueryRowContext(ctx, h.queries.getVersionResolution, versionID).Scan(&stored); err != nil {
+		return err
+	}
+	if stored != digest {
+		return fmt.Errorf("version %d already references dependency resolution %s, refusing %s", versionID, stored, digest)
+	}
 	return nil
 }
 

--- a/system/registry/history/postgres/postgres_test.go
+++ b/system/registry/history/postgres/postgres_test.go
@@ -45,6 +45,28 @@ func TestBuildQueriesUseImmutableRowsCASAndCorruptionAwareResolutionRead(t *test
 	assert.Contains(t, queries.setHead, "EXISTS", "SetHead must validate the target version")
 	assert.Contains(t, queries.getResolution, "LEFT JOIN", "dangling graph refs must be distinguishable from legacy versions")
 	assert.Contains(t, queries.getResolution, "resolution_digest", "the graph row key must be validated against its payload")
+	assert.Contains(t, queries.queryMaxVersionID, `"wippy_registry"."versions"`, "max ID lookup must respect the configured schema")
+	assert.Contains(t, queries.queryVersionLineage, "UNION", "target lookup must deduplicate cycles")
+	assert.NotContains(t, queries.queryVersionLineage, "UNION ALL", "target lookup must terminate on cycles")
+}
+
+func TestHistoryRejectsParentlessNonRootVersionBeforeDatabaseAccess(t *testing.T) {
+	hist := &History{}
+	err := hist.Save(version.New(1), nil, false)
+	require.ErrorContains(t, err, "non-root version 1 has no parent")
+}
+
+func TestHistoryRejectsMalformedResolutionBeforeDatabaseAccess(t *testing.T) {
+	hist := &History{}
+	malformed := (&registry.DependencyResolution{Roots: []registry.DependencyRoot{{
+		ID: "missing-component", Version: "1",
+	}}}).Canonical()
+	v0 := version.New(registry.RootVersion)
+	v1 := version.FromParent(v0, 1)
+
+	require.ErrorIs(t, hist.SaveWithDependencyResolution(v1, nil, malformed, false), registry.ErrInvalidDependencyResolution)
+	require.ErrorIs(t, hist.CheckpointDependencyResolution(v0, malformed), registry.ErrInvalidDependencyResolution)
+	require.ErrorIs(t, hist.CompareAndSetHeadWithDependencyResolution(v0, v0, malformed), registry.ErrInvalidDependencyResolution)
 }
 
 func TestPostgresHistory_SaveAndGet(t *testing.T) {
@@ -86,6 +108,56 @@ func TestPostgresHistory_SaveAndGet(t *testing.T) {
 	assert.Equal(t, registry.EntryCreate, retrieved[0].Kind)
 	assert.Equal(t, "test", retrieved[0].Entry.ID.NS)
 	assert.Equal(t, "entry1", retrieved[0].Entry.ID.Name)
+
+	v2 := version.FromParent(v1, 2)
+	require.NoError(t, hist.Save(v2, nil, false))
+	resolution := (&registry.DependencyResolution{InputDigest: "postgres-atomic"}).Canonical()
+	err = hist.CompareAndSetHeadWithDependencyResolution(v2, v2, resolution)
+	require.ErrorContains(t, err, "history head changed")
+	_, err = hist.GetDependencyResolution(v2)
+	require.ErrorIs(t, err, registry.ErrDependencyResolutionNotFound)
+	require.NoError(t, hist.CompareAndSetHeadWithDependencyResolution(v1, v2, resolution))
+	storedResolution, err := hist.GetDependencyResolution(v2)
+	require.NoError(t, err)
+	require.Equal(t, resolution.Digest, storedResolution.Digest)
+	var replayed int
+	require.NoError(t, hist.ReplayChanges(context.Background(), v2, func(registry.ChangeSet) error {
+		replayed++
+		return nil
+	}))
+	require.Equal(t, 2, replayed)
+
+	_, err = db.ExecContext(context.Background(), fmt.Sprintf(`
+		INSERT INTO %q.versions (id, parent_id)
+		SELECT n, n - 1 FROM generate_series(3, 5000) AS series(n)`, schemaName))
+	require.NoError(t, err)
+	_, err = db.ExecContext(context.Background(), fmt.Sprintf(`
+		INSERT INTO %q.changesets (version_id, data)
+		SELECT n, $1 FROM generate_series(3, 5000) AS series(n)`, schemaName), []byte{0x90})
+	require.NoError(t, err)
+	replayed = 0
+	require.NoError(t, hist.ReplayChanges(context.Background(), version.New(5000), func(registry.ChangeSet) error {
+		replayed++
+		return nil
+	}))
+	require.Equal(t, 5000, replayed)
+	stored, err := hist.GetVersion(5000)
+	require.NoError(t, err)
+	require.Equal(t, uint(5000), stored.ID())
+	lineageLength := 0
+	for current := stored; current != nil; current = current.Previous() {
+		lineageLength++
+	}
+	require.Equal(t, 5001, lineageLength)
+
+	_, err = db.ExecContext(context.Background(), fmt.Sprintf(`UPDATE %q.versions SET parent_id = 2 WHERE id = 1`, schemaName))
+	require.NoError(t, err)
+	err = hist.ReplayChanges(context.Background(), v2, func(registry.ChangeSet) error { return nil })
+	require.ErrorContains(t, err, "lineage")
+	_, err = hist.Head()
+	require.Error(t, err, "head reconstruction must terminate and reject cyclic lineage")
+	_, err = hist.GetVersion(2)
+	require.Error(t, err, "target lookup must terminate and reject cyclic lineage")
 
 	var schemaVersion string
 	err = db.QueryRowContext(

--- a/system/registry/history/postgres/postgres_test.go
+++ b/system/registry/history/postgres/postgres_test.go
@@ -81,7 +81,7 @@ func TestPostgresHistory_SaveAndGet(t *testing.T) {
 		fmt.Sprintf(`SELECT curr_version FROM %q.schema_version WHERE name = 'registry_history'`, schemaName),
 	).Scan(&schemaVersion)
 	require.NoError(t, err)
-	assert.Equal(t, "1.0", schemaVersion)
+	assert.Equal(t, "1.1", schemaVersion)
 }
 
 func TestPostgresHistory_ConcurrentColdOpenInitializesRootOnce(t *testing.T) {

--- a/system/registry/history/postgres/postgres_test.go
+++ b/system/registry/history/postgres/postgres_test.go
@@ -35,6 +35,18 @@ func TestNewPostgresRejectsInvalidSchemaName(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid schema name")
 }
 
+func TestBuildQueriesUseImmutableRowsCASAndCorruptionAwareResolutionRead(t *testing.T) {
+	queries := buildQueries("wippy_registry")
+
+	assert.NotContains(t, queries.insertVersion, "ON CONFLICT", "versions must be insert-only")
+	assert.NotContains(t, queries.insertChangeset, "ON CONFLICT", "changesets must be insert-only")
+	assert.Contains(t, queries.setVersionResolution, "DO NOTHING", "version resolution refs may only be inserted idempotently")
+	assert.Contains(t, queries.updateHeadCAS, "value = $2", "head advancement must compare the expected parent")
+	assert.Contains(t, queries.setHead, "EXISTS", "SetHead must validate the target version")
+	assert.Contains(t, queries.getResolution, "LEFT JOIN", "dangling graph refs must be distinguishable from legacy versions")
+	assert.Contains(t, queries.getResolution, "resolution_digest", "the graph row key must be validated against its payload")
+}
+
 func TestPostgresHistory_SaveAndGet(t *testing.T) {
 	dsn := os.Getenv("WIPPY_POSTGRES_HISTORY_TEST_DSN")
 	if strings.TrimSpace(dsn) == "" {

--- a/system/registry/history/schema/embed.go
+++ b/system/registry/history/schema/embed.go
@@ -9,13 +9,15 @@ import (
 )
 
 const (
-	BundleName         = "registry_history"
-	InitialVersion     = "1.0"
-	sqliteSchemaPath   = "sqlite/registry/schema.sql"
-	postgresSchemaPath = "postgres/registry/schema.sql"
+	BundleName            = "registry_history"
+	InitialVersion        = "1.0"
+	sqliteSchemaPath      = "sqlite/registry/schema.sql"
+	postgresSchemaPath    = "postgres/registry/schema.sql"
+	sqliteVersionedPath   = "sqlite/registry/versioned"
+	postgresVersionedPath = "postgres/registry/versioned"
 )
 
-//go:embed sqlite/registry/schema.sql postgres/registry/schema.sql
+//go:embed sqlite/registry/schema.sql sqlite/registry/versioned/*/* postgres/registry/schema.sql postgres/registry/versioned/*/*
 var assets embed.FS
 
 func SQLiteBundle() schemamanager.Bundle {
@@ -24,6 +26,7 @@ func SQLiteBundle() schemamanager.Bundle {
 		Name:           BundleName,
 		InitialVersion: InitialVersion,
 		SchemaPath:     sqliteSchemaPath,
+		VersionedPath:  sqliteVersionedPath,
 	}
 }
 
@@ -33,5 +36,6 @@ func PostgresBundle() schemamanager.Bundle {
 		Name:           BundleName,
 		InitialVersion: InitialVersion,
 		SchemaPath:     postgresSchemaPath,
+		VersionedPath:  postgresVersionedPath,
 	}
 }

--- a/system/registry/history/schema/postgres/registry/schema.sql
+++ b/system/registry/history/schema/postgres/registry/schema.sql
@@ -14,3 +14,13 @@ CREATE TABLE IF NOT EXISTS {{schema}}.changesets (
 );
 
 CREATE INDEX IF NOT EXISTS idx_versions_parent ON {{schema}}.versions(parent_id);
+
+CREATE TABLE IF NOT EXISTS {{schema}}.resolution_graphs (
+	digest TEXT PRIMARY KEY,
+	data BYTEA NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS {{schema}}.version_resolutions (
+	version_id BIGINT PRIMARY KEY REFERENCES {{schema}}.versions(id) ON DELETE CASCADE,
+	resolution_digest TEXT NOT NULL REFERENCES {{schema}}.resolution_graphs(digest)
+);

--- a/system/registry/history/schema/postgres/registry/versioned/v1.1/manifest.json
+++ b/system/registry/history/schema/postgres/registry/versioned/v1.1/manifest.json
@@ -1,0 +1,6 @@
+{
+  "curr_version": "1.1",
+  "min_compatible_version": "1.0",
+  "description": "store exact dependency resolutions per registry version",
+  "schema_update_files": ["resolution.sql"]
+}

--- a/system/registry/history/schema/postgres/registry/versioned/v1.1/resolution.sql
+++ b/system/registry/history/schema/postgres/registry/versioned/v1.1/resolution.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS {{schema}}.resolution_graphs (
+	digest TEXT PRIMARY KEY,
+	data BYTEA NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS {{schema}}.version_resolutions (
+	version_id BIGINT PRIMARY KEY REFERENCES {{schema}}.versions(id) ON DELETE CASCADE,
+	resolution_digest TEXT NOT NULL REFERENCES {{schema}}.resolution_graphs(digest)
+);

--- a/system/registry/history/schema/sqlite/registry/schema.sql
+++ b/system/registry/history/schema/sqlite/registry/schema.sql
@@ -16,3 +16,15 @@ CREATE TABLE IF NOT EXISTS changesets (
 );
 
 CREATE INDEX IF NOT EXISTS idx_versions_parent ON versions(parent_id);
+
+CREATE TABLE IF NOT EXISTS resolution_graphs (
+	digest TEXT PRIMARY KEY,
+	data BLOB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS version_resolutions (
+	version_id INTEGER PRIMARY KEY,
+	resolution_digest TEXT NOT NULL,
+	FOREIGN KEY (version_id) REFERENCES versions(id) ON DELETE CASCADE,
+	FOREIGN KEY (resolution_digest) REFERENCES resolution_graphs(digest)
+);

--- a/system/registry/history/schema/sqlite/registry/versioned/v1.1/manifest.json
+++ b/system/registry/history/schema/sqlite/registry/versioned/v1.1/manifest.json
@@ -1,0 +1,6 @@
+{
+  "curr_version": "1.1",
+  "min_compatible_version": "1.0",
+  "description": "store exact dependency resolutions per registry version",
+  "schema_update_files": ["resolution.sql"]
+}

--- a/system/registry/history/schema/sqlite/registry/versioned/v1.1/resolution.sql
+++ b/system/registry/history/schema/sqlite/registry/versioned/v1.1/resolution.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS resolution_graphs (
+	digest TEXT PRIMARY KEY,
+	data BLOB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS version_resolutions (
+	version_id INTEGER PRIMARY KEY,
+	resolution_digest TEXT NOT NULL,
+	FOREIGN KEY (version_id) REFERENCES versions(id) ON DELETE CASCADE,
+	FOREIGN KEY (resolution_digest) REFERENCES resolution_graphs(digest)
+);

--- a/system/registry/history/sqlite/sqlite.go
+++ b/system/registry/history/sqlite/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -254,6 +255,10 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 }
 
 func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) error {
+	return h.SaveWithDependencyResolution(v, cs, nil, head)
+}
+
+func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -338,6 +343,24 @@ func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) err
 	if err != nil {
 		return NewInsertChangesetError(err)
 	}
+	if resolution != nil {
+		canonical := resolution.Canonical()
+		data, marshalErr := json.Marshal(canonical)
+		if marshalErr != nil {
+			return NewEncodeChangesetError(marshalErr)
+		}
+		if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonical.Digest, data); err != nil {
+			return NewInsertChangesetError(err)
+		}
+		if _, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO version_resolutions (version_id, resolution_digest) VALUES (?, ?)", v.ID(), canonical.Digest); err != nil {
+			return NewInsertChangesetError(err)
+		}
+	} else if v.Previous() != nil {
+		if _, err = tx.ExecContext(ctx, `INSERT OR REPLACE INTO version_resolutions (version_id, resolution_digest)
+			SELECT ?, resolution_digest FROM version_resolutions WHERE version_id = ?`, v.ID(), v.Previous().ID()); err != nil {
+			return NewInsertChangesetError(err)
+		}
+	}
 
 	if head {
 		_, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO metadata (key, value) VALUES ('head', ?)", v.ID())
@@ -350,6 +373,60 @@ func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) err
 		return NewCommitTransactionError(err)
 	}
 
+	return nil
+}
+
+func (h *History) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	var data []byte
+	err := h.db.QueryRowContext(context.Background(), `
+		SELECT g.data
+		FROM version_resolutions vr
+		JOIN resolution_graphs g ON g.digest = vr.resolution_digest
+		WHERE vr.version_id = ?`, v.ID()).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, registry.ErrDependencyResolutionNotFound
+	}
+	if err != nil {
+		return nil, NewQueryChangesetError(err)
+	}
+	var resolution registry.DependencyResolution
+	if err := json.Unmarshal(data, &resolution); err != nil {
+		return nil, NewDecodeChangesetError(err)
+	}
+	if !resolution.Valid() {
+		return nil, NewDecodeChangesetError(errors.New("stored dependency resolution digest mismatch"))
+	}
+	return resolution.Canonical(), nil
+}
+
+func (h *History) CheckpointDependencyResolution(v registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	canonical := resolution.Canonical()
+	data, err := json.Marshal(canonical)
+	if err != nil {
+		return NewEncodeChangesetError(err)
+	}
+	ctx := context.Background()
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return NewBeginTransactionError(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonical.Digest, data); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	if _, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO version_resolutions (version_id, resolution_digest) VALUES (?, ?)", v.ID(), canonical.Digest); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	if err = tx.Commit(); err != nil {
+		return NewCommitTransactionError(err)
+	}
 	return nil
 }
 

--- a/system/registry/history/sqlite/sqlite.go
+++ b/system/registry/history/sqlite/sqlite.go
@@ -34,6 +34,14 @@ type History struct {
 
 var openMu sync.Mutex
 
+const queryVersionLineage = `WITH RECURSIVE lineage(id, parent_id) AS (
+	SELECT id, parent_id FROM versions WHERE id = ?
+	UNION
+	SELECT v.id, v.parent_id
+	FROM versions v JOIN lineage ON v.id = lineage.parent_id
+)
+SELECT id, parent_id FROM lineage`
+
 type encodedPayload struct {
 	Data   any
 	Format payload.Format
@@ -149,6 +157,78 @@ func (h *History) Versions() ([]registry.Version, error) {
 	return h.versions(context.Background())
 }
 
+func (h *History) MaxVersionID() (uint, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	var maxID uint
+	if err := h.db.QueryRowContext(context.Background(), "SELECT COALESCE(MAX(id), 0) FROM versions").Scan(&maxID); err != nil {
+		return 0, NewGetVersionsError(err)
+	}
+	return maxID, nil
+}
+
+func (h *History) GetVersion(id uint) (registry.Version, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	rows, err := h.db.QueryContext(context.Background(), queryVersionLineage, id)
+	if err != nil {
+		return nil, NewQueryVersionsError(err)
+	}
+	parents := make(map[uint]sql.NullInt64)
+	for rows.Next() {
+		var versionID uint
+		var parentID sql.NullInt64
+		if err := rows.Scan(&versionID, &parentID); err != nil {
+			_ = rows.Close()
+			return nil, NewScanVersionError(err)
+		}
+		parents[versionID] = parentID
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, NewIterateVersionsError(err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, NewIterateVersionsError(err)
+	}
+	stored, err := versionFromLineage(id, parents)
+	if err != nil {
+		return nil, NewQueryVersionsError(err)
+	}
+	return stored, nil
+}
+
+func versionFromLineage(targetID uint, parents map[uint]sql.NullInt64) (registry.Version, error) {
+	ids := make([]uint, 0, len(parents))
+	seen := make(map[uint]struct{}, len(parents))
+	currentID := targetID
+	for currentID != registry.RootVersion {
+		if _, duplicate := seen[currentID]; duplicate {
+			return nil, fmt.Errorf("version %d lineage contains a cycle", targetID)
+		}
+		seen[currentID] = struct{}{}
+		parentID, ok := parents[currentID]
+		if !ok {
+			return nil, fmt.Errorf("version %d not found", currentID)
+		}
+		if !parentID.Valid || parentID.Int64 < 0 {
+			return nil, fmt.Errorf("version %d lineage does not terminate at root", targetID)
+		}
+		ids = append(ids, currentID)
+		currentID = uint(parentID.Int64)
+	}
+	rootParent, ok := parents[registry.RootVersion]
+	if !ok || rootParent.Valid {
+		return nil, fmt.Errorf("version %d lineage does not terminate at root", targetID)
+	}
+	current := version.New(registry.RootVersion)
+	for i := len(ids) - 1; i >= 0; i-- {
+		current = version.FromParent(current, ids[i])
+	}
+	return current, nil
+}
+
 func (h *History) versions(ctx context.Context) ([]registry.Version, error) {
 	rows, err := h.db.QueryContext(ctx, "SELECT id, parent_id FROM versions ORDER BY id ASC")
 	if err != nil {
@@ -177,8 +257,10 @@ func (h *History) versions(ctx context.Context) ([]registry.Version, error) {
 				return nil, NewParentVersionNotFoundError(uint(parentID.Int64), id)
 			}
 			v = version.FromParent(parent, id)
-		} else {
+		} else if id == registry.RootVersion {
 			v = version.New(id)
+		} else {
+			return nil, NewParentVersionNotFoundError(registry.RootVersion, id)
 		}
 
 		versionMap[id] = v
@@ -258,38 +340,20 @@ func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	return cs, nil
 }
 
-// ReplayChanges streams one target lineage in a single query. This keeps boot
-// replay at constant query count and bounded decoded-payload memory even when a
-// project has accumulated a very long history.
-func (h *History) ReplayChanges(target registry.Version, apply func(registry.ChangeSet) error) error {
+// ReplayChanges loads one target lineage in a single query. Encoded rows are
+// buffered so callbacks run after the query and history lock are released.
+func (h *History) ReplayChanges(ctx context.Context, target registry.Version, apply func(registry.ChangeSet) error) error {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-	ctx := context.Background()
-	var exists int
-	if err := h.db.QueryRowContext(ctx, "SELECT 1 FROM versions WHERE id = ?", target.ID()).Scan(&exists); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return NewChangesetNotFoundError(target.ID())
-		}
-		return NewQueryChangesetError(err)
-	}
-	rows, err := h.db.QueryContext(ctx, `WITH RECURSIVE lineage(id, parent_id, depth) AS (
-		SELECT id, parent_id, 0 FROM versions WHERE id = ?
-		UNION ALL
-		SELECT v.id, v.parent_id, lineage.depth + 1
-		FROM versions v JOIN lineage ON v.id = lineage.parent_id
-	)
-	SELECT c.data FROM lineage JOIN changesets c ON c.version_id = lineage.id
-	WHERE lineage.id <> 0 ORDER BY lineage.depth DESC`, target.ID())
+	encoded, err := h.replayLineage(ctx, target)
+	h.mu.RUnlock()
 	if err != nil {
-		return NewQueryChangesetError(err)
+		return err
 	}
-	defer func() { _ = rows.Close() }()
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return NewQueryChangesetError(err)
+	for _, item := range encoded {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		changes, err := h.decodeChangeSet(data)
+		changes, err := h.decodeChangeSet(item)
 		if err != nil {
 			return err
 		}
@@ -297,10 +361,78 @@ func (h *History) ReplayChanges(target registry.Version, apply func(registry.Cha
 			return err
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return NewIterateVersionsError(err)
-	}
 	return nil
+}
+
+type replayLineageRow struct {
+	data     []byte
+	parentID sql.NullInt64
+}
+
+func (h *History) replayLineage(ctx context.Context, target registry.Version) ([][]byte, error) {
+	var exists int
+	if err := h.db.QueryRowContext(ctx, "SELECT 1 FROM versions WHERE id = ?", target.ID()).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, NewChangesetNotFoundError(target.ID())
+		}
+		return nil, NewQueryChangesetError(err)
+	}
+	rows, err := h.db.QueryContext(ctx, `WITH RECURSIVE lineage(id, parent_id) AS (
+		SELECT id, parent_id FROM versions WHERE id = ?
+		UNION
+		SELECT v.id, v.parent_id
+		FROM versions v JOIN lineage ON v.id = lineage.parent_id
+	)
+	SELECT lineage.id, lineage.parent_id, c.data
+	FROM lineage LEFT JOIN changesets c ON c.version_id = lineage.id`, target.ID())
+	if err != nil {
+		return nil, NewQueryChangesetError(err)
+	}
+	lineage := make(map[uint]replayLineageRow)
+	for rows.Next() {
+		var versionID uint
+		var parentID sql.NullInt64
+		var data []byte
+		if err := rows.Scan(&versionID, &parentID, &data); err != nil {
+			_ = rows.Close()
+			return nil, NewQueryChangesetError(err)
+		}
+		lineage[versionID] = replayLineageRow{parentID: parentID, data: data}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, NewIterateVersionsError(err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, NewIterateVersionsError(err)
+	}
+
+	encoded := make([][]byte, 0, len(lineage))
+	seen := make(map[uint]struct{}, len(lineage))
+	currentID := target.ID()
+	for currentID != registry.RootVersion {
+		if _, duplicate := seen[currentID]; duplicate {
+			return nil, NewQueryChangesetError(fmt.Errorf("version %d lineage is cyclic", target.ID()))
+		}
+		seen[currentID] = struct{}{}
+		row, ok := lineage[currentID]
+		if !ok || !row.parentID.Valid || row.parentID.Int64 < 0 {
+			return nil, NewQueryChangesetError(fmt.Errorf("version %d lineage does not terminate at root", target.ID()))
+		}
+		if row.data == nil {
+			return nil, NewChangesetNotFoundError(currentID)
+		}
+		encoded = append(encoded, row.data)
+		currentID = uint(row.parentID.Int64)
+	}
+	root, ok := lineage[registry.RootVersion]
+	if !ok || root.parentID.Valid {
+		return nil, NewQueryChangesetError(fmt.Errorf("version %d lineage does not terminate at root", target.ID()))
+	}
+	for left, right := 0, len(encoded)-1; left < right; left, right = left+1, right-1 {
+		encoded[left], encoded[right] = encoded[right], encoded[left]
+	}
+	return encoded, nil
 }
 
 func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) error {
@@ -308,6 +440,16 @@ func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) err
 }
 
 func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.ChangeSet, resolution *registry.DependencyResolution, head bool) error {
+	if v.ID() != registry.RootVersion && v.Previous() == nil {
+		return NewInsertVersionError(fmt.Errorf("non-root version %d has no parent", v.ID()))
+	}
+	var canonicalResolution *registry.DependencyResolution
+	if resolution != nil {
+		canonicalResolution = resolution.Canonical()
+		if !canonicalResolution.Valid() {
+			return registry.ErrInvalidDependencyResolution
+		}
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -321,8 +463,8 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	var parentID sql.NullInt64
 	if v.Previous() != nil {
 		prevID := v.Previous().ID()
-		const maxInt64 = uint(1<<63 - 1)
-		if prevID > maxInt64 {
+		const maxInt64 = uint64(1<<63 - 1)
+		if uint64(prevID) > maxInt64 {
 			return NewParentVersionIDTooLargeError(prevID)
 		}
 		parentID = sql.NullInt64{Int64: int64(prevID), Valid: true}
@@ -392,19 +534,18 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	if err != nil {
 		return NewInsertChangesetError(err)
 	}
-	if resolution != nil {
-		canonical := resolution.Canonical()
-		data, marshalErr := json.Marshal(canonical)
+	if canonicalResolution != nil {
+		data, marshalErr := json.Marshal(canonicalResolution)
 		if marshalErr != nil {
 			return NewEncodeChangesetError(marshalErr)
 		}
-		if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonical.Digest, data); err != nil {
+		if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonicalResolution.Digest, data); err != nil {
 			return NewInsertChangesetError(err)
 		}
-		if err = ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+		if err = ensureResolutionGraph(ctx, tx, canonicalResolution.Digest); err != nil {
 			return NewDecodeChangesetError(err)
 		}
-		if err = setVersionResolution(ctx, tx, v.ID(), canonical.Digest); err != nil {
+		if err = setVersionResolution(ctx, tx, v.ID(), canonicalResolution.Digest); err != nil {
 			return NewInsertChangesetError(err)
 		}
 	} else if v.Previous() != nil {
@@ -466,9 +607,12 @@ func (h *History) CheckpointDependencyResolution(v registry.Version, resolution 
 	if resolution == nil {
 		return registry.ErrDependencyResolutionNotFound
 	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	canonical := resolution.Canonical()
 	data, err := json.Marshal(canonical)
 	if err != nil {
 		return NewEncodeChangesetError(err)
@@ -508,18 +652,28 @@ func (h *History) Head() (registry.Version, error) {
 		return nil, NewQueryHeadError(err)
 	}
 
-	versions, err := h.versions(ctx)
+	rows, err := h.db.QueryContext(ctx, queryVersionLineage, headID)
 	if err != nil {
-		return nil, NewGetVersionsError(err)
+		return nil, NewQueryHeadError(err)
 	}
-
-	for _, v := range versions {
-		if v.ID() == headID {
-			return v, nil
+	defer func() { _ = rows.Close() }()
+	parents := make(map[uint]sql.NullInt64)
+	for rows.Next() {
+		var id uint
+		var parentID sql.NullInt64
+		if err := rows.Scan(&id, &parentID); err != nil {
+			return nil, NewQueryHeadError(err)
 		}
+		parents[id] = parentID
 	}
-
-	return nil, NewHeadVersionNotFoundError(headID)
+	if err := rows.Err(); err != nil {
+		return nil, NewQueryHeadError(err)
+	}
+	stored, err := versionFromLineage(headID, parents)
+	if err != nil {
+		return nil, NewHeadVersionNotFoundError(headID)
+	}
+	return stored, nil
 }
 
 func (h *History) SetHead(v registry.Version) error {
@@ -559,6 +713,54 @@ func (h *History) CompareAndSetHead(expected, target registry.Version) error {
 	}
 	if updated != 1 {
 		return NewSetHeadError(fmt.Errorf("history head changed or target version %d does not exist", target.ID()))
+	}
+	return nil
+}
+
+func (h *History) CompareAndSetHeadWithDependencyResolution(expected, target registry.Version, resolution *registry.DependencyResolution) error {
+	if resolution == nil {
+		return registry.ErrDependencyResolutionNotFound
+	}
+	canonical := resolution.Canonical()
+	if !canonical.Valid() {
+		return registry.ErrInvalidDependencyResolution
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	data, err := json.Marshal(canonical)
+	if err != nil {
+		return NewEncodeChangesetError(err)
+	}
+	ctx := context.Background()
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return NewBeginTransactionError(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonical.Digest, data); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	if err = ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+		return NewDecodeChangesetError(err)
+	}
+	if err = setVersionResolution(ctx, tx, target.ID(), canonical.Digest); err != nil {
+		return NewInsertChangesetError(err)
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE metadata SET value = ?
+		WHERE key = 'head' AND value = ? AND EXISTS (SELECT 1 FROM versions WHERE id = ?)`,
+		target.ID(), expected.ID(), target.ID())
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	if updated != 1 {
+		return NewSetHeadError(fmt.Errorf("history head changed or target version %d does not exist", target.ID()))
+	}
+	if err = tx.Commit(); err != nil {
+		return NewCommitTransactionError(err)
 	}
 	return nil
 }

--- a/system/registry/history/sqlite/sqlite.go
+++ b/system/registry/history/sqlite/sqlite.go
@@ -66,7 +66,7 @@ func NewSQLite(dbPath string, log *zap.Logger) (*History, error) {
 		}
 	}
 
-	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000", dbPath))
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on", dbPath))
 	if err != nil {
 		return nil, NewOpenDatabaseError(err)
 	}
@@ -206,6 +206,10 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 		return nil, NewQueryChangesetError(err)
 	}
 
+	return h.decodeChangeSet(data)
+}
+
+func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	var encodedOps []struct {
 		Entry         encodedEntry
 		OriginalEntry *encodedEntry
@@ -254,6 +258,51 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 	return cs, nil
 }
 
+// ReplayChanges streams one target lineage in a single query. This keeps boot
+// replay at constant query count and bounded decoded-payload memory even when a
+// project has accumulated a very long history.
+func (h *History) ReplayChanges(target registry.Version, apply func(registry.ChangeSet) error) error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	ctx := context.Background()
+	var exists int
+	if err := h.db.QueryRowContext(ctx, "SELECT 1 FROM versions WHERE id = ?", target.ID()).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewChangesetNotFoundError(target.ID())
+		}
+		return NewQueryChangesetError(err)
+	}
+	rows, err := h.db.QueryContext(ctx, `WITH RECURSIVE lineage(id, parent_id, depth) AS (
+		SELECT id, parent_id, 0 FROM versions WHERE id = ?
+		UNION ALL
+		SELECT v.id, v.parent_id, lineage.depth + 1
+		FROM versions v JOIN lineage ON v.id = lineage.parent_id
+	)
+	SELECT c.data FROM lineage JOIN changesets c ON c.version_id = lineage.id
+	WHERE lineage.id <> 0 ORDER BY lineage.depth DESC`, target.ID())
+	if err != nil {
+		return NewQueryChangesetError(err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return NewQueryChangesetError(err)
+		}
+		changes, err := h.decodeChangeSet(data)
+		if err != nil {
+			return err
+		}
+		if err := apply(changes); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return NewIterateVersionsError(err)
+	}
+	return nil
+}
+
 func (h *History) Save(v registry.Version, cs registry.ChangeSet, head bool) error {
 	return h.SaveWithDependencyResolution(v, cs, nil, head)
 }
@@ -279,7 +328,7 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 		parentID = sql.NullInt64{Int64: int64(prevID), Valid: true}
 	}
 
-	_, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO versions (id, parent_id) VALUES (?, ?)", v.ID(), parentID)
+	_, err = tx.ExecContext(ctx, "INSERT INTO versions (id, parent_id) VALUES (?, ?)", v.ID(), parentID)
 	if err != nil {
 		return NewInsertVersionError(err)
 	}
@@ -339,7 +388,7 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 		return NewEncodeChangesetError(err)
 	}
 
-	_, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO changesets (version_id, data) VALUES (?, ?)", v.ID(), buf.Bytes())
+	_, err = tx.ExecContext(ctx, "INSERT INTO changesets (version_id, data) VALUES (?, ?)", v.ID(), buf.Bytes())
 	if err != nil {
 		return NewInsertChangesetError(err)
 	}
@@ -352,20 +401,34 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 		if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonical.Digest, data); err != nil {
 			return NewInsertChangesetError(err)
 		}
-		if _, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO version_resolutions (version_id, resolution_digest) VALUES (?, ?)", v.ID(), canonical.Digest); err != nil {
+		if err = ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+			return NewDecodeChangesetError(err)
+		}
+		if err = setVersionResolution(ctx, tx, v.ID(), canonical.Digest); err != nil {
 			return NewInsertChangesetError(err)
 		}
 	} else if v.Previous() != nil {
-		if _, err = tx.ExecContext(ctx, `INSERT OR REPLACE INTO version_resolutions (version_id, resolution_digest)
+		if _, err = tx.ExecContext(ctx, `INSERT OR IGNORE INTO version_resolutions (version_id, resolution_digest)
 			SELECT ?, resolution_digest FROM version_resolutions WHERE version_id = ?`, v.ID(), v.Previous().ID()); err != nil {
 			return NewInsertChangesetError(err)
 		}
 	}
 
 	if head {
-		_, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO metadata (key, value) VALUES ('head', ?)", v.ID())
+		if v.Previous() == nil {
+			return NewUpdateHeadError(errors.New("head updates require an expected parent version"))
+		}
+		result, updateErr := tx.ExecContext(ctx, "UPDATE metadata SET value = ? WHERE key = 'head' AND value = ?", v.ID(), v.Previous().ID())
+		err = updateErr
 		if err != nil {
 			return NewUpdateHeadError(err)
+		}
+		updated, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return NewUpdateHeadError(rowsErr)
+		}
+		if updated != 1 {
+			return NewUpdateHeadError(fmt.Errorf("history head changed: expected version %d", v.Previous().ID()))
 		}
 	}
 
@@ -379,26 +442,24 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 func (h *History) GetDependencyResolution(v registry.Version) (*registry.DependencyResolution, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	var digest string
 	var data []byte
 	err := h.db.QueryRowContext(context.Background(), `
-		SELECT g.data
+		SELECT vr.resolution_digest, g.data
 		FROM version_resolutions vr
-		JOIN resolution_graphs g ON g.digest = vr.resolution_digest
-		WHERE vr.version_id = ?`, v.ID()).Scan(&data)
+		LEFT JOIN resolution_graphs g ON g.digest = vr.resolution_digest
+		WHERE vr.version_id = ?`, v.ID()).Scan(&digest, &data)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, registry.ErrDependencyResolutionNotFound
 	}
 	if err != nil {
 		return nil, NewQueryChangesetError(err)
 	}
-	var resolution registry.DependencyResolution
-	if err := json.Unmarshal(data, &resolution); err != nil {
+	resolution, err := decodeResolutionGraph(digest, data)
+	if err != nil {
 		return nil, NewDecodeChangesetError(err)
 	}
-	if !resolution.Valid() {
-		return nil, NewDecodeChangesetError(errors.New("stored dependency resolution digest mismatch"))
-	}
-	return resolution.Canonical(), nil
+	return resolution, nil
 }
 
 func (h *History) CheckpointDependencyResolution(v registry.Version, resolution *registry.DependencyResolution) error {
@@ -421,7 +482,10 @@ func (h *History) CheckpointDependencyResolution(v registry.Version, resolution 
 	if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO resolution_graphs (digest, data) VALUES (?, ?)", canonical.Digest, data); err != nil {
 		return NewInsertChangesetError(err)
 	}
-	if _, err = tx.ExecContext(ctx, "INSERT OR REPLACE INTO version_resolutions (version_id, resolution_digest) VALUES (?, ?)", v.ID(), canonical.Digest); err != nil {
+	if err = ensureResolutionGraph(ctx, tx, canonical.Digest); err != nil {
+		return NewDecodeChangesetError(err)
+	}
+	if err = setVersionResolution(ctx, tx, v.ID(), canonical.Digest); err != nil {
 		return NewInsertChangesetError(err)
 	}
 	if err = tx.Commit(); err != nil {
@@ -463,11 +527,90 @@ func (h *History) SetHead(v registry.Version) error {
 	defer h.mu.Unlock()
 
 	ctx := context.Background()
-	_, err := h.db.ExecContext(ctx, "INSERT OR REPLACE INTO metadata (key, value) VALUES ('head', ?)", v.ID())
+	result, err := h.db.ExecContext(ctx, `UPDATE metadata SET value = ?
+		WHERE key = 'head' AND EXISTS (SELECT 1 FROM versions WHERE id = ?)`, v.ID(), v.ID())
 	if err != nil {
 		return NewSetHeadError(err)
 	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	if updated != 1 {
+		return NewSetHeadError(fmt.Errorf("version %d does not exist", v.ID()))
+	}
 
+	return nil
+}
+
+func (h *History) CompareAndSetHead(expected, target registry.Version) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ctx := context.Background()
+	result, err := h.db.ExecContext(ctx, `UPDATE metadata SET value = ?
+		WHERE key = 'head' AND value = ? AND EXISTS (SELECT 1 FROM versions WHERE id = ?)`,
+		target.ID(), expected.ID(), target.ID())
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return NewSetHeadError(err)
+	}
+	if updated != 1 {
+		return NewSetHeadError(fmt.Errorf("history head changed or target version %d does not exist", target.ID()))
+	}
+	return nil
+}
+
+func ensureResolutionGraph(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, digest string) error {
+	var data []byte
+	if err := q.QueryRowContext(ctx, "SELECT data FROM resolution_graphs WHERE digest = ?", digest).Scan(&data); err != nil {
+		return fmt.Errorf("query stored dependency resolution %s: %w", digest, err)
+	}
+	_, err := decodeResolutionGraph(digest, data)
+	return err
+}
+
+func decodeResolutionGraph(digest string, data []byte) (*registry.DependencyResolution, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("stored dependency resolution %s has no graph payload", digest)
+	}
+	var resolution registry.DependencyResolution
+	if err := json.Unmarshal(data, &resolution); err != nil {
+		return nil, err
+	}
+	if !resolution.Valid() {
+		return nil, errors.New("stored dependency resolution digest mismatch")
+	}
+	canonical := resolution.Canonical()
+	if canonical.Digest != digest {
+		return nil, fmt.Errorf("stored dependency resolution key mismatch: row %s, payload %s", digest, canonical.Digest)
+	}
+	return canonical, nil
+}
+
+func setVersionResolution(ctx context.Context, tx *sql.Tx, versionID uint, digest string) error {
+	result, err := tx.ExecContext(ctx, "INSERT OR IGNORE INTO version_resolutions (version_id, resolution_digest) VALUES (?, ?)", versionID, digest)
+	if err != nil {
+		return err
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 1 {
+		return nil
+	}
+	var stored string
+	if err := tx.QueryRowContext(ctx, "SELECT resolution_digest FROM version_resolutions WHERE version_id = ?", versionID).Scan(&stored); err != nil {
+		return err
+	}
+	if stored != digest {
+		return fmt.Errorf("version %d already references dependency resolution %s, refusing %s", versionID, stored, digest)
+	}
 	return nil
 }
 

--- a/system/registry/history/sqlite/sqlite_test.go
+++ b/system/registry/history/sqlite/sqlite_test.go
@@ -100,6 +100,74 @@ func TestHistory_SaveAndGet(t *testing.T) {
 	assert.Equal(t, "test", retrieved[0].Entry.ID.NS)
 }
 
+func TestHistory_DependencyResolutionIsAtomicDeduplicatedAndInherited(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	resolution := (&registry.DependencyResolution{
+		InputDigest: "roots",
+		Modules: []registry.ResolvedModule{{
+			Name: "acme/crm", Version: "v1.6.0", VersionID: "crm-16", Digest: "sha256:crm",
+		}},
+	}).Canonical()
+	require.NoError(t, hist.SaveWithDependencyResolution(v1, registry.ChangeSet{{
+		Kind: registry.EntryCreate, Entry: registry.Entry{ID: registry.NewID("app.deps", "crm")},
+	}}, resolution, true))
+
+	got, err := hist.GetDependencyResolution(v1)
+	require.NoError(t, err)
+	require.Equal(t, resolution, got)
+
+	v2 := version.FromParent(v1, 2)
+	require.NoError(t, hist.Save(v2, registry.ChangeSet{{
+		Kind: registry.EntryCreate, Entry: registry.Entry{ID: registry.NewID("app", "unrelated")},
+	}}, true))
+	inherited, err := hist.GetDependencyResolution(v2)
+	require.NoError(t, err)
+	require.Equal(t, resolution.Digest, inherited.Digest)
+
+	var graphs int
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM resolution_graphs").Scan(&graphs))
+	require.Equal(t, 1, graphs, "versions sharing a graph must store its payload once")
+	var refs int
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM version_resolutions").Scan(&refs))
+	require.Equal(t, 2, refs)
+}
+
+func TestHistory_DependencyResolutionFailureRollsBackVersionAndHead(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	_, err = hist.db.ExecContext(context.Background(), `CREATE TRIGGER reject_resolution
+		BEFORE INSERT ON resolution_graphs
+		BEGIN SELECT RAISE(FAIL, 'injected resolution failure'); END`)
+	require.NoError(t, err)
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	err = hist.SaveWithDependencyResolution(v1, registry.ChangeSet{{
+		Kind: registry.EntryCreate, Entry: registry.Entry{ID: registry.NewID("app.deps", "crm")},
+	}}, (&registry.DependencyResolution{
+		InputDigest: "roots",
+		Modules:     []registry.ResolvedModule{{Name: "acme/crm", Version: "v1.6.0"}},
+	}).Canonical(), true)
+	require.ErrorContains(t, err, "injected resolution failure")
+
+	head, err := hist.Head()
+	require.NoError(t, err)
+	require.Equal(t, uint(0), head.ID())
+	versions, err := hist.Versions()
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	_, err = hist.Get(v1)
+	require.Error(t, err)
+}
+
 func TestHistory_Persistence(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
@@ -130,6 +198,31 @@ func TestHistory_Persistence(t *testing.T) {
 	versions, err := hist2.Versions()
 	require.NoError(t, err)
 	assert.Len(t, versions, 2)
+}
+
+func TestHistoryReplayUpdateReplacesCanonicalBaselineID(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	id := registry.NewID("app.deps", "agent")
+	baseline := registry.Entry{ID: id, Kind: registry.NamespaceDependency, Data: payload.New(map[string]any{"version": "*"})}
+	updated := baseline
+	updated.Data = payload.New(map[string]any{"version": "0.4.14"})
+	v1 := version.FromParent(v0, 1)
+	require.NoError(t, hist.Save(v1, registry.ChangeSet{{Kind: registry.EntryUpdate, Entry: updated, OriginalEntry: &baseline}}, true))
+
+	reg := registrysystem.NewRegistry(hist, &testRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop())
+	require.NoError(t, reg.LoadState(context.Background(), registry.State{baseline}, v1))
+	entry, err := reg.GetEntry(id)
+	require.NoError(t, err)
+	data, ok := entry.Data.Data().(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "0.4.14", data["version"])
+	entries, err := reg.GetAllEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
 }
 
 func TestHistory_ConcurrentColdOpenInitializesRootOnce(t *testing.T) {
@@ -289,7 +382,7 @@ func TestHistory_UsesManagedSchemaVersionTable(t *testing.T) {
 		"SELECT curr_version FROM schema_version WHERE name = 'registry_history'",
 	).Scan(&version)
 	require.NoError(t, err)
-	assert.Equal(t, "1.0", version)
+	assert.Equal(t, "1.1", version)
 }
 
 func TestSQLitePersistence_OriginalEntry(t *testing.T) {

--- a/system/registry/history/sqlite/sqlite_test.go
+++ b/system/registry/history/sqlite/sqlite_test.go
@@ -4,6 +4,9 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -56,6 +59,34 @@ func TestHistory_Basic(t *testing.T) {
 	head, err := hist.Head()
 	require.NoError(t, err)
 	assert.Equal(t, uint(0), head.ID())
+}
+
+func TestHistory_ReplayChangesStreamsVeryLongLineage(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "long.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, hist.Close()) }()
+
+	tx, err := hist.db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	ctx := context.Background()
+	target := version.New(0)
+	const versions = 5000
+	for i := 1; i <= versions; i++ {
+		_, err = tx.ExecContext(ctx, "INSERT INTO versions (id, parent_id) VALUES (?, ?)", i, i-1)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(ctx, "INSERT INTO changesets (version_id, data) VALUES (?, ?)", i, []byte{0x90})
+		require.NoError(t, err)
+		target = version.FromParent(target, uint(i))
+	}
+	require.NoError(t, tx.Commit())
+
+	count := 0
+	require.NoError(t, hist.ReplayChanges(target, func(cs registry.ChangeSet) error {
+		require.Empty(t, cs)
+		count++
+		return nil
+	}))
+	require.Equal(t, versions, count)
 }
 
 func TestHistory_CreatesParentDirectory(t *testing.T) {
@@ -166,6 +197,79 @@ func TestHistory_DependencyResolutionFailureRollsBackVersionAndHead(t *testing.T
 	require.Len(t, versions, 1)
 	_, err = hist.Get(v1)
 	require.Error(t, err)
+}
+
+func TestHistory_EnforcesForeignKeysAndRejectsMissingCheckpointVersion(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	var enabled int
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "PRAGMA foreign_keys").Scan(&enabled))
+	require.Equal(t, 1, enabled)
+
+	resolution := (&registry.DependencyResolution{InputDigest: "roots"}).Canonical()
+	err = hist.CheckpointDependencyResolution(version.New(99), resolution)
+	require.Error(t, err)
+	_, err = hist.GetDependencyResolution(version.New(99))
+	require.ErrorIs(t, err, registry.ErrDependencyResolutionNotFound)
+}
+
+func TestHistory_SaveIsInsertOnlyAndHeadUsesParentCAS(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	require.NoError(t, hist.Save(v1, nil, true))
+	require.Error(t, hist.Save(v1, nil, true), "a history version must never be overwritten")
+
+	v2 := version.FromParent(v1, 2)
+	require.NoError(t, hist.Save(v2, nil, true))
+	stale := version.FromParent(v1, 3)
+	require.ErrorContains(t, hist.Save(stale, nil, true), "history head changed")
+	_, err = hist.Get(stale)
+	require.Error(t, err, "the failed CAS must roll the version and changeset back")
+
+	require.Error(t, hist.SetHead(version.New(99)))
+	head, err := hist.Head()
+	require.NoError(t, err)
+	require.Equal(t, v2.ID(), head.ID())
+}
+
+func TestHistory_ResolutionReferenceIsImmutableAndCorruptionIsNotLegacy(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	first := (&registry.DependencyResolution{InputDigest: "first"}).Canonical()
+	second := (&registry.DependencyResolution{InputDigest: "second"}).Canonical()
+	require.NoError(t, hist.SaveWithDependencyResolution(v1, nil, first, true))
+	require.NoError(t, hist.CheckpointDependencyResolution(v1, first), "same graph checkpoint is idempotent")
+	require.Error(t, hist.CheckpointDependencyResolution(v1, second), "historical graph references are immutable")
+
+	secondData, err := json.Marshal(second)
+	require.NoError(t, err)
+	_, err = hist.db.ExecContext(context.Background(), "UPDATE resolution_graphs SET data = ? WHERE digest = ?", secondData, first.Digest)
+	require.NoError(t, err)
+	_, err = hist.GetDependencyResolution(v1)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, registry.ErrDependencyResolutionNotFound), "key/payload corruption must not trigger legacy resolution")
+
+	_, err = hist.db.ExecContext(context.Background(), "PRAGMA foreign_keys=OFF")
+	require.NoError(t, err)
+	_, err = hist.db.ExecContext(context.Background(), "UPDATE version_resolutions SET resolution_digest = 'sha256:missing' WHERE version_id = ?", v1.ID())
+	require.NoError(t, err)
+	_, err = hist.db.ExecContext(context.Background(), "PRAGMA foreign_keys=ON")
+	require.NoError(t, err)
+	_, err = hist.GetDependencyResolution(v1)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, registry.ErrDependencyResolutionNotFound), "a dangling graph reference is corruption, not a legacy version")
 }
 
 func TestHistory_Persistence(t *testing.T) {
@@ -317,7 +421,7 @@ func TestHistory_SetHead(t *testing.T) {
 	cs1 := registry.ChangeSet{
 		{Kind: registry.EntryCreate, Entry: registry.Entry{ID: registry.NewID("test", "entry1")}},
 	}
-	err = hist.Save(v1, cs1, false)
+	err = hist.Save(v1, cs1, true)
 	require.NoError(t, err)
 
 	v2 := version.FromParent(v1, 2)
@@ -383,6 +487,49 @@ func TestHistory_UsesManagedSchemaVersionTable(t *testing.T) {
 	).Scan(&version)
 	require.NoError(t, err)
 	assert.Equal(t, "1.1", version)
+}
+
+func TestHistory_MigratesV10WithoutChangingExistingHistory(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "history-v1.0.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	statements := []string{
+		`CREATE TABLE schema_version (name TEXT PRIMARY KEY, curr_version TEXT NOT NULL, min_compatible_version TEXT NOT NULL, updated_at TEXT NOT NULL)`,
+		`CREATE TABLE schema_update_history (name TEXT NOT NULL, update_time TEXT NOT NULL, old_version TEXT NOT NULL, new_version TEXT NOT NULL, manifest_sha256 TEXT NOT NULL, description TEXT, PRIMARY KEY (name, update_time, new_version))`,
+		`INSERT INTO schema_version (name, curr_version, min_compatible_version, updated_at) VALUES ('registry_history', '1.0', '1.0', '2025-01-01T00:00:00Z')`,
+		`CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		`CREATE TABLE versions (id INTEGER PRIMARY KEY, parent_id INTEGER, FOREIGN KEY (parent_id) REFERENCES versions(id))`,
+		`CREATE TABLE changesets (version_id INTEGER PRIMARY KEY, data BLOB NOT NULL, FOREIGN KEY (version_id) REFERENCES versions(id) ON DELETE CASCADE)`,
+		`CREATE INDEX idx_versions_parent ON versions(parent_id)`,
+		`INSERT INTO versions (id, parent_id) VALUES (0, NULL), (1, 0)`,
+		`INSERT INTO changesets (version_id, data) VALUES (0, X'90'), (1, X'90')`,
+		`INSERT INTO metadata (key, value) VALUES ('head', '1')`,
+	}
+	for _, statement := range statements {
+		_, execErr := db.ExecContext(context.Background(), statement)
+		require.NoError(t, execErr)
+	}
+	require.NoError(t, db.Close())
+
+	hist, err := NewSQLite(dbPath, zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+	head, err := hist.Head()
+	require.NoError(t, err)
+	require.Equal(t, uint(1), head.ID())
+	changes, err := hist.Get(head)
+	require.NoError(t, err)
+	require.Empty(t, changes)
+	versions, err := hist.Versions()
+	require.NoError(t, err)
+	require.Len(t, versions, 2)
+	_, err = hist.GetDependencyResolution(head)
+	require.ErrorIs(t, err, registry.ErrDependencyResolutionNotFound, "pre-1.1 versions remain explicit legacy versions")
+
+	var schemaVersion string
+	require.NoError(t, hist.db.QueryRowContext(context.Background(),
+		"SELECT curr_version FROM schema_version WHERE name = 'registry_history'").Scan(&schemaVersion))
+	require.Equal(t, "1.1", schemaVersion)
 }
 
 func TestSQLitePersistence_OriginalEntry(t *testing.T) {

--- a/system/registry/history/sqlite/sqlite_test.go
+++ b/system/registry/history/sqlite/sqlite_test.go
@@ -81,12 +81,128 @@ func TestHistory_ReplayChangesStreamsVeryLongLineage(t *testing.T) {
 	require.NoError(t, tx.Commit())
 
 	count := 0
-	require.NoError(t, hist.ReplayChanges(target, func(cs registry.ChangeSet) error {
+	require.NoError(t, hist.ReplayChanges(context.Background(), target, func(cs registry.ChangeSet) error {
 		require.Empty(t, cs)
 		count++
 		return nil
 	}))
 	require.Equal(t, versions, count)
+}
+
+func TestHistoryReplayRejectsMissingAncestorChangeset(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "missing.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, hist.Close()) }()
+
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	v2 := version.FromParent(v1, 2)
+	require.NoError(t, hist.Save(v1, registry.ChangeSet{}, true))
+	require.NoError(t, hist.Save(v2, registry.ChangeSet{}, true))
+	_, err = hist.db.ExecContext(context.Background(), "DELETE FROM changesets WHERE version_id = 1")
+	require.NoError(t, err)
+
+	err = hist.ReplayChanges(context.Background(), v2, func(registry.ChangeSet) error { return nil })
+	require.Error(t, err)
+}
+
+func TestHistoryReplayRejectsDisconnectedAndCyclicLineage(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		tamper string
+	}{
+		{name: "disconnected", tamper: "UPDATE versions SET parent_id = NULL WHERE id = 1"},
+		{name: "cycle", tamper: "UPDATE versions SET parent_id = 2 WHERE id = 1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			hist, err := NewSQLite(filepath.Join(t.TempDir(), "malformed.db"), zap.NewNop())
+			require.NoError(t, err)
+			defer func() { require.NoError(t, hist.Close()) }()
+			v0, err := hist.Head()
+			require.NoError(t, err)
+			v1 := version.FromParent(v0, 1)
+			v2 := version.FromParent(v1, 2)
+			require.NoError(t, hist.Save(v1, nil, true))
+			require.NoError(t, hist.Save(v2, nil, true))
+			_, err = hist.db.ExecContext(context.Background(), test.tamper)
+			require.NoError(t, err)
+
+			err = hist.ReplayChanges(context.Background(), v2, func(registry.ChangeSet) error { return nil })
+			require.ErrorContains(t, err, "lineage")
+			_, err = hist.Head()
+			require.Error(t, err, "head reconstruction must terminate and reject malformed lineage")
+		})
+	}
+}
+
+func TestHistoryReplayClosesRowsBeforeCallback(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "callback.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, hist.Close()) }()
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	require.NoError(t, hist.Save(v1, nil, true))
+
+	require.NoError(t, hist.ReplayChanges(context.Background(), v1, func(registry.ChangeSet) error {
+		_, callbackErr := hist.MaxVersionID()
+		return callbackErr
+	}))
+}
+
+func TestHistoryGetVersionIgnoresUnrelatedBranchCycle(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "lookup.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, hist.Close()) }()
+
+	tx, err := hist.db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	for id := 1; id <= 2000; id++ {
+		_, err = tx.ExecContext(context.Background(), "INSERT INTO versions (id, parent_id) VALUES (?, 0)", id)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(context.Background(), "INSERT INTO changesets (version_id, data) VALUES (?, ?)", id, []byte{0x90})
+		require.NoError(t, err)
+	}
+	_, err = tx.ExecContext(context.Background(), "INSERT INTO versions (id, parent_id) VALUES (2001, 1)")
+	require.NoError(t, err)
+	_, err = tx.ExecContext(context.Background(), "INSERT INTO changesets (version_id, data) VALUES (2001, ?)", []byte{0x90})
+	require.NoError(t, err)
+	_, err = tx.ExecContext(context.Background(), "UPDATE versions SET parent_id = 2000 WHERE id = 1999")
+	require.NoError(t, err)
+	_, err = tx.ExecContext(context.Background(), "UPDATE versions SET parent_id = 1999 WHERE id = 2000")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	stored, err := hist.GetVersion(2001)
+	require.NoError(t, err)
+	require.Equal(t, uint(2001), stored.ID())
+	require.NotNil(t, stored.Previous())
+	require.Equal(t, uint(1), stored.Previous().ID())
+	require.Equal(t, registry.RootVersion, stored.Previous().Previous().ID())
+	_, err = hist.GetVersion(2000)
+	require.Error(t, err)
+}
+
+func TestHistoryRejectsMalformedResolutionBeforeWrite(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "invalid-resolution.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, hist.Close()) }()
+	malformed := (&registry.DependencyResolution{Modules: []registry.ResolvedModule{
+		{Name: "duplicate", Version: "1"},
+		{Name: "duplicate", Version: "2"},
+	}}).Canonical()
+	v1 := version.FromParent(version.New(registry.RootVersion), 1)
+
+	require.ErrorIs(t, hist.SaveWithDependencyResolution(v1, nil, malformed, true), registry.ErrInvalidDependencyResolution)
+	var versions, graphs int
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM versions WHERE id = 1").Scan(&versions))
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM resolution_graphs").Scan(&graphs))
+	require.Zero(t, versions)
+	require.Zero(t, graphs)
+	head, err := hist.Head()
+	require.NoError(t, err)
+	require.Equal(t, registry.RootVersion, head.ID())
 }
 
 func TestHistory_CreatesParentDirectory(t *testing.T) {
@@ -185,7 +301,7 @@ func TestHistory_DependencyResolutionFailureRollsBackVersionAndHead(t *testing.T
 		Kind: registry.EntryCreate, Entry: registry.Entry{ID: registry.NewID("app.deps", "crm")},
 	}}, (&registry.DependencyResolution{
 		InputDigest: "roots",
-		Modules:     []registry.ResolvedModule{{Name: "acme/crm", Version: "v1.6.0"}},
+		Modules:     []registry.ResolvedModule{{Name: "acme/crm", Version: "v1.6.0", Digest: "sha256:crm"}},
 	}).Canonical(), true)
 	require.ErrorContains(t, err, "injected resolution failure")
 
@@ -197,6 +313,26 @@ func TestHistory_DependencyResolutionFailureRollsBackVersionAndHead(t *testing.T
 	require.Len(t, versions, 1)
 	_, err = hist.Get(v1)
 	require.Error(t, err)
+}
+
+func TestHistory_AtomicResolutionHeadCASFailureLeavesTargetUnannotated(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = hist.Close() }()
+
+	v0, err := hist.Head()
+	require.NoError(t, err)
+	v1 := version.FromParent(v0, 1)
+	require.NoError(t, hist.Save(v1, nil, false))
+	resolution := (&registry.DependencyResolution{InputDigest: "losing-command"}).Canonical()
+
+	err = hist.CompareAndSetHeadWithDependencyResolution(v1, v1, resolution)
+	require.ErrorContains(t, err, "history head changed")
+	_, err = hist.GetDependencyResolution(v1)
+	require.ErrorIs(t, err, registry.ErrDependencyResolutionNotFound)
+	var graphs int
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM resolution_graphs").Scan(&graphs))
+	require.Zero(t, graphs, "the losing transaction must roll back its graph payload and version reference")
 }
 
 func TestHistory_EnforcesForeignKeysAndRejectsMissingCheckpointVersion(t *testing.T) {
@@ -237,6 +373,19 @@ func TestHistory_SaveIsInsertOnlyAndHeadUsesParentCAS(t *testing.T) {
 	head, err := hist.Head()
 	require.NoError(t, err)
 	require.Equal(t, v2.ID(), head.ID())
+}
+
+func TestHistoryRejectsParentlessNonRootVersionBeforePersistence(t *testing.T) {
+	hist, err := NewSQLite(filepath.Join(t.TempDir(), "history.db"), zap.NewNop())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, hist.Close()) }()
+
+	err = hist.Save(version.New(1), nil, false)
+	require.ErrorContains(t, err, "non-root version 1 has no parent")
+
+	var count int
+	require.NoError(t, hist.db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM versions WHERE id = 1").Scan(&count))
+	require.Zero(t, count)
 }
 
 func TestHistory_ResolutionReferenceIsImmutableAndCorruptionIsNotLegacy(t *testing.T) {

--- a/system/registry/load_state_test.go
+++ b/system/registry/load_state_test.go
@@ -80,6 +80,103 @@ func TestRegistry_LoadState_V0(t *testing.T) {
 	assert.Len(t, reg.state, 2)
 }
 
+func TestRegistry_LoadState_V0ExpandsBaselineDirectives(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	hist := history.NewMemory()
+	resolver := topology.NewResolver()
+
+	depEntry := registry.Entry{
+		ID:   registry.NewID("app.deps", "analysis"),
+		Kind: registry.NamespaceDependency,
+		Data: payload.New("dependency"),
+	}
+	expandedEntry := registry.Entry{
+		ID:   registry.NewID("analysis", "runtime"),
+		Kind: "process.host",
+		Data: payload.New("expanded"),
+	}
+
+	expander := directiveFunc(func(_ context.Context, op registry.Operation, snapshot registry.State) (registry.DirectiveResult, error) {
+		require.Equal(t, registry.EntryUpdate, op.Kind)
+		require.Equal(t, depEntry.ID, op.Entry.ID)
+		require.Contains(t, snapshot, depEntry)
+		return registry.DirectiveResult{
+			Applied: true,
+			Additional: []registry.ScopedOperation{{
+				Operation: registry.Operation{Kind: registry.EntryCreate, Entry: expandedEntry},
+				Scope:     registry.ScopeBaseline,
+			}},
+		}, nil
+	})
+
+	runner := NewMockRunner()
+	runner.RunFunc = func(state registry.State, changes registry.ChangeSet) (registry.State, error) {
+		stateMap := topology.NewStateMap(state)
+		for _, op := range changes {
+			switch op.Kind {
+			case registry.EntryCreate, registry.EntryUpdate:
+				stateMap[op.Entry.ID] = op.Entry
+			case registry.EntryDelete:
+				delete(stateMap, op.Entry.ID)
+			}
+		}
+		return topology.StateMapToSlice(stateMap), nil
+	}
+
+	reg := NewRegistry(
+		hist,
+		runner,
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+		WithKindDirective(registry.NamespaceDependency, expander),
+	)
+
+	head, err := reg.Current()
+	require.NoError(t, err)
+	require.NoError(t, reg.LoadState(ctx, registry.State{depEntry}, head))
+
+	_, err = reg.GetEntry(depEntry.ID)
+	require.NoError(t, err)
+	_, err = reg.GetEntry(expandedEntry.ID)
+	require.NoError(t, err)
+}
+
+func TestRegistry_LoadState_V0RejectsBaselineDirectiveExpansionFailure(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	resolver := topology.NewResolver()
+	depEntry := registry.Entry{
+		ID:   registry.NewID("app.deps", "missing"),
+		Kind: registry.NamespaceDependency,
+	}
+
+	runner := NewMockRunner()
+	runner.RunFunc = func(state registry.State, _ registry.ChangeSet) (registry.State, error) {
+		return state, nil
+	}
+	reg := NewRegistry(
+		history.NewMemory(),
+		runner,
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+		WithKindDirective(registry.NamespaceDependency, directiveFunc(
+			func(context.Context, registry.Operation, registry.State) (registry.DirectiveResult, error) {
+				return registry.DirectiveResult{}, assert.AnError
+			},
+		)),
+	)
+
+	head, err := reg.Current()
+	require.NoError(t, err)
+	err = reg.LoadState(ctx, registry.State{depEntry}, head)
+	require.ErrorIs(t, err, assert.AnError)
+	_, err = reg.GetEntry(depEntry.ID)
+	require.Error(t, err, "a failed declaration must not be published as a partial root")
+}
+
 func TestRegistry_LoadState_WithHistory(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.NewNop()

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -343,15 +343,14 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		currentVersionID = baseVersion.ID()
 	}
 
-	targetVersion, path, err := r.computeVersionPath(baseVersion, v, currentVersionID)
+	targetVersion, err := r.findStoredVersion(v)
 	if err != nil {
 		return err
 	}
 
-	r.log.Debug("computed version path",
+	r.log.Debug("resolving version transition",
 		zap.Uint("from", currentVersionID),
-		zap.Uint("to", targetVersion.ID()),
-		zap.Int("steps", len(path)))
+		zap.Uint("to", targetVersion.ID()))
 
 	changeset, err := r.collectTransitionChangesets(baseVersion, targetVersion)
 	if err != nil {
@@ -546,14 +545,9 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		}
 	}
 
-	if err := r.history.SetHead(targetVersion); err != nil {
+	if err := compareAndSetHistoryHead(r.history, baseVersion, targetVersion); err != nil {
 		headErr := NewSetHeadError(targetVersion.ID(), err)
 		var compensationErr error
-		if baseVersion != nil {
-			if restoreErr := r.history.SetHead(baseVersion); restoreErr != nil {
-				compensationErr = errors.Join(compensationErr, restoreErr)
-			}
-		}
 		if rollbackErr := r.rollback(ctx, newState, r.state); rollbackErr != nil {
 			compensationErr = errors.Join(compensationErr, rollbackErr)
 		}
@@ -571,7 +565,7 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		if checkpointErr := resolutionHistory.CheckpointDependencyResolution(targetVersion, targetResolution); checkpointErr != nil {
 			var compensationErr error
 			if baseVersion != nil {
-				if restoreErr := r.history.SetHead(baseVersion); restoreErr != nil {
+				if restoreErr := compareAndSetHistoryHead(r.history, targetVersion, baseVersion); restoreErr != nil {
 					compensationErr = errors.Join(compensationErr, restoreErr)
 				}
 			}
@@ -600,39 +594,24 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	return nil
 }
 
-func (r *Reg) computeVersionPath(current registry.Version, v registry.Version, currentVersionID uint) (registry.Version, []registry.Version, error) {
+func compareAndSetHistoryHead(history registry.History, expected, target registry.Version) error {
+	if cas, ok := history.(registry.HeadCASHistory); ok && expected != nil {
+		return cas.CompareAndSetHead(expected, target)
+	}
+	return history.SetHead(target)
+}
+
+func (r *Reg) findStoredVersion(v registry.Version) (registry.Version, error) {
 	versions, err := r.history.Versions()
 	if err != nil {
-		return nil, nil, NewGetVersionsError(err)
+		return nil, NewGetVersionsError(err)
 	}
-
-	var targetVersion registry.Version
 	for _, ver := range versions {
 		if ver.ID() == v.ID() {
-			targetVersion = ver
-			break
+			return ver, nil
 		}
 	}
-	if targetVersion == nil {
-		return nil, nil, NewVersionNotFoundError(v.ID())
-	}
-
-	vm := version.NewVersionMap()
-	for _, ver := range versions {
-		if err := vm.Add(ver); err != nil {
-			r.log.Warn("failed to add version to map", zap.Uint("version", ver.ID()), zap.Error(err))
-		}
-	}
-
-	path, err := vm.Path(current, targetVersion)
-	if err != nil {
-		return nil, nil, NewComputePathError(currentVersionID, targetVersion.ID(), err)
-	}
-	if len(path) == 0 {
-		return nil, nil, NewComputePathError(currentVersionID, targetVersion.ID(), ErrEmptyVersionPath)
-	}
-
-	return targetVersion, path, nil
+	return nil, NewVersionNotFoundError(v.ID())
 }
 
 // collectTransitionChangesets builds a source-to-target transition from parent
@@ -769,31 +748,32 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	// without expanding directives: expansion can consult external systems and
 	// must never run once per historical version during boot.
 	if targetVersion.ID() > 0 {
-		current := targetVersion
-		var versions []registry.Version
-
-		for current != nil && current.ID() > 0 {
-			versions = append(versions, current)
-			current = current.Previous()
-		}
-		for left, right := 0, len(versions)-1; left < right; left, right = left+1, right-1 {
-			versions[left], versions[right] = versions[right], versions[left]
-		}
-
-		r.log.Debug("replaying changesets on baseline",
-			zap.Uint("target_version", targetVersion.ID()),
-			zap.Int("changeset_count", len(versions)))
-
-		for _, ver := range versions {
-			cs, err := r.history.Get(ver)
-			if err != nil {
-				if planner != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-				}
-				return NewGetChangesetError(ver.ID(), err)
-			}
+		applyChanges := func(cs registry.ChangeSet) error {
 			canonicalizeChangeSetIDs(cs)
 			applyStateOperations(stateMap, cs)
+			return nil
+		}
+		if replayer, ok := r.history.(registry.ChangeSetReplayer); ok {
+			r.log.Debug("streaming history changesets on baseline", zap.Uint("target_version", targetVersion.ID()))
+			if err := replayer.ReplayChanges(targetVersion, applyChanges); err != nil {
+				return NewGetChangesetError(targetVersion.ID(), err)
+			}
+		} else {
+			current := targetVersion
+			var versions []registry.Version
+			for current != nil && current.ID() > 0 {
+				versions = append(versions, current)
+				current = current.Previous()
+			}
+			for i := len(versions) - 1; i >= 0; i-- {
+				cs, err := r.history.Get(versions[i])
+				if err != nil {
+					return NewGetChangesetError(versions[i].ID(), err)
+				}
+				if err := applyChanges(cs); err != nil {
+					return NewGetChangesetError(versions[i].ID(), err)
+				}
+			}
 		}
 	}
 

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -142,6 +142,7 @@ func (r *Reg) GetEntry(path registry.ID) (registry.Entry, error) {
 func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.Version, error) {
 	r.applyMu.Lock()
 	defer r.applyMu.Unlock()
+	changes = append(registry.ChangeSet(nil), changes...)
 	canonicalizeChangeSetIDs(changes)
 
 	r.log.Info("apply started", zap.Int("change_count", len(changes)))
@@ -174,6 +175,7 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 
 		plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
 		if err != nil {
+			planner.RollbackEffects(ctx, plan.Effects)
 			return nil, NewSortChangesError(err)
 		}
 
@@ -264,7 +266,7 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 		if resolutionChanged {
 			resolutionHistory, ok := r.history.(registry.ResolutionHistory)
 			if !ok {
-				saveErr = errors.New("history does not support durable dependency resolutions")
+				saveErr = ErrDurableResolutionUnsupported
 			} else {
 				saveErr = resolutionHistory.SaveWithDependencyResolution(newVersion, enrichedChanges, resolution, true)
 			}
@@ -335,6 +337,11 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	r.mu.RUnlock()
 
 	if baseVersion != nil && baseVersion.ID() == v.ID() {
+		if cas, ok := r.history.(registry.HeadCASHistory); ok {
+			if err := cas.CompareAndSetHead(baseVersion, baseVersion); err != nil {
+				return NewSetHeadError(baseVersion.ID(), err)
+			}
+		}
 		return nil
 	}
 
@@ -363,13 +370,11 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		preparedEff      []registry.Effect
 		planner          *regexp.Planner
 		targetResolution *registry.DependencyResolution
-		resolutionStored bool
 	)
 	if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
 		stored, resolutionErr := resolutionHistory.GetDependencyResolution(targetVersion)
 		if resolutionErr == nil {
 			targetResolution = stored
-			resolutionStored = true
 		} else if !errors.Is(resolutionErr, registry.ErrDependencyResolutionNotFound) {
 			return NewGetChangesetError(targetVersion.ID(), resolutionErr)
 		}
@@ -428,6 +433,7 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 
 		plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
 		if err != nil {
+			planner.RollbackEffects(ctx, plan.Effects)
 			return NewSortChangesError(err)
 		}
 
@@ -460,10 +466,12 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 					return NewExpandChangesError(expandErr)
 				}
 				if rootPlan.Resolution == nil {
+					planner.RollbackEffects(ctx, rootPlan.Effects)
 					continue
 				}
 				rootPlan.Ops, expandErr = planner.SortOps(intermediate, rootPlan.Ops)
 				if expandErr != nil {
+					planner.RollbackEffects(ctx, rootPlan.Effects)
 					planner.RollbackEffects(ctx, preparedEff)
 					return NewSortChangesError(expandErr)
 				}
@@ -491,6 +499,14 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			return NewSortChangesError(err)
 		}
 		allOps = sorted
+	}
+
+	resolutionHeadCAS, supportsAtomicResolutionHead := r.history.(registry.ResolutionHeadCASHistory)
+	if targetResolution != nil && !supportsAtomicResolutionHead {
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		return NewSaveVersionError(ErrDurableResolutionUnsupported, nil)
 	}
 
 	// Topologically sort before dispatching to the runner. Same invariant as
@@ -545,8 +561,14 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		}
 	}
 
-	if err := compareAndSetHistoryHead(r.history, baseVersion, targetVersion); err != nil {
-		headErr := NewSetHeadError(targetVersion.ID(), err)
+	var headUpdateErr error
+	if targetResolution != nil {
+		headUpdateErr = resolutionHeadCAS.CompareAndSetHeadWithDependencyResolution(baseVersion, targetVersion, targetResolution)
+	} else {
+		headUpdateErr = compareAndSetHistoryHead(r.history, baseVersion, targetVersion)
+	}
+	if headUpdateErr != nil {
+		headErr := NewSetHeadError(targetVersion.ID(), headUpdateErr)
 		var compensationErr error
 		if rollbackErr := r.rollback(ctx, newState, r.state); rollbackErr != nil {
 			compensationErr = errors.Join(compensationErr, rollbackErr)
@@ -558,25 +580,6 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			return NewApplyVersionChangesError(headErr, compensationErr)
 		}
 		return headErr
-	}
-
-	resolutionHistory, supportsResolutionHistory := r.history.(registry.ResolutionHistory)
-	if targetResolution != nil && supportsResolutionHistory && !resolutionStored {
-		if checkpointErr := resolutionHistory.CheckpointDependencyResolution(targetVersion, targetResolution); checkpointErr != nil {
-			var compensationErr error
-			if baseVersion != nil {
-				if restoreErr := compareAndSetHistoryHead(r.history, targetVersion, baseVersion); restoreErr != nil {
-					compensationErr = errors.Join(compensationErr, restoreErr)
-				}
-			}
-			if rollbackErr := r.rollback(ctx, newState, r.state); rollbackErr != nil {
-				compensationErr = errors.Join(compensationErr, rollbackErr)
-			}
-			if planner != nil {
-				planner.RollbackEffects(ctx, preparedEff)
-			}
-			return NewSaveVersionError(checkpointErr, compensationErr)
-		}
 	}
 	if planner != nil {
 		if finalizeErr := planner.FinalizeEffects(ctx, preparedEff); finalizeErr != nil {
@@ -595,13 +598,24 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 }
 
 func compareAndSetHistoryHead(history registry.History, expected, target registry.Version) error {
-	if cas, ok := history.(registry.HeadCASHistory); ok && expected != nil {
-		return cas.CompareAndSetHead(expected, target)
+	if expected == nil {
+		return history.SetHead(target)
 	}
-	return history.SetHead(target)
+	cas, ok := history.(registry.HeadCASHistory)
+	if !ok {
+		return errors.New("history does not support atomic head updates")
+	}
+	return cas.CompareAndSetHead(expected, target)
 }
 
 func (r *Reg) findStoredVersion(v registry.Version) (registry.Version, error) {
+	if lookup, ok := r.history.(registry.VersionLookup); ok {
+		stored, err := lookup.GetVersion(v.ID())
+		if err != nil {
+			return nil, NewGetVersionsError(err)
+		}
+		return stored, nil
+	}
 	versions, err := r.history.Versions()
 	if err != nil {
 		return nil, NewGetVersionsError(err)
@@ -719,8 +733,15 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	defer r.mu.Unlock()
 
 	allocatorVersion := targetVersion.ID()
-	versionsInHistory, versionsErr := r.history.Versions()
-	if versionsErr != nil {
+	if bounds, ok := r.history.(registry.VersionIDBounds); ok {
+		maxID, err := bounds.MaxVersionID()
+		if err != nil {
+			return NewGetVersionsError(err)
+		}
+		if maxID > allocatorVersion {
+			allocatorVersion = maxID
+		}
+	} else if versionsInHistory, versionsErr := r.history.Versions(); versionsErr != nil {
 		// Forward-only histories cannot enumerate versions and have no branches to
 		// preserve. Durable histories must enumerate successfully so a rewind does
 		// not make the allocator reuse an existing branch ID.
@@ -739,7 +760,6 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	var planner *regexp.Planner
 	var preparedEff []registry.Effect
 	var resolution *registry.DependencyResolution
-	resolutionWasStored := false
 	if len(r.directivesByKind) > 0 {
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
 	}
@@ -755,7 +775,7 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		}
 		if replayer, ok := r.history.(registry.ChangeSetReplayer); ok {
 			r.log.Debug("streaming history changesets on baseline", zap.Uint("target_version", targetVersion.ID()))
-			if err := replayer.ReplayChanges(targetVersion, applyChanges); err != nil {
+			if err := replayer.ReplayChanges(ctx, targetVersion, applyChanges); err != nil {
 				return NewGetChangesetError(targetVersion.ID(), err)
 			}
 		} else {
@@ -781,7 +801,6 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		stored, err := resolutionHistory.GetDependencyResolution(targetVersion)
 		if err == nil {
 			resolution = stored
-			resolutionWasStored = true
 		} else if !errors.Is(err, registry.ErrDependencyResolutionNotFound) {
 			return NewGetChangesetError(targetVersion.ID(), err)
 		}
@@ -813,6 +832,7 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			}
 			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
 			if err != nil {
+				planner.RollbackEffects(ctx, plan.Effects)
 				planner.RollbackEffects(ctx, preparedEff)
 				return NewSortChangesError(err)
 			}
@@ -850,6 +870,7 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			}
 			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
 			if err != nil {
+				planner.RollbackEffects(ctx, plan.Effects)
 				planner.RollbackEffects(ctx, preparedEff)
 				return NewSortChangesError(err)
 			}
@@ -865,6 +886,15 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 				resolution = plan.Resolution.Canonical()
 			}
 			applyStateOperations(stateMap, ops)
+		}
+	}
+
+	if resolution != nil {
+		if _, ok := r.history.(registry.ResolutionHeadCASHistory); !ok {
+			if planner != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+			}
+			return NewSaveVersionError(ErrDurableResolutionUnsupported, nil)
 		}
 	}
 
@@ -898,19 +928,22 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		}
 	}
 
-	if resolution != nil && !resolutionWasStored {
-		if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
-			if checkpointErr := resolutionHistory.CheckpointDependencyResolution(targetVersion, resolution); checkpointErr != nil {
-				var rollbackErr error
-				if transitionErr := r.rollback(ctx, newState, r.state); transitionErr != nil {
-					rollbackErr = transitionErr
-				}
-				if planner != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-				}
-				return NewSaveVersionError(checkpointErr, rollbackErr)
-			}
+	var headCheckErr error
+	if resolution != nil {
+		headCheckErr = r.history.(registry.ResolutionHeadCASHistory).
+			CompareAndSetHeadWithDependencyResolution(targetVersion, targetVersion, resolution)
+	} else if cas, ok := r.history.(registry.HeadCASHistory); ok {
+		headCheckErr = cas.CompareAndSetHead(targetVersion, targetVersion)
+	}
+	if headCheckErr != nil {
+		var rollbackErr error
+		if transitionErr := r.rollback(ctx, newState, r.state); transitionErr != nil {
+			rollbackErr = transitionErr
 		}
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		return NewSaveVersionError(headCheckErr, rollbackErr)
 	}
 	if planner != nil {
 		if finalizeErr := planner.FinalizeEffects(ctx, preparedEff); finalizeErr != nil {

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -4,6 +4,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 
@@ -24,19 +25,20 @@ type indexedSortBuilder interface {
 }
 
 type Reg struct {
-	history          registry.History
-	runner           registry.Runner
-	builder          registry.StateBuilder
-	resolver         registry.DependencyResolver
-	directivesByKind map[registry.Kind][]registry.Directive
-	currentVersion   registry.Version
-	stateIndex       map[registry.ID]int
-	depIndex         *topology.DepIndex
-	log              *zap.Logger
-	state            registry.State
-	versionNum       atomic.Uint64
-	applyMu          sync.Mutex
-	mu               sync.RWMutex
+	history           registry.History
+	runner            registry.Runner
+	builder           registry.StateBuilder
+	resolver          registry.DependencyResolver
+	directivesByKind  map[registry.Kind][]registry.Directive
+	currentVersion    registry.Version
+	currentResolution *registry.DependencyResolution
+	stateIndex        map[registry.ID]int
+	depIndex          *topology.DepIndex
+	log               *zap.Logger
+	state             registry.State
+	versionNum        atomic.Uint64
+	applyMu           sync.Mutex
+	mu                sync.RWMutex
 }
 
 // NewRegistry creates a new registry instance.
@@ -140,22 +142,26 @@ func (r *Reg) GetEntry(path registry.ID) (registry.Entry, error) {
 func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.Version, error) {
 	r.applyMu.Lock()
 	defer r.applyMu.Unlock()
+	canonicalizeChangeSetIDs(changes)
 
 	r.log.Info("apply started", zap.Int("change_count", len(changes)))
 
 	var (
-		allOps      registry.ChangeSet
-		historyOps  registry.ChangeSet
-		preparedEff []registry.Effect
-		planner     *regexp.Planner
-		snapshot    registry.State
-		baseVersion registry.Version
+		allOps            registry.ChangeSet
+		historyOps        registry.ChangeSet
+		preparedEff       []registry.Effect
+		planner           *regexp.Planner
+		snapshot          registry.State
+		baseVersion       registry.Version
+		resolution        *registry.DependencyResolution
+		resolutionChanged bool
 	)
 
 	r.mu.RLock()
 	snapshot = make(registry.State, len(r.state))
 	copy(snapshot, r.state)
 	baseVersion = r.currentVersion
+	resolution = r.currentResolution
 	r.mu.RUnlock()
 
 	if len(r.directivesByKind) > 0 {
@@ -172,6 +178,10 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 		}
 
 		allOps, historyOps = plan.SplitScopes()
+		if plan.Resolution != nil {
+			resolution = plan.Resolution.Canonical()
+			resolutionChanged = true
+		}
 
 		preparedEff, err = planner.PrepareEffects(ctx, plan.Effects)
 		if err != nil {
@@ -245,24 +255,36 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 		r.log.Debug("saving new version", zap.Any("new_version", newVersion))
 
 		enrichedChanges := r.enrichChangeset(historyOps)
-		if err := r.history.Save(newVersion, enrichedChanges, true); err != nil {
-			r.log.Error("failed to save new version", zap.Error(err))
+		var saveErr error
+		if resolutionChanged {
+			resolutionHistory, ok := r.history.(registry.ResolutionHistory)
+			if !ok {
+				saveErr = errors.New("history does not support durable dependency resolutions")
+			} else {
+				saveErr = resolutionHistory.SaveWithDependencyResolution(newVersion, enrichedChanges, resolution, true)
+			}
+		} else {
+			saveErr = r.history.Save(newVersion, enrichedChanges, true)
+		}
+		if saveErr != nil {
+			r.log.Error("failed to save new version", zap.Error(saveErr))
 			if rerr := r.rollback(ctx, newState, r.state); rerr != nil {
 				if planner != nil {
 					planner.RollbackEffects(ctx, preparedEff)
 				}
-				return nil, NewSaveVersionError(err, rerr)
+				return nil, NewSaveVersionError(saveErr, rerr)
 			}
 			if planner != nil {
 				planner.RollbackEffects(ctx, preparedEff)
 			}
-			return nil, NewSaveVersionError(err, nil)
+			return nil, NewSaveVersionError(saveErr, nil)
 		}
 
 		r.state = newState
 		r.rebuildIndex()
 		r.patchDepIndex(allOps)
 		r.currentVersion = newVersion
+		r.currentResolution = resolution
 		return newVersion, nil
 	}
 
@@ -327,14 +349,65 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	if err != nil {
 		return err
 	}
+	canonicalizeChangeSetIDs(changeset)
 
 	var (
-		allOps      registry.ChangeSet
-		preparedEff []registry.Effect
-		planner     *regexp.Planner
+		allOps           registry.ChangeSet
+		preparedEff      []registry.Effect
+		planner          *regexp.Planner
+		targetResolution *registry.DependencyResolution
 	)
+	if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
+		stored, resolutionErr := resolutionHistory.GetDependencyResolution(targetVersion)
+		if resolutionErr == nil {
+			targetResolution = stored
+		} else if !errors.Is(resolutionErr, registry.ErrDependencyResolutionNotFound) {
+			return NewGetChangesetError(targetVersion.ID(), resolutionErr)
+		}
+	}
 
-	if len(r.directivesByKind) > 0 {
+	if targetResolution != nil {
+		if len(r.directivesByKind) == 0 {
+			return NewExpandChangesError(errors.New("stored dependency resolution has no configured reconciler"))
+		}
+		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
+		stateMap := topology.NewStateMap(snapshot)
+		applyStateOperations(stateMap, changeset)
+		reconciled := false
+		for _, directive := range r.directivesByKind[registry.NamespaceDependency] {
+			reconciler, ok := directive.(registry.ResolutionDirective)
+			if !ok {
+				continue
+			}
+			intermediate := topology.StateMapToSlice(stateMap)
+			result, reconcileErr := reconciler.ReconcileResolution(ctx, intermediate, targetResolution)
+			if reconcileErr != nil {
+				return NewExpandChangesError(reconcileErr)
+			}
+			reconciled = reconciled || result.Applied
+			prepared, prepareErr := planner.PrepareEffects(ctx, result.Effects)
+			if prepareErr != nil {
+				planner.RollbackEffects(ctx, prepared)
+				return NewPrepareEffectsError(prepareErr)
+			}
+			preparedEff = append(preparedEff, prepared...)
+			additional := make(registry.ChangeSet, 0, len(result.Additional))
+			for _, operation := range result.Additional {
+				additional = append(additional, operation.Operation)
+			}
+			applyStateOperations(stateMap, additional)
+		}
+		if !reconciled {
+			planner.RollbackEffects(ctx, preparedEff)
+			return NewExpandChangesError(errors.New("stored dependency resolution has no configured reconciler"))
+		}
+		var buildErr error
+		allOps, buildErr = r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
+		if buildErr != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+			return NewComputeTransitionError(buildErr)
+		}
+	} else if len(r.directivesByKind) > 0 {
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
 
 		plan, err := planner.Expand(ctx, changeset, snapshot)
@@ -416,6 +489,7 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	r.rebuildIndex()
 	r.rebuildDepIndex()
 	r.currentVersion = targetVersion
+	r.currentResolution = targetResolution
 
 	r.log.Debug("version applied successfully", zap.Uint("version", targetVersion.ID()))
 	return nil
@@ -523,72 +597,32 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	stateMap := topology.NewStateMap(baseline)
 	var planner *regexp.Planner
 	var preparedEff []registry.Effect
+	var resolution *registry.DependencyResolution
+	resolutionWasStored := false
 	if len(r.directivesByKind) > 0 {
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
 	}
 
-	// Baseline entries are declarations just like entries restored from history.
-	// Expand them before replay so every history operation observes a complete
-	// state rather than causing an unrelated declaration to materialize later.
-	if planner != nil {
-		baselineEntries := topology.StateMapToSlice(stateMap)
-		for _, entry := range baselineEntries {
-			if len(r.directivesByKind[entry.Kind]) == 0 {
-				continue
-			}
-
-			snapshot := topology.StateMapToSlice(stateMap)
-			plan, err := planner.Expand(ctx, registry.ChangeSet{{
-				Kind:  registry.EntryUpdate,
-				Entry: entry,
-			}}, snapshot)
-			if err != nil {
-				planner.RollbackEffects(ctx, preparedEff)
-				return NewExpandChangesError(err)
-			}
-			if !plan.Expanded {
-				continue
-			}
-
-			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
-			if err != nil {
-				planner.RollbackEffects(ctx, preparedEff)
-				return NewSortChangesError(err)
-			}
-			ops, _ := plan.SplitScopes()
-
-			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
-			if err != nil {
-				planner.RollbackEffects(ctx, preparedEff)
-				planner.RollbackEffects(ctx, prepared)
-				return NewPrepareEffectsError(err)
-			}
-			preparedEff = append(preparedEff, prepared...)
-
-			for _, op := range ops {
-				switch op.Kind {
-				case registry.EntryCreate, registry.EntryUpdate:
-					stateMap[op.Entry.ID] = op.Entry
-				case registry.EntryDelete:
-					delete(stateMap, op.Entry.ID)
-				}
-			}
-		}
-	}
-
+	// History contains declarative operations. Reduce it to the target state
+	// without expanding directives: expansion can consult external systems and
+	// must never run once per historical version during boot.
 	if targetVersion.ID() > 0 {
 		current := targetVersion
 		var versions []registry.Version
 
 		for current != nil && current.ID() > 0 {
-			versions = append([]registry.Version{current}, versions...)
+			versions = append(versions, current)
 			current = current.Previous()
+		}
+		for left, right := 0, len(versions)-1; left < right; left, right = left+1, right-1 {
+			versions[left], versions[right] = versions[right], versions[left]
 		}
 
 		r.log.Debug("replaying changesets on baseline",
 			zap.Uint("target_version", targetVersion.ID()),
 			zap.Int("changeset_count", len(versions)))
 
+		changesets := make([]registry.ChangeSet, 0, len(versions))
 		for _, ver := range versions {
 			cs, err := r.history.Get(ver)
 			if err != nil {
@@ -598,45 +632,114 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 				return NewGetChangesetError(ver.ID(), err)
 			}
 
-			ops := cs
+			changesets = append(changesets, cs)
+		}
+		// Squash the declarative tail before touching the state. History reads are
+		// linear, while superseded edits do not make registry reconstruction grow.
+		changes := r.builder.SquashChangesets(changesets)
+		snapshot := topology.StateMapToSlice(stateMap)
+		if sorted, err := r.builder.SortChangeSet(snapshot, changes); err == nil {
+			changes = sorted
+		}
+		applyStateOperations(stateMap, changes)
+	}
+
+	if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
+		stored, err := resolutionHistory.GetDependencyResolution(targetVersion)
+		if err == nil {
+			resolution = stored
+			resolutionWasStored = true
+		} else if !errors.Is(err, registry.ErrDependencyResolutionNotFound) {
+			return NewGetChangesetError(targetVersion.ID(), err)
+		}
+	}
+
+	// A modern history version carries its exact graph. Reconcile that graph
+	// once. Legacy versions are expanded once from their final declarations and
+	// checkpointed after a successful transition.
+	if resolution != nil {
+		if planner == nil {
+			return NewExpandChangesError(errors.New("stored dependency resolution has no configured reconciler"))
+		}
+		reconciled := false
+		for _, directive := range r.directivesByKind[registry.NamespaceDependency] {
+			reconciler, ok := directive.(registry.ResolutionDirective)
+			if !ok {
+				continue
+			}
 			snapshot := topology.StateMapToSlice(stateMap)
-			if planner != nil {
-				plan, err := planner.Expand(ctx, cs, snapshot)
-				if err != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-					return NewExpandChangesError(err)
-				}
-				plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
-				if err != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-					return NewSortChangesError(err)
-				}
-				ops, _ = plan.SplitScopes()
-
-				prepared, err := planner.PrepareEffects(ctx, plan.Effects)
-				if err != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-					planner.RollbackEffects(ctx, prepared)
-					return NewPrepareEffectsError(err)
-				}
-				preparedEff = append(preparedEff, prepared...)
+			result, err := reconciler.ReconcileResolution(ctx, snapshot, resolution)
+			if err != nil {
+				return NewExpandChangesError(err)
 			}
-			if sorted, err := r.builder.SortChangeSet(snapshot, ops); err == nil {
-				ops = sorted
+			reconciled = reconciled || result.Applied
+			plan := &regexp.Plan{Effects: result.Effects, Resolution: result.Resolution, Expanded: result.Applied}
+			for _, additional := range result.Additional {
+				plan.Ops = append(plan.Ops, regexp.ScopedOp{Operation: additional.Operation, Scope: additional.Scope})
 			}
-
-			for _, op := range ops {
-				switch op.Kind {
-				case registry.EntryCreate, registry.EntryUpdate:
-					stateMap[op.Entry.ID] = op.Entry
-				case registry.EntryDelete:
-					delete(stateMap, op.Entry.ID)
-				}
+			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
+			if err != nil {
+				return NewSortChangesError(err)
 			}
+			ops, _ := plan.SplitScopes()
+			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
+			if err != nil {
+				planner.RollbackEffects(ctx, prepared)
+				return NewPrepareEffectsError(err)
+			}
+			preparedEff = append(preparedEff, prepared...)
+			applyStateOperations(stateMap, ops)
+		}
+		if !reconciled {
+			planner.RollbackEffects(ctx, preparedEff)
+			return NewExpandChangesError(errors.New("stored dependency resolution has no configured reconciler"))
+		}
+	} else if planner != nil {
+		declarations := topology.StateMapToSlice(stateMap)
+		for _, entry := range declarations {
+			if len(r.directivesByKind[entry.Kind]) == 0 {
+				continue
+			}
+			snapshot := topology.StateMapToSlice(stateMap)
+			plan, err := planner.Expand(ctx, registry.ChangeSet{{Kind: registry.EntryUpdate, Entry: entry}}, snapshot)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewExpandChangesError(err)
+			}
+			if !plan.Expanded {
+				continue
+			}
+			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewSortChangesError(err)
+			}
+			ops, _ := plan.SplitScopes()
+			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				planner.RollbackEffects(ctx, prepared)
+				return NewPrepareEffectsError(err)
+			}
+			preparedEff = append(preparedEff, prepared...)
+			if plan.Resolution != nil {
+				resolution = plan.Resolution.Canonical()
+			}
+			applyStateOperations(stateMap, ops)
 		}
 	}
 
 	finalState := topology.StateMapToSlice(stateMap)
+	if resolution != nil && !resolutionWasStored {
+		if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
+			if err := resolutionHistory.CheckpointDependencyResolution(targetVersion, resolution); err != nil {
+				if planner != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+				}
+				return NewSaveVersionError(err, nil)
+			}
+		}
+	}
 
 	newState, err := r.transitionState(ctx, r.state, finalState)
 	if err != nil {
@@ -671,9 +774,34 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	r.rebuildIndex()
 	r.rebuildDepIndex()
 	r.currentVersion = targetVersion
+	r.currentResolution = resolution
 	r.versionNum.Store(uint64(targetVersion.ID()))
 
 	return nil
+}
+
+func applyStateOperations(stateMap registry.StateMap, ops registry.ChangeSet) {
+	for _, op := range ops {
+		id := registry.NewID(op.Entry.ID.NS, op.Entry.ID.Name)
+		switch op.Kind {
+		case registry.EntryCreate, registry.EntryUpdate:
+			op.Entry.ID = id
+			stateMap[id] = op.Entry
+		case registry.EntryDelete:
+			delete(stateMap, id)
+		}
+	}
+}
+
+func canonicalizeChangeSetIDs(changes registry.ChangeSet) {
+	for i := range changes {
+		changes[i].Entry.ID = registry.NewID(changes[i].Entry.ID.NS, changes[i].Entry.ID.Name)
+		if changes[i].OriginalEntry != nil {
+			original := *changes[i].OriginalEntry
+			original.ID = registry.NewID(original.ID.NS, original.ID.Name)
+			changes[i].OriginalEntry = &original
+		}
+	}
 }
 
 // rollback state desync between actual state in system and state in history

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -204,6 +204,11 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 	// against any dependency-aware runner (memory_graph.RemoveNode).
 	if sorted, sortErr := r.sortWithIndex(snapshot, allOps); sortErr == nil {
 		allOps = sorted
+	} else {
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		return nil, NewSortChangesError(sortErr)
 	}
 
 	r.mu.Lock()
@@ -279,6 +284,11 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 			}
 			return nil, NewSaveVersionError(saveErr, nil)
 		}
+		if planner != nil {
+			if finalizeErr := planner.FinalizeEffects(ctx, preparedEff); finalizeErr != nil {
+				r.log.Warn("failed to finalize effects after saving version", zap.Error(finalizeErr))
+			}
+		}
 
 		r.state = newState
 		r.rebuildIndex()
@@ -291,6 +301,11 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 	r.state = newState
 	r.rebuildIndex()
 	r.patchDepIndex(allOps)
+	if planner != nil {
+		if finalizeErr := planner.FinalizeEffects(ctx, preparedEff); finalizeErr != nil {
+			r.log.Warn("failed to finalize effects after baseline transition", zap.Error(finalizeErr))
+		}
+	}
 	return r.currentVersion, nil
 }
 
@@ -338,14 +353,7 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		zap.Uint("to", targetVersion.ID()),
 		zap.Int("steps", len(path)))
 
-	isForward := currentVersionID < targetVersion.ID()
-	var changeset registry.ChangeSet
-
-	if isForward {
-		changeset, err = r.collectForwardChangesets(path)
-	} else {
-		changeset, err = r.collectBackwardChangesets(path, targetVersion)
-	}
+	changeset, err := r.collectTransitionChangesets(baseVersion, targetVersion)
 	if err != nil {
 		return err
 	}
@@ -356,11 +364,13 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		preparedEff      []registry.Effect
 		planner          *regexp.Planner
 		targetResolution *registry.DependencyResolution
+		resolutionStored bool
 	)
 	if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
 		stored, resolutionErr := resolutionHistory.GetDependencyResolution(targetVersion)
 		if resolutionErr == nil {
 			targetResolution = stored
+			resolutionStored = true
 		} else if !errors.Is(resolutionErr, registry.ErrDependencyResolutionNotFound) {
 			return NewGetChangesetError(targetVersion.ID(), resolutionErr)
 		}
@@ -382,12 +392,14 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			intermediate := topology.StateMapToSlice(stateMap)
 			result, reconcileErr := reconciler.ReconcileResolution(ctx, intermediate, targetResolution)
 			if reconcileErr != nil {
+				planner.RollbackEffects(ctx, preparedEff)
 				return NewExpandChangesError(reconcileErr)
 			}
 			reconciled = reconciled || result.Applied
 			prepared, prepareErr := planner.PrepareEffects(ctx, result.Effects)
 			if prepareErr != nil {
 				planner.RollbackEffects(ctx, prepared)
+				planner.RollbackEffects(ctx, preparedEff)
 				return NewPrepareEffectsError(prepareErr)
 			}
 			preparedEff = append(preparedEff, prepared...)
@@ -421,10 +433,58 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		}
 
 		allOps, _ = plan.SplitScopes()
+		if plan.Resolution != nil {
+			targetResolution = plan.Resolution.Canonical()
+		}
 		preparedEff, err = planner.PrepareEffects(ctx, plan.Effects)
 		if err != nil {
 			planner.RollbackEffects(ctx, preparedEff)
 			return NewPrepareEffectsError(err)
+		}
+
+		// A legacy target may change only unrelated declarations even though its
+		// final state still contains dependency roots. Resolve that final root set
+		// once so the target can be checkpointed instead of inheriting whatever
+		// derived modules happen to be present in the source state.
+		if targetResolution == nil {
+			stateMap := topology.NewStateMap(snapshot)
+			applyStateOperations(stateMap, allOps)
+			declarations := topology.StateMapToSlice(stateMap)
+			for _, entry := range declarations {
+				if entry.Kind != registry.NamespaceDependency {
+					continue
+				}
+				intermediate := topology.StateMapToSlice(stateMap)
+				rootPlan, expandErr := planner.Expand(ctx, registry.ChangeSet{{Kind: registry.EntryUpdate, Entry: entry}}, intermediate)
+				if expandErr != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+					return NewExpandChangesError(expandErr)
+				}
+				if rootPlan.Resolution == nil {
+					continue
+				}
+				rootPlan.Ops, expandErr = planner.SortOps(intermediate, rootPlan.Ops)
+				if expandErr != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+					return NewSortChangesError(expandErr)
+				}
+				rootOps, _ := rootPlan.SplitScopes()
+				rootPrepared, prepareErr := planner.PrepareEffects(ctx, rootPlan.Effects)
+				if prepareErr != nil {
+					planner.RollbackEffects(ctx, rootPrepared)
+					planner.RollbackEffects(ctx, preparedEff)
+					return NewPrepareEffectsError(prepareErr)
+				}
+				preparedEff = append(preparedEff, rootPrepared...)
+				applyStateOperations(stateMap, rootOps)
+				targetResolution = rootPlan.Resolution.Canonical()
+				allOps, expandErr = r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
+				if expandErr != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+					return NewComputeTransitionError(expandErr)
+				}
+				break
+			}
 		}
 	} else {
 		sorted, err := r.builder.SortChangeSet(snapshot, changeset)
@@ -440,6 +500,11 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	// through expansion.
 	if sorted, sortErr := r.builder.SortChangeSet(snapshot, allOps); sortErr == nil {
 		allOps = sorted
+	} else {
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		return NewSortChangesError(sortErr)
 	}
 
 	r.mu.Lock()
@@ -482,7 +547,47 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	}
 
 	if err := r.history.SetHead(targetVersion); err != nil {
-		return NewSetHeadError(targetVersion.ID(), err)
+		headErr := NewSetHeadError(targetVersion.ID(), err)
+		var compensationErr error
+		if baseVersion != nil {
+			if restoreErr := r.history.SetHead(baseVersion); restoreErr != nil {
+				compensationErr = errors.Join(compensationErr, restoreErr)
+			}
+		}
+		if rollbackErr := r.rollback(ctx, newState, r.state); rollbackErr != nil {
+			compensationErr = errors.Join(compensationErr, rollbackErr)
+		}
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		if compensationErr != nil {
+			return NewApplyVersionChangesError(headErr, compensationErr)
+		}
+		return headErr
+	}
+
+	resolutionHistory, supportsResolutionHistory := r.history.(registry.ResolutionHistory)
+	if targetResolution != nil && supportsResolutionHistory && !resolutionStored {
+		if checkpointErr := resolutionHistory.CheckpointDependencyResolution(targetVersion, targetResolution); checkpointErr != nil {
+			var compensationErr error
+			if baseVersion != nil {
+				if restoreErr := r.history.SetHead(baseVersion); restoreErr != nil {
+					compensationErr = errors.Join(compensationErr, restoreErr)
+				}
+			}
+			if rollbackErr := r.rollback(ctx, newState, r.state); rollbackErr != nil {
+				compensationErr = errors.Join(compensationErr, rollbackErr)
+			}
+			if planner != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+			}
+			return NewSaveVersionError(checkpointErr, compensationErr)
+		}
+	}
+	if planner != nil {
+		if finalizeErr := planner.FinalizeEffects(ctx, preparedEff); finalizeErr != nil {
+			r.log.Warn("failed to finalize effects after applying version", zap.Error(finalizeErr))
+		}
 	}
 
 	r.state = newState
@@ -530,13 +635,53 @@ func (r *Reg) computeVersionPath(current registry.Version, v registry.Version, c
 	return targetVersion, path, nil
 }
 
-func (r *Reg) collectForwardChangesets(path []registry.Version) (registry.ChangeSet, error) {
-	changesets := make([]registry.ChangeSet, 0, len(path))
-	for _, ver := range path {
-		cs, err := r.history.Get(ver)
-		if err != nil {
-			return nil, NewGetChangesetError(ver.ID(), err)
+// collectTransitionChangesets builds a source-to-target transition from parent
+// edges. Numeric version IDs are allocation order only; they do not tell us
+// whether two versions are ancestors or siblings on different branches.
+func (r *Reg) collectTransitionChangesets(source, target registry.Version) (registry.ChangeSet, error) {
+	if source == nil || target == nil {
+		return nil, NewComputePathError(0, 0, ErrNoCommonAncestor)
+	}
+
+	sourceAncestors := make(map[uint]registry.Version)
+	for current := source; current != nil; current = current.Previous() {
+		sourceAncestors[current.ID()] = current
+	}
+
+	var (
+		commonAncestor registry.Version
+		targetTail     []registry.Version
+	)
+	for current := target; current != nil; current = current.Previous() {
+		if ancestor, ok := sourceAncestors[current.ID()]; ok {
+			commonAncestor = ancestor
+			break
 		}
+		targetTail = append(targetTail, current)
+	}
+	if commonAncestor == nil {
+		return nil, NewComputePathError(source.ID(), target.ID(), ErrNoCommonAncestor)
+	}
+
+	changesets := make([]registry.ChangeSet, 0, len(targetTail)+1)
+	for current := source; current != nil && current.ID() != commonAncestor.ID(); current = current.Previous() {
+		cs, err := r.history.Get(current)
+		if err != nil {
+			return nil, NewGetChangesetError(current.ID(), err)
+		}
+		canonicalizeChangeSetIDs(cs)
+		reversed, err := r.builder.ReverseChangeset(cs)
+		if err != nil {
+			return nil, NewReverseChangesetError(err)
+		}
+		changesets = append(changesets, reversed)
+	}
+	for i := len(targetTail) - 1; i >= 0; i-- {
+		cs, err := r.history.Get(targetTail[i])
+		if err != nil {
+			return nil, NewGetChangesetError(targetTail[i].ID(), err)
+		}
+		canonicalizeChangeSetIDs(cs)
 		changesets = append(changesets, cs)
 	}
 
@@ -594,6 +739,23 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	allocatorVersion := targetVersion.ID()
+	versionsInHistory, versionsErr := r.history.Versions()
+	if versionsErr != nil {
+		// Forward-only histories cannot enumerate versions and have no branches to
+		// preserve. Durable histories must enumerate successfully so a rewind does
+		// not make the allocator reuse an existing branch ID.
+		if targetVersion.ID() > registry.RootVersion {
+			return NewGetVersionsError(versionsErr)
+		}
+	} else {
+		for _, storedVersion := range versionsInHistory {
+			if storedVersion.ID() > allocatorVersion {
+				allocatorVersion = storedVersion.ID()
+			}
+		}
+	}
+
 	stateMap := topology.NewStateMap(baseline)
 	var planner *regexp.Planner
 	var preparedEff []registry.Effect
@@ -622,7 +784,6 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			zap.Uint("target_version", targetVersion.ID()),
 			zap.Int("changeset_count", len(versions)))
 
-		changesets := make([]registry.ChangeSet, 0, len(versions))
 		for _, ver := range versions {
 			cs, err := r.history.Get(ver)
 			if err != nil {
@@ -631,17 +792,9 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 				}
 				return NewGetChangesetError(ver.ID(), err)
 			}
-
-			changesets = append(changesets, cs)
+			canonicalizeChangeSetIDs(cs)
+			applyStateOperations(stateMap, cs)
 		}
-		// Squash the declarative tail before touching the state. History reads are
-		// linear, while superseded edits do not make registry reconstruction grow.
-		changes := r.builder.SquashChangesets(changesets)
-		snapshot := topology.StateMapToSlice(stateMap)
-		if sorted, err := r.builder.SortChangeSet(snapshot, changes); err == nil {
-			changes = sorted
-		}
-		applyStateOperations(stateMap, changes)
 	}
 
 	if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
@@ -670,6 +823,7 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			snapshot := topology.StateMapToSlice(stateMap)
 			result, err := reconciler.ReconcileResolution(ctx, snapshot, resolution)
 			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
 				return NewExpandChangesError(err)
 			}
 			reconciled = reconciled || result.Applied
@@ -679,12 +833,14 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			}
 			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
 			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
 				return NewSortChangesError(err)
 			}
 			ops, _ := plan.SplitScopes()
 			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
 			if err != nil {
 				planner.RollbackEffects(ctx, prepared)
+				planner.RollbackEffects(ctx, preparedEff)
 				return NewPrepareEffectsError(err)
 			}
 			preparedEff = append(preparedEff, prepared...)
@@ -697,6 +853,9 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	} else if planner != nil {
 		declarations := topology.StateMapToSlice(stateMap)
 		for _, entry := range declarations {
+			if resolution != nil && entry.Kind == registry.NamespaceDependency {
+				continue // One dependency expansion resolves the complete legacy root graph.
+			}
 			if len(r.directivesByKind[entry.Kind]) == 0 {
 				continue
 			}
@@ -717,8 +876,8 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 			ops, _ := plan.SplitScopes()
 			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
 			if err != nil {
-				planner.RollbackEffects(ctx, preparedEff)
 				planner.RollbackEffects(ctx, prepared)
+				planner.RollbackEffects(ctx, preparedEff)
 				return NewPrepareEffectsError(err)
 			}
 			preparedEff = append(preparedEff, prepared...)
@@ -730,17 +889,6 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	}
 
 	finalState := topology.StateMapToSlice(stateMap)
-	if resolution != nil && !resolutionWasStored {
-		if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
-			if err := resolutionHistory.CheckpointDependencyResolution(targetVersion, resolution); err != nil {
-				if planner != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-				}
-				return NewSaveVersionError(err, nil)
-			}
-		}
-	}
-
 	newState, err := r.transitionState(ctx, r.state, finalState)
 	if err != nil {
 		r.log.Error("failed to load state", zap.String("version", targetVersion.String()), zap.Error(err))
@@ -770,12 +918,32 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		}
 	}
 
+	if resolution != nil && !resolutionWasStored {
+		if resolutionHistory, ok := r.history.(registry.ResolutionHistory); ok {
+			if checkpointErr := resolutionHistory.CheckpointDependencyResolution(targetVersion, resolution); checkpointErr != nil {
+				var rollbackErr error
+				if transitionErr := r.rollback(ctx, newState, r.state); transitionErr != nil {
+					rollbackErr = transitionErr
+				}
+				if planner != nil {
+					planner.RollbackEffects(ctx, preparedEff)
+				}
+				return NewSaveVersionError(checkpointErr, rollbackErr)
+			}
+		}
+	}
+	if planner != nil {
+		if finalizeErr := planner.FinalizeEffects(ctx, preparedEff); finalizeErr != nil {
+			r.log.Warn("failed to finalize effects after loading state", zap.Error(finalizeErr))
+		}
+	}
+
 	r.state = newState
 	r.rebuildIndex()
 	r.rebuildDepIndex()
 	r.currentVersion = targetVersion
 	r.currentResolution = resolution
-	r.versionNum.Store(uint64(targetVersion.ID()))
+	r.versionNum.Store(uint64(allocatorVersion))
 
 	return nil
 }

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -527,6 +527,55 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
 	}
 
+	// Baseline entries are declarations just like entries restored from history.
+	// Expand them before replay so every history operation observes a complete
+	// state rather than causing an unrelated declaration to materialize later.
+	if planner != nil {
+		baselineEntries := topology.StateMapToSlice(stateMap)
+		for _, entry := range baselineEntries {
+			if len(r.directivesByKind[entry.Kind]) == 0 {
+				continue
+			}
+
+			snapshot := topology.StateMapToSlice(stateMap)
+			plan, err := planner.Expand(ctx, registry.ChangeSet{{
+				Kind:  registry.EntryUpdate,
+				Entry: entry,
+			}}, snapshot)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewExpandChangesError(err)
+			}
+			if !plan.Expanded {
+				continue
+			}
+
+			plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewSortChangesError(err)
+			}
+			ops, _ := plan.SplitScopes()
+
+			prepared, err := planner.PrepareEffects(ctx, plan.Effects)
+			if err != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				planner.RollbackEffects(ctx, prepared)
+				return NewPrepareEffectsError(err)
+			}
+			preparedEff = append(preparedEff, prepared...)
+
+			for _, op := range ops {
+				switch op.Kind {
+				case registry.EntryCreate, registry.EntryUpdate:
+					stateMap[op.Entry.ID] = op.Entry
+				case registry.EntryDelete:
+					delete(stateMap, op.Entry.ID)
+				}
+			}
+		}
+	}
+
 	if targetVersion.ID() > 0 {
 		current := targetVersion
 		var versions []registry.Version

--- a/system/registry/registry_hardening_test.go
+++ b/system/registry/registry_hardening_test.go
@@ -22,6 +22,22 @@ type hardeningHistory struct {
 	failCheckpoint bool
 }
 
+// historyWithoutResolution deliberately exposes only the base History method
+// set even when the wrapped backend supports richer optional capabilities.
+type historyWithoutResolution struct {
+	regapi.History
+}
+
+type lookupHistory struct {
+	*memory.Storage
+	versionsCalled bool
+}
+
+func (h *lookupHistory) Versions() ([]regapi.Version, error) {
+	h.versionsCalled = true
+	return nil, errors.New("full history enumeration must not be used")
+}
+
 func (h *hardeningHistory) SetHead(v regapi.Version) error {
 	if h.failSetHeadFor != 0 && h.failSetHeadFor == v.ID() {
 		h.failSetHeadFor = 0
@@ -43,6 +59,17 @@ func (h *hardeningHistory) CheckpointDependencyResolution(v regapi.Version, reso
 		return errors.New("injected checkpoint failure")
 	}
 	return h.Storage.CheckpointDependencyResolution(v, resolution)
+}
+
+func (h *hardeningHistory) CompareAndSetHeadWithDependencyResolution(expected, target regapi.Version, resolution *regapi.DependencyResolution) error {
+	if h.failCheckpoint {
+		return errors.New("injected checkpoint failure")
+	}
+	if h.failSetHeadFor != 0 && h.failSetHeadFor == target.ID() {
+		h.failSetHeadFor = 0
+		return errors.New("injected set-head failure")
+	}
+	return h.Storage.CompareAndSetHeadWithDependencyResolution(expected, target, resolution)
 }
 
 type hardeningRunner struct {
@@ -110,7 +137,7 @@ func (d hardeningDirective) ReconcileResolution(ctx context.Context, state regap
 func hardeningResolution() *regapi.DependencyResolution {
 	return (&regapi.DependencyResolution{
 		InputDigest: "legacy-roots",
-		Modules:     []regapi.ResolvedModule{{Name: "acme/module", Version: "v1.0.0"}},
+		Modules:     []regapi.ResolvedModule{{Name: "acme/module", Version: "v1.0.0", Digest: "sha256:test"}},
 	}).Canonical()
 }
 
@@ -139,9 +166,30 @@ func TestApplyVersion_SetHeadFailureCompensatesRuntimeAndEffects(t *testing.T) {
 	head, headErr := history.Head()
 	require.NoError(t, headErr)
 	require.Equal(t, v0.ID(), head.ID())
+	_, resolutionErr := history.GetDependencyResolution(v1)
+	require.ErrorIs(t, resolutionErr, regapi.ErrDependencyResolutionNotFound,
+		"a failed atomic head update must not annotate the target graph")
 	require.Equal(t, 2, runner.transitions, "target transition must be compensated")
 	require.Equal(t, 1, effect.committed)
 	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestApplyVersionNoOpRejectsChangedDurableHead(t *testing.T) {
+	ctx := context.Background()
+	history := memory.New()
+	reg := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop())
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{
+		Kind:  regapi.EntryCreate,
+		Entry: regapi.Entry{ID: regapi.NewID("app", "one"), Kind: "service"},
+	}})
+	require.NoError(t, err)
+	require.NoError(t, history.SetHead(version.New(0)), "simulate a concurrent runtime moving durable head")
+
+	err = reg.ApplyVersion(ctx, v1)
+	require.ErrorContains(t, err, "history head changed")
+	current, currentErr := reg.Current()
+	require.NoError(t, currentErr)
+	require.Equal(t, v1.ID(), current.ID(), "failed validation must not mutate local state")
 }
 
 func TestApplyVersion_LegacyResolutionCheckpointFailureCompensates(t *testing.T) {
@@ -193,6 +241,36 @@ func TestApplyVersion_LegacyResolutionIsCheckpointed(t *testing.T) {
 	require.Equal(t, hardeningResolution().Digest, stored.Digest)
 }
 
+func TestApplyVersionRejectsExactResolutionWithoutDurableHistorySupport(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	durable := memory.New()
+	require.NoError(t, durable.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+	require.NoError(t, durable.SetHead(v0))
+	history := &historyWithoutResolution{History: durable}
+	effect := &hardeningEffect{}
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution(), Effects: []regapi.Effect{effect}}, nil
+	}}
+	runner := &hardeningRunner{}
+	reg := NewRegistry(history, runner, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+
+	err := reg.ApplyVersion(ctx, v1)
+	require.ErrorContains(t, err, "history does not support durable dependency resolutions")
+	head, headErr := durable.Head()
+	require.NoError(t, headErr)
+	require.Equal(t, v0.ID(), head.ID())
+	_, getErr := reg.GetEntry(dep.ID)
+	require.Error(t, getErr)
+	require.Zero(t, runner.transitions, "capability failure must happen before runtime transition")
+	require.Equal(t, 1, effect.prepared)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
 func TestApplyVersion_LegacyUnrelatedTransitionResolvesFinalRoots(t *testing.T) {
 	ctx := context.Background()
 	v0 := version.New(0)
@@ -239,6 +317,29 @@ func TestLoadState_CheckpointFailureCompensatesRuntimeAndEffects(t *testing.T) {
 	require.Empty(t, entries)
 	require.Equal(t, 2, runner.transitions)
 	require.Equal(t, 1, effect.committed)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestLoadStateRejectsExactResolutionWithoutDurableHistorySupport(t *testing.T) {
+	ctx := context.Background()
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	durable := memory.New()
+	history := &historyWithoutResolution{History: durable}
+	effect := &hardeningEffect{}
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution(), Effects: []regapi.Effect{effect}}, nil
+	}}
+	runner := &hardeningRunner{}
+	reg := NewRegistry(history, runner, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+
+	err := reg.LoadState(ctx, regapi.State{dep}, version.New(0))
+	require.ErrorContains(t, err, "history does not support durable dependency resolutions")
+	entries, getErr := reg.GetAllEntries()
+	require.NoError(t, getErr)
+	require.Empty(t, entries)
+	require.Zero(t, runner.transitions, "capability failure must happen before runtime transition")
+	require.Equal(t, 1, effect.prepared)
 	require.Equal(t, 1, effect.rolledBack)
 }
 
@@ -339,4 +440,23 @@ func TestApplyVersion_CrossBranchWorksInBothIDDirections(t *testing.T) {
 	require.Error(t, err)
 	_, err = reg.GetEntry(branchBID)
 	require.NoError(t, err)
+}
+
+func TestFindStoredVersionUsesTargetLookupAcrossManyBranches(t *testing.T) {
+	storage := memory.New()
+	root := version.New(regapi.RootVersion)
+	const branches = 5000
+	for id := uint(1); id <= branches; id++ {
+		require.NoError(t, storage.Save(version.FromParent(root, id), nil, false))
+	}
+	target := version.FromParent(version.FromParent(root, 1), branches+1)
+	require.NoError(t, storage.Save(target, nil, false))
+	history := &lookupHistory{Storage: storage}
+	reg := &Reg{history: history}
+
+	stored, err := reg.findStoredVersion(version.New(branches + 1))
+	require.NoError(t, err)
+	require.False(t, history.versionsCalled)
+	require.Equal(t, uint(branches+1), stored.ID())
+	require.Equal(t, uint(1), stored.Previous().ID())
 }

--- a/system/registry/registry_hardening_test.go
+++ b/system/registry/registry_hardening_test.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	"github.com/wippyai/runtime/system/registry/history/memory"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"go.uber.org/zap"
+)
+
+type hardeningHistory struct {
+	*memory.Storage
+	failSetHeadFor uint
+	failCheckpoint bool
+}
+
+func (h *hardeningHistory) SetHead(v regapi.Version) error {
+	if h.failSetHeadFor != 0 && h.failSetHeadFor == v.ID() {
+		h.failSetHeadFor = 0
+		return errors.New("injected set-head failure")
+	}
+	return h.Storage.SetHead(v)
+}
+
+func (h *hardeningHistory) CheckpointDependencyResolution(v regapi.Version, resolution *regapi.DependencyResolution) error {
+	if h.failCheckpoint {
+		return errors.New("injected checkpoint failure")
+	}
+	return h.Storage.CheckpointDependencyResolution(v, resolution)
+}
+
+type hardeningRunner struct {
+	transitions      int
+	failTransitionAt int
+}
+
+func (r *hardeningRunner) Transition(_ context.Context, state regapi.State, changes regapi.ChangeSet) (regapi.State, error) {
+	r.transitions++
+	if r.failTransitionAt == r.transitions {
+		return state, errors.New("injected transition failure")
+	}
+	stateMap := topology.NewStateMap(state)
+	for _, op := range changes {
+		switch op.Kind {
+		case regapi.EntryCreate, regapi.EntryUpdate:
+			stateMap[op.Entry.ID] = op.Entry
+		case regapi.EntryDelete:
+			delete(stateMap, op.Entry.ID)
+		}
+	}
+	return topology.StateMapToSlice(stateMap), nil
+}
+
+type hardeningEffect struct {
+	prepared   int
+	committed  int
+	rolledBack int
+}
+
+func (e *hardeningEffect) Prepare(context.Context) error {
+	e.prepared++
+	return nil
+}
+
+func (e *hardeningEffect) Commit(context.Context) error {
+	e.committed++
+	return nil
+}
+
+func (e *hardeningEffect) Rollback(context.Context) error {
+	e.rolledBack++
+	return nil
+}
+
+type hardeningDirective struct {
+	expand    func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error)
+	reconcile func(context.Context, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error)
+}
+
+func (d hardeningDirective) Expand(ctx context.Context, op regapi.Operation, state regapi.State) (regapi.DirectiveResult, error) {
+	if d.expand == nil {
+		return regapi.DirectiveResult{}, nil
+	}
+	return d.expand(ctx, op, state)
+}
+
+func (d hardeningDirective) ReconcileResolution(ctx context.Context, state regapi.State, resolution *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
+	if d.reconcile == nil {
+		return regapi.DirectiveResult{}, nil
+	}
+	return d.reconcile(ctx, state, resolution)
+}
+
+func hardeningResolution() *regapi.DependencyResolution {
+	return (&regapi.DependencyResolution{
+		InputDigest: "legacy-roots",
+		Modules:     []regapi.ResolvedModule{{Name: "acme/module", Version: "v1.0.0"}},
+	}).Canonical()
+}
+
+func TestApplyVersion_SetHeadFailureCompensatesRuntimeAndEffects(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	history := &hardeningHistory{Storage: memory.New(), failSetHeadFor: v1.ID()}
+	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+
+	effect := &hardeningEffect{}
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution(), Effects: []regapi.Effect{effect}}, nil
+	}}
+	runner := &hardeningRunner{}
+	reg := NewRegistry(history, runner, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+
+	err := reg.ApplyVersion(ctx, v1)
+	require.ErrorContains(t, err, "failed to set head version")
+	_, getErr := reg.GetEntry(dep.ID)
+	require.Error(t, getErr)
+	head, headErr := history.Head()
+	require.NoError(t, headErr)
+	require.Equal(t, v0.ID(), head.ID())
+	require.Equal(t, 2, runner.transitions, "target transition must be compensated")
+	require.Equal(t, 1, effect.committed)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestApplyVersion_LegacyResolutionCheckpointFailureCompensates(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	history := &hardeningHistory{Storage: memory.New(), failCheckpoint: true}
+	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+
+	effect := &hardeningEffect{}
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution(), Effects: []regapi.Effect{effect}}, nil
+	}}
+	runner := &hardeningRunner{}
+	reg := NewRegistry(history, runner, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+
+	err := reg.ApplyVersion(ctx, v1)
+	require.ErrorContains(t, err, "injected checkpoint failure")
+	_, getErr := reg.GetEntry(dep.ID)
+	require.Error(t, getErr)
+	head, headErr := history.Head()
+	require.NoError(t, headErr)
+	require.Equal(t, v0.ID(), head.ID())
+	require.Equal(t, 2, runner.transitions)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestApplyVersion_LegacyResolutionIsCheckpointed(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	history := &hardeningHistory{Storage: memory.New()}
+	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution()}, nil
+	}}
+	reg := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	stored, err := history.GetDependencyResolution(v1)
+	require.NoError(t, err)
+	require.Equal(t, hardeningResolution().Digest, stored.Digest)
+}
+
+func TestApplyVersion_LegacyUnrelatedTransitionResolvesFinalRoots(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	unrelated := regapi.Entry{ID: regapi.NewID("app", "setting"), Kind: "setting"}
+	history := &hardeningHistory{Storage: memory.New()}
+	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: unrelated}}, false))
+	expansions := 0
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		expansions++
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution()}, nil
+	}}
+	reg := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+	require.NoError(t, reg.LoadState(ctx, regapi.State{dep}, v0))
+	expansions = 0
+
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	require.Equal(t, 1, expansions, "the final dependency root graph must be resolved once")
+	stored, err := history.GetDependencyResolution(v1)
+	require.NoError(t, err)
+	require.Equal(t, hardeningResolution().Digest, stored.Digest)
+}
+
+func TestLoadState_CheckpointFailureCompensatesRuntimeAndEffects(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	history := &hardeningHistory{Storage: memory.New(), failCheckpoint: true}
+	effect := &hardeningEffect{}
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution(), Effects: []regapi.Effect{effect}}, nil
+	}}
+	runner := &hardeningRunner{}
+	reg := NewRegistry(history, runner, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+
+	err := reg.LoadState(ctx, regapi.State{dep}, v0)
+	require.ErrorContains(t, err, "injected checkpoint failure")
+	entries, getErr := reg.GetAllEntries()
+	require.NoError(t, getErr)
+	require.Empty(t, entries)
+	require.Equal(t, 2, runner.transitions)
+	require.Equal(t, 1, effect.committed)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestLoadState_TransitionFailureDoesNotCheckpointLegacyResolution(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	history := &hardeningHistory{Storage: memory.New()}
+	effect := &hardeningEffect{}
+	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution(), Effects: []regapi.Effect{effect}}, nil
+	}}
+	reg := NewRegistry(history, &hardeningRunner{failTransitionAt: 1}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, directive))
+
+	err := reg.LoadState(ctx, regapi.State{dep}, v0)
+	require.ErrorContains(t, err, "injected transition failure")
+	_, resolutionErr := history.GetDependencyResolution(v0)
+	require.ErrorIs(t, resolutionErr, regapi.ErrDependencyResolutionNotFound)
+	require.Equal(t, 0, effect.committed)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestApplyVersion_ReconcilerErrorRollsBackPreviouslyPreparedEffects(t *testing.T) {
+	ctx := context.Background()
+	v0 := version.New(0)
+	v1 := version.FromParent(v0, 1)
+	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
+	history := memory.New()
+	require.NoError(t, history.SaveWithDependencyResolution(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, hardeningResolution(), false))
+	effect := &hardeningEffect{}
+	first := hardeningDirective{reconcile: func(context.Context, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{Applied: true, Effects: []regapi.Effect{effect}}, nil
+	}}
+	second := hardeningDirective{reconcile: func(context.Context, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
+		return regapi.DirectiveResult{}, errors.New("injected reconcile failure")
+	}}
+	reg := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),
+		WithKindDirective(regapi.NamespaceDependency, first), WithKindDirective(regapi.NamespaceDependency, second))
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+	err := reg.ApplyVersion(ctx, v1)
+	require.ErrorContains(t, err, "injected reconcile failure")
+	require.Equal(t, 1, effect.prepared)
+	require.Equal(t, 1, effect.rolledBack)
+}
+
+func TestLoadState_AllocatorUsesMaximumStoredVersionAfterRewind(t *testing.T) {
+	ctx := context.Background()
+	history := memory.New()
+	runner := &hardeningRunner{}
+	reg := NewRegistry(history, runner, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop())
+
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: regapi.NewID("app", "one"), Kind: "service"}}})
+	require.NoError(t, err)
+	v2, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: regapi.NewID("app", "two"), Kind: "service"}}})
+	require.NoError(t, err)
+	v3, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: regapi.NewID("app", "three"), Kind: "service"}}})
+	require.NoError(t, err)
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+
+	restored := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop())
+	require.NoError(t, restored.LoadState(ctx, nil, v1))
+	v4, err := restored.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: regapi.NewID("app", "branch"), Kind: "service"}}})
+	require.NoError(t, err)
+	require.Equal(t, uint(4), v4.ID())
+	_, err = history.Get(v2)
+	require.NoError(t, err)
+	_, err = history.Get(v3)
+	require.NoError(t, err)
+}
+
+func TestApplyVersion_CrossBranchWorksInBothIDDirections(t *testing.T) {
+	ctx := context.Background()
+	history := memory.New()
+	reg := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop())
+	anchorID := regapi.NewID("app", "anchor")
+	branchAID := regapi.NewID("app", "branch_a")
+	branchBID := regapi.NewID("app", "branch_b")
+
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: anchorID, Kind: "service", Data: payload.New("v1")}}})
+	require.NoError(t, err)
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: branchAID, Kind: "service"}}})
+	require.NoError(t, err)
+	v3, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: regapi.Entry{ID: anchorID, Kind: "service", Data: payload.New("branch-a")}}})
+	require.NoError(t, err)
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	v4, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: regapi.Entry{ID: branchBID, Kind: "service"}}})
+	require.NoError(t, err)
+
+	require.NoError(t, reg.ApplyVersion(ctx, v3))
+	_, err = reg.GetEntry(branchAID)
+	require.NoError(t, err)
+	_, err = reg.GetEntry(branchBID)
+	require.Error(t, err)
+
+	require.NoError(t, reg.ApplyVersion(ctx, v4))
+	_, err = reg.GetEntry(branchAID)
+	require.Error(t, err)
+	_, err = reg.GetEntry(branchBID)
+	require.NoError(t, err)
+}

--- a/system/registry/registry_hardening_test.go
+++ b/system/registry/registry_hardening_test.go
@@ -30,6 +30,14 @@ func (h *hardeningHistory) SetHead(v regapi.Version) error {
 	return h.Storage.SetHead(v)
 }
 
+func (h *hardeningHistory) CompareAndSetHead(expected, target regapi.Version) error {
+	if h.failSetHeadFor != 0 && h.failSetHeadFor == target.ID() {
+		h.failSetHeadFor = 0
+		return errors.New("injected set-head failure")
+	}
+	return h.Storage.CompareAndSetHead(expected, target)
+}
+
 func (h *hardeningHistory) CheckpointDependencyResolution(v regapi.Version, resolution *regapi.DependencyResolution) error {
 	if h.failCheckpoint {
 		return errors.New("injected checkpoint failure")
@@ -113,6 +121,7 @@ func TestApplyVersion_SetHeadFailureCompensatesRuntimeAndEffects(t *testing.T) {
 	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
 	history := &hardeningHistory{Storage: memory.New(), failSetHeadFor: v1.ID()}
 	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+	require.NoError(t, history.SetHead(v0))
 
 	effect := &hardeningEffect{}
 	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
@@ -142,6 +151,7 @@ func TestApplyVersion_LegacyResolutionCheckpointFailureCompensates(t *testing.T)
 	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
 	history := &hardeningHistory{Storage: memory.New(), failCheckpoint: true}
 	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+	require.NoError(t, history.SetHead(v0))
 
 	effect := &hardeningEffect{}
 	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
@@ -170,6 +180,7 @@ func TestApplyVersion_LegacyResolutionIsCheckpointed(t *testing.T) {
 	dep := regapi.Entry{ID: regapi.NewID("app.deps", "module"), Kind: regapi.NamespaceDependency}
 	history := &hardeningHistory{Storage: memory.New()}
 	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, false))
+	require.NoError(t, history.SetHead(v0))
 	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
 		return regapi.DirectiveResult{Applied: true, Resolution: hardeningResolution()}, nil
 	}}
@@ -190,6 +201,7 @@ func TestApplyVersion_LegacyUnrelatedTransitionResolvesFinalRoots(t *testing.T) 
 	unrelated := regapi.Entry{ID: regapi.NewID("app", "setting"), Kind: "setting"}
 	history := &hardeningHistory{Storage: memory.New()}
 	require.NoError(t, history.Save(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: unrelated}}, false))
+	require.NoError(t, history.SetHead(v0))
 	expansions := 0
 	directive := hardeningDirective{expand: func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
 		expansions++

--- a/system/registry/registry_test.go
+++ b/system/registry/registry_test.go
@@ -352,6 +352,7 @@ func TestInMemoryRegistry_ApplyVersion(t *testing.T) {
 
 	reg := NewRegistry(hist, runner, stateBuilder, topology.NewResolver(), zap.NewNop())
 	reg.currentVersion = v2 // Set current version to v2
+	_ = hist.SetHead(v2)
 	// Set initial state to v2 state
 	reg.state = registry.State{
 		{ID: registry.NewID("", "/foo"), Kind: "test", Data: payload.New("data2")},
@@ -1703,6 +1704,7 @@ func TestApplyVersion_Rollback_RespectsDependencyOrder(t *testing.T) {
 
 	reg := NewRegistry(hist, runner, stateBuilder, resolver, zap.NewNop())
 	reg.currentVersion = v1
+	_ = hist.SetHead(v1)
 	reg.state = registry.State{
 		{ID: libID, Kind: "library", Data: payload.New("lib")},
 		{ID: testID, Kind: "test", Data: payload.New("test")},

--- a/system/registry/registry_test.go
+++ b/system/registry/registry_test.go
@@ -251,13 +251,15 @@ func TestInMemoryRegistry_Apply(t *testing.T) {
 		t.Errorf("Expected new version to be v1, got: %v", newVersion)
 	}
 
-	if !reflect.DeepEqual(head, newVersion) {
-		t.Errorf("Expected new version to be head: %v, got: %v", head, newVersion)
+	if head == nil || head.ID() != newVersion.ID() {
+		t.Errorf("Expected head version %v, got: %v", newVersion, head)
 	}
 
 	savedChanges, _ := hist.Get(newVersion)
-	if !reflect.DeepEqual(savedChanges, changes) {
-		t.Errorf("Expected saved changes: %v, got: %v", changes, savedChanges)
+	expectedChanges := append(registry.ChangeSet(nil), changes...)
+	canonicalizeChangeSetIDs(expectedChanges)
+	if !reflect.DeepEqual(savedChanges, expectedChanges) {
+		t.Errorf("Expected saved changes: %v, got: %v", expectedChanges, savedChanges)
 	}
 
 	// Verify that the state is updated from the runner
@@ -372,7 +374,7 @@ func TestInMemoryRegistry_ApplyVersion(t *testing.T) {
 		t.Errorf("Expected state: %v, got: %v", runner.newState, reg.state)
 	}
 
-	if !reflect.DeepEqual(reg.currentVersion, v1) {
+	if reg.currentVersion == nil || reg.currentVersion.ID() != v1.ID() {
 		t.Errorf("Expected current version: %v, got: %v", v1, reg.currentVersion)
 	}
 

--- a/system/registry/topology/state_builder.go
+++ b/system/registry/topology/state_builder.go
@@ -3,6 +3,7 @@
 package topology
 
 import (
+	"context"
 	"reflect"
 	"sort"
 
@@ -132,6 +133,29 @@ func (b *StateBuilder) GetInverseOperation(op registry.Operation) (registry.Oper
 
 // BuildState constructs a registry State by applying the version history up to targetVersion.
 func (b *StateBuilder) BuildState(history registry.History, targetVersion registry.Version) (registry.State, error) {
+	if replayer, ok := history.(registry.ChangeSetReplayer); ok {
+		state := make(StateMap)
+		var replayApplyErr error
+		err := replayer.ReplayChanges(context.Background(), targetVersion, func(changes registry.ChangeSet) error {
+			for _, operation := range changes {
+				newState, applyErr := b.ApplyOperation(state, operation)
+				if applyErr != nil {
+					replayApplyErr = NewApplyOperationError(targetVersion.String(), operation.Entry.ID.String(), applyErr)
+					return replayApplyErr
+				}
+				state = newState
+			}
+			return nil
+		})
+		if err != nil {
+			if replayApplyErr != nil {
+				return nil, replayApplyErr
+			}
+			return nil, NewGetChangesetError(targetVersion.String(), err)
+		}
+		return StateMapToSlice(state), nil
+	}
+
 	vm := version.NewVersionMap()
 	versions, err := history.Versions()
 	if err != nil {


### PR DESCRIPTION
## What changes

Runtime dependency changes keep one control path: Lua, the UI, or an agent updates an `ns.dependency` entry through the normal registry changeset API.

- Resolve the transaction's final declared ranges once.
- Atomically store the authored changeset, exact root set, content-addressed resolved graph, and new history head.
- Inherit the graph reference across unrelated versions without duplicating graph payloads.
- Boot by replaying the selected lineage and reconciling only that version's stored graph. Modern history never solves again during boot.
- Rollback/redo select an explicit history version and reconcile its exact graph.
- Cache artifacts immutably by digest, verify digest and size before use, and retain distinct payloads that share a module version.
- Resolve legacy history when first visited and immutably checkpoint the result.
- Add schema v1.1 migrations for SQLite and PostgreSQL.

## Hardening

- History versions, changesets, graphs, and version-to-graph references are immutable; concurrent writers use expected-parent head CAS.
- Durable resolutions require a digest for every module. Presigned URLs are never persisted.
- SQLite enforces foreign keys; SQLite and PostgreSQL reject missing, corrupt, or mismatched graphs.
- Artifact publication is create-if-absent and verifies concurrent winners. Invalid immutable entries are neither overwritten nor silently deleted.
- Activation, restoration, staged cleanup, backup cleanup, and discard cleanup remain retryable after injected filesystem failures.
- Batched multi-root changes reconcile the final declared root set and remove modules no longer owned by any root.
- Stored identities, artifact paths, and download metadata are validated before materialization.
- Long-history boot/snapshot work is proportional to the selected lineage, with direct version lookup and a constant SQL query count.

## Compatibility and operational boundaries

- The deployed application baseline must match the baseline used to create its history. A baseline snapshot ID is not persisted yet.
- A legacy version with no stored graph is resolved using the compatible graph available when that version is first visited; history cannot reconstruct a resolution that was never recorded.
- Local replacements are development-only/nonportable unless every runtime has the identical source tree.
- If an already-active embedded module has the same version but a different digest, reconciliation fails closed until embedded identity becomes digest-aware.
- Branch redo must select the target version ID explicitly. `Version.Next()` is only a deterministic legacy convenience.
- Multi-instance stale writes fail CAS, but existing readers do not receive live cross-process synchronization.
- Lineage replay has constant query count but buffers the encoded selected-lineage payload. History and the offline rollback artifact cache are intentionally unbounded; future compaction/GC must retain every referenced graph artifact.

This includes and supersedes #465, #468, #469, #470, and #478. It intentionally excludes #461's local overlay and #471's transport change.

## Validation

- `go test ./... -count=1`
- `go test -race ./api/registry ./api/modules ./internal/version ./runtime/lua/modules/registry ./system/registry/... ./boot/deps/hub/... -count=1`
- `WIPPY_POSTGRES_HISTORY_TEST_DSN=... go test ./system/registry/history/postgres -count=1` against PostgreSQL 16
- `make lint`
- `make build-wippy-local`
- Deterministic fault tests for activation/restore/cleanup retries; immutable cache concurrency, corruption, rollback, and same-version/different-digest tests; SQLite/PostgreSQL migration, CAS, branch, path-containment, and long-lineage tests.
- Built the production binary and booted a disposable current Kicksite twice against the same SQLite history: both boots reached runtime-ready and served HTTP 200; history remained exactly 1 version, 1 changeset, 1 graph, and 1 graph reference with 45 roots and 48 exact modules.
