### PR TITLE
fix(publish): synchronize declared module type safely

### DIFF
--- a/boot/deps/hub/register_module.go
+++ b/boot/deps/hub/register_module.go
@@ -31,6 +31,14 @@ type RegisterModuleParams struct {
 	Keywords      []string `json:"keywords"`
 }
 
+// UpdateModuleTypeParams covers the publisher-only classification endpoint.
+// It intentionally cannot replace owner-managed catalog metadata.
+type UpdateModuleTypeParams struct {
+	Org        string `json:"-"`
+	Name       string `json:"-"`
+	ModuleType string `json:"module_type"`
+}
+
 // RegisteredModule is the subset of the hub's REST response we surface to
 // the CLI; the full payload includes timestamps, owner ID, etc.
 type RegisteredModule struct {
@@ -92,4 +100,42 @@ func (c *Client) RegisterModule(ctx context.Context, p *RegisterModuleParams) (*
 	default:
 		return nil, fmt.Errorf("hub register-module %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
+}
+
+// UpdateModuleType synchronizes only the manifest-declared classification for
+// an existing module.
+func (c *Client) UpdateModuleType(ctx context.Context, p *UpdateModuleTypeParams) (*RegisteredModule, error) {
+	if c.baseURL == "" {
+		return nil, errors.New("hub client missing base URL")
+	}
+	body, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update-module-type request: %w", err)
+	}
+
+	path := c.baseURL + "/api/v1/account/modules/" + p.Org + "/" + p.Name + "/type"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build update-module-type request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("put update-module-type: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, &hubStatusError{statusCode: resp.StatusCode, body: strings.TrimSpace(string(respBody))}
+	}
+
+	var out RegisteredModule
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode update-module-type response: %w", err)
+	}
+	return &out, nil
 }

--- a/boot/deps/hub/register_module_test.go
+++ b/boot/deps/hub/register_module_test.go
@@ -98,3 +98,61 @@ func TestRegisterModule_BadStatus(t *testing.T) {
 		t.Fatalf("expected 403 error, got %v", err)
 	}
 }
+
+func TestUpdateModuleType_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/account/modules/tmp/hello-world/type" {
+			http.NotFound(w, r)
+			return
+		}
+		var got map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(got) != 1 || got["module_type"] != "plugin" {
+			http.Error(w, "unexpected fields", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc","org_name":"tmp","name":"hello-world","display_name":"Hello","module_type":"plugin","visibility":"private"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(Options{BaseURL: srv.URL, Token: "wpy_test"})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	c.httpClient = srv.Client()
+	got, err := c.UpdateModuleType(context.Background(), &UpdateModuleTypeParams{
+		Org: "tmp", Name: "hello-world", ModuleType: "plugin",
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.ModuleType != "plugin" {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+func TestUpdateModuleType_NotFoundIsClassified(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"module not found"}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(Options{BaseURL: srv.URL, Token: "wpy_test"})
+	c.httpClient = srv.Client()
+	_, err := c.UpdateModuleType(context.Background(), &UpdateModuleTypeParams{
+		Org: "tmp", Name: "missing", ModuleType: "plugin",
+	})
+	if !IsModuleNotFound(err) {
+		t.Fatalf("expected module-not-found classification, got %v", err)
+	}
+}

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -199,6 +199,16 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Minute)
 	defer cancel()
+	if cfg.Type != "" {
+		if syncErr := synchronizeDeclaredModuleType(ctx, client, registryURL, cfg); syncErr != nil {
+			// A normal first publish discovers absence here before the existing
+			// auto-registration path below. Let that path create the module with
+			// the requested type; every other sync failure is actionable.
+			if registeredThisRun || !hub.IsModuleNotFound(syncErr) {
+				return syncErr
+			}
+		}
+	}
 
 	// Prefer the hub-mediated upload path (one robust HTTP hop, hub-side
 	// retry into S3, never the brittle client→S3 path that's bitten
@@ -729,6 +739,9 @@ func ensureModuleRegistered(ctx context.Context, client *hub.Client, registryURL
 	})
 	switch {
 	case regErr == nil:
+		if regResult.ModuleType != moduleType {
+			return fmt.Errorf("register module on %s: hub returned type %q, want %q", registryURL, regResult.ModuleType, moduleType)
+		}
 		printStatus(fmt.Sprintf("Registered module %s/%s (visibility=%s, type=%s)",
 			regResult.OrgName, regResult.Name, regResult.Visibility, regResult.ModuleType))
 		return nil
@@ -738,6 +751,24 @@ func ensureModuleRegistered(ctx context.Context, client *hub.Client, registryURL
 	default:
 		return fmt.Errorf("register module on %s: %w", registryURL, regErr)
 	}
+}
+
+func synchronizeDeclaredModuleType(ctx context.Context, client *hub.Client, registryURL string, cfg *config.ModuleConfig) error {
+	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	updated, err := client.UpdateModuleType(syncCtx, &hub.UpdateModuleTypeParams{
+		Org: cfg.Organization, Name: cfg.ModuleName, ModuleType: cfg.Type,
+	})
+	if err != nil {
+		return fmt.Errorf("synchronize module type on %s: %w", registryURL, err)
+	}
+	if updated.ModuleType != cfg.Type {
+		return fmt.Errorf("synchronize module type on %s: hub returned type %q, want %q", registryURL, updated.ModuleType, cfg.Type)
+	}
+
+	printStatus(fmt.Sprintf("Synchronized module %s/%s (type=%s)", updated.OrgName, updated.Name, updated.ModuleType))
+	return nil
 }
 
 func NewPublishUploadError(registryURL string, cause error) error {

--- a/cmd/wippy/cmd/publish_module_type_test.go
+++ b/cmd/wippy/cmd/publish_module_type_test.go
@@ -63,3 +63,56 @@ func TestEnsureModuleRegistered_DefaultsAndWarnsWhenTypeUndeclared(t *testing.T)
 		t.Errorf("module_type sent = %q, want %q (grace-period default)", gotType, "application")
 	}
 }
+
+func TestSynchronizeDeclaredModuleType_UsesNarrowEndpoint(t *testing.T) {
+	t.Parallel()
+	cfg := &config.ModuleConfig{
+		Organization: "acme", ModuleName: "widgets", Type: "plugin",
+	}
+	var updatedType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/api/v1/account/modules/acme/widgets/type" {
+			var body struct {
+				ModuleType string `json:"module_type"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			updatedType = body.ModuleType
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"org_name": "acme", "name": "widgets", "module_type": body.ModuleType,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client, err := hub.NewClient(hub.Options{BaseURL: srv.URL, Token: "tok"})
+	if err != nil {
+		t.Fatalf("NewClient(): %v", err)
+	}
+	if err := synchronizeDeclaredModuleType(t.Context(), client, srv.URL, cfg); err != nil {
+		t.Fatalf("synchronizeDeclaredModuleType(): %v", err)
+	}
+	if updatedType != "plugin" {
+		t.Fatalf("updated module_type = %q, want plugin", updatedType)
+	}
+}
+
+func TestSynchronizeDeclaredModuleType_RejectsUnconfirmedType(t *testing.T) {
+	t.Parallel()
+	cfg := &config.ModuleConfig{Organization: "acme", ModuleName: "widgets", Type: "plugin"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"org_name": "acme", "name": "widgets", "module_type": "application",
+		})
+	}))
+	defer srv.Close()
+
+	client, err := hub.NewClient(hub.Options{BaseURL: srv.URL, Token: "tok"})
+	if err != nil {
+		t.Fatalf("NewClient(): %v", err)
+	}
+	if err := synchronizeDeclaredModuleType(t.Context(), client, srv.URL, cfg); err == nil {
+		t.Fatal("expected a mismatched response type to fail publish preparation")
+	}
+}


### PR DESCRIPTION
## Root cause

Publishing carried the manifest type in the upload request, but an already-registered catalog row was never updated. The previous patch only synchronized under --create and reused the Hub full metadata PUT, which could replace owner-managed catalog fields.

## Fix

- synchronize every declared type before publishing an existing module
- use the dedicated Hub type-only endpoint (companion Hub MR !51)
- preserve the first-publish auto-registration flow
- require Hub to echo the requested type, including registration
- retain the grace-period application default only for undeclared new modules

## Tests

- narrow request contains only module_type
- structured 404 is classified for first-publish fallback
- mismatched Hub response blocks publication
- go test ./boot/deps/hub ./cmd/wippy/cmd