### PR TITLE
fix(deps): honor source excludes in replacements

### DIFF
--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -175,6 +176,83 @@ func (c *ModuleConfig) EntryExcludes() []string {
 	}
 
 	return out
+}
+
+// SourceExcludes returns module-root-relative file globs from exclude. Registry
+// entry patterns contain ':' and are handled after entries are decoded.
+func (c *ModuleConfig) SourceExcludes() []string {
+	if len(c.Exclude) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(c.Exclude))
+	for _, pattern := range c.Exclude {
+		if !strings.Contains(pattern, ":") {
+			out = append(out, pattern)
+		}
+	}
+	return out
+}
+
+// ExcludesSourcePath reports whether a module-root-relative source path matches
+// a file exclusion. A ** path segment spans zero or more directory segments;
+// other segments use path.Match semantics.
+func (c *ModuleConfig) ExcludesSourcePath(relative string) bool {
+	relative = cleanSourcePath(relative)
+	if relative == "" {
+		return false
+	}
+	for _, pattern := range c.SourceExcludes() {
+		if matchSourceGlob(cleanSourcePath(pattern), relative) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanSourcePath(value string) string {
+	value = filepath.ToSlash(strings.TrimSpace(value))
+	value = strings.TrimPrefix(value, "./")
+	if value == "" || value == "." {
+		return ""
+	}
+	return strings.TrimPrefix(path.Clean(value), "/")
+}
+
+func matchSourceGlob(pattern, relative string) bool {
+	if pattern == "" || relative == "" {
+		return false
+	}
+	patterns := strings.Split(pattern, "/")
+	parts := strings.Split(relative, "/")
+	type position struct{ pattern, part int }
+	memo := make(map[position]bool)
+	seen := make(map[position]bool)
+
+	var match func(int, int) bool
+	match = func(patternIndex, partIndex int) bool {
+		key := position{pattern: patternIndex, part: partIndex}
+		if seen[key] {
+			return memo[key]
+		}
+		seen[key] = true
+
+		var matched bool
+		switch {
+		case patternIndex == len(patterns):
+			matched = partIndex == len(parts)
+		case patterns[patternIndex] == "**":
+			matched = match(patternIndex+1, partIndex) ||
+				(partIndex < len(parts) && match(patternIndex, partIndex+1))
+		case partIndex < len(parts):
+			segmentMatched, err := path.Match(patterns[patternIndex], parts[partIndex])
+			matched = err == nil && segmentMatched && match(patternIndex+1, partIndex+1)
+		}
+		memo[key] = matched
+		return matched
+	}
+
+	return match(0, 0)
 }
 
 func (c *ModuleConfig) Namespace() string {

--- a/boot/deps/config/config_test.go
+++ b/boot/deps/config/config_test.go
@@ -354,6 +354,43 @@ func TestEntryExcludes(t *testing.T) {
 	}
 }
 
+func TestSourceExcludesAndMatching(t *testing.T) {
+	cfg := &ModuleConfig{Exclude: []string{
+		"test/**",
+		"ui/node_modules/**",
+		"src/**/stubs/**",
+		"src/**/*.spec.ts",
+		"app:**",
+	}}
+
+	assert.Equal(t, []string{
+		"test/**",
+		"ui/node_modules/**",
+		"src/**/stubs/**",
+		"src/**/*.spec.ts",
+	}, cfg.SourceExcludes())
+
+	for _, relative := range []string{
+		"test",
+		"test/_index.yaml",
+		"ui/node_modules",
+		"ui/node_modules/.bin/css-beautify",
+		"src/feature/stubs/_index.yaml",
+		"src/root.spec.ts",
+		"src/feature/deep/view.spec.ts",
+	} {
+		assert.True(t, cfg.ExcludesSourcePath(relative), relative)
+	}
+	for _, relative := range []string{
+		"src/_index.yaml",
+		"src/feature/view.ts",
+		"ui/dist/index.js",
+		"app:entry",
+	} {
+		assert.False(t, cfg.ExcludesSourcePath(relative), relative)
+	}
+}
+
 func TestValidateModuleType(t *testing.T) {
 	t.Parallel()
 

--- a/boot/deps/config/source_fs.go
+++ b/boot/deps/config/source_fs.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	"io/fs"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// SourcePrefix returns loadRoot relative to moduleRoot using slash-separated
+// paths. An unrelated load root has no safe module-relative prefix and returns
+// the empty string; normal module layouts always keep loadRoot below the
+// manifest directory.
+func SourcePrefix(moduleRoot, loadRoot string) string {
+	root, err := filepath.Abs(moduleRoot)
+	if err != nil {
+		return ""
+	}
+	load, err := filepath.Abs(loadRoot)
+	if err != nil {
+		return ""
+	}
+	relative, err := filepath.Rel(root, load)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return filepath.ToSlash(relative)
+}
+
+// NewSourceFS applies a module's source policy to a load root. Keeping root
+// translation here prevents publish, install, update, and restart from each
+// inventing subtly different exclusion behavior.
+func NewSourceFS(base fs.FS, config *ModuleConfig, moduleRoot, loadRoot string) fs.FS {
+	return config.FilterSourceFS(base, SourcePrefix(moduleRoot, loadRoot))
+}
+
+// FilterSourceFS returns a view of base that hides paths excluded by the
+// module manifest. sourcePrefix is the load root relative to the module root
+// (for example "src" when base is os.DirFS(<module>/src)). Keeping the prefix
+// explicit makes the same manifest rules apply to publish, update, replacement
+// resolution, install, and restart loads.
+func (c *ModuleConfig) FilterSourceFS(base fs.FS, sourcePrefix string) fs.FS {
+	if c == nil || len(c.SourceExcludes()) == 0 {
+		return base
+	}
+	return &sourceFilterFS{
+		base:   base,
+		config: c,
+		prefix: cleanSourcePath(sourcePrefix),
+	}
+}
+
+type sourceFilterFS struct {
+	base   fs.FS
+	config *ModuleConfig
+	prefix string
+}
+
+func (f *sourceFilterFS) Open(name string) (fs.File, error) {
+	if f.excluded(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return f.base.Open(name)
+}
+
+func (f *sourceFilterFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if f.excluded(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	entries, err := fs.ReadDir(f.base, name)
+	if err != nil {
+		return nil, err
+	}
+	visible := make([]fs.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !f.excluded(path.Join(name, entry.Name())) {
+			visible = append(visible, entry)
+		}
+	}
+	return visible, nil
+}
+
+func (f *sourceFilterFS) ReadFile(name string) ([]byte, error) {
+	if f.excluded(name) {
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
+	}
+	return fs.ReadFile(f.base, name)
+}
+
+func (f *sourceFilterFS) Stat(name string) (fs.FileInfo, error) {
+	if f.excluded(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	}
+	return fs.Stat(f.base, name)
+}
+
+func (f *sourceFilterFS) excluded(name string) bool {
+	name = cleanSourcePath(name)
+	if name == "" {
+		return false
+	}
+	if f.prefix != "" {
+		name = path.Join(f.prefix, name)
+	}
+	return f.config.ExcludesSourcePath(name)
+}

--- a/boot/deps/config/source_fs_test.go
+++ b/boot/deps/config/source_fs_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSourceFSUsesModuleRelativePaths(t *testing.T) {
+	cfg := &ModuleConfig{Exclude: []string{
+		"test/**",
+		"src/**/stubs/**",
+		"src/**/*.spec.yaml",
+	}}
+	base := fstest.MapFS{
+		"_index.yaml":              {Data: []byte("root")},
+		"feature/_index.yaml":      {Data: []byte("feature")},
+		"feature/worker.spec.yaml": {Data: []byte("spec")},
+		"feature/stubs/fake.yaml":  {Data: []byte("stub")},
+		"test/inside-src.yaml":     {Data: []byte("source test")},
+	}
+
+	filtered := cfg.FilterSourceFS(base, "src")
+	var paths []string
+	require.NoError(t, fs.WalkDir(filtered, ".", func(name string, _ fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		paths = append(paths, name)
+		return nil
+	}))
+
+	assert.Equal(t, []string{
+		".",
+		"_index.yaml",
+		"feature",
+		"feature/_index.yaml",
+		"test",
+		"test/inside-src.yaml",
+	}, paths)
+}
+
+func TestFilterSourceFSAtModuleRoot(t *testing.T) {
+	cfg := &ModuleConfig{Exclude: []string{"test/**"}}
+	base := fstest.MapFS{
+		"src/_index.yaml":  {Data: []byte("source")},
+		"test/_index.yaml": {Data: []byte("test")},
+	}
+
+	filtered := cfg.FilterSourceFS(base, "")
+	_, err := fs.Stat(filtered, "test/_index.yaml")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	data, err := fs.ReadFile(filtered, "src/_index.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "source", string(data))
+}
+
+func TestSourcePrefix(t *testing.T) {
+	root := t.TempDir()
+	assert.Equal(t, "src/components", SourcePrefix(root, filepath.Join(root, "src", "components")))
+	assert.Empty(t, SourcePrefix(root, root+"-sibling"))
+}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1288,9 +1288,6 @@ func loadReplacementEntries(
 		if err != nil {
 			return err
 		}
-		if d.IsDir() && d.Name() == "node_modules" {
-			return fs.SkipDir
-		}
 		if rel != "." && cfg != nil && cfg.ExcludesSourcePath(rel) {
 			if d.IsDir() {
 				return fs.SkipDir

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1281,18 +1281,12 @@ func loadReplacementEntries(
 	}
 
 	cfg, _ := depconfig.Load(path)
-	dirFS := os.DirFS(path)
+	dirFS := depconfig.NewSourceFS(os.DirFS(path), cfg, path, path)
 	ldr := loaderFromContext(ctx, logger, transcoder)
 	var entries []regapi.Entry
 	if err := fs.WalkDir(dirFS, ".", func(rel string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
-		}
-		if rel != "." && cfg != nil && cfg.ExcludesSourcePath(rel) {
-			if d.IsDir() {
-				return fs.SkipDir
-			}
-			return nil
 		}
 		if d.IsDir() || rel == depconfig.DefaultConfigFile {
 			return nil

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1045,7 +1045,7 @@ func (h *DependencyHandler) completeResolvedModuleIdentities(ctx context.Context
 		mod := &modules[i]
 		name := graph.Name{Organization: mod.Org, Module: mod.Name}
 		if replacement, ok := h.replacementPath(name.String()); ok {
-			digest, size, err := digestDirectoryTree(replacement)
+			digest, size, err := digestReplacementTree(replacement)
 			if err != nil {
 				return NewDependencyIntegrityError(modKey(*mod), err, mod.Digest, mod.SizeBytes)
 			}
@@ -1228,7 +1228,7 @@ func (p *replacementManifestProvider) localReplacementDependencies(ctx context.C
 		return nil, ErrDependencyTranscoderMissing
 	}
 
-	entries, err := loadReplacementDependencyEntries(ctx, path, p.handler.logger, transcoder)
+	entries, err := loadReplacementEntries(ctx, path, p.handler.logger, transcoder)
 	if err != nil {
 		return nil, err
 	}
@@ -1269,7 +1269,7 @@ func (p *replacementManifestProvider) localReplacementDependencies(ctx context.C
 	return deps, nil
 }
 
-func loadReplacementDependencyEntries(
+func loadReplacementEntries(
 	ctx context.Context,
 	path string,
 	logger *zap.Logger,
@@ -1280,12 +1280,22 @@ func loadReplacementDependencyEntries(
 		return nil, nil
 	}
 
+	cfg, _ := depconfig.Load(path)
 	dirFS := os.DirFS(path)
 	ldr := loaderFromContext(ctx, logger, transcoder)
 	var entries []regapi.Entry
 	if err := fs.WalkDir(dirFS, ".", func(rel string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if d.IsDir() && d.Name() == "node_modules" {
+			return fs.SkipDir
+		}
+		if rel != "." && cfg != nil && cfg.ExcludesSourcePath(rel) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
 		}
 		if d.IsDir() || rel == depconfig.DefaultConfigFile {
 			return nil
@@ -1513,7 +1523,12 @@ func (h *DependencyHandler) loadEntriesForModulePlan(ctx context.Context, transc
 	if err != nil {
 		return nil, nil, err
 	}
-	entries, err := loadRawEntriesFromPaths(ctx, []string{modulePath}, h.logger, transcoder)
+	var entries []regapi.Entry
+	if mod.Source == moduleSourceReplacementTreeV1 {
+		entries, err = loadReplacementEntries(ctx, modulePath, h.logger, transcoder)
+	} else {
+		entries, err = loadRawEntriesFromPaths(ctx, []string{modulePath}, h.logger, transcoder)
+	}
 	if err != nil {
 		if staged != nil {
 			_ = os.RemoveAll(staged.stagingDir)
@@ -1528,7 +1543,7 @@ func (h *DependencyHandler) loadEntriesForModulePlan(ctx context.Context, transc
 		return nil, nil, err
 	}
 	if mod.Source == moduleSourceReplacementTreeV1 {
-		digest, size, digestErr := digestDirectoryTree(modulePath)
+		digest, size, digestErr := digestReplacementTree(modulePath)
 		if digestErr != nil {
 			return nil, nil, NewDependencyIntegrityError(modKey(mod), digestErr, mod.Digest, mod.SizeBytes)
 		}
@@ -1664,7 +1679,7 @@ func (h *DependencyHandler) ensureModuleAvailable(ctx context.Context, mod Resol
 		if !stat.IsDir() {
 			return "", NewDependencyLoadError(replacementPath, fmt.Errorf("replacement path is not a directory"))
 		}
-		digest, size, err := digestDirectoryTree(replacementPath)
+		digest, size, err := digestReplacementTree(replacementPath)
 		if err != nil {
 			return "", NewDependencyIntegrityError(modKey(mod), err, mod.Digest, mod.SizeBytes)
 		}

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -2645,7 +2645,7 @@ func TestDependencyHandler_Expand_ReplacedModuleDependenciesResolveFromLocalEntr
 
 	require.NoError(t, os.MkdirAll(localMod, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(localMod, "wippy.yaml"),
-		[]byte("organization: local\nmodule: mod\nversion: v0.1.0\n"), 0600))
+		[]byte("organization: local\nmodule: mod\nversion: v0.1.0\nexclude:\n  - test/**\n  - ui/node_modules/**\n"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(localMod, "_index.json"), []byte(`{
   "namespace": "local.mod",
   "entries": [
@@ -2664,6 +2664,22 @@ func TestDependencyHandler_Expand_ReplacedModuleDependenciesResolveFromLocalEntr
     }
   ]
 }`), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(localMod, "test"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localMod, "test", "_index.json"), []byte(`{
+  "namespace": "local.mod.test",
+  "entries": [
+    {
+      "name": "excluded_dependency",
+      "kind": "ns.dependency",
+      "data": {
+        "component": "acme/excluded-test-dependency",
+        "version": "v1.0.0"
+      }
+    }
+  ]
+}`), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(localMod, "ui", "node_modules", ".bin"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localMod, "ui", "node_modules", ".bin", "tool"), []byte("excluded"), 0600))
 	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
   modules: .wippy
   src: ./src
@@ -2676,6 +2692,7 @@ replacements:
 		{ID: wapp.NewID("acme.transitive", "svc"), Kind: "process.lua", Data: map[string]any{}},
 	})
 
+	excludedManifestRequests := 0
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub: &fakeHub{
 			getManifest: func(_ context.Context, org, module, version string) (*ModuleManifest, error) {
@@ -2684,6 +2701,10 @@ replacements:
 				}
 				if org == "acme" && module == "transitive" && version == "v1.0.0" {
 					return &ModuleManifest{Org: org, Name: module, Version: version}, nil
+				}
+				if org == "acme" && module == "excluded-test-dependency" {
+					excludedManifestRequests++
+					return nil, fmt.Errorf("excluded dependency must not be resolved")
 				}
 				return nil, fmt.Errorf("unexpected manifest request: %s/%s@%s", org, module, version)
 			},
@@ -2713,6 +2734,8 @@ replacements:
 
 	assert.True(t, created[regapi.NewID("local.mod", "svc")], "replacement root entry should be loaded")
 	assert.True(t, created[regapi.NewID("acme.transitive", "svc")], "replacement transitive dependency should be resolved and loaded")
+	assert.Zero(t, excludedManifestRequests, "dependencies declared under excluded source trees must not be resolved")
+	assert.False(t, created[regapi.NewID("local.mod.test", "excluded_dependency")])
 }
 
 func TestDependencyHandler_ResolveModules_ReplacedModuleRangeConstraintFromLocalManifest(t *testing.T) {

--- a/boot/deps/hub/tree_digest.go
+++ b/boot/deps/hub/tree_digest.go
@@ -10,6 +10,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
 )
 
 const treeIdentityModeMask = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
@@ -19,6 +21,20 @@ const treeIdentityModeMask = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.Mo
 // deterministic and unambiguous. Empty directories and executable/permission
 // changes are significant; unstable or unsupported node types fail closed.
 func digestDirectoryTree(root string) (string, uint64, error) {
+	return digestDirectoryTreeFiltered(root, nil)
+}
+
+// digestReplacementTree applies the same source exclusions used when loading
+// entries from a replacement tree.
+func digestReplacementTree(root string) (string, uint64, error) {
+	cfg, err := depconfig.Load(root)
+	if err != nil {
+		return digestDirectoryTree(root)
+	}
+	return digestDirectoryTreeFiltered(root, cfg.ExcludesSourcePath)
+}
+
+func digestDirectoryTreeFiltered(root string, excluded func(string) bool) (string, uint64, error) {
 	hash := sha256.New()
 	var total uint64
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -34,6 +50,12 @@ func digestDirectoryTree(root string) (string, uint64, error) {
 			return filepath.SkipDir
 		}
 		if rel == extractedModuleMeta {
+			return nil
+		}
+		if rel != "." && excluded != nil && excluded(rel) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/boot/deps/hub/tree_digest_test.go
+++ b/boot/deps/hub/tree_digest_test.go
@@ -83,6 +83,25 @@ exclude:
 	assert.Equal(t, beforeSize, afterSize)
 }
 
+func TestDigestReplacementTree_UnexcludedNodeModulesSymlinkFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires additional privileges")
+	}
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "wippy.yaml"), []byte(`organization: local
+module: mod
+version: v0.1.0
+`), 0644))
+
+	binDir := filepath.Join(root, "ui", "node_modules", ".bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+	require.NoError(t, os.Symlink("../css-beautify/bin/css-beautify.js", filepath.Join(binDir, "css-beautify")))
+
+	_, _, err := digestReplacementTree(root)
+	require.ErrorContains(t, err, "module tree contains symlink")
+}
+
 func writeDigestFixture(t *testing.T, root string, names []string) {
 	t.Helper()
 	for _, name := range names {

--- a/boot/deps/hub/tree_digest_test.go
+++ b/boot/deps/hub/tree_digest_test.go
@@ -55,6 +55,34 @@ func TestDigestDirectoryTree_IsDeterministicAcrossCreationOrder(t *testing.T) {
 	assert.Equal(t, firstSize, secondSize)
 }
 
+func TestDigestReplacementTree_ExcludesNodeModulesSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires additional privileges")
+	}
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "wippy.yaml"), []byte(`organization: local
+module: mod
+version: v0.1.0
+exclude:
+  - ui/node_modules/**
+`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "module.lua"), []byte("return true"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "ui"), 0755))
+
+	before, beforeSize, err := digestReplacementTree(root)
+	require.NoError(t, err)
+
+	binDir := filepath.Join(root, "ui", "node_modules", ".bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+	require.NoError(t, os.Symlink("../css-beautify/bin/css-beautify.js", filepath.Join(binDir, "css-beautify")))
+
+	after, afterSize, err := digestReplacementTree(root)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+	assert.Equal(t, beforeSize, afterSize)
+}
+
 func writeDigestFixture(t *testing.T, root string, names []string) {
 	t.Helper()
 	for _, name := range names {

--- a/boot/deps/hub/unpack_effect.go
+++ b/boot/deps/hub/unpack_effect.go
@@ -129,7 +129,7 @@ func (h *DependencyHandler) hasCurrentUnpackedModule(mod ResolvedModule) bool {
 		if !ok {
 			return false
 		}
-		digest, size, err := digestDirectoryTree(path)
+		digest, size, err := digestReplacementTree(path)
 		return err == nil && strings.EqualFold(digest, mod.Digest) && (mod.SizeBytes == 0 || size == mod.SizeBytes)
 	}
 	if !h.shouldUnpackModules() {

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -344,7 +344,7 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 	var entries []regapi.Entry
 
 	for _, mp := range modulePaths {
-		loaded, err := loadEntriesFromPath(ctx, mp.Path, ldr, dtt, logger)
+		loaded, err := loadEntriesFromModulePath(ctx, mp, ldr, dtt, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -453,8 +453,11 @@ func NormalizeEntries(ctx context.Context, entries *[]regapi.Entry) error {
 	return nil
 }
 
-// loadEntriesFromPath loads entries from a single path (directory or .wapp file).
-func loadEntriesFromPath(ctx context.Context, path string, ldr boot.Loader, dtt payload.Transcoder, logger *zap.Logger) ([]regapi.Entry, error) {
+// loadEntriesFromModulePath loads entries from a single module path and applies
+// source-file exclusions before decoding manifests. Entry-ID and metadata
+// filters are applied separately after decoding.
+func loadEntriesFromModulePath(ctx context.Context, mp lock.ModuleLoadPath, ldr boot.Loader, dtt payload.Transcoder, logger *zap.Logger) ([]regapi.Entry, error) {
+	path := mp.Path
 	if filepath.Ext(path) == ".wapp" {
 		return loadEntriesFromWapp(path, dtt)
 	}
@@ -469,7 +472,16 @@ func loadEntriesFromPath(ctx context.Context, path string, ldr boot.Loader, dtt 
 	}
 
 	if stat.IsDir() {
-		dirFS := os.DirFS(path)
+		configDir := path
+		var moduleConfig *depconfig.ModuleConfig
+		if shouldApplyModuleConfigFilters(mp) {
+			configDir = mp.SourceRoot
+			if configDir == "" {
+				configDir = path
+			}
+			moduleConfig, _ = depconfig.Load(configDir)
+		}
+		dirFS := depconfig.NewSourceFS(os.DirFS(path), moduleConfig, configDir, path)
 		loaded, err := ldr.LoadFS(ctx, dirFS)
 		if err != nil {
 			return nil, NewLoadFromPathError(path, err)

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -1152,11 +1152,9 @@ entries:
 	}
 }
 
-// A module whose exclude list holds only source-file globs (no entry-ID
-// patterns and no exclude_meta) must load all its entries unchanged: file
-// globs are pack-time file filters, not entry patterns, so they neither drop
-// entries nor error out.
-func TestLoadEntriesFromModuleLoadPaths_OnlyFileGlobExcludesIsNoOp(t *testing.T) {
+// Source globs are evaluated before manifests are decoded, using paths relative
+// to the module root even when the actual load root is <module>/src.
+func TestLoadEntriesFromModuleLoadPaths_AppliesSourceGlobsWithSrcLayout(t *testing.T) {
 	ctx := setupTestContext(t)
 	logger := zap.NewNop()
 	tmpDir := t.TempDir()
@@ -1169,7 +1167,7 @@ func TestLoadEntriesFromModuleLoadPaths_OnlyFileGlobExcludesIsNoOp(t *testing.T)
 	moduleConfig := `organization: kickside
 module: events
 exclude:
-  - "_old/**"
+  - "src/_old/**"
   - "test/**"
 `
 	if err := os.WriteFile(filepath.Join(moduleRoot, "wippy.yaml"), []byte(moduleConfig), 0o644); err != nil {
@@ -1190,6 +1188,20 @@ entries:
 	if err := os.WriteFile(filepath.Join(srcDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
 		t.Fatalf("write module _index.yaml: %v", err)
 	}
+	excludedYAML := `version: "1.0"
+namespace: kickside.events
+entries:
+  - name: legacy
+    kind: function.lua
+    source: |
+      return {}
+`
+	if err := os.MkdirAll(filepath.Join(srcDir, "_old"), 0o755); err != nil {
+		t.Fatalf("mkdir excluded source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "_old", "_index.yaml"), []byte(excludedYAML), 0o644); err != nil {
+		t.Fatalf("write excluded source: %v", err)
+	}
 
 	entries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
 		{Path: srcDir, Module: "kickside/events", SourceRoot: moduleRoot},
@@ -1206,6 +1218,9 @@ entries:
 		if !found[id] {
 			t.Fatalf("entry %s dropped by file-glob-only exclude", id)
 		}
+	}
+	if found["kickside.events:legacy"] {
+		t.Fatal("source-glob-excluded entry was loaded on restart path")
 	}
 }
 

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -439,7 +439,7 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		srcPath = filepath.Join(srcDir, "src")
 	}
 
-	dirFS := os.DirFS(srcPath)
+	dirFS := config.NewSourceFS(os.DirFS(srcPath), cfg, srcDir, srcPath)
 	srcEntries, err := app.Loader.LoadFS(ctx, dirFS)
 	if err != nil {
 		return nil, NewLoadEntriesError(fmt.Sprintf("source path %s", srcPath), err)

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/graph"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
@@ -498,11 +499,16 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 		logger = zap.NewNop()
 	}
 
+	moduleRoot, _ := os.Getwd()
+	if lockObj != nil {
+		moduleRoot = filepath.Dir(lockObj.Path())
+	}
 	paths := []struct {
 		label string
 		path  string
+		root  string
 	}{
-		{label: "source", path: srcDir},
+		{label: "source", path: srcDir, root: moduleRoot},
 	}
 
 	if lockObj != nil {
@@ -514,12 +520,18 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 			if mp.Module == "" || !replacements[mp.Module] {
 				continue
 			}
+			replacementRoot := mp.SourceRoot
+			if replacementRoot == "" {
+				replacementRoot = mp.Path
+			}
 			paths = append(paths, struct {
 				label string
 				path  string
+				root  string
 			}{
 				label: "replacement " + mp.Module,
 				path:  mp.Path,
+				root:  replacementRoot,
 			})
 		}
 	}
@@ -540,7 +552,9 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 			zap.String("kind", scanPath.label),
 			zap.String("path", absPath))
 
-		loaded, err := ldr.LoadFS(ctx, os.DirFS(absPath))
+		cfg, _ := depconfig.Load(scanPath.root)
+		sourceFS := depconfig.NewSourceFS(os.DirFS(absPath), cfg, scanPath.root, absPath)
+		loaded, err := ldr.LoadFS(ctx, sourceFS)
 		if err != nil {
 			return nil, fmt.Errorf("%s path %s: %w", scanPath.label, absPath, err)
 		}

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -208,6 +208,27 @@ entries:
 	if err := os.WriteFile(filepath.Join(replacementSrcDir, "_index.yaml"), []byte(replacementYAML), 0o644); err != nil {
 		t.Fatalf("write replacement index: %v", err)
 	}
+	replacementConfig := `organization: acme
+module: ui
+exclude:
+  - "src/excluded/**"
+`
+	if err := os.WriteFile(filepath.Join(replacementDir, "wippy.yaml"), []byte(replacementConfig), 0o644); err != nil {
+		t.Fatalf("write replacement config: %v", err)
+	}
+	excludedYAML := `version: "1.0"
+namespace: local.ui.deps
+entries:
+  - name: excluded
+    kind: ns.dependency
+    component: bad/excluded
+`
+	if err := os.MkdirAll(filepath.Join(replacementSrcDir, "excluded"), 0o755); err != nil {
+		t.Fatalf("mkdir excluded replacement source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replacementSrcDir, "excluded", "_index.yaml"), []byte(excludedYAML), 0o644); err != nil {
+		t.Fatalf("write excluded replacement source: %v", err)
+	}
 
 	nodeModulesYAML := `version: "1.0"
 namespace: should.not.load
@@ -251,6 +272,9 @@ entries:
 	}
 	if _, ok := got["bad/module"]; ok {
 		t.Fatalf("replacement scan should use src subtree and ignore node_modules noise: got %v", got)
+	}
+	if _, ok := got["bad/excluded"]; ok {
+		t.Fatalf("replacement scan ignored manifest source exclusions: got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- apply module source exclusions while discovering and loading local replacement entries
- exclude the same paths from replacement content identity and integrity checks
- cover excluded test dependencies and node_modules symlinks with regressions

## Verification
- go test ./boot/deps/config ./boot/deps/hub
- go test ./boot/deps/...
- go test ./boot/...
- go build -buildvcs=false -o /tmp/wippy-replacement-source-excludes-bin ./cmd/wippy