### PR TITLE
fix(update): prune stale lock modules on full resolve

### DIFF
--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -142,6 +142,12 @@ func (l *Lock) SetModule(module Module) {
 	l.data.Modules = append(l.data.Modules, module)
 }
 
+// ReplaceModules replaces the complete resolved module snapshot while leaving
+// lock-level configuration such as directories, replacements, and options intact.
+func (l *Lock) ReplaceModules(modules []Module) {
+	l.data.Modules = append([]Module(nil), modules...)
+}
+
 // RemoveModule removes a module by name.
 func (l *Lock) RemoveModule(name string) {
 	filtered := make([]Module, 0, len(l.data.Modules))

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -288,13 +288,15 @@ func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, mo
 		Src:     srcDir,
 	})
 
+	lockedModules := make([]lock.Module, 0, len(modules))
 	for _, m := range modules {
-		lockObj.SetModule(lock.Module{
+		lockedModules = append(lockedModules, lock.Module{
 			Name:    fmt.Sprintf("%s/%s", m.Org, m.Name),
 			Version: m.Version,
 			Hash:    m.Digest,
 		})
 	}
+	lockObj.ReplaceModules(lockedModules)
 
 	return lockObj, nil
 }

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -47,6 +47,55 @@ func TestConvertResolvedToLock_UsesProvidedPath(t *testing.T) {
 	}
 }
 
+func TestConvertResolvedToLock_ReplacesResolvedGraphAndPreservesLockConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+
+	existing, err := lock.New(lockPath)
+	if err != nil {
+		t.Fatalf("create existing lock: %v", err)
+	}
+	existing.SetDirectories(lock.Directories{Modules: "old-modules", Src: "old-src"})
+	existing.SetModule(lock.Module{Name: "acme/keep", Version: "1.0.0", Hash: "old"})
+	existing.SetModule(lock.Module{Name: "acme/stale", Version: "1.0.0", Hash: "stale"})
+	existing.SetModule(lock.Module{Name: "acme/local", Version: "1.0.0", LocalHash: "local"})
+	existing.SetReplacement(lock.Replacement{From: "acme/local", To: "../local"})
+	existing.SetOptions(lock.Options{UnpackModules: true})
+	if err := existing.Write(); err != nil {
+		t.Fatalf("write existing lock: %v", err)
+	}
+
+	regenerated, err := convertResolvedToLock(lockPath, []hub.ResolvedModule{
+		{Org: "acme", Name: "keep", Version: "2.0.0", Digest: "new"},
+	}, "new-modules", "new-src")
+	if err != nil {
+		t.Fatalf("convertResolvedToLock failed: %v", err)
+	}
+
+	modules := regenerated.GetModules()
+	if len(modules) != 1 {
+		t.Fatalf("modules = %+v, want only the newly resolved graph", modules)
+	}
+	if modules[0].Name != "acme/keep" || modules[0].Version != "2.0.0" || modules[0].Hash != "new" {
+		t.Fatalf("resolved module = %+v, want regenerated acme/keep", modules[0])
+	}
+	if _, ok := regenerated.GetModule("acme/stale"); ok {
+		t.Fatal("stale module survived full graph regeneration")
+	}
+	if _, ok := regenerated.GetModule("acme/local"); ok {
+		t.Fatal("replacement-only module should not survive as a locked remote module")
+	}
+	if replacement, ok := regenerated.GetReplacement("acme/local"); !ok || replacement.To != "../local" {
+		t.Fatalf("replacement = %+v, %v; want preserved local replacement", replacement, ok)
+	}
+	if !regenerated.ShouldUnpackModules() {
+		t.Fatal("lock options were not preserved")
+	}
+	if dirs := regenerated.GetDirectories(); dirs.Modules != "new-modules" || dirs.Src != "new-src" {
+		t.Fatalf("directories = %+v, want command-selected directories", dirs)
+	}
+}
+
 func TestPreserveReplacements_KeepsAll(t *testing.T) {
 	tmpDir := t.TempDir()
 	lockPath := filepath.Join(tmpDir, "wippy.lock")


### PR DESCRIPTION
## Summary

- Replace the lock module snapshot during a full dependency re-resolution.
- Preserve lock directories, replacements, and options while removing modules absent from the new graph.
- Add a regression test covering stale, retained, and replacement-only modules.

## Root cause

convertResolvedToLock reopened the existing lock and called SetModule for every newly resolved module. Because it never cleared the previous module slice, dependencies removed from source or the resolved graph survived indefinitely and lock.Diff incorrectly reported no removal.

## Validation

- go test ./cmd/wippy/cmd -run TestConvertResolvedToLock -count=1
- go test ./boot/deps/lock -count=1
- go test ./cmd/wippy/cmd ./boot/deps/lock -count=1
- go build -buildvcs=false -o /tmp/wippy-update-prune-bin ./cmd/wippy
- End to end against a temporary Kickside lock: full update resolved 42 modules from 39 roots and removed the one stale kickside/kb10 module from the prior 43-module lock.

This PR is intentionally left unmerged for review.