### PR TITLE
feat(excel): streaming row cursor wb:rows()

### DIFF
--- a/runtime/lua/modules/excel/module.go
+++ b/runtime/lua/modules/excel/module.go
@@ -98,10 +98,8 @@ func (wb *Workbook) Close() {
 // closeCursors closes all row cursors still open on this workbook.
 func (wb *Workbook) closeCursors() {
 	for r := range wb.cursors {
-		if !r.closed {
-			r.closed = true
-			_ = r.rows.Close()
-		}
+		r.closed = true
+		_ = r.release()
 	}
 	wb.cursors = nil
 }

--- a/runtime/lua/modules/excel/module.go
+++ b/runtime/lua/modules/excel/module.go
@@ -27,6 +27,10 @@ func init() {
 		map[string]lua.LGoFunc{"__tostring": workbookToString},
 		workbookMethods)
 
+	rowsMetatable = value.RegisterTypeMethods(nil, rowsTypeName,
+		map[string]lua.LGoFunc{"__tostring": rowsToString},
+		rowsMethods)
+
 	moduleTable = lua.CreateTable(0, 2)
 	moduleTable.RawSetString("new", lua.LGoFunc(excelNew))
 	moduleTable.RawSetString("open", lua.LGoFunc(excelOpen))
@@ -48,6 +52,7 @@ var Module = &luaapi.ModuleDef{
 type Workbook struct {
 	file          *excelize.File
 	cancelCleanup func()
+	cursors       map[*Rows]struct{}
 	closed        bool
 }
 
@@ -61,6 +66,7 @@ func newWorkbook(ctx context.Context, file *excelize.File) *Workbook {
 	if store := resource.GetStore(ctx); store != nil {
 		wb.cancelCleanup = store.AddCleanup(func() error {
 			if !wb.closed && wb.file != nil {
+				wb.closeCursors()
 				_ = wb.file.Close()
 				wb.closed = true
 			}
@@ -71,12 +77,13 @@ func newWorkbook(ctx context.Context, file *excelize.File) *Workbook {
 	return wb
 }
 
-// Close closes the workbook and cancels cleanup registration.
+// Close closes the workbook, its open row cursors, and cancels cleanup registration.
 func (wb *Workbook) Close() {
 	if wb.closed {
 		return
 	}
 
+	wb.closeCursors()
 	if wb.file != nil {
 		_ = wb.file.Close()
 	}
@@ -88,10 +95,22 @@ func (wb *Workbook) Close() {
 	}
 }
 
+// closeCursors closes all row cursors still open on this workbook.
+func (wb *Workbook) closeCursors() {
+	for r := range wb.cursors {
+		if !r.closed {
+			r.closed = true
+			_ = r.rows.Close()
+		}
+	}
+	wb.cursors = nil
+}
+
 var workbookMethods = map[string]lua.LGoFunc{
 	"new_sheet":      workbookNewSheet,
 	"get_sheet_list": workbookGetSheetList,
 	"get_rows":       workbookGetRows,
+	"rows":           workbookRows,
 	"set_cell_value": workbookSetCellValue,
 	"write_to":       workbookWriteTo,
 	"close":          workbookClose,
@@ -107,6 +126,15 @@ func checkWorkbook(l *lua.LState, _ int) *Workbook {
 
 func invalidError(l *lua.LState, msg string) int {
 	err := lua.NewLuaError(l, msg).
+		WithKind(lua.Invalid).
+		WithRetryable(false)
+	l.Push(lua.LNil)
+	l.Push(err)
+	return 2
+}
+
+func invalidWrapError(l *lua.LState, goErr error, context string) int {
+	err := lua.WrapErrorWithLua(l, goErr, context).
 		WithKind(lua.Invalid).
 		WithRetryable(false)
 	l.Push(lua.LNil)

--- a/runtime/lua/modules/excel/module_test.go
+++ b/runtime/lua/modules/excel/module_test.go
@@ -5,11 +5,15 @@ package excel
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/runtime/resource"
 	"github.com/xuri/excelize/v2"
 )
 
@@ -335,6 +339,420 @@ func TestWorkbook_GetRows(t *testing.T) {
 		`)
 		assert.NoError(t, err)
 	})
+}
+
+// createStreamTestWorkbook builds a sheet with mixed value shapes: numbers,
+// floats, styled dates, booleans, empty cells mid-row, and a full empty-row
+// gap before the final row.
+func createStreamTestWorkbook(t *testing.T, rowCount int) *bytes.Buffer {
+	t.Helper()
+
+	f := excelize.NewFile()
+	_, err := f.NewSheet("Data")
+	require.NoError(t, err)
+
+	dateStyle, err := f.NewStyle(&excelize.Style{NumFmt: 14})
+	require.NoError(t, err)
+
+	require.NoError(t, f.SetCellValue("Data", "A1", "ID"))
+	require.NoError(t, f.SetCellValue("Data", "B1", "Amount"))
+	require.NoError(t, f.SetCellValue("Data", "C1", "Date"))
+	require.NoError(t, f.SetCellValue("Data", "D1", "Flag"))
+
+	for i := 0; i < rowCount; i++ {
+		rowNum := i + 2
+		require.NoError(t, f.SetCellValue("Data", fmt.Sprintf("A%d", rowNum), i+1))
+		if i%5 != 0 {
+			require.NoError(t, f.SetCellValue("Data", fmt.Sprintf("B%d", rowNum), float64(i)*1.5))
+		}
+		cell := fmt.Sprintf("C%d", rowNum)
+		require.NoError(t, f.SetCellValue("Data", cell, time.Date(2026, 1, 1+i%28, 0, 0, 0, 0, time.UTC)))
+		require.NoError(t, f.SetCellStyle("Data", cell, cell, dateStyle))
+		require.NoError(t, f.SetCellValue("Data", fmt.Sprintf("D%d", rowNum), i%2 == 0))
+	}
+
+	// Leave one fully empty row, then a final row after the gap.
+	require.NoError(t, f.SetCellValue("Data", fmt.Sprintf("A%d", rowCount+3), "after-gap"))
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, f.Write(buf))
+	require.NoError(t, f.Close())
+	return buf
+}
+
+func setReaderGlobal(t *testing.T, l *lua.LState, name string, buf *bytes.Buffer) {
+	t.Helper()
+	ud := l.NewUserData()
+	ud.Value = bytes.NewReader(buf.Bytes())
+	l.SetGlobal(name, ud)
+}
+
+func TestWorkbook_Rows(t *testing.T) {
+	t.Run("values match get_rows", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		setReaderGlobal(t, l, "test_reader", createStreamTestWorkbook(t, 23))
+
+		err := l.DoString(`
+			local wb, err = excel.open(test_reader)
+			assert(err == nil, "open should succeed")
+
+			local expected, gerr = wb:get_rows("Data")
+			assert(gerr == nil, "get_rows should succeed")
+			assert(#expected > 20, "sheet should have data rows")
+
+			local cur, rerr = wb:rows("Data")
+			assert(cur ~= nil, "cursor should not be nil")
+			assert(rerr == nil, "rows should not error")
+
+			local i = 0
+			while true do
+				local batch, berr = cur:read(7)
+				assert(berr == nil, "read should not error")
+				if batch == nil then break end
+				assert(#batch >= 1, "batch should not be empty")
+				for _, row in ipairs(batch) do
+					i = i + 1
+					local exp = expected[i]
+					assert(exp ~= nil, "unexpected extra row " .. i)
+					assert(#row == #exp, "row " .. i .. " width mismatch: " .. #row .. " vs " .. #exp)
+					for c = 1, #exp do
+						assert(row[c] == exp[c],
+							"cell " .. i .. "," .. c .. " mismatch: " .. tostring(row[c]) .. " vs " .. tostring(exp[c]))
+					end
+				end
+			end
+			assert(i == #expected, "row count mismatch: " .. i .. " vs " .. #expected)
+
+			local cerr = cur:close()
+			assert(cerr == nil, "close should succeed")
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("batch boundaries", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			for i = 1, 10 do
+				wb:set_cell_value("Data", "A" .. i, "row" .. i)
+			end
+
+			-- default n = 1
+			local cur = wb:rows("Data")
+			for i = 1, 10 do
+				local batch, err = cur:read()
+				assert(err == nil, "read should not error")
+				assert(#batch == 1, "default batch should hold one row")
+				assert(batch[1][1] == "row" .. i, "row " .. i .. " value mismatch")
+			end
+			local tail, err = cur:read()
+			assert(tail == nil and err == nil, "should reach EOF")
+			cur:close()
+
+			-- n larger than row count
+			local cur2 = wb:rows("Data")
+			local batch2, err2 = cur2:read(25)
+			assert(err2 == nil, "read should not error")
+			assert(#batch2 == 10, "oversized batch should hold all rows")
+			local tail2, terr2 = cur2:read(25)
+			assert(tail2 == nil and terr2 == nil, "should reach EOF")
+			cur2:close()
+
+			-- n exact multiple of row count
+			local cur3 = wb:rows("Data")
+			local a = cur3:read(5)
+			local b = cur3:read(5)
+			assert(#a == 5 and #b == 5, "exact batches should hold five rows each")
+			assert(b[5][1] == "row10", "last row value mismatch")
+			local tail3, terr3 = cur3:read(5)
+			assert(tail3 == nil and terr3 == nil, "should reach EOF")
+			cur3:close()
+
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("eof is idempotent", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			wb:set_cell_value("Data", "A1", "only")
+
+			local cur = wb:rows("Data")
+			cur:read(10)
+			for i = 1, 3 do
+				local batch, err = cur:read(10)
+				assert(batch == nil, "EOF batch should stay nil")
+				assert(err == nil, "EOF should stay error-free")
+			end
+			cur:close()
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("early close", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			for i = 1, 10 do
+				wb:set_cell_value("Data", "A" .. i, i)
+			end
+
+			local cur = wb:rows("Data")
+			local batch = cur:read(2)
+			assert(#batch == 2, "should read first two rows")
+
+			local cerr = cur:close()
+			assert(cerr == nil, "close should succeed mid-iteration")
+
+			local after, aerr = cur:read()
+			assert(after == nil, "read after close should return nil rows")
+			assert(aerr ~= nil, "read after close should error")
+			assert(aerr:kind() == errors.INVALID, "error kind should be INVALID")
+
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("close is idempotent", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			wb:set_cell_value("Data", "A1", "x")
+
+			local cur = wb:rows("Data")
+			assert(cur:close() == nil, "first close should succeed")
+			assert(cur:close() == nil, "second close should succeed")
+
+			-- close after EOF
+			local cur2 = wb:rows("Data")
+			cur2:read(10)
+			cur2:read(10)
+			assert(cur2:close() == nil, "close after EOF should succeed")
+
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("workbook close reaps abandoned cursor", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			for i = 1, 10 do
+				wb:set_cell_value("Data", "A" .. i, i)
+			end
+
+			local cur = wb:rows("Data")
+			cur:read()
+			-- abandon the cursor mid-sheet
+			wb:close()
+
+			local batch, err = cur:read()
+			assert(batch == nil, "read after workbook close should return nil rows")
+			assert(err ~= nil, "read after workbook close should error")
+			assert(err:kind() == errors.INVALID, "error kind should be INVALID")
+
+			assert(cur:close() == nil, "close after workbook close should succeed")
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing sheet", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+
+			local cur, err = wb:rows("NonExistentSheet")
+			assert(cur == nil, "cursor should be nil")
+			assert(err ~= nil, "error should not be nil")
+			assert(err:kind() == errors.INVALID, "error kind should be INVALID")
+			assert(err:retryable() == false, "error should not be retryable")
+
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty sheet", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Empty")
+
+			local cur, err = wb:rows("Empty")
+			assert(cur ~= nil, "cursor should not be nil")
+			assert(err == nil, "rows should not error")
+
+			local batch, nerr = cur:read(10)
+			assert(batch == nil, "empty sheet should yield no rows")
+			assert(nerr == nil, "empty sheet EOF should be error-free")
+
+			cur:close()
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid batch size", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			wb:set_cell_value("Data", "A1", "x")
+
+			local cur = wb:rows("Data")
+			local batch, err = cur:read(0)
+			assert(batch == nil, "zero batch should return nil rows")
+			assert(err ~= nil, "zero batch should error")
+			assert(err:kind() == errors.INVALID, "error kind should be INVALID")
+
+			-- argument error does not poison the cursor
+			local ok, okerr = cur:read(1)
+			assert(okerr == nil, "read should recover after invalid batch size")
+			assert(ok[1][1] == "x", "row value mismatch")
+
+			cur:close()
+			wb:close()
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("closed workbook", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:new_sheet("Data")
+			wb:close()
+
+			local cur, err = wb:rows("Data")
+			assert(cur == nil, "cursor should be nil")
+			assert(err ~= nil, "error should not be nil")
+			assert(err:kind() == errors.INVALID, "error kind should be INVALID")
+		`)
+		assert.NoError(t, err)
+	})
+}
+
+func TestWorkbook_RowsContextCancellation(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l.SetContext(ctx)
+	lua.OpenErrors(l)
+	bindExcel(l)
+
+	err := l.DoString(`
+		wb = excel.new()
+		wb:new_sheet("Data")
+		for i = 1, 20 do
+			wb:set_cell_value("Data", "A" .. i, i)
+		end
+		cur = wb:rows("Data")
+		local batch, err = cur:read(5)
+		assert(err == nil, "read should succeed before cancellation")
+		assert(#batch == 5, "batch should hold five rows")
+	`)
+	require.NoError(t, err)
+
+	cancel()
+
+	// The VM refuses to execute Lua code once the context is cancelled, so
+	// drive the cursor's Go function directly to exercise its own ctx check.
+	cur := l.GetGlobal("cur")
+	readCursor := func() (lua.LValue, lua.LValue) {
+		require.NoError(t, l.CallByParam(lua.P{Fn: lua.LGoFunc(rowsRead), NRet: 2, Protect: true}, cur, lua.LNumber(5)))
+		batch, errVal := l.Get(-2), l.Get(-1)
+		l.Pop(2)
+		return batch, errVal
+	}
+
+	batch, errVal := readCursor()
+	assert.Equal(t, lua.LNil, batch, "read after cancellation should return nil rows")
+	assert.NotEqual(t, lua.LNil, errVal, "read after cancellation should error")
+
+	// cancellation is terminal
+	batch, errVal = readCursor()
+	assert.Equal(t, lua.LNil, batch, "terminal state should persist")
+	assert.NotEqual(t, lua.LNil, errVal, "terminal error should persist")
+
+	// close after cancellation succeeds
+	require.NoError(t, l.CallByParam(lua.P{Fn: lua.LGoFunc(rowsClose), NRet: 1, Protect: true}, cur))
+	assert.Equal(t, lua.LNil, l.Get(-1), "close after cancellation should succeed")
+	l.Pop(1)
+}
+
+func TestWorkbook_RowsResourceStoreCleanup(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ctx := ctxapi.NewRootContext()
+	ctx, _ = ctxapi.OpenFrameContext(ctx)
+	store := resource.NewStore()
+	require.NoError(t, resource.SetStore(ctx, store))
+
+	l.SetContext(ctx)
+	lua.OpenErrors(l)
+	bindExcel(l)
+
+	err := l.DoString(`
+		wb = excel.new()
+		wb:new_sheet("Data")
+		for i = 1, 10 do
+			wb:set_cell_value("Data", "A" .. i, i)
+		end
+		cur = wb:rows("Data")
+		local batch, err = cur:read(3)
+		assert(err == nil, "read should succeed before store close")
+		assert(#batch == 3, "batch should hold three rows")
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Close())
+
+	err = l.DoString(`
+		local batch, err = cur:read()
+		assert(batch == nil, "read after store close should return nil rows")
+		assert(err ~= nil, "read after store close should error")
+		assert(err:kind() == errors.INVALID, "error kind should be INVALID")
+
+		local sheets, werr = wb:get_sheet_list()
+		assert(sheets == nil, "workbook should be closed by store cleanup")
+		assert(werr ~= nil, "workbook operations should error after store cleanup")
+
+		assert(cur:close() == nil, "close after store cleanup should succeed")
+	`)
+	assert.NoError(t, err)
 }
 
 func TestWorkbook_SetCellValue(t *testing.T) {

--- a/runtime/lua/modules/excel/module_test.go
+++ b/runtime/lua/modules/excel/module_test.go
@@ -484,18 +484,28 @@ func TestWorkbook_Rows(t *testing.T) {
 		defer l.Close()
 
 		err := l.DoString(`
-			local wb = excel.new()
+			wb = excel.new()
 			wb:new_sheet("Data")
 			wb:set_cell_value("Data", "A1", "only")
 
-			local cur = wb:rows("Data")
+			cur = wb:rows("Data")
 			cur:read(10)
 			for i = 1, 3 do
 				local batch, err = cur:read(10)
 				assert(batch == nil, "EOF batch should stay nil")
 				assert(err == nil, "EOF should stay error-free")
 			end
-			cur:close()
+		`)
+		require.NoError(t, err)
+
+		wb := l.GetGlobal("wb").(*lua.LUserData).Value.(*Workbook)
+		cur := l.GetGlobal("cur").(*lua.LUserData).Value.(*Rows)
+		assert.Empty(t, wb.cursors, "EOF cursor should unregister from workbook")
+		assert.True(t, cur.released, "EOF cursor should release its iterator")
+		assert.False(t, cur.closed, "automatic release should preserve EOF reads")
+
+		err = l.DoString(`
+			assert(cur:close() == nil, "close after EOF should succeed")
 			wb:close()
 		`)
 		assert.NoError(t, err)
@@ -700,6 +710,12 @@ func TestWorkbook_RowsContextCancellation(t *testing.T) {
 	batch, errVal := readCursor()
 	assert.Equal(t, lua.LNil, batch, "read after cancellation should return nil rows")
 	assert.NotEqual(t, lua.LNil, errVal, "read after cancellation should error")
+
+	wb := l.GetGlobal("wb").(*lua.LUserData).Value.(*Workbook)
+	rows := cur.(*lua.LUserData).Value.(*Rows)
+	assert.Empty(t, wb.cursors, "cancelled cursor should unregister from workbook")
+	assert.True(t, rows.released, "cancelled cursor should release its iterator")
+	assert.False(t, rows.closed, "automatic release should preserve terminal error reads")
 
 	// cancellation is terminal
 	batch, errVal = readCursor()

--- a/runtime/lua/modules/excel/rows.go
+++ b/runtime/lua/modules/excel/rows.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package excel
+
+import (
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	"github.com/xuri/excelize/v2"
+)
+
+const rowsTypeName = "excel.Rows"
+
+// maxReadBatch bounds the number of rows a single read(n) call can return.
+const maxReadBatch = 10000
+
+var rowsMetatable *lua.LTable
+
+// Rows is a streaming cursor over the rows of a single sheet. It reads the
+// sheet XML incrementally instead of materializing the whole sheet in memory.
+// A cursor is owned by the workbook that created it: closing the workbook
+// closes any cursors still open on it. Reads are pull-based and synchronous;
+// once the cursor reaches end of sheet or fails, that terminal state is
+// sticky for all subsequent read() calls.
+type Rows struct {
+	rows   *excelize.Rows
+	wb     *Workbook
+	err    error
+	done   bool
+	closed bool
+}
+
+// Close closes the cursor and unregisters it from its workbook. Idempotent.
+func (r *Rows) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+
+	err := r.rows.Close()
+	if r.wb != nil && r.wb.cursors != nil {
+		delete(r.wb.cursors, r)
+	}
+	return err
+}
+
+var rowsMethods = map[string]lua.LGoFunc{
+	"read":  rowsRead,
+	"close": rowsClose,
+}
+
+func checkRows(l *lua.LState, _ int) *Rows {
+	ud := l.CheckUserData(1)
+	if v, ok := ud.Value.(*Rows); ok {
+		return v
+	}
+	return nil
+}
+
+func workbookRows(l *lua.LState) int {
+	wb := checkWorkbook(l, 1)
+	if wb == nil {
+		return invalidError(l, "workbook expected")
+	}
+
+	if wb.closed {
+		return invalidError(l, "workbook is closed")
+	}
+
+	sheetName := l.CheckString(2)
+	rows, err := wb.file.Rows(sheetName)
+	if err != nil {
+		return invalidWrapError(l, err, "open rows cursor")
+	}
+
+	r := &Rows{rows: rows, wb: wb}
+	if wb.cursors == nil {
+		wb.cursors = make(map[*Rows]struct{})
+	}
+	wb.cursors[r] = struct{}{}
+
+	value.PushUserData(l, r, rowsMetatable)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func rowsRead(l *lua.LState) int {
+	r := checkRows(l, 1)
+	if r == nil {
+		return invalidError(l, "rows cursor expected")
+	}
+
+	if r.closed {
+		return invalidError(l, "rows cursor is closed")
+	}
+
+	if r.err != nil {
+		return internalError(l, r.err, "read rows")
+	}
+
+	if r.done {
+		l.Push(lua.LNil)
+		l.Push(lua.LNil)
+		return 2
+	}
+
+	n := l.OptInt(2, 1)
+	if n < 1 {
+		return invalidError(l, "batch size must be positive")
+	}
+	if n > maxReadBatch {
+		n = maxReadBatch
+	}
+
+	ctx := l.Context()
+	batch := lua.CreateTable(n, 0)
+	count := 0
+	for count < n {
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				r.err = ctx.Err()
+				return internalError(l, r.err, "read rows")
+			default:
+			}
+		}
+
+		if !r.rows.Next() {
+			if err := r.rows.Error(); err != nil {
+				r.err = err
+				return internalError(l, err, "read rows")
+			}
+			r.done = true
+			break
+		}
+
+		row, err := r.rows.Columns()
+		if err != nil {
+			r.err = err
+			return internalError(l, err, "read row")
+		}
+
+		luaRow := lua.CreateTable(len(row), 0)
+		for colIdx, cellValue := range row {
+			luaRow.RawSetInt(colIdx+1, lua.LString(cellValue))
+		}
+		count++
+		batch.RawSetInt(count, luaRow)
+	}
+
+	if count == 0 {
+		l.Push(lua.LNil)
+		l.Push(lua.LNil)
+		return 2
+	}
+
+	l.Push(batch)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func rowsClose(l *lua.LState) int {
+	r := checkRows(l, 1)
+	if r == nil {
+		return singleErrorMsg(l, "rows cursor expected")
+	}
+
+	if err := r.Close(); err != nil {
+		return singleError(l, err, "close rows cursor")
+	}
+
+	l.Push(lua.LNil)
+	return 1
+}
+
+func rowsToString(l *lua.LState) int {
+	r := checkRows(l, 1)
+	if r == nil {
+		return 0
+	}
+
+	if r.closed {
+		l.Push(lua.LString("excel.Rows{closed}"))
+	} else {
+		l.Push(lua.LString("excel.Rows{}"))
+	}
+	return 1
+}

--- a/runtime/lua/modules/excel/rows.go
+++ b/runtime/lua/modules/excel/rows.go
@@ -22,11 +22,12 @@ var rowsMetatable *lua.LTable
 // once the cursor reaches end of sheet or fails, that terminal state is
 // sticky for all subsequent read() calls.
 type Rows struct {
-	rows   *excelize.Rows
-	wb     *Workbook
-	err    error
-	done   bool
-	closed bool
+	rows     *excelize.Rows
+	wb       *Workbook
+	err      error
+	done     bool
+	closed   bool
+	released bool
 }
 
 // Close closes the cursor and unregisters it from its workbook. Idempotent.
@@ -35,6 +36,17 @@ func (r *Rows) Close() error {
 		return nil
 	}
 	r.closed = true
+	return r.release()
+}
+
+// release closes the underlying iterator and unregisters it from its
+// workbook. Unlike Close, it does not make a terminal EOF or error state
+// unreadable, so subsequent reads can keep returning that sticky state.
+func (r *Rows) release() error {
+	if r.released {
+		return nil
+	}
+	r.released = true
 
 	err := r.rows.Close()
 	if r.wb != nil && r.wb.cursors != nil {
@@ -119,15 +131,22 @@ func rowsRead(l *lua.LState) int {
 			select {
 			case <-ctx.Done():
 				r.err = ctx.Err()
+				_ = r.release()
 				return internalError(l, r.err, "read rows")
 			default:
 			}
 		}
 
 		if !r.rows.Next() {
-			if err := r.rows.Error(); err != nil {
-				r.err = err
-				return internalError(l, err, "read rows")
+			readErr := r.rows.Error()
+			closeErr := r.release()
+			if readErr != nil {
+				r.err = readErr
+				return internalError(l, readErr, "read rows")
+			}
+			if closeErr != nil {
+				r.err = closeErr
+				return internalError(l, closeErr, "close rows cursor")
 			}
 			r.done = true
 			break
@@ -136,6 +155,7 @@ func rowsRead(l *lua.LState) int {
 		row, err := r.rows.Columns()
 		if err != nil {
 			r.err = err
+			_ = r.release()
 			return internalError(l, err, "read row")
 		}
 

--- a/runtime/lua/modules/excel/spec.md
+++ b/runtime/lua/modules/excel/spec.md
@@ -58,6 +58,7 @@ Returned by `excel.new()` and `excel.open()`. Represents an Excel .xlsx workbook
 | new_sheet | (name: string) → integer, error | Sheet index | Creates sheet or returns existing index |
 | get_sheet_list | () → string[], error | Sheet names | Returns all sheet names as array |
 | get_rows | (sheet: string) → string[][], error | 2D array of cells | All values as strings |
+| rows | (sheet: string) → Rows, error | Streaming cursor | Reads rows incrementally, constant memory |
 | set_cell_value | (sheet: string, cell: string, value: any) → error | - | Sets single cell value |
 | write_to | (writer: File) → error | - | Writes workbook to writer |
 | close | () → error | - | Closes workbook, releases resources |
@@ -131,6 +132,33 @@ Gets all rows from a sheet as 2D array.
 - Numbers returned as string representation ("123", "45.67")
 - Arrays are 1-indexed (Lua convention)
 
+#### workbook:rows(sheet: string) → Rows, error
+
+Opens a streaming cursor over the rows of a sheet. Rows are decoded from the
+sheet XML incrementally, so large sheets can be processed in constant memory
+(unlike `get_rows`, which materializes the whole sheet).
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| sheet | string | yes | - | Sheet name |
+
+**Returns:**
+- Success: `Rows, nil` - streaming row cursor
+- Error: `nil, error` - structured error
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| invalid workbook | errors.INVALID | no |
+| workbook closed | errors.INVALID | no |
+| non-existent sheet | errors.INVALID | no |
+
+**Notes:**
+- Cell values have the same string formatting as `get_rows`
+- Closing the workbook closes any cursors still open on it
+- Unlike `get_rows`, trailing empty rows present in the sheet XML are not trimmed
+
 #### workbook:set_cell_value(sheet: string, cell: string, value: any) → error
 
 Sets value of a single cell.
@@ -203,8 +231,66 @@ Closes workbook and releases resources.
 **Notes:**
 - Idempotent - safe to call multiple times
 - All operations after close will error with "workbook is closed"
+- Closing the workbook also closes any open row cursors
 - Workbooks are automatically closed when Lua context ends
 - Best practice: always call close when done
+
+### Rows
+
+Streaming cursor over the rows of a single sheet. Returned by `workbook:rows()`.
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| read | (n?: integer) → string[][], error | Batch of rows | Reads up to n rows, nil at EOF |
+| close | () → error | - | Closes cursor, releases resources |
+
+#### rows:read(n?: integer) → string[][], error
+
+Reads the next batch of up to n rows.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| n | integer | no | 1 | Rows per batch, capped at 10000 |
+
+**Returns:**
+- Success: `string[][], nil` - batch of 1..n rows, each a string array of cell values
+- EOF: `nil, nil` - end of sheet
+- Error: `nil, error` - structured error
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| cursor closed | errors.INVALID | no |
+| batch size < 1 | errors.INVALID | no |
+| read failure | errors.INTERNAL | no |
+| context cancelled | errors.INTERNAL | no |
+
+**Notes:**
+- Synchronous, pull-based; does not yield
+- Cell value semantics identical to `get_rows` (numbers, booleans, dates formatted to strings)
+- EOF and errors are terminal: subsequent `read()` calls keep returning the same state
+- A read failure is never reported as EOF
+- Empty rows are returned as empty tables `{}` (distinct from `nil` EOF)
+- An argument error (batch size < 1) does not poison the cursor
+
+#### rows:close() → error
+
+Closes the cursor and releases resources.
+
+**Returns:**
+- Success: `nil`
+- Error: `error` - structured error
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| close failure | errors.INTERNAL | no |
+
+**Notes:**
+- Idempotent - safe to call multiple times, including after EOF, read error, or workbook close
+- Cursors left open are closed automatically when the workbook closes or the Lua context ends
 
 ## Dependencies
 
@@ -294,6 +380,21 @@ if err then error(err) end
 
 local rows2 = wb2:get_rows("Sales")
 -- Access data: rows2[2][1] == "Jan"
+
+-- Stream rows without loading the whole sheet
+local cur, err = wb2:rows("Sales")
+if err then error(err) end
+
+while true do
+    local batch, err = cur:read(500)
+    if err then error(err) end
+    if batch == nil then break end
+    for _, row in ipairs(batch) do
+        -- process row (array of strings)
+    end
+end
+
+cur:close()
 
 wb2:close()
 file2:close()

--- a/runtime/lua/modules/excel/spec.md
+++ b/runtime/lua/modules/excel/spec.md
@@ -270,7 +270,8 @@ Reads the next batch of up to n rows.
 - Synchronous, pull-based; does not yield
 - Cell value semantics identical to `get_rows` (numbers, booleans, dates formatted to strings)
 - EOF and errors are terminal: subsequent `read()` calls keep returning the same state
-- A read failure is never reported as EOF
+- Iterator errors reported by the Excel reader are returned as errors, not EOF
+- The underlying iterator is released automatically at EOF or a terminal read error
 - Empty rows are returned as empty tables `{}` (distinct from `nil` EOF)
 - An argument error (batch size < 1) does not poison the cursor
 

--- a/runtime/lua/modules/excel/types.go
+++ b/runtime/lua/modules/excel/types.go
@@ -7,11 +7,18 @@ import (
 	"github.com/wippyai/go-lua/types/typ"
 )
 
+// Rows cursor type
+var rowsType = typ.NewInterface("excel.Rows", []typ.Method{
+	{Name: "read", Type: typ.Func().Param("self", typ.Self).OptParam("n", typ.Number).Returns(typ.NewOptional(typ.NewArray(typ.NewArray(typ.String))), typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(typ.LuaError)).Build()},
+})
+
 // Workbook type
 var workbookType = typ.NewInterface("excel.Workbook", []typ.Method{
 	{Name: "new_sheet", Type: typ.Func().Param("self", typ.Self).Param("name", typ.String).Returns(typ.Number, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "get_sheet_list", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewArray(typ.String), typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "get_rows", Type: typ.Func().Param("self", typ.Self).Param("sheet", typ.String).Returns(typ.NewArray(typ.NewArray(typ.String)), typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "rows", Type: typ.Func().Param("self", typ.Self).Param("sheet", typ.String).Returns(rowsType, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "set_cell_value", Type: typ.Func().Param("self", typ.Self).Param("sheet", typ.String).Param("cell", typ.String).Param("value", typ.Any).Returns(typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "write_to", Type: typ.Func().Param("self", typ.Self).Param("dest", typ.Any).Returns(typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(typ.LuaError)).Build()},
@@ -22,6 +29,7 @@ func ModuleTypes() *io.Manifest {
 	m := io.NewManifest("excel")
 
 	m.DefineType("Workbook", workbookType)
+	m.DefineType("Rows", rowsType)
 
 	moduleType := typ.NewInterface("excel", []typ.Method{
 		{Name: "new", Type: typ.Func().Returns(workbookType, typ.NewOptional(typ.LuaError)).Build()},

--- a/runtime/lua/modules/manifest_test.go
+++ b/runtime/lua/modules/manifest_test.go
@@ -60,6 +60,8 @@ func TestModuleTypes_ReturnsWithError(t *testing.T) {
 		{name: "excel.Workbook.new_sheet", manifest: excel.ModuleTypes(), typeName: "Workbook", method: "new_sheet"},
 		{name: "excel.Workbook.get_sheet_list", manifest: excel.ModuleTypes(), typeName: "Workbook", method: "get_sheet_list"},
 		{name: "excel.Workbook.get_rows", manifest: excel.ModuleTypes(), typeName: "Workbook", method: "get_rows"},
+		{name: "excel.Workbook.rows", manifest: excel.ModuleTypes(), typeName: "Workbook", method: "rows"},
+		{name: "excel.Rows.read", manifest: excel.ModuleTypes(), typeName: "Rows", method: "read"},
 		{name: "excel.new", manifest: excel.ModuleTypes(), method: "new"},
 		{name: "excel.open", manifest: excel.ModuleTypes(), method: "open"},
 		{name: "http_client.StreamReader.read", manifest: httpclient.ModuleTypes(), typeName: "StreamReader", method: "read"},

--- a/tests/app/src/test/excel/_index.yaml
+++ b/tests/app/src/test/excel/_index.yaml
@@ -56,6 +56,19 @@ entries:
     imports:
       assert_primitives: app.lib:assert
 
+  - name: stream
+    kind: function.lua
+    meta:
+      type: test
+      suite: excel
+      description: excel workbook rows streaming cursor
+    source: file://stream.lua
+    method: main
+    modules:
+      - excel
+    imports:
+      assert_primitives: app.lib:assert
+
   - name: errors
     kind: function.lua
     meta:

--- a/tests/app/src/test/excel/stream.lua
+++ b/tests/app/src/test/excel/stream.lua
@@ -1,0 +1,69 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: excel workbook rows streaming cursor
+local assert = require("assert_primitives")
+
+local function main()
+	local excel = require("excel")
+
+	local wb = excel.new()
+	wb:new_sheet("Data")
+
+	for i = 1, 12 do
+		wb:set_cell_value("Data", "A" .. i, "name" .. i)
+		wb:set_cell_value("Data", "B" .. i, i * 10)
+	end
+
+	-- Full iteration matches get_rows
+	local expected, gerr = wb:get_rows("Data")
+	assert.is_nil(gerr, "get_rows should not error")
+	assert.eq(#expected, 12, "should have 12 rows")
+
+	local cur, err = wb:rows("Data")
+	assert.is_nil(err, "rows should not error")
+	assert.not_nil(cur, "cursor should not be nil")
+
+	local count = 0
+	while true do
+		local batch, rerr = cur:read(5)
+		assert.is_nil(rerr, "read should not error")
+		if batch == nil then break end
+		for _, row in ipairs(batch) do
+			count = count + 1
+			assert.eq(row[1], expected[count][1], "cell A" .. count)
+			assert.eq(row[2], expected[count][2], "cell B" .. count)
+		end
+	end
+	assert.eq(count, 12, "cursor should yield all rows")
+
+	-- EOF is stable
+	local tail, terr = cur:read()
+	assert.is_nil(tail, "EOF should return nil rows")
+	assert.is_nil(terr, "EOF should not error")
+
+	local cerr = cur:close()
+	assert.is_nil(cerr, "close should not error")
+
+	-- Early close
+	local cur2, err2 = wb:rows("Data")
+	assert.is_nil(err2, "rows should not error")
+
+	local batch2, rerr2 = cur2:read(3)
+	assert.is_nil(rerr2, "read should not error")
+	assert.eq(#batch2, 3, "batch should hold 3 rows")
+
+	local cerr2 = cur2:close()
+	assert.is_nil(cerr2, "early close should not error")
+
+	local after, aerr = cur2:read()
+	assert.is_nil(after, "read after close should return nil rows")
+	assert.not_nil(aerr, "read after close should error")
+
+	-- Idempotent close
+	assert.is_nil(cur2:close(), "second close should not error")
+
+	wb:close()
+	return true
+end
+
+return { main = main }


### PR DESCRIPTION
## Motivation

`wb:get_rows()` materializes the entire sheet as `[][]string` plus a full Lua-table copy — a real-world 56MB/465k-row xlsx peaks ~1.15GB RSS under GOMEMLIMIT. Sheet XML is sequential, so a pull cursor is the correct primitive (ranged/sliced reads would re-decode from row 0 per call).

## API

- `wb:rows(sheet) → Rows, error` — constructor, `stream:scanner()`-style
- `cursor:read(n?) → string[][], error` — batch of up to n rows (default 1, cap 10000). Tri-state mirrors `stream:read`: `rows,nil` data · `nil,nil` EOF · `nil,error` failure. Errors reported by the Excel iterator are structured and non-retryable rather than treated as EOF. Terminal-sticky after EOF/error; per-read context cancellation check.
- `cursor:close() → error?` — idempotent, safe after EOF/error/workbook close.

Row values are byte-identical to `get_rows` (same excelize `Columns()` path). Cursors register on the workbook; `wb:close()` and resource-store cleanup reap open cursors. Completed and failed cursors release and unregister their iterator immediately while retaining their terminal state. Synchronous, no goroutines, no yields (module stays deterministic).

## Coverage

`TestWorkbook_Rows` covers value fidelity (including styled dates, floats, empty cells, and uneven batches), batch boundaries, stable EOF, early/idempotent close, abandoned-cursor reap, missing/empty sheets, invalid batch size, and closed workbooks. Separate tests cover context cancellation, terminal resource release, and resource-store cleanup. The Lua application harness includes an end-to-end streaming test; `spec.md` and the type manifest are updated.

Reviewed cleanup verification:

- Rebased onto current `main`; unrelated Dependabot ownership commit removed
- `make lint`: 0 issues
- `make test`: pass (full short race suite)
- `tests/app/test.sh`: 390/390 pass, including `excel/stream`
