### PR TITLE
fix(registry): reconcile only changed modules during restore

### DIFF
--- a/api/registry/expansion.go
+++ b/api/registry/expansion.go
@@ -36,6 +36,15 @@ type ResolutionDirective interface {
 	ReconcileResolution(context.Context, State, *DependencyResolution) (DirectiveResult, error)
 }
 
+// ResolutionTransitionDirective is the transition-aware form of
+// ResolutionDirective. Current is the live state before the transition and
+// target is the declarative target reconstructed from history. The registry
+// prefers this interface when implemented and falls back to
+// ResolutionDirective for compatibility.
+type ResolutionTransitionDirective interface {
+	ReconcileResolutionTransition(context.Context, State, State, *DependencyResolution) (DirectiveResult, error)
+}
+
 // ChangesDirective expands all same-kind operations in one resolution pass.
 // It prevents a multi-root transaction from staging intermediate graphs.
 type ChangesDirective interface {

--- a/boot/components/core/registry.go
+++ b/boot/components/core/registry.go
@@ -124,7 +124,7 @@ func Registry() boot.Component {
 				logger.Warn("dependency handler disabled", zap.Error(err))
 			} else if depHandler != nil {
 				registryOpts = append(registryOpts,
-					registry.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(depHandler.Expand, depHandler.ReconcileResolution).WithChangesExpansion(depHandler.ExpandChanges)),
+					registry.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(depHandler.Expand).WithResolutionTransition(depHandler.ReconcileResolution).WithChangesExpansion(depHandler.ExpandChanges)),
 				)
 			}
 

--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -75,7 +75,7 @@ func TestDependencyHandler_PersistedResolutionBootRollbackRedoAndLongHistory(t *
 		handler.resolver = resolver
 		return registryimpl.NewRegistry(
 			hist, &bootRecordingRunner{}, topology.NewStateBuilder(zap.NewNop(), resolver), resolver, zap.NewNop(),
-			registryimpl.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(handler.Expand, handler.ReconcileResolution)),
+			registryimpl.WithKindDirective(regapi.NamespaceDependency, regexp.NewDependencyDirective(handler.Expand).WithResolutionTransition(handler.ReconcileResolution)),
 		)
 	}
 

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -451,7 +451,8 @@ func rootExpansionDriver(op regapi.Operation, snapshot regapi.State) (regapi.Ope
 // history is first reduced to its final declarative state, then reconciled once.
 func (h *DependencyHandler) ReconcileResolution(
 	ctx context.Context,
-	snapshot regapi.State,
+	current regapi.State,
+	target regapi.State,
 	resolution *regapi.DependencyResolution,
 ) (regapi.DirectiveResult, error) {
 	if h == nil || h.hub == nil {
@@ -465,7 +466,7 @@ func (h *DependencyHandler) ReconcileResolution(
 		return regapi.DirectiveResult{}, ErrDependencyTranscoderMissing
 	}
 
-	desiredDeps, err := h.collectResolutionDependencies(ctx, snapshot, transcoder, resolution.Roots)
+	desiredDeps, err := h.collectResolutionDependencies(ctx, target, transcoder, resolution.Roots)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -515,16 +516,41 @@ func (h *DependencyHandler) ReconcileResolution(
 	// A stored graph is authoritative by content identity, not merely version.
 	// Reload modules whose entries do not carry the exact stored digest. Entries
 	// written before module_digest existed are deliberately reloaded once.
-	installedDigests := snapshotModuleDigests(snapshot)
+	installedDigests := snapshotModuleDigests(target)
+	lockedDigests := h.lockedModuleDigests()
 	touched := make(map[string]struct{}, len(desiredModules))
+	mutable := make(map[string]struct{}, len(desiredModules))
+	parameterModules, err := changedDependencyParameterModules(ctx, current, target, transcoder)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
+	}
+	for module := range parameterModules {
+		if _, desired := desiredModules[module]; !desired {
+			continue
+		}
+		// Parameter changes must be linked from the raw artifact. Re-linking the
+		// resident entry would apply append targets ("+=") a second time.
+		mutable[module] = struct{}{}
+		touched[module] = struct{}{}
+	}
 	for _, mod := range resolved {
 		module := mod.Org + "/" + mod.Name
-		if installedDigests[module] != mod.Digest || !h.hasCurrentUnpackedModule(mod) {
+		installedDigest := installedDigests[module]
+		if installedDigest == "" {
+			// Legacy entries predate module_digest. The exact name@version lock
+			// hash is still authoritative and prevents a history restore from
+			// rewriting every resident module merely to backfill metadata.
+			installedDigest = lockedDigests[module+"@"+mod.Version]
+		}
+		if !artifactDigestsEqual(installedDigest, mod.Digest) {
+			mutable[module] = struct{}{}
+			touched[module] = struct{}{}
+		} else if !h.hasCurrentUnpackedModule(mod) {
 			touched[module] = struct{}{}
 		}
 	}
-	controlled := make(map[string]struct{}, len(snapshot)+len(desiredModules))
-	for _, entry := range snapshot {
+	controlled := make(map[string]struct{}, len(target)+len(desiredModules))
+	for _, entry := range target {
 		if module := entryModule(entry); module != "" {
 			controlled[module] = struct{}{}
 		}
@@ -533,7 +559,7 @@ func (h *DependencyHandler) ReconcileResolution(
 		controlled[module] = struct{}{}
 	}
 
-	moduleEntries, unpackPlan, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touched), resolved, snapshot, transcoder)
+	moduleEntries, unpackPlan, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touched), resolved, target, transcoder)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -542,8 +568,8 @@ func (h *DependencyHandler) ReconcileResolution(
 	for _, dep := range desiredDeps {
 		desiredDepEntries = append(desiredDepEntries, dep.entry)
 	}
-	combined := make([]regapi.Entry, 0, len(snapshot)+len(moduleEntries))
-	for _, entry := range snapshot {
+	combined := make([]regapi.Entry, 0, len(target)+len(moduleEntries))
+	for _, entry := range target {
 		if module := entryModule(entry); module != "" {
 			if _, desired := desiredModules[module]; !desired {
 				continue
@@ -566,7 +592,13 @@ func (h *DependencyHandler) ReconcileResolution(
 		return regapi.DirectiveResult{}, NewDependencyPipelineError(err)
 	}
 
-	additional, err := h.buildOperations(snapshot, combined, regapi.ID{}, controlled, controlled)
+	// Reconciliation owns the whole graph for deletes, but only artifacts whose
+	// content identity or authored root parameters changed are mutable. A module
+	// can be reloaded solely to repair its unpacked filesystem cache; relinking
+	// that artifact must not turn harmless normalization into registry updates
+	// and restart unrelated services during undo/redo (including the governance
+	// worker itself).
+	additional, err := h.buildOperations(target, combined, regapi.ID{}, controlled, mutable)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -574,7 +606,7 @@ func (h *DependencyHandler) ReconcileResolution(
 	for _, op := range additional {
 		scoped = append(scoped, regapi.ScopedOperation{Operation: op, Scope: regapi.ScopeBaseline})
 	}
-	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, snapshot, controlled)
+	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, target, controlled)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -595,6 +627,87 @@ func (h *DependencyHandler) ReconcileResolution(
 		Additional: scoped,
 		Effects:    effects,
 	}, nil
+}
+
+// changedDependencyParameterModules returns the modules whose authored root
+// parameters differ across a history transition. A root parameter normally
+// configures its own component. Fully-qualified requirement IDs may address a
+// requirement in another module, so those owners are included as well.
+func changedDependencyParameterModules(
+	ctx context.Context,
+	current regapi.State,
+	target regapi.State,
+	transcoder payload.Transcoder,
+) (map[string]struct{}, error) {
+	type declaration struct {
+		definition DependencyDefinition
+		present    bool
+	}
+
+	decodeRoots := func(state regapi.State) (map[string]declaration, error) {
+		roots := make(map[string]declaration)
+		for _, entry := range state {
+			if !isRootDependency(entry) {
+				continue
+			}
+			definition, err := decodeDependency(ctx, transcoder, entry)
+			if err != nil {
+				return nil, err
+			}
+			roots[idKey(entry.ID)] = declaration{definition: definition, present: true}
+		}
+		return roots, nil
+	}
+
+	currentRoots, err := decodeRoots(current)
+	if err != nil {
+		return nil, err
+	}
+	targetRoots, err := decodeRoots(target)
+	if err != nil {
+		return nil, err
+	}
+
+	changed := make(map[string]struct{})
+	rootIDs := make(map[string]struct{}, len(currentRoots)+len(targetRoots))
+	for id := range currentRoots {
+		rootIDs[id] = struct{}{}
+	}
+	for id := range targetRoots {
+		rootIDs[id] = struct{}{}
+	}
+	for id := range rootIDs {
+		before := currentRoots[id]
+		after := targetRoots[id]
+		if before.present == after.present && reflect.DeepEqual(before.definition.Parameters, after.definition.Parameters) {
+			continue
+		}
+		for _, item := range []declaration{before, after} {
+			if !item.present {
+				continue
+			}
+			if item.definition.Component != "" {
+				changed[item.definition.Component] = struct{}{}
+			}
+			for _, parameter := range item.definition.Parameters {
+				if !strings.Contains(parameter.Name, ":") {
+					continue
+				}
+				requirementID := regapi.ParseID(parameter.Name)
+				for _, state := range []regapi.State{current, target} {
+					for _, entry := range state {
+						if entry.ID != requirementID || entry.Kind != regapi.NamespaceRequirement {
+							continue
+						}
+						if module := entryModule(entry); module != "" {
+							changed[module] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+	return changed, nil
 }
 
 // storedVersionSatisfies validates selectors that can be checked without the
@@ -2165,6 +2278,13 @@ func parseExpectedDigest(raw string) (algorithm string, value string, err error)
 		return "", "", fmt.Errorf("invalid digest format %q", raw)
 	}
 	return algorithm, value, nil
+}
+
+func artifactDigestsEqual(left, right string) bool {
+	leftAlgorithm, leftValue, leftErr := parseExpectedDigest(left)
+	rightAlgorithm, rightValue, rightErr := parseExpectedDigest(right)
+	return leftErr == nil && rightErr == nil &&
+		leftAlgorithm == rightAlgorithm && strings.EqualFold(leftValue, rightValue)
 }
 
 func sha256FileHex(path string) (string, error) {

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -444,6 +444,34 @@ func TestBuildOperations_UpdatedEntries(t *testing.T) {
 	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
 }
 
+func TestBuildOperations_ReconcileSkipsUntouchedImmutableModuleUpdates(t *testing.T) {
+	moduleMeta := attrs.NewBagFrom(map[string]any{
+		metaModuleKey:        "acme/http",
+		metaModuleVersionKey: "v1.0.0",
+	})
+	current := regapi.State{{
+		ID:   regapi.NewID("app", "svc"),
+		Kind: "service",
+		Meta: moduleMeta,
+		Data: payload.New("resident"),
+	}}
+	desired := []regapi.Entry{{
+		ID:   regapi.NewID("app", "svc"),
+		Kind: "service",
+		Meta: moduleMeta,
+		Data: payload.New("normalized"),
+	}}
+
+	ops, err := buildOperations(current, desired, regapi.ID{}, map[string]struct{}{"acme/http": {}}, map[string]struct{}{})
+	require.NoError(t, err)
+	require.Empty(t, ops, "an unchanged immutable artifact must not be rewritten during history reconciliation")
+
+	ops, err = buildOperations(current, desired, regapi.ID{}, map[string]struct{}{"acme/http": {}}, map[string]struct{}{"acme/http": {}})
+	require.NoError(t, err)
+	require.Len(t, ops, 1, "an explicitly mutable artifact must still update")
+	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
+}
+
 func TestBuildOperations_KindChangeUsesDeleteCreate(t *testing.T) {
 	id := regapi.NewID("ui", "assets")
 	current := regapi.State{{

--- a/boot/deps/hub/resolution_hardening_test.go
+++ b/boot/deps/hub/resolution_hardening_test.go
@@ -4,8 +4,11 @@ package hub
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -95,6 +98,12 @@ func hardeningResolution(roots ...regapi.Entry) *regapi.DependencyResolution {
 }
 
 const hardeningDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestArtifactDigestsEqualNormalizesLegacyLockHashes(t *testing.T) {
+	require.True(t, artifactDigestsEqual(strings.TrimPrefix(hardeningDigest, "sha256:"), hardeningDigest))
+	require.False(t, artifactDigestsEqual("", hardeningDigest))
+	require.False(t, artifactDigestsEqual("sha256:deadbeef", hardeningDigest))
+}
 
 func TestDependencyHandler_ExpandChangesDeletesEarlierRootModulesAndReturnsResolution(t *testing.T) {
 	ctx := newTestContext()
@@ -224,17 +233,17 @@ func TestDependencyHandler_ReconcileRejectsRootSetDriftAndDuplicates(t *testing.
 	rootA := hardeningRoot("app.deps:a", "acme/a", "v1.0.0")
 	rootB := hardeningRoot("app.deps:b", "acme/b", "v1.0.0")
 
-	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, hardeningResolution(rootA))
+	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, regapi.State{rootA, rootB}, hardeningResolution(rootA))
 	require.ErrorContains(t, err, "root set")
 
 	duplicate := hardeningResolution(rootA, rootB)
 	duplicate.Roots[1] = duplicate.Roots[0]
 	duplicate = duplicate.Canonical()
-	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, duplicate)
+	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootB}, regapi.State{rootA, rootB}, duplicate)
 	require.ErrorContains(t, err, "stored dependency resolution is invalid")
 
 	rootBDuplicateComponent := hardeningRoot("app.deps:b", "acme/a", "v1.0.0")
-	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootBDuplicateComponent}, hardeningResolution(rootA, rootBDuplicateComponent))
+	_, err = handler.ReconcileResolution(ctx, regapi.State{rootA, rootBDuplicateComponent}, regapi.State{rootA, rootBDuplicateComponent}, hardeningResolution(rootA, rootBDuplicateComponent))
 	require.ErrorContains(t, err, "stored dependency resolution is invalid")
 }
 
@@ -245,9 +254,94 @@ func TestDependencyHandler_ReconcileAcceptsStoredLabelSelectionOffline(t *testin
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir()})
 	require.NoError(t, err)
 	resolution := hardeningResolution(root)
-	result, err := handler.ReconcileResolution(ctx, regapi.State{root, module}, resolution)
+	result, err := handler.ReconcileResolution(ctx, regapi.State{root, module}, regapi.State{root, module}, resolution)
 	require.NoError(t, err)
 	require.Equal(t, resolution.Digest, result.Resolution.Digest)
+}
+
+func TestDependencyHandler_ReconcileReloadsOnlyModuleWithChangedRootParameters(t *testing.T) {
+	ctx := newTestContext()
+	vendorDir := t.TempDir()
+	artifact := buildWappBytes(t, []wapp.Entry{
+		{
+			ID:   wapp.NewID("acme.feature", "scope"),
+			Kind: regapi.NamespaceRequirement,
+			Data: map[string]any{
+				"targets": []any{map[string]any{"entry": "policy", "path": ".groups +="}},
+			},
+		},
+		{
+			ID:   wapp.NewID("acme.feature", "policy"),
+			Kind: "security.policy",
+			Data: map[string]any{"groups": []any{}},
+		},
+	})
+	require.NoError(t, os.MkdirAll(filepath.Join(vendorDir, "acme"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(vendorDir, "acme", "feature-v1.0.0.wapp"), artifact, 0o600))
+	sum := sha256.Sum256(artifact)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	root := func(value string) regapi.Entry {
+		return regapi.Entry{
+			ID:             regapi.NewID("app.deps", "feature"),
+			Kind:           regapi.NamespaceDependency,
+			DependencyRoot: true,
+			Data: payload.New(map[string]any{
+				"component": "acme/feature",
+				"version":   "v1.0.0",
+				"parameters": []any{
+					map[string]any{"name": "scope", "value": value},
+				},
+			}),
+		}
+	}
+	moduleMeta := attrs.NewBagFrom(map[string]any{
+		metaModuleKey:        "acme/feature",
+		metaModuleVersionKey: "v1.0.0",
+		metaModuleDigestKey:  digest,
+	})
+	requirement := regapi.Entry{
+		ID:   regapi.NewID("acme.feature", "scope"),
+		Kind: regapi.NamespaceRequirement,
+		Meta: moduleMeta,
+		Data: payload.New(map[string]any{
+			"targets": []any{map[string]any{"entry": "policy", "path": ".groups +="}},
+		}),
+	}
+	policy := regapi.Entry{
+		ID:   regapi.NewID("acme.feature", "policy"),
+		Kind: "security.policy",
+		Meta: moduleMeta,
+		Data: payload.New(map[string]any{"groups": []any{"scope:old"}}),
+	}
+	beforeRoot, targetRoot := root("scope:old"), root("scope:new")
+	current := regapi.State{beforeRoot, requirement, policy}
+	target := regapi.State{targetRoot, requirement, policy}
+	resolution := hardeningResolution(targetRoot)
+	resolution.Modules[0].Digest = digest
+	resolution.Modules[0].SizeBytes = uint64(len(artifact))
+	resolution = resolution.Canonical()
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       &fakeHub{},
+		Logger:    zap.NewNop(),
+		VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+	result, err := handler.ReconcileResolution(ctx, current, target, resolution)
+	require.NoError(t, err)
+
+	var updated *regapi.Entry
+	for _, scoped := range result.Additional {
+		if scoped.Operation.Kind == regapi.EntryUpdate && scoped.Operation.Entry.ID == policy.ID {
+			entry := scoped.Operation.Entry
+			updated = &entry
+		}
+	}
+	require.NotNil(t, updated, "changed root parameter must update its linked target")
+	data, ok := updated.Data.Data().(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []any{"scope:new"}, data["groups"], "reconciliation must link from raw artifact without duplicating append values")
 }
 
 func TestDependencyHandler_ReconcileRejectsUnsafeStoredArtifactIdentity(t *testing.T) {
@@ -256,14 +350,14 @@ func TestDependencyHandler_ReconcileRejectsUnsafeStoredArtifactIdentity(t *testi
 	resolution := hardeningResolution(root)
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir()})
 	require.NoError(t, err)
-	_, err = handler.ReconcileResolution(ctx, regapi.State{root}, resolution)
+	_, err = handler.ReconcileResolution(ctx, regapi.State{root}, regapi.State{root}, resolution)
 	require.ErrorContains(t, err, "invalid module name")
 
 	safeRoot := hardeningRoot("app.deps:safe", "acme/safe", "v1.0.0")
 	badDigest := hardeningResolution(safeRoot)
 	badDigest.Modules[0].Digest = "sha256:deadbeef"
 	badDigest = badDigest.Canonical()
-	_, err = handler.ReconcileResolution(ctx, regapi.State{safeRoot}, badDigest)
+	_, err = handler.ReconcileResolution(ctx, regapi.State{safeRoot}, regapi.State{safeRoot}, badDigest)
 	require.ErrorContains(t, err, "invalid sha256 digest")
 
 	require.Error(t, validateModuleArtifactIdentity(graph.Name{Organization: "acme", Module: "safe"}, "1.0.0/../../escape", ""))

--- a/system/registry/expansion/dependency_directive.go
+++ b/system/registry/expansion/dependency_directive.go
@@ -13,12 +13,14 @@ import (
 type DependencyDirectiveFunc func(ctx context.Context, op registry.Operation, snapshot registry.State) (registry.DirectiveResult, error)
 type DependencyChangesDirectiveFunc func(ctx context.Context, changes registry.ChangeSet, snapshot registry.State) (registry.DirectiveResult, error)
 type ResolutionDirectiveFunc func(ctx context.Context, snapshot registry.State, resolution *registry.DependencyResolution) (registry.DirectiveResult, error)
+type ResolutionTransitionDirectiveFunc func(ctx context.Context, current registry.State, target registry.State, resolution *registry.DependencyResolution) (registry.DirectiveResult, error)
 
 // DependencyDirective expands dependency operations using a direct handler.
 type DependencyDirective struct {
-	ExpandFunc    DependencyDirectiveFunc
-	ChangesFunc   DependencyChangesDirectiveFunc
-	ReconcileFunc ResolutionDirectiveFunc
+	ExpandFunc              DependencyDirectiveFunc
+	ChangesFunc             DependencyChangesDirectiveFunc
+	ReconcileFunc           ResolutionDirectiveFunc
+	ReconcileTransitionFunc ResolutionTransitionDirectiveFunc
 }
 
 // NewDependencyDirective constructs a dependency directive backed by the given handler.
@@ -39,6 +41,15 @@ func (d *DependencyDirective) WithChangesExpansion(expand DependencyChangesDirec
 	return d
 }
 
+// WithResolutionTransition configures exact graph reconciliation with both the
+// live source and declarative target state.
+func (d *DependencyDirective) WithResolutionTransition(reconcile ResolutionTransitionDirectiveFunc) *DependencyDirective {
+	if d != nil {
+		d.ReconcileTransitionFunc = reconcile
+	}
+	return d
+}
+
 func (d *DependencyDirective) ExpandChanges(ctx context.Context, changes registry.ChangeSet, snapshot registry.State) (registry.DirectiveResult, error) {
 	if d == nil || d.ChangesFunc == nil {
 		return registry.DirectiveResult{}, nil
@@ -47,10 +58,23 @@ func (d *DependencyDirective) ExpandChanges(ctx context.Context, changes registr
 }
 
 func (d *DependencyDirective) ReconcileResolution(ctx context.Context, snapshot registry.State, resolution *registry.DependencyResolution) (registry.DirectiveResult, error) {
-	if d == nil || d.ReconcileFunc == nil {
+	if d == nil {
 		return registry.DirectiveResult{}, nil
 	}
-	return d.ReconcileFunc(ctx, snapshot, resolution)
+	if d.ReconcileFunc != nil {
+		return d.ReconcileFunc(ctx, snapshot, resolution)
+	}
+	if d.ReconcileTransitionFunc != nil {
+		return d.ReconcileTransitionFunc(ctx, snapshot, snapshot, resolution)
+	}
+	return registry.DirectiveResult{}, nil
+}
+
+func (d *DependencyDirective) ReconcileResolutionTransition(ctx context.Context, current registry.State, target registry.State, resolution *registry.DependencyResolution) (registry.DirectiveResult, error) {
+	if d == nil || d.ReconcileTransitionFunc == nil {
+		return registry.DirectiveResult{}, nil
+	}
+	return d.ReconcileTransitionFunc(ctx, current, target, resolution)
 }
 
 // Expand implements registry.Directive.

--- a/system/registry/expansion/directive_test.go
+++ b/system/registry/expansion/directive_test.go
@@ -53,6 +53,36 @@ func TestDependencyDirective_Expand_CancelledContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+func TestDependencyDirective_ReconcileResolutionCompatibility(t *testing.T) {
+	called := false
+	d := NewDependencyDirective(nil, func(_ context.Context, snapshot registry.State, _ *registry.DependencyResolution) (registry.DirectiveResult, error) {
+		called = true
+		require.Len(t, snapshot, 1)
+		return registry.DirectiveResult{Applied: true}, nil
+	})
+
+	result, err := d.ReconcileResolution(context.Background(), registry.State{{Kind: "service"}}, nil)
+	require.NoError(t, err)
+	require.True(t, called)
+	require.True(t, result.Applied)
+}
+
+func TestDependencyDirective_ReconcileResolutionTransitionKeepsSourceAndTarget(t *testing.T) {
+	current := registry.State{{ID: registry.NewID("app", "before"), Kind: "service"}}
+	target := registry.State{{ID: registry.NewID("app", "after"), Kind: "service"}}
+	d := NewDependencyDirective(nil).WithResolutionTransition(
+		func(_ context.Context, gotCurrent registry.State, gotTarget registry.State, _ *registry.DependencyResolution) (registry.DirectiveResult, error) {
+			require.Equal(t, current, gotCurrent)
+			require.Equal(t, target, gotTarget)
+			return registry.DirectiveResult{Applied: true}, nil
+		},
+	)
+
+	result, err := d.ReconcileResolutionTransition(context.Background(), current, target, nil)
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+}
+
 // --- Error constructors ---
 
 func TestNewDirectiveResultInvalidError(t *testing.T) {

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -389,12 +389,10 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		applyStateOperations(stateMap, changeset)
 		reconciled := false
 		for _, directive := range r.directivesByKind[registry.NamespaceDependency] {
-			reconciler, ok := directive.(registry.ResolutionDirective)
+			result, ok, reconcileErr := reconcileStoredResolution(ctx, directive, snapshot, topology.StateMapToSlice(stateMap), targetResolution)
 			if !ok {
 				continue
 			}
-			intermediate := topology.StateMapToSlice(stateMap)
-			result, reconcileErr := reconciler.ReconcileResolution(ctx, intermediate, targetResolution)
 			if reconcileErr != nil {
 				planner.RollbackEffects(ctx, preparedEff)
 				return NewExpandChangesError(reconcileErr)
@@ -815,12 +813,11 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		}
 		reconciled := false
 		for _, directive := range r.directivesByKind[registry.NamespaceDependency] {
-			reconciler, ok := directive.(registry.ResolutionDirective)
+			snapshot := topology.StateMapToSlice(stateMap)
+			result, ok, err := reconcileStoredResolution(ctx, directive, baseline, snapshot, resolution)
 			if !ok {
 				continue
 			}
-			snapshot := topology.StateMapToSlice(stateMap)
-			result, err := reconciler.ReconcileResolution(ctx, snapshot, resolution)
 			if err != nil {
 				planner.RollbackEffects(ctx, preparedEff)
 				return NewExpandChangesError(err)
@@ -959,6 +956,24 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	r.versionNum.Store(uint64(allocatorVersion))
 
 	return nil
+}
+
+func reconcileStoredResolution(
+	ctx context.Context,
+	directive registry.Directive,
+	current registry.State,
+	target registry.State,
+	resolution *registry.DependencyResolution,
+) (registry.DirectiveResult, bool, error) {
+	if reconciler, ok := directive.(registry.ResolutionTransitionDirective); ok {
+		result, err := reconciler.ReconcileResolutionTransition(ctx, current, target, resolution)
+		return result, true, err
+	}
+	if reconciler, ok := directive.(registry.ResolutionDirective); ok {
+		result, err := reconciler.ReconcileResolution(ctx, target, resolution)
+		return result, true, err
+	}
+	return registry.DirectiveResult{}, false, nil
 }
 
 func applyStateOperations(stateMap registry.StateMap, ops registry.ChangeSet) {

--- a/system/registry/registry_hardening_test.go
+++ b/system/registry/registry_hardening_test.go
@@ -117,7 +117,7 @@ func (e *hardeningEffect) Rollback(context.Context) error {
 
 type hardeningDirective struct {
 	expand    func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error)
-	reconcile func(context.Context, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error)
+	reconcile func(context.Context, regapi.State, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error)
 }
 
 func (d hardeningDirective) Expand(ctx context.Context, op regapi.Operation, state regapi.State) (regapi.DirectiveResult, error) {
@@ -131,7 +131,14 @@ func (d hardeningDirective) ReconcileResolution(ctx context.Context, state regap
 	if d.reconcile == nil {
 		return regapi.DirectiveResult{}, nil
 	}
-	return d.reconcile(ctx, state, resolution)
+	return d.reconcile(ctx, state, state, resolution)
+}
+
+func (d hardeningDirective) ReconcileResolutionTransition(ctx context.Context, current regapi.State, target regapi.State, resolution *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
+	if d.reconcile == nil {
+		return regapi.DirectiveResult{}, nil
+	}
+	return d.reconcile(ctx, current, target, resolution)
 }
 
 func hardeningResolution() *regapi.DependencyResolution {
@@ -371,10 +378,10 @@ func TestApplyVersion_ReconcilerErrorRollsBackPreviouslyPreparedEffects(t *testi
 	history := memory.New()
 	require.NoError(t, history.SaveWithDependencyResolution(v1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: dep}}, hardeningResolution(), false))
 	effect := &hardeningEffect{}
-	first := hardeningDirective{reconcile: func(context.Context, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
+	first := hardeningDirective{reconcile: func(context.Context, regapi.State, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
 		return regapi.DirectiveResult{Applied: true, Effects: []regapi.Effect{effect}}, nil
 	}}
-	second := hardeningDirective{reconcile: func(context.Context, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
+	second := hardeningDirective{reconcile: func(context.Context, regapi.State, regapi.State, *regapi.DependencyResolution) (regapi.DirectiveResult, error) {
 		return regapi.DirectiveResult{}, errors.New("injected reconcile failure")
 	}}
 	reg := NewRegistry(history, &hardeningRunner{}, topology.NewStateBuilder(zap.NewNop(), nil), nil, zap.NewNop(),


### PR DESCRIPTION
## Root cause

Exact history reconciliation treated every dependency-controlled module as mutable. Undo/redo therefore emitted normalization updates for unrelated resident modules and could restart the governance process that was applying the undo, cancelling its own operation.

Legacy installed entries may also lack module digests, even when the exact artifact hash is already pinned in the deployment lock.

## Fix

- compare stored artifact identity against resident `module_digest`, with an exact name@version lock-hash fallback for legacy entries;
- distinguish modules that need cache repair from modules whose registry content may change;
- pass current and target state through a backward-compatible transition-aware reconciliation interface;
- reload and relink only modules whose authored root parameters changed, so append targets are rebuilt from raw artifacts instead of duplicated;
- retain whole-graph ownership for correct deletes while suppressing unrelated updates.

The implementation is generic. It contains no Kickside package names, namespaces, fixtures, or policy.

## Verification

- `make test` (full race-enabled repository matrix)
- `make lint` (`0 issues`)
- `go test -race -short ./boot/... ./system/registry/...`
- separate Kickside black-box lifecycle harness against this exact binary: install old version, update, governance undo/redo, explicit rollback/redo, restart persistence, failed-update atomicity, uninstall preview, delete, final restart and exact baseline recovery (passed)
- parameter-only regression covers `+=` relinking without duplicate values
