### PR TITLE
fix(run): track deployment roots independently of ownership

### DIFF
--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -98,6 +98,10 @@ type (
 		Meta attrs.Bag       `json:"meta"`
 		ID   ID              `json:"id"`
 		Kind Kind            `json:"kind"`
+		// DependencyRoot identifies an ns.dependency selected as a deployment
+		// root. It is independent of package ownership, so a published app entry
+		// can retain meta.module while remaining a root.
+		DependencyRoot bool `json:"dependency_root,omitempty"`
 	}
 
 	// ChangeSet represents a set of operations to transition the registry from one state to another
@@ -105,9 +109,9 @@ type (
 
 	// Operation represents a single operation within a ChangeSet
 	Operation struct {
-		Entry         Entry      `json:"entry"`
 		OriginalEntry *Entry     `json:"original_entry,omitempty"`
 		Kind          event.Kind `json:"kind"`
+		Entry         Entry      `json:"entry"`
 	}
 
 	// DependencyPattern defines a pattern for extracting dependencies from entries

--- a/boot/build/stages/linking.go
+++ b/boot/build/stages/linking.go
@@ -219,7 +219,7 @@ func (s *linkStage) collectDependencies(ctx context.Context, transcoder payload.
 			definition:      def,
 			moduleNamespace: moduleNamespace,
 			component:       def.Component,
-			transitive:      requirementModuleFromEntry(e) != "",
+			transitive:      requirementModuleFromEntry(e) != "" && !e.DependencyRoot,
 		}
 	}
 
@@ -235,8 +235,9 @@ type decodedDependency struct {
 	definition      *DependencyDefinition
 	moduleNamespace string
 	component       string
-	// transitive marks a dependency injected by a package (its ns.dependency
-	// entry carries meta.module) as opposed to an explicit root dependency.
+	// transitive marks a dependency injected by a package, as opposed to an
+	// explicitly selected deployment root. Ownership and root provenance are
+	// independent for published application modules.
 	transitive bool
 }
 

--- a/boot/build/stages/linking_test.go
+++ b/boot/build/stages/linking_test.go
@@ -2474,8 +2474,10 @@ func TestLink_RootParameterBeatsTransitiveBareAliasSpelling(t *testing.T) {
 
 	entries := []registry.Entry{
 		{
-			ID:   registry.NewID("app.deps", "telegram_root"),
-			Kind: registry.NamespaceDependency,
+			ID:             registry.NewID("app.deps", "telegram_root"),
+			Kind:           registry.NamespaceDependency,
+			Meta:           map[string]any{"module": "acme/app"},
+			DependencyRoot: true,
 			Data: payload.New(map[string]any{
 				"component": "butschster/telegram",
 				"parameters": []any{

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -2588,7 +2588,7 @@ func snapshotModuleDigests(snapshot regapi.State) map[string]string {
 }
 
 func isRootDependency(entry regapi.Entry) bool {
-	return entry.Kind == regapi.NamespaceDependency && entryModule(entry) == ""
+	return entry.Kind == regapi.NamespaceDependency && (entry.DependencyRoot || entryModule(entry) == "")
 }
 
 func markModuleMeta(entry regapi.Entry, moduleName, moduleVersion string) regapi.Entry {

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -172,6 +172,21 @@ func TestEntryModule_ValidModule(t *testing.T) {
 	assert.Equal(t, "acme/http", entryModule(e))
 }
 
+func TestIsRootDependencyKeepsOwnershipSeparate(t *testing.T) {
+	root := regapi.Entry{
+		ID:             regapi.NewID("workspace.modules", "search"),
+		Kind:           regapi.NamespaceDependency,
+		Meta:           attrs.NewBagFrom(map[string]any{metaModuleKey: "acme/app"}),
+		DependencyRoot: true,
+	}
+	assert.True(t, isRootDependency(root))
+	assert.Equal(t, "acme/app", entryModule(root))
+
+	transitive := root
+	transitive.DependencyRoot = false
+	assert.False(t, isRootDependency(transitive))
+}
+
 // --- markModuleMeta ---
 
 func TestMarkModuleMeta_NilMeta(t *testing.T) {

--- a/boot/deps/lock/errors.go
+++ b/boot/deps/lock/errors.go
@@ -26,6 +26,10 @@ func NewModuleEmptyVersionError(moduleName string) apierror.Error {
 	return apierror.New(apierror.Invalid, fmt.Sprintf("module %q has empty version", moduleName))
 }
 
+func NewMultipleRootModulesError() apierror.Error {
+	return apierror.New(apierror.Invalid, "lock file selects more than one deployment root").WithRetryable(apierror.False)
+}
+
 func NewInvalidReplacementsError(cause error) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid replacements").WithCause(cause)
 }

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -177,6 +177,9 @@ func (l *Lock) GetModule(name string) (Module, bool) {
 func (l *Lock) SetModule(module Module) {
 	for i, mod := range l.data.Modules {
 		if mod.Name == module.Name {
+			if mod.Root {
+				module.Root = true
+			}
 			l.data.Modules[i] = module
 			return
 		}
@@ -187,7 +190,50 @@ func (l *Lock) SetModule(module Module) {
 // ReplaceModules replaces the complete resolved module snapshot while leaving
 // lock-level configuration such as directories, replacements, and options intact.
 func (l *Lock) ReplaceModules(modules []Module) {
+	roots := make(map[string]struct{})
+	for _, module := range l.data.Modules {
+		if module.Root {
+			roots[module.Name] = struct{}{}
+		}
+	}
+	for i := range modules {
+		if _, root := roots[modules[i].Name]; root {
+			modules[i].Root = true
+		}
+	}
 	l.data.Modules = append([]Module(nil), modules...)
+}
+
+// SetRootModule makes name the sole selected published deployment root.
+func (l *Lock) SetRootModule(name string) {
+	for i := range l.data.Modules {
+		l.data.Modules[i].Root = name != "" && l.data.Modules[i].Name == name
+	}
+}
+
+// IsRootModule reports whether name is the selected published deployment root.
+func (l *Lock) IsRootModule(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, module := range l.data.Modules {
+		if module.Name == name {
+			return module.Root
+		}
+	}
+	return false
+}
+
+// GetRootModules returns selected root identities in stable order.
+func (l *Lock) GetRootModules() []string {
+	roots := make([]string, 0, 1)
+	for _, module := range l.data.Modules {
+		if module.Root {
+			roots = append(roots, module.Name)
+		}
+	}
+	sort.Strings(roots)
+	return roots
 }
 
 // RemoveModule removes a module by name.
@@ -362,6 +408,7 @@ type ModuleLoadPath struct {
 	Module     string // module name in org/module format, empty for app source
 	Version    string // module version, empty for app source
 	SourceRoot string // module root for module-relative resources; defaults to Path
+	Root       bool   // selected deployment root from the lock graph
 }
 
 // GetModuleLoadPaths returns load paths annotated with module ownership.
@@ -388,6 +435,7 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 				Path:       path,
 				Module:     repl.From,
 				SourceRoot: root,
+				Root:       l.IsRootModule(repl.From),
 			})
 		}
 	}
@@ -411,6 +459,7 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 			Module:     mod.Name,
 			Version:    mod.Version,
 			SourceRoot: resolved.Path,
+			Root:       mod.Root,
 		})
 	}
 

--- a/boot/deps/lock/module_load_paths_test.go
+++ b/boot/deps/lock/module_load_paths_test.go
@@ -267,3 +267,39 @@ func TestLock_GetModuleLoadPaths(t *testing.T) {
 		}
 	})
 }
+
+func TestLock_GetModuleLoadPathsCarriesSelectedRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	l, err := New(filepath.Join(tmpDir, DefaultFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.SetDirectories(Directories{Modules: ".wippy", Src: "src"})
+	l.SetModule(Module{Name: "acme/lib", Version: "v1.0.0"})
+	l.SetModule(Module{Name: "acme/app", Version: "v2.0.0"})
+	l.SetRootModule("acme/app")
+
+	paths := l.GetModuleLoadPaths()
+	if len(paths) != 3 {
+		t.Fatalf("paths = %d, want source plus two modules", len(paths))
+	}
+	for _, modulePath := range paths {
+		if modulePath.Module == "acme/app" && !modulePath.Root {
+			t.Fatal("selected application module was not marked as root")
+		}
+		if modulePath.Module == "acme/lib" && modulePath.Root {
+			t.Fatal("transitive library was incorrectly marked as root")
+		}
+	}
+
+	if err := l.Write(); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := New(l.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reloaded.IsRootModule("acme/app") || reloaded.IsRootModule("acme/lib") {
+		t.Fatalf("root provenance did not survive lock round trip: %v", reloaded.GetRootModules())
+	}
+}

--- a/boot/deps/lock/types.go
+++ b/boot/deps/lock/types.go
@@ -27,6 +27,7 @@ type Module struct {
 	Version   string `yaml:"version"`              // Semantic version (e.g., v0.0.11)
 	Hash      string `yaml:"hash,omitempty"`       // Manifest digest (e.g. sha256:...), populated on install
 	LocalHash string `yaml:"local_hash,omitempty"` // Computed hash from loaded entries for verification
+	Root      bool   `yaml:"root,omitempty"`       // Selected deployment root, not a transitive module
 }
 
 // Replacement represents a local module override for development.

--- a/boot/deps/lock/validate.go
+++ b/boot/deps/lock/validate.go
@@ -11,6 +11,7 @@ import (
 // Validate validates the entire lock file structure.
 // Returns an error if any validation fails.
 func Validate(l *Lock) error {
+	rootCount := 0
 	for _, mod := range l.data.Modules {
 		if err := ValidateModuleName(mod.Name); err != nil {
 			return NewInvalidModuleError(mod.Name, err)
@@ -19,6 +20,12 @@ func Validate(l *Lock) error {
 		if mod.Version == "" {
 			return NewModuleEmptyVersionError(mod.Name)
 		}
+		if mod.Root {
+			rootCount++
+		}
+	}
+	if rootCount > 1 {
+		return NewMultipleRootModulesError()
 	}
 
 	if err := ValidateReplacements(l.path, l.GetReplacements()); err != nil {

--- a/boot/deps/lock/validate_test.go
+++ b/boot/deps/lock/validate_test.go
@@ -93,6 +93,15 @@ func TestValidate(t *testing.T) {
 			t.Error("expected error for nonexistent replacement path")
 		}
 	})
+
+	t.Run("multiple deployment roots fail", func(t *testing.T) {
+		lock, _ := New(filepath.Join(t.TempDir(), "test.lock"))
+		lock.SetModule(Module{Name: "acme/app-a", Version: "v1.0.0", Root: true})
+		lock.SetModule(Module{Name: "acme/app-b", Version: "v1.0.0", Root: true})
+		if err := Validate(lock); err == nil {
+			t.Fatal("expected multiple deployment roots to be rejected")
+		}
+	})
 }
 
 func TestValidateReplacements(t *testing.T) {

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -359,6 +359,9 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 		if mp.Module != "" {
 			for i := range loaded {
 				loaded[i] = markModuleMeta(loaded[i], mp.Module, mp.Version)
+				if mp.Root && loaded[i].Kind == regapi.NamespaceDependency {
+					loaded[i].DependencyRoot = true
+				}
 			}
 		}
 

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -211,6 +211,38 @@ func setupTestContext(t *testing.T) context.Context {
 	return ctx
 }
 
+func TestLoadEntriesFromModuleLoadPathsPreservesRootAndOwnership(t *testing.T) {
+	ctx := setupTestContext(t)
+	moduleDir := t.TempDir()
+	manifest := `version: "1.0"
+namespace: workspace.modules
+entries:
+  - name: search
+    kind: ns.dependency
+    component: acme/search
+    version: "*"
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{{
+		Path: moduleDir, Module: "acme/app", Version: "1.0.0", SourceRoot: moduleDir, Root: true,
+	}}, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("entries = %d, want 1", len(loaded))
+	}
+	if !loaded[0].DependencyRoot {
+		t.Fatal("selected lock root dependency lost root provenance")
+	}
+	if got := loaded[0].Meta.GetString("module", ""); got != "acme/app" {
+		t.Fatalf("package ownership = %q, want acme/app", got)
+	}
+}
+
 func TestLoadEntriesFromPathsSingleWapp(t *testing.T) {
 	ctx := setupTestContext(t)
 	logger := zap.NewNop()

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -323,7 +323,8 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 			return nil, err
 		}
 
-		if err := updateLockFile(moduleName, m.Version, m.Digest); err != nil {
+		isRoot := m.Org == org && m.Name == module
+		if err := updateLockFile(moduleName, m.Version, m.Digest, isRoot); err != nil {
 			fmt.Printf("%s Warning: could not update lock file for %s: %v\n", dimStyle.Render(""), moduleName, err)
 		}
 
@@ -374,7 +375,7 @@ func ensureHubPackCached(ctx context.Context, client hubPackDownloader, m hub.Re
 }
 
 // updateLockFile persists resolved module version/hash into wippy.lock.
-func updateLockFile(moduleName, version, digest string) error {
+func updateLockFile(moduleName, version, digest string, root bool) error {
 	lockObj, err := lock.New(defaultLockFile)
 	if err != nil {
 		return fmt.Errorf("lock file %s: %w", defaultLockFile, err)
@@ -387,6 +388,9 @@ func updateLockFile(moduleName, version, digest string) error {
 	}
 
 	lockObj.SetModule(mod)
+	if root {
+		lockObj.SetRootModule(moduleName)
+	}
 	if err := lockObj.Write(); err != nil {
 		return fmt.Errorf("lock file %s: %w", lockObj.Path(), err)
 	}
@@ -456,15 +460,15 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase
 	}
 	defer embedReg.Close()
 
-	packEntries, err := loadPackEntries([]string{packFile}, embedReg)
-	if err != nil {
-		runLogger.Error("failed to load entries from pack", zap.Error(err))
-		return NewLoadEntriesError(packFile, err)
-	}
-
 	mainModule, _, err := moduleIdentityFromPackFile(packFile)
 	if err != nil {
 		return fmt.Errorf("failed to load main module identity from pack metadata: %w", err)
+	}
+
+	packEntries, err := loadPackEntries([]string{packFile}, mainModule, embedReg)
+	if err != nil {
+		runLogger.Error("failed to load entries from pack", zap.Error(err))
+		return NewLoadEntriesError(packFile, err)
 	}
 
 	runLogger.Info("loaded entries from pack", zap.Int("count", len(packEntries)))
@@ -509,7 +513,7 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, use
 		}
 	}
 
-	packEntries, err := loadPackEntries(packFiles, embedReg)
+	packEntries, err := loadPackEntries(packFiles, mainModule, embedReg)
 	if err != nil {
 		runLogger.Error("failed to load entries from packs", zap.Error(err))
 		return NewLoadEntriesError("pack files", err)
@@ -614,7 +618,7 @@ type modulePackReaderRegistry interface {
 	RegisterPack(packPath, module, version string, reader *wapp.Reader, file *os.File) error
 }
 
-func loadPackEntries(packFiles []string, embedReg packReaderRegistry) ([]registry.Entry, error) {
+func loadPackEntries(packFiles []string, rootModule string, embedReg packReaderRegistry) ([]registry.Entry, error) {
 	packEntries := make([]registry.Entry, 0)
 
 	for _, packFile := range packFiles {
@@ -645,7 +649,7 @@ func loadPackEntries(packFiles []string, embedReg packReaderRegistry) ([]registr
 		}
 
 		if moduleName != "" {
-			annotateEntriesModuleMeta(loadedEntries, moduleName, moduleVersion)
+			annotateEntriesModuleMeta(loadedEntries, moduleName, moduleVersion, moduleName == rootModule)
 		} else {
 			if err := registerMonolithicPackResourceAliases(embedReg, packFile, packReader.Reader(), loadedEntries); err != nil {
 				return nil, fmt.Errorf("register embed resource aliases for %s: %w", packFile, err)
@@ -737,12 +741,15 @@ func moduleIdentityFromPackMetadata(reader *wapp.Reader) (moduleName string, mod
 	return org + "/" + name, version
 }
 
-func annotateEntriesModuleMeta(items []registry.Entry, moduleName string, moduleVersion string) {
+func annotateEntriesModuleMeta(items []registry.Entry, moduleName string, moduleVersion string, root bool) {
 	if moduleName == "" {
 		return
 	}
 
 	for i := range items {
+		if root && items[i].Kind == registry.NamespaceDependency {
+			items[i].DependencyRoot = true
+		}
 		meta := items[i].Meta
 		if meta == nil {
 			meta = attrs.NewBag()

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -615,7 +615,7 @@ func TestLoadPackEntries_RawLoadSkipsLinkPipeline(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	packEntries, err := loadPackEntries([]string{packPath}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestLoadPackEntries_RejectsUnsupportedExtension(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	_, err := loadPackEntries([]string{"./not-a-pack.yaml"}, embedReg)
+	_, err := loadPackEntries([]string{"./not-a-pack.yaml"}, "", embedReg)
 	if err == nil {
 		t.Fatal("expected error for unsupported pack extension")
 	}
@@ -657,7 +657,7 @@ func TestLoadPackEntries_AcceptsUppercaseExtension(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{upperPath}, embedReg)
+	packEntries, err := loadPackEntries([]string{upperPath}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}
@@ -676,7 +676,7 @@ func TestLoadPackEntries_RegisterErrorIncludesPath(t *testing.T) {
 		},
 	})
 
-	_, err := loadPackEntries([]string{packPath}, failingPackRegistry{err: errors.New("boom")})
+	_, err := loadPackEntries([]string{packPath}, "", failingPackRegistry{err: errors.New("boom")})
 	if err == nil {
 		t.Fatal("expected register error")
 	}
@@ -708,7 +708,7 @@ func TestLoadPackEntries_MultiPackOrder(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{depPack, mainPack}, embedReg)
+	packEntries, err := loadPackEntries([]string{depPack, mainPack}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}
@@ -753,7 +753,7 @@ func TestLoadPackEntries_AnnotatesModuleMetadataFromPackMetadata(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	packEntries, err := loadPackEntries([]string{packPath}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}
@@ -770,6 +770,44 @@ func TestLoadPackEntries_AnnotatesModuleMetadataFromPackMetadata(t *testing.T) {
 	}
 }
 
+func TestLoadPackEntries_UsesExplicitRootIdentityNotPackOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	rootPack := createTestPackFileWithMetadata(t, tmpDir, "root-pack", wapp.Metadata{
+		"name": "app", "namespace": "acme.app", "version": "1.0.0",
+	}, []wapp.Entry{{
+		ID: wapp.NewID("workspace.modules", "search"), Kind: regapi.NamespaceDependency,
+		Data: map[string]any{"component": "acme/search", "version": "*"},
+	}})
+	transitivePack := createTestPackFileWithMetadata(t, tmpDir, "transitive-pack", wapp.Metadata{
+		"name": "lib", "namespace": "acme.lib", "version": "2.0.0",
+	}, []wapp.Entry{{
+		ID: wapp.NewID("acme.lib", "dep.child"), Kind: regapi.NamespaceDependency,
+		Data: map[string]any{"component": "acme/child", "version": "*"},
+	}})
+
+	embedReg := embedpkg.NewRegistry()
+	defer func() { _ = embedReg.Close() }()
+	packEntries, err := loadPackEntries([]string{rootPack, transitivePack}, "acme/app", embedReg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packEntries) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(packEntries))
+	}
+	if !packEntries[0].DependencyRoot {
+		t.Fatal("explicit root module dependency was not marked as a deployment root")
+	}
+	if packEntries[1].DependencyRoot {
+		t.Fatal("last pack was incorrectly promoted to a deployment root")
+	}
+	if got := packEntries[0].Meta.GetString("module", ""); got != "acme/app" {
+		t.Fatalf("root ownership was discarded: %q", got)
+	}
+	if got := packEntries[1].Meta.GetString("module", ""); got != "acme/lib" {
+		t.Fatalf("transitive ownership = %q, want acme/lib", got)
+	}
+}
+
 func TestLoadPackEntries_RegistersModuleOwnedEmbeddedResources(t *testing.T) {
 	tmpDir := t.TempDir()
 	packPath := createModulePackWithEmbeddedResource(t, tmpDir, "ui-pack", wapp.Metadata{
@@ -781,7 +819,7 @@ func TestLoadPackEntries_RegistersModuleOwnedEmbeddedResources(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	packEntries, err := loadPackEntries([]string{packPath}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}
@@ -823,7 +861,7 @@ func TestLoadPackEntries_DoesNotOverrideExistingModuleMetadata(t *testing.T) {
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	packEntries, err := loadPackEntries([]string{packPath}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}
@@ -862,7 +900,7 @@ func TestLoadPackEntries_MonolithicPackRegistersModuleResourceAliases(t *testing
 	embedReg := embedpkg.NewRegistry()
 	defer func() { _ = embedReg.Close() }()
 
-	packEntries, err := loadPackEntries([]string{packPath}, embedReg)
+	packEntries, err := loadPackEntries([]string{packPath}, "", embedReg)
 	if err != nil {
 		t.Fatalf("loadPackEntries failed: %v", err)
 	}

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -56,7 +56,7 @@ func TestConvertResolvedToLock_ReplacesResolvedGraphAndPreservesLockConfig(t *te
 		t.Fatalf("create existing lock: %v", err)
 	}
 	existing.SetDirectories(lock.Directories{Modules: "old-modules", Src: "old-src"})
-	existing.SetModule(lock.Module{Name: "acme/keep", Version: "1.0.0", Hash: "old"})
+	existing.SetModule(lock.Module{Name: "acme/keep", Version: "1.0.0", Hash: "old", Root: true})
 	existing.SetModule(lock.Module{Name: "acme/stale", Version: "1.0.0", Hash: "stale"})
 	existing.SetModule(lock.Module{Name: "acme/local", Version: "1.0.0", LocalHash: "local"})
 	existing.SetReplacement(lock.Replacement{From: "acme/local", To: "../local"})
@@ -78,6 +78,9 @@ func TestConvertResolvedToLock_ReplacesResolvedGraphAndPreservesLockConfig(t *te
 	}
 	if modules[0].Name != "acme/keep" || modules[0].Version != "2.0.0" || modules[0].Hash != "new" {
 		t.Fatalf("resolved module = %+v, want regenerated acme/keep", modules[0])
+	}
+	if !modules[0].Root {
+		t.Fatal("full graph regeneration demoted the selected deployment root")
 	}
 	if _, ok := regenerated.GetModule("acme/stale"); ok {
 		t.Fatal("stale module survived full graph regeneration")

--- a/service/di/manager_test.go
+++ b/service/di/manager_test.go
@@ -468,11 +468,11 @@ func TestManager_BindingOperations(t *testing.T) {
 
 	t.Run("binding validation errors", func(t *testing.T) {
 		tests := []struct {
-			entry         registry.Entry
 			assertDetails func(*testing.T, apierror.Error)
 			name          string
 			expectedKind  apierror.Kind
 			expectedMsg   string
+			entry         registry.Entry
 		}{
 			{
 				name: "wrong entry kind",

--- a/system/registry/history/memory/memory.go
+++ b/system/registry/history/memory/memory.go
@@ -163,10 +163,11 @@ func cloneEntry(e registry.Entry) registry.Entry {
 		data = payload.NewPayload(snapshotValue(e.Data.Data()), e.Data.Format())
 	}
 	return registry.Entry{
-		ID:   e.ID,
-		Kind: e.Kind,
-		Meta: meta,
-		Data: data,
+		ID:             e.ID,
+		Kind:           e.Kind,
+		Meta:           meta,
+		Data:           data,
+		DependencyRoot: e.DependencyRoot,
 	}
 }
 

--- a/system/registry/history/postgres/postgres.go
+++ b/system/registry/history/postgres/postgres.go
@@ -65,10 +65,11 @@ type encodedPayload struct {
 }
 
 type encodedEntry struct {
-	Meta attrs.Bag
-	Data *encodedPayload
-	ID   registry.ID
-	Kind string
+	Meta           attrs.Bag
+	Data           *encodedPayload
+	ID             registry.ID
+	Kind           string
+	DependencyRoot bool
 }
 
 func newMsgpackHandle() *codec.MsgpackHandle {
@@ -362,9 +363,9 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 
 func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	var encodedOps []struct {
-		Entry         encodedEntry
 		OriginalEntry *encodedEntry
 		Kind          string
+		Entry         encodedEntry
 	}
 
 	decoder := codec.NewDecoder(bytes.NewReader(data), h.handle)
@@ -375,9 +376,10 @@ func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	cs := make(registry.ChangeSet, len(encodedOps))
 	for i, encOp := range encodedOps {
 		entry := registry.Entry{
-			ID:   encOp.Entry.ID,
-			Kind: encOp.Entry.Kind,
-			Meta: encOp.Entry.Meta,
+			ID:             encOp.Entry.ID,
+			Kind:           encOp.Entry.Kind,
+			Meta:           encOp.Entry.Meta,
+			DependencyRoot: encOp.Entry.DependencyRoot,
 		}
 
 		if encOp.Entry.Data != nil {
@@ -391,9 +393,10 @@ func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 
 		if encOp.OriginalEntry != nil {
 			originalEntry := registry.Entry{
-				ID:   encOp.OriginalEntry.ID,
-				Kind: encOp.OriginalEntry.Kind,
-				Meta: encOp.OriginalEntry.Meta,
+				ID:             encOp.OriginalEntry.ID,
+				Kind:           encOp.OriginalEntry.Kind,
+				Meta:           encOp.OriginalEntry.Meta,
+				DependencyRoot: encOp.OriginalEntry.DependencyRoot,
 			}
 
 			if encOp.OriginalEntry.Data != nil {
@@ -536,9 +539,9 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	}
 
 	encodedOps := make([]struct {
-		Entry         encodedEntry
 		OriginalEntry *encodedEntry
 		Kind          string
+		Entry         encodedEntry
 	}, len(cs))
 
 	for i, op := range cs {
@@ -561,24 +564,26 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 			}
 
 			encOriginal = &encodedEntry{
-				ID:   op.OriginalEntry.ID,
-				Kind: op.OriginalEntry.Kind,
-				Meta: op.OriginalEntry.Meta,
-				Data: encOrigPayload,
+				ID:             op.OriginalEntry.ID,
+				Kind:           op.OriginalEntry.Kind,
+				Meta:           op.OriginalEntry.Meta,
+				Data:           encOrigPayload,
+				DependencyRoot: op.OriginalEntry.DependencyRoot,
 			}
 		}
 
 		encodedOps[i] = struct {
-			Entry         encodedEntry
 			OriginalEntry *encodedEntry
 			Kind          string
+			Entry         encodedEntry
 		}{
 			Kind: op.Kind,
 			Entry: encodedEntry{
-				ID:   op.Entry.ID,
-				Kind: op.Entry.Kind,
-				Meta: op.Entry.Meta,
-				Data: encPayload,
+				ID:             op.Entry.ID,
+				Kind:           op.Entry.Kind,
+				Meta:           op.Entry.Meta,
+				Data:           encPayload,
+				DependencyRoot: op.Entry.DependencyRoot,
 			},
 			OriginalEntry: encOriginal,
 		}

--- a/system/registry/history/sqlite/sqlite.go
+++ b/system/registry/history/sqlite/sqlite.go
@@ -48,10 +48,11 @@ type encodedPayload struct {
 }
 
 type encodedEntry struct {
-	Meta attrs.Bag
-	Data *encodedPayload
-	ID   registry.ID
-	Kind string
+	Meta           attrs.Bag
+	Data           *encodedPayload
+	ID             registry.ID
+	Kind           string
+	DependencyRoot bool
 }
 
 func newMsgpackHandle() *codec.MsgpackHandle {
@@ -293,9 +294,9 @@ func (h *History) Get(v registry.Version) (registry.ChangeSet, error) {
 
 func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	var encodedOps []struct {
-		Entry         encodedEntry
 		OriginalEntry *encodedEntry
 		Kind          string
+		Entry         encodedEntry
 	}
 
 	decoder := codec.NewDecoder(bytes.NewReader(data), h.handle)
@@ -306,9 +307,10 @@ func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 	cs := make(registry.ChangeSet, len(encodedOps))
 	for i, encOp := range encodedOps {
 		entry := registry.Entry{
-			ID:   encOp.Entry.ID,
-			Kind: encOp.Entry.Kind,
-			Meta: encOp.Entry.Meta,
+			ID:             encOp.Entry.ID,
+			Kind:           encOp.Entry.Kind,
+			Meta:           encOp.Entry.Meta,
+			DependencyRoot: encOp.Entry.DependencyRoot,
 		}
 
 		if encOp.Entry.Data != nil {
@@ -322,9 +324,10 @@ func (h *History) decodeChangeSet(data []byte) (registry.ChangeSet, error) {
 
 		if encOp.OriginalEntry != nil {
 			originalEntry := registry.Entry{
-				ID:   encOp.OriginalEntry.ID,
-				Kind: encOp.OriginalEntry.Kind,
-				Meta: encOp.OriginalEntry.Meta,
+				ID:             encOp.OriginalEntry.ID,
+				Kind:           encOp.OriginalEntry.Kind,
+				Meta:           encOp.OriginalEntry.Meta,
+				DependencyRoot: encOp.OriginalEntry.DependencyRoot,
 			}
 
 			if encOp.OriginalEntry.Data != nil {
@@ -476,9 +479,9 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 	}
 
 	encodedOps := make([]struct {
-		Entry         encodedEntry
 		OriginalEntry *encodedEntry
 		Kind          string
+		Entry         encodedEntry
 	}, len(cs))
 
 	for i, op := range cs {
@@ -501,24 +504,26 @@ func (h *History) SaveWithDependencyResolution(v registry.Version, cs registry.C
 			}
 
 			encOriginal = &encodedEntry{
-				ID:   op.OriginalEntry.ID,
-				Kind: op.OriginalEntry.Kind,
-				Meta: op.OriginalEntry.Meta,
-				Data: encOrigPayload,
+				ID:             op.OriginalEntry.ID,
+				Kind:           op.OriginalEntry.Kind,
+				Meta:           op.OriginalEntry.Meta,
+				Data:           encOrigPayload,
+				DependencyRoot: op.OriginalEntry.DependencyRoot,
 			}
 		}
 
 		encodedOps[i] = struct {
-			Entry         encodedEntry
 			OriginalEntry *encodedEntry
 			Kind          string
+			Entry         encodedEntry
 		}{
 			Kind: op.Kind,
 			Entry: encodedEntry{
-				ID:   op.Entry.ID,
-				Kind: op.Entry.Kind,
-				Meta: op.Entry.Meta,
-				Data: encPayload,
+				ID:             op.Entry.ID,
+				Kind:           op.Entry.Kind,
+				Meta:           op.Entry.Meta,
+				Data:           encPayload,
+				DependencyRoot: op.Entry.DependencyRoot,
 			},
 			OriginalEntry: encOriginal,
 		}

--- a/system/registry/history/sqlite/sqlite_test.go
+++ b/system/registry/history/sqlite/sqlite_test.go
@@ -712,27 +712,21 @@ func TestSQLitePersistence_OriginalEntry(t *testing.T) {
 
 	v1, err := reg.Apply(ctx, registry.ChangeSet{
 		{Kind: registry.EntryCreate, Entry: registry.Entry{
-			ID:   entryID,
-			Kind: "service",
-			Data: payload.NewString("v1"),
+			ID: entryID, Kind: "service", Data: payload.NewString("v1"), DependencyRoot: true,
 		}},
 	})
 	require.NoError(t, err)
 
 	v2, err := reg.Apply(ctx, registry.ChangeSet{
 		{Kind: registry.EntryUpdate, Entry: registry.Entry{
-			ID:   entryID,
-			Kind: "service",
-			Data: payload.NewString("v2"),
+			ID: entryID, Kind: "service", Data: payload.NewString("v2"), DependencyRoot: true,
 		}},
 	})
 	require.NoError(t, err)
 
 	_, err = reg.Apply(ctx, registry.ChangeSet{
 		{Kind: registry.EntryUpdate, Entry: registry.Entry{
-			ID:   entryID,
-			Kind: "service",
-			Data: payload.NewString("v3"),
+			ID: entryID, Kind: "service", Data: payload.NewString("v3"), DependencyRoot: true,
 		}},
 	})
 	require.NoError(t, err)
@@ -748,12 +742,14 @@ func TestSQLitePersistence_OriginalEntry(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cs1, 1)
 	assert.Nil(t, cs1[0].OriginalEntry, "Create operation should not have OriginalEntry")
+	assert.True(t, cs1[0].Entry.DependencyRoot, "root provenance must survive SQLite persistence")
 
 	cs2, err := hist2.Get(v2)
 	require.NoError(t, err)
 	require.Len(t, cs2, 1)
 	require.NotNil(t, cs2[0].OriginalEntry, "Update operation MUST have OriginalEntry after loading from SQLite")
 	assert.Equal(t, "v1", cs2[0].OriginalEntry.Data.Data().(string), "OriginalEntry should contain v1 data")
+	assert.True(t, cs2[0].OriginalEntry.DependencyRoot, "original root provenance must survive SQLite persistence")
 
 	runner2 := &testRunner{}
 	builder2 := topology.NewStateBuilder(logger, nil)


### PR DESCRIPTION
## Summary
- add explicit deployment-root provenance to lock modules and registry entries
- keep meta.module ownership on every published module entry, including root dependencies
- make link and dependency expansion use explicit root provenance
- select the root by resolved module identity, not pack order or namespace convention
- persist root provenance through memory, SQLite, and Postgres registry history

## Root cause
Package ownership and deployment-root role were both inferred from the presence of meta.module. A published application therefore became transitive when ownership was added. The prior patch compensated by deleting ownership for dependencies in namespaces inferred from registry config and GOV_MANAGED_NAMESPACES.

This version separates those concepts. The selected Hub module is recorded as root in wippy.lock; its ns.dependency entries carry DependencyRoot while retaining module ownership. Local source dependencies remain roots through the backward-compatible unowned path.

## Explicitly removed
- no app.deps hardcoding
- no managed-namespace inference
- no GOV_MANAGED_NAMESPACES parsing
- no last-pack-is-root assumption
- no deletion of module, module_version, or module_digest

## Verification
- go test ./boot/deps/lock ./boot/build/stages ./boot/deps/hub ./cmd/internal/entries ./cmd/wippy/cmd ./system/registry/...
- pack-order regression places the selected root first and proves the last pack stays transitive
- lock round-trip and full update tests preserve root provenance
- linking test proves an owned root parameter still overrides a transitive package parameter