### PR TITLE
fix(registry): reject unsatisfiable same-ID replacements

### DIFF
--- a/system/registry/topology/errors.go
+++ b/system/registry/topology/errors.go
@@ -3,10 +3,25 @@
 package topology
 
 import (
+	"sort"
+
 	"github.com/wippyai/runtime/api/attrs"
 	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/registry"
 )
+
+// NewReplacementDependencyCycleError reports a same-ID delete/create
+// replacement that cannot be serialized without breaking a live dependency.
+func NewReplacementDependencyCycleError(ids []registry.ID) apierror.Error {
+	entryIDs := make([]string, len(ids))
+	for i, id := range ids {
+		entryIDs[i] = id.String()
+	}
+	sort.Strings(entryIDs)
+	return apierror.New(apierror.Conflict, "same-ID replacement has an unsatisfiable dependency cycle").
+		WithRetryable(apierror.False).
+		WithDetails(attrs.NewBagFrom(map[string]any{"entry_ids": entryIDs}))
+}
 
 // ErrEmptyPatternPath is a sentinel error
 var (

--- a/system/registry/topology/sort_changeset.go
+++ b/system/registry/topology/sort_changeset.go
@@ -319,10 +319,22 @@ func sortChangeSetInputForStableOrder(changeSet registry.ChangeSet) registry.Cha
 // cyclic dependency graphs. It prefers install/update before cleanup, but the
 // result may still be invalid and must be rejected by normal apply validation.
 func (b *StateBuilder) fallbackSortChangeSet(fromState registry.State, changeSet registry.ChangeSet) registry.ChangeSet {
+	replacementIDs := make(map[registry.ID]struct{})
+	for _, operation := range changeSet {
+		if operation.Kind == registry.EntryCreate {
+			replacementIDs[operation.Entry.ID] = struct{}{}
+		}
+	}
+
+	replacementDeleteOps := make([]registry.Operation, 0)
 	deleteOps := make([]registry.Operation, 0, len(changeSet))
 	createUpdateOps := make([]registry.Operation, 0, len(changeSet))
 	for _, operation := range changeSet {
 		if operation.Kind == registry.EntryDelete {
+			if _, replacing := replacementIDs[operation.Entry.ID]; replacing {
+				replacementDeleteOps = append(replacementDeleteOps, operation)
+				continue
+			}
 			deleteOps = append(deleteOps, operation)
 		} else {
 			createUpdateOps = append(createUpdateOps, operation)
@@ -330,6 +342,10 @@ func (b *StateBuilder) fallbackSortChangeSet(fromState registry.State, changeSet
 	}
 
 	sortedChangeSet := make(registry.ChangeSet, 0, len(changeSet))
+	if len(replacementDeleteOps) > 0 {
+		sortedReplacementDeletes := b.sortDeleteOperations(fromState, replacementDeleteOps)
+		sortedChangeSet = append(sortedChangeSet, sortedReplacementDeletes...)
+	}
 	if len(createUpdateOps) > 0 {
 		sortedCreateUpdates := b.sortCreateUpdateOperations(createUpdateOps)
 		sortedChangeSet = append(sortedChangeSet, sortedCreateUpdates...)

--- a/system/registry/topology/sort_changeset.go
+++ b/system/registry/topology/sort_changeset.go
@@ -81,6 +81,18 @@ func (b *StateBuilder) SortChangeSetWithIndex(fromState registry.State, changeSe
 			createUpdateEntries = append(createUpdateEntries, operation.Entry)
 		}
 	}
+	replacementIDs := make(map[registry.ID]struct{})
+	for id, deleteIndexes := range deleteIndexesByID {
+		if len(deleteIndexes) == 0 {
+			continue
+		}
+		for _, index := range createUpdateIndexesByID[id] {
+			if changeSet[index].Kind == registry.EntryCreate {
+				replacementIDs[id] = struct{}{}
+				break
+			}
+		}
+	}
 
 	// Same-ID replacement needs the old entry removed before the new entry can
 	// be created. If live dependents still point at the old ID, the dependent
@@ -112,6 +124,7 @@ func (b *StateBuilder) SortChangeSetWithIndex(fromState registry.State, changeSe
 	// Source-side dependencies: every live dependent must be updated or deleted
 	// before a dependency can be removed. Missing dependent operations are left
 	// unconstrained so the normal listener validation rejects invalid changesets.
+	blockedReplacementIDs := make(map[registry.ID]struct{})
 	if depIdx != nil && len(deleteIndexesByID) > 0 {
 		stateByID := stateIDIndex(fromState)
 		dependents := make(map[registry.ID]struct{})
@@ -136,21 +149,38 @@ func (b *StateBuilder) SortChangeSetWithIndex(fromState registry.State, changeSe
 					zap.Strings("dependents", depIDs))
 			}
 			for dependentID := range dependents {
+				hasDependentMutation := false
 				for _, dependentIndex := range opIndexesByID[dependentID] {
 					kind := changeSet[dependentIndex].Kind
 					if kind != registry.EntryUpdate && kind != registry.EntryDelete {
 						continue
 					}
+					hasDependentMutation = true
 					for _, deleteIndex := range deleteIndexes {
 						addConstraint(dependentIndex, deleteIndex)
+					}
+				}
+				if !hasDependentMutation {
+					if _, replacing := replacementIDs[id]; replacing {
+						blockedReplacementIDs[id] = struct{}{}
 					}
 				}
 			}
 		}
 	}
+	if len(blockedReplacementIDs) > 0 {
+		ids := make([]registry.ID, 0, len(blockedReplacementIDs))
+		for id := range blockedReplacementIDs {
+			ids = append(ids, id)
+		}
+		return nil, NewReplacementDependencyCycleError(ids)
+	}
 
 	order, ok := stableTopologicalOrder(len(changeSet), constraints)
 	if !ok {
+		if ids := unsatisfiableReplacementCycleIDs(changeSet, deleteIndexesByID, createUpdateIndexesByID, constraints); len(ids) > 0 {
+			return nil, NewReplacementDependencyCycleError(ids)
+		}
 		b.log.Warn("operation dependency cycle detected while sorting changeset; using deterministic fallback")
 		return b.fallbackSortChangeSet(fromState, changeSet), nil
 	}
@@ -161,6 +191,58 @@ func (b *StateBuilder) SortChangeSetWithIndex(fromState registry.State, changeSe
 	}
 
 	return sortedChangeSet, nil
+}
+
+// unsatisfiableReplacementCycleIDs returns same-ID delete/create replacements
+// whose required delete -> create edge is part of a cycle. Those cycles cannot
+// be repaired by choosing a different sequential order: some live dependent
+// must remain attached to the old ID until after the replacement is created,
+// while the replacement cannot be created until the old ID is deleted.
+func unsatisfiableReplacementCycleIDs(
+	changeSet registry.ChangeSet,
+	deleteIndexesByID map[registry.ID][]int,
+	createUpdateIndexesByID map[registry.ID][]int,
+	constraints map[int]map[int]struct{},
+) []registry.ID {
+	ids := make([]registry.ID, 0)
+	for id, deleteIndexes := range deleteIndexesByID {
+		cyclic := false
+		for _, createIndex := range createUpdateIndexesByID[id] {
+			if changeSet[createIndex].Kind != registry.EntryCreate {
+				continue
+			}
+			for _, deleteIndex := range deleteIndexes {
+				if hasConstraintPath(constraints, createIndex, deleteIndex, make(map[int]struct{})) {
+					cyclic = true
+					break
+				}
+			}
+			if cyclic {
+				break
+			}
+		}
+		if cyclic {
+			ids = append(ids, id)
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+	return ids
+}
+
+func hasConstraintPath(constraints map[int]map[int]struct{}, from, target int, seen map[int]struct{}) bool {
+	if from == target {
+		return true
+	}
+	if _, visited := seen[from]; visited {
+		return false
+	}
+	seen[from] = struct{}{}
+	for next := range constraints[from] {
+		if hasConstraintPath(constraints, next, target, seen) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasDeleteOp(changeSet registry.ChangeSet) bool {
@@ -319,22 +401,10 @@ func sortChangeSetInputForStableOrder(changeSet registry.ChangeSet) registry.Cha
 // cyclic dependency graphs. It prefers install/update before cleanup, but the
 // result may still be invalid and must be rejected by normal apply validation.
 func (b *StateBuilder) fallbackSortChangeSet(fromState registry.State, changeSet registry.ChangeSet) registry.ChangeSet {
-	replacementIDs := make(map[registry.ID]struct{})
-	for _, operation := range changeSet {
-		if operation.Kind == registry.EntryCreate {
-			replacementIDs[operation.Entry.ID] = struct{}{}
-		}
-	}
-
-	replacementDeleteOps := make([]registry.Operation, 0)
 	deleteOps := make([]registry.Operation, 0, len(changeSet))
 	createUpdateOps := make([]registry.Operation, 0, len(changeSet))
 	for _, operation := range changeSet {
 		if operation.Kind == registry.EntryDelete {
-			if _, replacing := replacementIDs[operation.Entry.ID]; replacing {
-				replacementDeleteOps = append(replacementDeleteOps, operation)
-				continue
-			}
 			deleteOps = append(deleteOps, operation)
 		} else {
 			createUpdateOps = append(createUpdateOps, operation)
@@ -342,10 +412,6 @@ func (b *StateBuilder) fallbackSortChangeSet(fromState registry.State, changeSet
 	}
 
 	sortedChangeSet := make(registry.ChangeSet, 0, len(changeSet))
-	if len(replacementDeleteOps) > 0 {
-		sortedReplacementDeletes := b.sortDeleteOperations(fromState, replacementDeleteOps)
-		sortedChangeSet = append(sortedChangeSet, sortedReplacementDeletes...)
-	}
 	if len(createUpdateOps) > 0 {
 		sortedCreateUpdates := b.sortCreateUpdateOperations(createUpdateOps)
 		sortedChangeSet = append(sortedChangeSet, sortedCreateUpdates...)

--- a/system/registry/topology/sort_changeset_test.go
+++ b/system/registry/topology/sort_changeset_test.go
@@ -1236,6 +1236,7 @@ func TestSortChangeSet_RewireMetaDependencies(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		assertOperationBefore(t, sorted, registry.EntryDelete, oldHandler.ID, registry.EntryCreate, newHandler.ID)
 		assertCannotApplyWithoutIncomingDependencyDelete(t, builder, registry.State{oldHandler, endpoint}, sorted)
 	})
 

--- a/system/registry/topology/sort_changeset_test.go
+++ b/system/registry/topology/sort_changeset_test.go
@@ -1211,12 +1211,15 @@ func TestSortChangeSet_RewireMetaDependencies(t *testing.T) {
 		}
 
 		sorted, err := builder.SortChangeSet(registry.State{oldHandler, endpoint}, changeSet)
-		if err != nil {
+		if err == nil {
+			t.Fatalf("expected unsatisfiable replacement cycle error, got sorted changeset:\n%s", formatDelta(sorted))
+		}
+		if !strings.Contains(err.Error(), "same-ID replacement has an unsatisfiable dependency cycle") {
 			t.Fatalf("unexpected error: %v", err)
 		}
-
-		assertOperationBefore(t, sorted, registry.EntryDelete, oldHandler.ID, registry.EntryCreate, newHandler.ID)
-		assertCannotApplyWithoutIncomingDependencyDelete(t, builder, registry.State{oldHandler, endpoint}, sorted)
+		if sorted != nil {
+			t.Fatalf("unsatisfiable replacement must not return a fallback changeset:\n%s", formatDelta(sorted))
+		}
 	})
 
 	t.Run("same id replacement cannot be repaired by dependent update to same id", func(t *testing.T) {
@@ -1232,12 +1235,15 @@ func TestSortChangeSet_RewireMetaDependencies(t *testing.T) {
 		}
 
 		sorted, err := builder.SortChangeSet(registry.State{oldHandler, endpoint}, changeSet)
-		if err != nil {
+		if err == nil {
+			t.Fatalf("expected unsatisfiable replacement cycle error, got sorted changeset:\n%s", formatDelta(sorted))
+		}
+		if !strings.Contains(err.Error(), "same-ID replacement has an unsatisfiable dependency cycle") {
 			t.Fatalf("unexpected error: %v", err)
 		}
-
-		assertOperationBefore(t, sorted, registry.EntryDelete, oldHandler.ID, registry.EntryCreate, newHandler.ID)
-		assertCannotApplyWithoutIncomingDependencyDelete(t, builder, registry.State{oldHandler, endpoint}, sorted)
+		if sorted != nil {
+			t.Fatalf("unsatisfiable replacement must not return a fallback changeset:\n%s", formatDelta(sorted))
+		}
 	})
 
 	t.Run("missing dependent operation remains visibly invalid", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve normal topological ordering for solvable same-ID delete/create replacements
- detect a live dependent with no mutation before dispatch
- detect replacement delete/create edges that participate in an operation cycle
- return a deterministic non-retryable conflict instead of an unapplyable fallback changeset

## Why
The previous patch only moved the delete before the create in the cyclic fallback. Its regression test still proved that the returned changeset could not apply. No sequential ordering can repair that graph, so dispatching a fallback is compensating behavior and risks partial listener work before rollback.

## Verification
- go test ./system/registry/topology ./system/registry/runner ./system/registry