### PR TITLE
fix(deps): preserve deployment ownership during reconciliation

### DIFF
--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -157,7 +157,7 @@ func TestDependencyHandler_PersistedResolutionBootRollbackRedoAndLongHistory(t *
 func TestDependencyHandler_ApplyVersionReconciliationSemantics(t *testing.T) {
 	t.Run("removes departing graph without touching deployment owner", func(t *testing.T) {
 		packRegistry := embedpkg.NewRegistry()
-		t.Cleanup(func() { require.NoError(t, packRegistry.Close()) })
+		defer func() { require.NoError(t, packRegistry.Close()) }()
 		ctx := embedapi.WithRegistry(newTestContext(), packRegistry)
 		reg, runner, baselineVersion, hostID := newLegacyArtifactRollbackRegistry(ctx, t)
 
@@ -210,7 +210,7 @@ func TestDependencyHandler_ApplyVersionReconciliationSemantics(t *testing.T) {
 
 	t.Run("restores authored host drift without derived rewrite", func(t *testing.T) {
 		packRegistry := embedpkg.NewRegistry()
-		t.Cleanup(func() { require.NoError(t, packRegistry.Close()) })
+		defer func() { require.NoError(t, packRegistry.Close()) }()
 		ctx := embedapi.WithRegistry(newTestContext(), packRegistry)
 		reg, runner, baselineVersion, hostID := newLegacyArtifactRollbackRegistry(ctx, t)
 

--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -14,9 +14,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	embedapi "github.com/wippyai/runtime/api/service/fs/embed"
 	"github.com/wippyai/runtime/internal/version"
+	embedpkg "github.com/wippyai/runtime/service/fs/embed"
 	registryimpl "github.com/wippyai/runtime/system/registry"
 	regexp "github.com/wippyai/runtime/system/registry/expansion"
 	historymem "github.com/wippyai/runtime/system/registry/history/memory"
@@ -149,6 +152,224 @@ func TestDependencyHandler_PersistedResolutionBootRollbackRedoAndLongHistory(t *
 	require.NoError(t, err)
 	require.Equal(t, "v2.0.0", moduleVersion(entry))
 	require.Zero(t, manifestCalls)
+}
+
+func TestDependencyHandler_ApplyVersionReconciliationSemantics(t *testing.T) {
+	t.Run("removes departing graph without touching deployment owner", func(t *testing.T) {
+		packRegistry := embedpkg.NewRegistry()
+		t.Cleanup(func() { require.NoError(t, packRegistry.Close()) })
+		ctx := embedapi.WithRegistry(newTestContext(), packRegistry)
+		reg, runner, baselineVersion, hostID := newLegacyArtifactRollbackRegistry(ctx, t)
+
+		addonRoot := regapi.Entry{
+			ID:             regapi.NewID("app.deps", "addon"),
+			Kind:           regapi.NamespaceDependency,
+			DependencyRoot: true,
+			Meta: attrs.NewBagFrom(map[string]any{
+				metaModuleKey: "acme/deployment", metaModuleVersionKey: "v1.0.0",
+			}),
+			Data: payload.New(map[string]any{"component": "acme/addon", "version": "v1.0.0"}),
+		}
+		_, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: addonRoot}})
+		require.NoError(t, err)
+		_, err = reg.GetEntry(regapi.NewID("acme.addon", "service"))
+		require.NoError(t, err, "fixture must install the departing module before rollback")
+		require.True(t, packRegistry.HasModulePack("acme/addon", "v1.0.0"))
+		runner.transitions = nil
+
+		require.NoError(t, reg.ApplyVersion(ctx, baselineVersion))
+		var rollbackOps []regapi.Operation
+		for _, transition := range runner.transitions {
+			rollbackOps = append(rollbackOps, transition...)
+		}
+		require.Len(t, rollbackOps, 2, "rollback must remove only the departing root and module entry")
+		deleted := make(map[regapi.ID]struct{}, len(rollbackOps))
+		for _, op := range rollbackOps {
+			require.Equal(t, regapi.EntryDelete, op.Kind)
+			deleted[op.Entry.ID] = struct{}{}
+			require.NotEqual(t, hostID, op.Entry.ID)
+		}
+		require.Contains(t, deleted, addonRoot.ID)
+		require.Contains(t, deleted, regapi.NewID("acme.addon", "service"))
+		_, err = reg.GetEntry(regapi.NewID("app.security", "admin_all_access"))
+		require.NoError(t, err, "rollback must preserve entries owned by the deployment package")
+		_, err = reg.GetEntry(regapi.NewID("app.deps", "app"))
+		require.NoError(t, err, "an owned deployment root must remain present after rollback")
+		_, err = reg.GetEntry(addonRoot.ID)
+		require.Error(t, err)
+		_, err = reg.GetEntry(regapi.NewID("acme.addon", "service"))
+		require.Error(t, err)
+		require.False(t, packRegistry.HasModulePack("acme/addon", "v1.0.0"), "rollback must unregister the departing embedded pack")
+
+		_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: addonRoot}})
+		require.NoError(t, err, "a follow-up install must succeed after rollback")
+		_, err = reg.GetEntry(regapi.NewID("acme.addon", "service"))
+		require.NoError(t, err)
+		require.True(t, packRegistry.HasModulePack("acme/addon", "v1.0.0"))
+	})
+
+	t.Run("restores authored host drift without derived rewrite", func(t *testing.T) {
+		packRegistry := embedpkg.NewRegistry()
+		t.Cleanup(func() { require.NoError(t, packRegistry.Close()) })
+		ctx := embedapi.WithRegistry(newTestContext(), packRegistry)
+		reg, runner, baselineVersion, hostID := newLegacyArtifactRollbackRegistry(ctx, t)
+
+		current, err := reg.GetEntry(hostID)
+		require.NoError(t, err)
+		changed := current
+		changed.Data = payload.New(map[string]any{
+			"host":      map[string]any{"max_processes": 500, "workers": 16},
+			"lifecycle": map[string]any{"auto_start": true},
+		})
+		_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: changed}})
+		require.NoError(t, err)
+		runner.transitions = nil
+
+		require.NoError(t, reg.ApplyVersion(ctx, baselineVersion))
+		var hostOps []regapi.Operation
+		for _, transition := range runner.transitions {
+			for _, op := range transition {
+				if op.Entry.ID == hostID {
+					hostOps = append(hostOps, op)
+				}
+			}
+		}
+		require.Len(t, hostOps, 1)
+		require.Equal(t, regapi.EntryUpdate, hostOps[0].Kind)
+		hostData, ok := hostOps[0].Entry.Data.Data().(map[string]any)
+		require.True(t, ok)
+		hostConfig, ok := hostData["host"].(map[string]any)
+		require.True(t, ok)
+		require.EqualValues(t, 8, hostConfig["workers"])
+	})
+}
+
+func newLegacyArtifactRollbackRegistry(
+	ctx context.Context,
+	t *testing.T,
+) (*registryimpl.Reg, *bootRecordingRunner, regapi.Version, regapi.ID) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, "vendor")
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	hostID := regapi.NewID("keeper.gov", "processes")
+	hostData := map[string]any{
+		"host":      map[string]any{"max_processes": 500, "workers": 8},
+		"lifecycle": map[string]any{"auto_start": true},
+	}
+	artifacts := map[string][]byte{
+		"app": buildWappBytes(t, []wapp.Entry{{
+			ID: wapp.NewID("acme.app", "marker"), Kind: regapi.EntryKind,
+			Data: map[string]any{"enabled": true},
+		}}),
+		"runtime": buildWappBytes(t, []wapp.Entry{{
+			ID: wapp.NewID(hostID.NS, hostID.Name), Kind: "process.host", Data: hostData,
+		}}),
+		"addon": buildWappBytes(t, []wapp.Entry{{
+			ID: wapp.NewID("acme.addon", "service"), Kind: regapi.EntryKind,
+			Data: map[string]any{"enabled": true},
+		}}),
+	}
+	digests := make(map[string]string, len(artifacts))
+	for module, artifact := range artifacts {
+		sum := sha256.Sum256(artifact)
+		digests[module] = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	require.NoError(t, os.WriteFile(lockPath, []byte(fmt.Sprintf(`directories:
+  modules: vendor
+modules:
+  - name: acme/app
+    version: v1.0.0
+    hash: %s
+  - name: acme/runtime
+    version: v1.0.0
+    hash: %s
+`, digests["app"], digests["runtime"])), 0o600))
+
+	fixturePath := filepath.Join(tmpDir, "runtime-fixture.wapp")
+	require.NoError(t, os.WriteFile(fixturePath, artifacts["runtime"], 0o600))
+	loadedRuntime, err := loadEntriesFromWapp(fixturePath)
+	require.NoError(t, err)
+	require.Len(t, loadedRuntime, 1)
+	legacyHost := loadedRuntime[0]
+	legacyHost.Meta = attrs.NewBagFrom(map[string]any{
+		metaModuleKey: "acme/runtime", metaModuleVersionKey: "v1.0.0",
+	})
+
+	hubClient := &fakeHub{
+		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			artifact, ok := artifacts[module]
+			if !ok {
+				return nil, fmt.Errorf("unexpected module %s/%s", org, module)
+			}
+			manifest := &ModuleManifest{
+				Org: org, Name: module, Version: "v1.0.0", VersionID: "v1.0.0",
+				Digest: digests[module], SizeBytes: uint64(len(artifact)), URL: "memory://" + module,
+			}
+			if module == "app" {
+				manifest.Dependencies = []ManifestDep{{Org: "acme", Name: "runtime", Version: "v1.0.0"}}
+			}
+			return manifest, nil
+		},
+		downloadFile: func(_ context.Context, url, dest string) error {
+			module := strings.TrimPrefix(url, "memory://")
+			artifact, ok := artifacts[module]
+			if !ok {
+				return fmt.Errorf("unexpected artifact %q", url)
+			}
+			if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(dest, artifact, 0o600)
+		},
+	}
+	resolver := topology.NewResolver()
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: hubClient, Logger: zap.NewNop(), Resolver: resolver,
+		LockPath: lockPath, VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+	runner := &bootRecordingRunner{}
+	reg := registryimpl.NewRegistry(
+		historymem.New(), runner, topology.NewStateBuilder(zap.NewNop(), resolver), resolver, zap.NewNop(),
+		registryimpl.WithKindDirective(
+			regapi.NamespaceDependency,
+			regexp.NewDependencyDirective(handler.Expand).WithResolutionTransition(handler.ReconcileResolution),
+		),
+	)
+	root := regapi.Entry{
+		ID: regapi.NewID("app.deps", "app"), Kind: regapi.NamespaceDependency,
+		DependencyRoot: true,
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey: "acme/deployment", metaModuleVersionKey: "v1.0.0",
+		}),
+		Data: payload.New(map[string]any{"component": "acme/app", "version": "v1.0.0"}),
+	}
+	baseline := regapi.State{
+		root,
+		{
+			ID: regapi.NewID("app.security", "admin_all_access"), Kind: "security.policy",
+			Meta: attrs.NewBagFrom(map[string]any{
+				metaModuleKey: "acme/deployment", metaModuleVersionKey: "v1.0.0",
+			}),
+			Data: payload.New(map[string]any{"allow": true}),
+		},
+		{
+			ID: regapi.NewID("acme.app", "marker"), Kind: regapi.EntryKind,
+			Meta: attrs.NewBagFrom(map[string]any{
+				metaModuleKey: "acme/app", metaModuleVersionKey: "v1.0.0",
+			}),
+			Data: payload.New(map[string]any{"enabled": true}),
+		},
+		legacyHost,
+	}
+	baselineVersion := version.FromParent(nil, 0)
+	require.NoError(t, reg.LoadState(ctx, baseline, baselineVersion))
+	persistedHost, err := reg.GetEntry(hostID)
+	require.NoError(t, err)
+	require.Empty(t, moduleDigest(persistedHost), "fixture requires a legacy host without module_digest")
+	runner.transitions = nil
+	return reg, runner, baselineVersion, hostID
 }
 
 type bootDirectiveFunc func(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error)

--- a/boot/deps/hub/dependency_control.go
+++ b/boot/deps/hub/dependency_control.go
@@ -10,6 +10,9 @@ import (
 )
 
 func isRootDependency(entry regapi.Entry) bool {
+	// DependencyRoot is authoritative for every current source and pack ingest
+	// path. The ownership fallback is retained only so registries persisted
+	// before dependency_root was introduced remain upgradeable.
 	return entry.Kind == regapi.NamespaceDependency && (entry.DependencyRoot || entryModule(entry) == "")
 }
 

--- a/boot/deps/hub/dependency_control.go
+++ b/boot/deps/hub/dependency_control.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+)
+
+func isRootDependency(entry regapi.Entry) bool {
+	return entry.Kind == regapi.NamespaceDependency && (entry.DependencyRoot || entryModule(entry) == "")
+}
+
+// collectControlledModules returns the dependency graph reachable from the
+// state's deployment roots. A root's package owner is provenance, not part of
+// that graph: the root controls its declared component, while ordinary owned
+// dependencies extend the graph from owner to component.
+func (h *DependencyHandler) collectControlledModules(
+	ctx context.Context,
+	snapshot regapi.State,
+	transcoder payload.Transcoder,
+) (map[string]struct{}, error) {
+	controlled := make(map[string]struct{})
+	dependencyLinks := make(map[string][]string)
+
+	for _, entry := range snapshot {
+		if entry.Kind != regapi.NamespaceDependency {
+			continue
+		}
+		def, err := decodeDependency(ctx, transcoder, entry)
+		if err != nil {
+			return nil, err
+		}
+		if def.Component == "" {
+			return nil, NewDependencyEntryInvalidError(entry.ID.String(), "component is required", "")
+		}
+
+		if isRootDependency(entry) {
+			controlled[def.Component] = struct{}{}
+			continue
+		}
+		if owner := entryModule(entry); owner != "" {
+			dependencyLinks[owner] = append(dependencyLinks[owner], def.Component)
+		}
+	}
+
+	queue := sortedSetKeys(controlled)
+	for len(queue) > 0 {
+		module := queue[0]
+		queue = queue[1:]
+		for _, dependency := range dependencyLinks[module] {
+			if _, seen := controlled[dependency]; seen {
+				continue
+			}
+			controlled[dependency] = struct{}{}
+			queue = append(queue, dependency)
+		}
+	}
+
+	return controlled, nil
+}
+
+// reconciliationControlledModules joins both sides of a version transition.
+// Current roots retain authority over departing modules; target roots and the
+// stored resolution cover retained and incoming modules. Package owners that
+// are not dependency graph members remain outside reconciliation authority.
+func (h *DependencyHandler) reconciliationControlledModules(
+	ctx context.Context,
+	current regapi.State,
+	target regapi.State,
+	transcoder payload.Transcoder,
+	desired map[string]struct{},
+) (map[string]struct{}, error) {
+	controlled, err := h.collectControlledModules(ctx, current, transcoder)
+	if err != nil {
+		return nil, err
+	}
+	targetControlled, err := h.collectControlledModules(ctx, target, transcoder)
+	if err != nil {
+		return nil, err
+	}
+	addModuleSet(controlled, targetControlled)
+	addModuleSet(controlled, desired)
+	return controlled, nil
+}
+
+func addModuleSet(target, source map[string]struct{}) {
+	for module := range source {
+		target[module] = struct{}{}
+	}
+}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -40,10 +40,6 @@ import (
 )
 
 const (
-	metaModuleKey        = "module"
-	metaModuleVersionKey = "module_version"
-	metaModuleDigestKey  = "module_digest"
-
 	moduleSourceHub               = "hub"
 	moduleSourceReplacementTreeV1 = "replacement-tree-v1"
 	extractedModuleMeta           = ".wippy-module.yaml"
@@ -268,6 +264,7 @@ func (h *DependencyHandler) expand(
 		touchedModules[module] = struct{}{}
 	}
 	desiredModules := resolvedModuleSet(resolved)
+	addModuleSet(controlledModules, desiredModules)
 
 	moduleEntries, unpackPlan, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touchedModules), resolved, snapshot, transcoder)
 	if err != nil {
@@ -279,11 +276,13 @@ func (h *DependencyHandler) expand(
 	combined := make([]regapi.Entry, 0, len(snapshot)+len(moduleEntries))
 	for _, e := range snapshot {
 		if module := entryModule(e); module != "" {
-			if _, desired := desiredModules[module]; !desired {
-				continue
-			}
-			if _, touched := touchedModules[module]; touched {
-				continue
+			if _, controlled := controlledModules[module]; controlled {
+				if _, desired := desiredModules[module]; !desired {
+					continue
+				}
+				if _, touched := touchedModules[module]; touched {
+					continue
+				}
 			}
 		}
 		combined = append(combined, e)
@@ -300,7 +299,11 @@ func (h *DependencyHandler) expand(
 		return regapi.DirectiveResult{}, NewDependencyPipelineError(err)
 	}
 
-	additional, err := h.buildOperations(snapshot, combined, op.Entry.ID, controlledModules, mutableModules)
+	additional, err := (operationPlanner{resolver: h.resolver}).plan(snapshot, combined, operationPlanOptions{
+		originalKey:       idKey(op.Entry.ID),
+		controlledModules: controlledModules,
+		mutableModules:    mutableModules,
+	})
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -549,14 +552,9 @@ func (h *DependencyHandler) ReconcileResolution(
 			touched[module] = struct{}{}
 		}
 	}
-	controlled := make(map[string]struct{}, len(target)+len(desiredModules))
-	for _, entry := range target {
-		if module := entryModule(entry); module != "" {
-			controlled[module] = struct{}{}
-		}
-	}
-	for module := range desiredModules {
-		controlled[module] = struct{}{}
+	controlled, err := h.reconciliationControlledModules(ctx, current, target, transcoder, desiredModules)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
 	}
 
 	moduleEntries, unpackPlan, err := h.loadModuleEntries(ctx, filterResolvedModules(resolved, touched), resolved, target, transcoder)
@@ -571,11 +569,13 @@ func (h *DependencyHandler) ReconcileResolution(
 	combined := make([]regapi.Entry, 0, len(target)+len(moduleEntries))
 	for _, entry := range target {
 		if module := entryModule(entry); module != "" {
-			if _, desired := desiredModules[module]; !desired {
-				continue
-			}
-			if _, changed := touched[module]; changed {
-				continue
+			if _, dependencyOwned := controlled[module]; dependencyOwned {
+				if _, desired := desiredModules[module]; !desired {
+					continue
+				}
+				if _, changed := touched[module]; changed {
+					continue
+				}
 			}
 		}
 		combined = append(combined, entry)
@@ -598,7 +598,10 @@ func (h *DependencyHandler) ReconcileResolution(
 	// that artifact must not turn harmless normalization into registry updates
 	// and restart unrelated services during undo/redo (including the governance
 	// worker itself).
-	additional, err := h.buildOperations(target, combined, regapi.ID{}, controlled, mutable)
+	additional, err := (operationPlanner{resolver: h.resolver}).plan(target, combined, operationPlanOptions{
+		controlledModules: controlled,
+		mutableModules:    mutable,
+	})
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -606,7 +609,7 @@ func (h *DependencyHandler) ReconcileResolution(
 	for _, op := range additional {
 		scoped = append(scoped, regapi.ScopedOperation{Operation: op, Scope: regapi.ScopeBaseline})
 	}
-	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, target, controlled)
+	packEffect, err := h.buildEmbedPackEffect(ctx, resolved, current, controlled)
 	if err != nil {
 		return regapi.DirectiveResult{}, err
 	}
@@ -850,52 +853,6 @@ func (h *DependencyHandler) collectSnapshotDependencies(
 	return deps, nil
 }
 
-func (h *DependencyHandler) collectControlledModules(
-	ctx context.Context,
-	snapshot regapi.State,
-	transcoder payload.Transcoder,
-) (map[string]struct{}, error) {
-	controlled := make(map[string]struct{})
-	dependencyLinks := make(map[string][]string)
-
-	for _, entry := range snapshot {
-		if entry.Kind != regapi.NamespaceDependency {
-			continue
-		}
-		def, err := decodeDependency(ctx, transcoder, entry)
-		if err != nil {
-			return nil, err
-		}
-		if def.Component == "" {
-			return nil, NewDependencyEntryInvalidError(entry.ID.String(), "component is required", "")
-		}
-
-		if owner := entryModule(entry); owner != "" {
-			dependencyLinks[owner] = append(dependencyLinks[owner], def.Component)
-			continue
-		}
-		controlled[def.Component] = struct{}{}
-	}
-
-	queue := make([]string, 0, len(controlled))
-	for module := range controlled {
-		queue = append(queue, module)
-	}
-	for len(queue) > 0 {
-		module := queue[0]
-		queue = queue[1:]
-		for _, dep := range dependencyLinks[module] {
-			if _, seen := controlled[dep]; seen {
-				continue
-			}
-			controlled[dep] = struct{}{}
-			queue = append(queue, dep)
-		}
-	}
-
-	return controlled, nil
-}
-
 func dependencyDefinitions(deps []desiredDependency) []DependencyDefinition {
 	roots := make([]DependencyDefinition, 0, len(deps))
 	for _, dep := range deps {
@@ -991,35 +948,6 @@ func (h *DependencyHandler) installedModuleVersions(ctx context.Context, transco
 		}
 	}
 	return versions, nil
-}
-
-func snapshotModuleVersions(snapshot regapi.State) map[string]string {
-	versions := make(map[string]string)
-	ambiguous := make(map[string]struct{})
-	for _, entry := range snapshot {
-		module := entryModule(entry)
-		if module == "" || entry.Meta == nil {
-			continue
-		}
-		raw, ok := entry.Meta[metaModuleVersionKey]
-		if !ok {
-			continue
-		}
-		version, ok := raw.(string)
-		if !ok || version == "" {
-			continue
-		}
-		if _, bad := ambiguous[module]; bad {
-			continue
-		}
-		if existing, seen := versions[module]; seen && existing != version {
-			delete(versions, module)
-			ambiguous[module] = struct{}{}
-			continue
-		}
-		versions[module] = version
-	}
-	return versions
 }
 
 func mergeLinkDependencies(explicitDeps, moduleEntries []regapi.Entry) []regapi.Entry {
@@ -1574,44 +1502,6 @@ func preserveHostSnapshotEntry(entry regapi.Entry, moduleName string, snapshot m
 		return regapi.Entry{}, false
 	}
 	return existing, true
-}
-
-type moduleOwner struct {
-	name    string
-	version string
-	digest  string
-}
-
-func moduleOwnersByNamespace(modules []ResolvedModule) map[string]moduleOwner {
-	owners := make(map[string]moduleOwner, len(modules))
-	for _, mod := range modules {
-		if mod.Org == "" || mod.Name == "" {
-			continue
-		}
-		namespace := mod.Org + "." + mod.Name
-		owners[namespace] = moduleOwner{
-			name:    mod.Org + "/" + mod.Name,
-			version: mod.Version,
-			digest:  mod.Digest,
-		}
-	}
-	return owners
-}
-
-func moduleOwnersByEntryID(entries regapi.State) map[string]moduleOwner {
-	owners := make(map[string]moduleOwner, len(entries))
-	for _, entry := range entries {
-		module := entryModule(entry)
-		if module == "" {
-			continue
-		}
-		owners[idKey(entry.ID)] = moduleOwner{
-			name:    module,
-			version: moduleVersion(entry),
-			digest:  moduleDigest(entry),
-		}
-	}
-	return owners
 }
 
 func (h *DependencyHandler) loadEntriesForModule(ctx context.Context, transcoder payload.Transcoder, mod ResolvedModule) ([]regapi.Entry, error) {
@@ -2425,374 +2315,6 @@ func unwrapPayloadData(data any) any {
 	return data
 }
 
-func (h *DependencyHandler) buildOperations(
-	current regapi.State,
-	desired []regapi.Entry,
-	originalID regapi.ID,
-	controlledModules map[string]struct{},
-	mutableModules map[string]struct{},
-) ([]regapi.Operation, error) {
-	var resolver regapi.DependencyResolver
-	if h != nil {
-		resolver = h.resolver
-	}
-	return buildOperationsWithResolver(current, desired, originalID, controlledModules, mutableModules, resolver)
-}
-
-func buildOperations(
-	current regapi.State,
-	desired []regapi.Entry,
-	originalID regapi.ID,
-	controlledModules map[string]struct{},
-	mutableModules map[string]struct{},
-) ([]regapi.Operation, error) {
-	return buildOperationsWithResolver(current, desired, originalID, controlledModules, mutableModules, nil)
-}
-
-func buildOperationsWithResolver(
-	current regapi.State,
-	desired []regapi.Entry,
-	originalID regapi.ID,
-	controlledModules map[string]struct{},
-	mutableModules map[string]struct{},
-	resolver regapi.DependencyResolver,
-) ([]regapi.Operation, error) {
-	currentByID := make(map[string]regapi.Entry, len(current))
-	for _, entry := range current {
-		currentByID[idKey(entry.ID)] = entry
-	}
-
-	desiredByID := make(map[string]regapi.Entry, len(desired))
-	for _, entry := range desired {
-		desiredByID[idKey(entry.ID)] = entry
-	}
-
-	ops := make([]regapi.Operation, 0)
-	originalKey := idKey(originalID)
-
-	for key, entry := range desiredByID {
-		if key == originalKey {
-			continue
-		}
-		if existing, ok := currentByID[key]; ok {
-			if entryConflict(existing, entry) {
-				return nil, NewDependencyEntryConflictError(entry.ID.String(), entryModule(existing), entryModule(entry))
-			}
-			if !entriesEqual(existing, entry) {
-				if existing.Kind != entry.Kind {
-					ops = append(ops,
-						regapi.Operation{Kind: regapi.EntryDelete, Entry: existing},
-						regapi.Operation{Kind: regapi.EntryCreate, Entry: entry},
-					)
-					continue
-				}
-				if sameImmutableModuleVersion(existing, entry, mutableModules) {
-					continue
-				}
-				ops = append(ops, regapi.Operation{Kind: regapi.EntryUpdate, Entry: entry})
-			}
-		} else {
-			ops = append(ops, regapi.Operation{Kind: regapi.EntryCreate, Entry: entry})
-		}
-	}
-
-	for key, entry := range currentByID {
-		if key == originalKey {
-			continue
-		}
-		if _, ok := desiredByID[key]; ok {
-			continue
-		}
-		if module := entryModule(entry); module != "" {
-			if controlledModules != nil {
-				if _, ok := controlledModules[module]; !ok {
-					continue
-				}
-			}
-			if hasLiveDependent(entry.ID, currentByID, desiredByID, controlledModules, resolver) {
-				continue
-			}
-			ops = append(ops, regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: entry.ID}})
-		}
-	}
-
-	return ops, nil
-}
-
-func hasLiveDependent(
-	target regapi.ID,
-	currentByID map[string]regapi.Entry,
-	desiredByID map[string]regapi.Entry,
-	controlledModules map[string]struct{},
-	resolver regapi.DependencyResolver,
-) bool {
-	if resolver == nil {
-		return false
-	}
-	universe := dependencyEntryUniverse(currentByID)
-	targetKey := idKey(target)
-	for key, current := range currentByID {
-		if key == targetKey {
-			continue
-		}
-		check := current
-		if desired, ok := desiredByID[key]; ok {
-			check = desired
-		} else if missingDesiredEntryWillBeDeleted(current, controlledModules) {
-			continue
-		}
-		if entryDependsOn(check, target, universe, resolver) {
-			return true
-		}
-	}
-	return false
-}
-
-func missingDesiredEntryWillBeDeleted(entry regapi.Entry, controlledModules map[string]struct{}) bool {
-	module := entryModule(entry)
-	if module == "" {
-		return false
-	}
-	if controlledModules == nil {
-		return true
-	}
-	_, ok := controlledModules[module]
-	return ok
-}
-
-type dependencyEntryUniverseView struct {
-	entries map[string]regapi.ID
-	groups  map[string][]regapi.ID
-	ns      map[string][]regapi.ID
-}
-
-func dependencyEntryUniverse(entries map[string]regapi.Entry) dependencyEntryUniverseView {
-	universe := dependencyEntryUniverseView{
-		entries: make(map[string]regapi.ID, len(entries)),
-		groups:  make(map[string][]regapi.ID),
-		ns:      make(map[string][]regapi.ID),
-	}
-	for key, entry := range entries {
-		universe.entries[key] = entry.ID
-		for _, group := range entry.Meta.GetSlice(regapi.TagGroups) {
-			universe.groups[group] = append(universe.groups[group], entry.ID)
-		}
-		if entry.ID.NS != "" {
-			universe.ns[entry.ID.NS] = append(universe.ns[entry.ID.NS], entry.ID)
-		}
-	}
-	return universe
-}
-
-func entryDependsOn(entry regapi.Entry, target regapi.ID, universe dependencyEntryUniverseView, resolver regapi.DependencyResolver) bool {
-	dependencies := entry.Meta.GetSlice(regapi.TagDependsOn)
-	dependencies = append(dependencies, resolver.Extract(entry)...)
-	for _, dep := range dependencies {
-		switch depType, value := parseDependencyRef(dep); depType {
-		case "direct":
-			if resolveDependencyRef(entry.ID.NS, value) == target {
-				return true
-			}
-		case "group":
-			for _, id := range universe.groups[value] {
-				if id == target {
-					return true
-				}
-			}
-		case "namespace":
-			for _, id := range universe.ns[value] {
-				if id == target {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-func parseDependencyRef(dep string) (depType string, value string) {
-	if strings.HasPrefix(dep, "group:") {
-		return "group", strings.TrimPrefix(dep, "group:")
-	}
-	if strings.HasPrefix(dep, "ns:") {
-		return "namespace", strings.TrimPrefix(dep, "ns:")
-	}
-	return "direct", dep
-}
-
-func resolveDependencyRef(sourceNS string, dep string) regapi.ID {
-	if strings.Contains(dep, ":") {
-		return regapi.ParseID(dep)
-	}
-	return regapi.NewID(sourceNS, dep)
-}
-
-func sameImmutableModuleVersion(existing, desired regapi.Entry, mutableModules map[string]struct{}) bool {
-	if mutableModules == nil {
-		return false
-	}
-	module := entryModule(desired)
-	if module == "" || module != entryModule(existing) {
-		return false
-	}
-	if _, mutable := mutableModules[module]; mutable {
-		return false
-	}
-	existingVersion := moduleVersion(existing)
-	desiredVersion := moduleVersion(desired)
-	if existingVersion != "" && desiredVersion != "" && existingVersion != desiredVersion {
-		return false
-	}
-	return true
-}
-
-func entryConflict(existing, desired regapi.Entry) bool {
-	desiredModule := entryModule(desired)
-	if desiredModule == "" {
-		return false
-	}
-	existingModule := entryModule(existing)
-	return existingModule == "" || existingModule != desiredModule
-}
-
-func entryModule(entry regapi.Entry) string {
-	if entry.Meta == nil {
-		return ""
-	}
-	if v, ok := entry.Meta[metaModuleKey]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
-func moduleVersion(entry regapi.Entry) string {
-	if entry.Meta == nil {
-		return ""
-	}
-	if v, ok := entry.Meta[metaModuleVersionKey]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
-func moduleDigest(entry regapi.Entry) string {
-	if entry.Meta == nil {
-		return ""
-	}
-	if v, ok := entry.Meta[metaModuleDigestKey]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
-	}
-	return ""
-}
-
-func snapshotModuleDigests(snapshot regapi.State) map[string]string {
-	digests := make(map[string]string)
-	ambiguous := make(map[string]struct{})
-	for _, entry := range snapshot {
-		module := entryModule(entry)
-		digest := moduleDigest(entry)
-		if module == "" || digest == "" {
-			continue
-		}
-		if _, bad := ambiguous[module]; bad {
-			continue
-		}
-		if existing, seen := digests[module]; seen && !strings.EqualFold(existing, digest) {
-			delete(digests, module)
-			ambiguous[module] = struct{}{}
-			continue
-		}
-		digests[module] = digest
-	}
-	return digests
-}
-
-func isRootDependency(entry regapi.Entry) bool {
-	return entry.Kind == regapi.NamespaceDependency && (entry.DependencyRoot || entryModule(entry) == "")
-}
-
-func markModuleMeta(entry regapi.Entry, moduleName, moduleVersion string) regapi.Entry {
-	meta := entry.Meta
-	if meta == nil {
-		meta = attrs.NewBag()
-	} else {
-		meta = attrs.NewBagFrom(meta)
-	}
-	existingModule := strings.TrimSpace(meta.GetString(metaModuleKey, ""))
-	if existingModule == "" {
-		meta.Set(metaModuleKey, moduleName)
-		if moduleVersion != "" {
-			meta.Set(metaModuleVersionKey, moduleVersion)
-		}
-	} else if existingModule == moduleName && moduleVersion != "" && meta.GetString(metaModuleVersionKey, "") == "" {
-		meta.Set(metaModuleVersionKey, moduleVersion)
-	}
-	entry.Meta = meta
-	return entry
-}
-
-func markModuleIdentity(entry regapi.Entry, moduleName, moduleVersion, digest string) regapi.Entry {
-	entry = markModuleMeta(entry, moduleName, moduleVersion)
-	if entryModule(entry) != moduleName || digest == "" {
-		return entry
-	}
-	meta := attrs.NewBagFrom(entry.Meta)
-	meta.Set(metaModuleDigestKey, digest)
-	entry.Meta = meta
-	return entry
-}
-
-func markModuleIdentityForGraph(
-	entry regapi.Entry,
-	moduleName string,
-	moduleVersion string,
-	digest string,
-	namespaceOwners map[string]moduleOwner,
-	entryOwners map[string]moduleOwner,
-) regapi.Entry {
-	if entryModule(entry) != "" {
-		return markModuleIdentity(entry, moduleName, moduleVersion, digest)
-	}
-	if owner, ok := entryOwners[idKey(entry.ID)]; ok && owner.name != "" {
-		if owner.name == moduleName {
-			return markModuleIdentity(entry, moduleName, moduleVersion, digest)
-		}
-		return markModuleIdentity(entry, owner.name, owner.version, owner.digest)
-	}
-	if owner, ok := namespaceOwners[entry.ID.NS]; ok && owner.name != "" {
-		return markModuleIdentity(entry, owner.name, owner.version, owner.digest)
-	}
-	return markModuleIdentity(entry, moduleName, moduleVersion, digest)
-}
-
-func markModuleMetaForGraph(
-	entry regapi.Entry,
-	moduleName string,
-	moduleVersion string,
-	namespaceOwners map[string]moduleOwner,
-	entryOwners map[string]moduleOwner,
-) regapi.Entry {
-	if entryModule(entry) != "" {
-		return markModuleMeta(entry, moduleName, moduleVersion)
-	}
-	if owner, ok := entryOwners[idKey(entry.ID)]; ok && owner.name != "" {
-		if owner.name == moduleName {
-			return markModuleMeta(entry, moduleName, moduleVersion)
-		}
-		return markModuleMeta(entry, owner.name, owner.version)
-	}
-	if owner, ok := namespaceOwners[entry.ID.NS]; ok && owner.name != "" {
-		return markModuleMeta(entry, owner.name, owner.version)
-	}
-	return markModuleMeta(entry, moduleName, moduleVersion)
-}
-
 func idKey(id regapi.ID) string {
 	if strings.TrimSpace(id.NS) == "" {
 		name := strings.TrimSpace(id.Name)
@@ -2823,25 +2345,6 @@ func idsEqual(a, b regapi.ID) bool {
 		return true
 	}
 	return strings.TrimSpace(a.String()) == strings.TrimSpace(b.String())
-}
-
-func entriesEqual(a, b regapi.Entry) bool {
-	if !idsEqual(a.ID, b.ID) || a.Kind != b.Kind {
-		return false
-	}
-	if !reflect.DeepEqual(a.Meta, b.Meta) {
-		return false
-	}
-	switch {
-	case a.Data == nil && b.Data == nil:
-		return true
-	case a.Data == nil || b.Data == nil:
-		return false
-	}
-	if a.Data.Format() != b.Data.Format() {
-		return false
-	}
-	return reflect.DeepEqual(a.Data.Data(), b.Data.Data())
 }
 
 func resolveOperationEntry(op regapi.Operation, snapshot regapi.State) (regapi.Entry, bool) {

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -353,28 +353,42 @@ func TestUnwrapPayloadData_MapWithExtraKeys(t *testing.T) {
 	assert.Equal(t, m, unwrapPayloadData(m))
 }
 
-// --- buildOperations ---
+// --- operationPlanner ---
 
-func TestBuildOperations_EmptyBoth(t *testing.T) {
-	ops, err := buildOperations(nil, nil, regapi.NewID("app", "dep"), nil, nil)
+func planTestOperations(
+	current regapi.State,
+	desired []regapi.Entry,
+	originalID regapi.ID,
+	controlledModules map[string]struct{},
+	mutableModules map[string]struct{},
+) ([]regapi.Operation, error) {
+	return (operationPlanner{}).plan(current, desired, operationPlanOptions{
+		originalKey:       idKey(originalID),
+		controlledModules: controlledModules,
+		mutableModules:    mutableModules,
+	})
+}
+
+func TestOperationPlanner_EmptyBoth(t *testing.T) {
+	ops, err := planTestOperations(nil, nil, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, ops)
 }
 
-func TestBuildOperations_NewEntries(t *testing.T) {
+func TestOperationPlanner_NewEntries(t *testing.T) {
 	desired := []regapi.Entry{
 		{ID: regapi.NewID("app", "dep"), Kind: "ns.dependency"},
 		{ID: regapi.NewID("app", "svc"), Kind: "service", Data: payload.New("data")},
 	}
 
-	ops, err := buildOperations(nil, desired, regapi.NewID("app", "dep"), nil, nil)
+	ops, err := planTestOperations(nil, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	require.Len(t, ops, 1) // dep is excluded (originalID)
 	assert.Equal(t, regapi.EntryCreate, ops[0].Kind)
 	assert.Equal(t, regapi.NewID("app", "svc"), ops[0].Entry.ID)
 }
 
-func TestBuildOperations_DeletedEntries(t *testing.T) {
+func TestOperationPlanner_DeletedEntries(t *testing.T) {
 	current := regapi.State{
 		{ID: regapi.NewID("app", "dep"), Kind: "ns.dependency"},
 		{
@@ -387,14 +401,14 @@ func TestBuildOperations_DeletedEntries(t *testing.T) {
 		{ID: regapi.NewID("app", "dep"), Kind: "ns.dependency"},
 	}
 
-	ops, err := buildOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
+	ops, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	assert.Equal(t, regapi.EntryDelete, ops[0].Kind)
 	assert.Equal(t, regapi.NewID("app", "old-svc"), ops[0].Entry.ID)
 }
 
-func TestBuildOperations_DeletesOnlyControlledModules(t *testing.T) {
+func TestOperationPlanner_DeletesOnlyControlledModules(t *testing.T) {
 	current := regapi.State{
 		{ID: regapi.NewID("app", "dep"), Kind: "ns.dependency"},
 		{
@@ -413,14 +427,14 @@ func TestBuildOperations_DeletesOnlyControlledModules(t *testing.T) {
 	}
 	controlled := map[string]struct{}{"acme/http": {}}
 
-	ops, err := buildOperations(current, desired, regapi.NewID("app", "dep"), controlled, nil)
+	ops, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), controlled, nil)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	assert.Equal(t, regapi.EntryDelete, ops[0].Kind)
 	assert.Equal(t, regapi.NewID("app", "old-svc"), ops[0].Entry.ID)
 }
 
-func TestBuildOperations_UpdatedEntries(t *testing.T) {
+func TestOperationPlanner_UpdatedEntries(t *testing.T) {
 	current := regapi.State{
 		{
 			ID:   regapi.NewID("app", "svc"),
@@ -438,13 +452,13 @@ func TestBuildOperations_UpdatedEntries(t *testing.T) {
 		},
 	}
 
-	ops, err := buildOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
+	ops, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
 }
 
-func TestBuildOperations_ReconcileSkipsUntouchedImmutableModuleUpdates(t *testing.T) {
+func TestOperationPlanner_ReconcileSkipsUntouchedImmutableModuleUpdates(t *testing.T) {
 	moduleMeta := attrs.NewBagFrom(map[string]any{
 		metaModuleKey:        "acme/http",
 		metaModuleVersionKey: "v1.0.0",
@@ -462,17 +476,17 @@ func TestBuildOperations_ReconcileSkipsUntouchedImmutableModuleUpdates(t *testin
 		Data: payload.New("normalized"),
 	}}
 
-	ops, err := buildOperations(current, desired, regapi.ID{}, map[string]struct{}{"acme/http": {}}, map[string]struct{}{})
+	ops, err := planTestOperations(current, desired, regapi.ID{}, map[string]struct{}{"acme/http": {}}, map[string]struct{}{})
 	require.NoError(t, err)
 	require.Empty(t, ops, "an unchanged immutable artifact must not be rewritten during history reconciliation")
 
-	ops, err = buildOperations(current, desired, regapi.ID{}, map[string]struct{}{"acme/http": {}}, map[string]struct{}{"acme/http": {}})
+	ops, err = planTestOperations(current, desired, regapi.ID{}, map[string]struct{}{"acme/http": {}}, map[string]struct{}{"acme/http": {}})
 	require.NoError(t, err)
 	require.Len(t, ops, 1, "an explicitly mutable artifact must still update")
 	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
 }
 
-func TestBuildOperations_KindChangeUsesDeleteCreate(t *testing.T) {
+func TestOperationPlanner_KindChangeUsesDeleteCreate(t *testing.T) {
 	id := regapi.NewID("ui", "assets")
 	current := regapi.State{{
 		ID:   id,
@@ -487,7 +501,7 @@ func TestBuildOperations_KindChangeUsesDeleteCreate(t *testing.T) {
 		Data: payload.New(map[string]any{"directory": "assets", "base": "module"}),
 	}}
 
-	ops, err := buildOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
+	ops, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	require.Len(t, ops, 2)
 	assert.Equal(t, regapi.EntryDelete, ops[0].Kind)
@@ -496,7 +510,7 @@ func TestBuildOperations_KindChangeUsesDeleteCreate(t *testing.T) {
 	assert.Equal(t, regapi.Kind("fs.directory"), ops[1].Entry.Kind)
 }
 
-func TestBuildOperations_UnchangedEntries(t *testing.T) {
+func TestOperationPlanner_UnchangedEntries(t *testing.T) {
 	entry := regapi.Entry{
 		ID:   regapi.NewID("app", "svc"),
 		Kind: "service",
@@ -505,12 +519,12 @@ func TestBuildOperations_UnchangedEntries(t *testing.T) {
 	current := regapi.State{entry}
 	desired := []regapi.Entry{entry}
 
-	ops, err := buildOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
+	ops, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, ops)
 }
 
-func TestBuildOperations_ConflictError(t *testing.T) {
+func TestOperationPlanner_ConflictError(t *testing.T) {
 	current := regapi.State{
 		{ID: regapi.NewID("app", "svc"), Kind: "service", Data: payload.New("local")},
 	}
@@ -523,12 +537,12 @@ func TestBuildOperations_ConflictError(t *testing.T) {
 		},
 	}
 
-	_, err := buildOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
+	_, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conflict")
 }
 
-func TestBuildOperations_SkipsNonModuleDeletes(t *testing.T) {
+func TestOperationPlanner_SkipsNonModuleDeletes(t *testing.T) {
 	current := regapi.State{
 		{ID: regapi.NewID("app", "dep"), Kind: "ns.dependency"},
 		{ID: regapi.NewID("app", "local-svc"), Kind: "service", Data: payload.New("local")},
@@ -537,7 +551,7 @@ func TestBuildOperations_SkipsNonModuleDeletes(t *testing.T) {
 		{ID: regapi.NewID("app", "dep"), Kind: "ns.dependency"},
 	}
 
-	ops, err := buildOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
+	ops, err := planTestOperations(current, desired, regapi.NewID("app", "dep"), nil, nil)
 	require.NoError(t, err)
 	// local-svc has no module meta, so it won't be deleted
 	assert.Empty(t, ops)

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2947,9 +2948,11 @@ func TestDependencyHandler_CollectControlledModules_FollowsInstalledDependencyLi
 	require.NoError(t, err)
 
 	rootDep := regapi.Entry{
-		ID:   regapi.NewID("app.deps", "root"),
-		Kind: regapi.NamespaceDependency,
-		Data: payload.NewPayload(`{"component":"acme/app","version":"1.0.0"}`, payload.JSON),
+		ID:             regapi.NewID("app.deps", "root"),
+		Kind:           regapi.NamespaceDependency,
+		DependencyRoot: true,
+		Meta:           attrs.NewBagFrom(map[string]any{metaModuleKey: "acme/deployment"}),
+		Data:           payload.NewPayload(`{"component":"acme/app","version":"1.0.0"}`, payload.JSON),
 	}
 	appDep := regapi.Entry{
 		ID:   regapi.NewID("acme.app", "lib_dep"),
@@ -2975,8 +2978,49 @@ func TestDependencyHandler_CollectControlledModules_FollowsInstalledDependencyLi
 	assert.Contains(t, controlled, "acme/app")
 	assert.Contains(t, controlled, "acme/lib")
 	assert.Contains(t, controlled, "acme/core")
+	assert.NotContains(t, controlled, "acme/deployment", "an owned root controls its declared component, not its deployment package")
 	assert.NotContains(t, controlled, "keeper/keeper")
 	assert.NotContains(t, controlled, "keeper/helper")
+}
+
+func TestDependencyHandler_ReconciliationControlSpansBothGraphsWithoutOwningDeployment(t *testing.T) {
+	ctx := newTestContext()
+	transcoder := payload.GetTranscoder(ctx)
+	require.NotNil(t, transcoder)
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{}, Logger: zap.NewNop(), VendorDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	root := func(name, component string) regapi.Entry {
+		return regapi.Entry{
+			ID:             regapi.NewID("app.deps", name),
+			Kind:           regapi.NamespaceDependency,
+			DependencyRoot: true,
+			Meta:           attrs.NewBagFrom(map[string]any{metaModuleKey: "acme/deployment"}),
+			Data:           payload.New(map[string]any{"component": component, "version": "v1.0.0"}),
+		}
+	}
+	child := func(owner, component string) regapi.Entry {
+		return regapi.Entry{
+			ID:   regapi.NewID(strings.ReplaceAll(owner, "/", "."), "child_dep"),
+			Kind: regapi.NamespaceDependency,
+			Meta: attrs.NewBagFrom(map[string]any{metaModuleKey: owner}),
+			Data: payload.New(map[string]any{"component": component, "version": "v1.0.0"}),
+		}
+	}
+
+	current := regapi.State{root("old", "acme/old"), child("acme/old", "acme/old-child")}
+	target := regapi.State{root("new", "acme/new"), child("acme/new", "acme/new-child")}
+	controlled, err := handler.reconciliationControlledModules(
+		ctx, current, target, transcoder, map[string]struct{}{"acme/new": {}},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, controlled, "acme/old")
+	assert.Contains(t, controlled, "acme/old-child")
+	assert.Contains(t, controlled, "acme/new")
+	assert.Contains(t, controlled, "acme/new-child")
+	assert.NotContains(t, controlled, "acme/deployment")
 }
 
 func TestDependencyHandler_Expand_PreservesLockLoadedModuleEntries(t *testing.T) {

--- a/boot/deps/hub/entry_provenance.go
+++ b/boot/deps/hub/entry_provenance.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"strings"
+
+	"github.com/wippyai/runtime/api/attrs"
+	regapi "github.com/wippyai/runtime/api/registry"
+)
+
+const (
+	metaModuleKey        = "module"
+	metaModuleVersionKey = "module_version"
+	metaModuleDigestKey  = "module_digest"
+)
+
+type moduleOwner struct {
+	name    string
+	version string
+	digest  string
+}
+
+func moduleOwnersByNamespace(modules []ResolvedModule) map[string]moduleOwner {
+	owners := make(map[string]moduleOwner, len(modules))
+	for _, mod := range modules {
+		if mod.Org == "" || mod.Name == "" {
+			continue
+		}
+		namespace := mod.Org + "." + mod.Name
+		owners[namespace] = moduleOwner{
+			name:    mod.Org + "/" + mod.Name,
+			version: mod.Version,
+			digest:  mod.Digest,
+		}
+	}
+	return owners
+}
+
+func moduleOwnersByEntryID(entries regapi.State) map[string]moduleOwner {
+	owners := make(map[string]moduleOwner, len(entries))
+	for _, entry := range entries {
+		module := entryModule(entry)
+		if module == "" {
+			continue
+		}
+		owners[idKey(entry.ID)] = moduleOwner{
+			name:    module,
+			version: moduleVersion(entry),
+			digest:  moduleDigest(entry),
+		}
+	}
+	return owners
+}
+
+func snapshotModuleVersions(snapshot regapi.State) map[string]string {
+	versions := make(map[string]string)
+	ambiguous := make(map[string]struct{})
+	for _, entry := range snapshot {
+		module := entryModule(entry)
+		if module == "" || entry.Meta == nil {
+			continue
+		}
+		raw, ok := entry.Meta[metaModuleVersionKey]
+		if !ok {
+			continue
+		}
+		version, ok := raw.(string)
+		if !ok || version == "" {
+			continue
+		}
+		if _, bad := ambiguous[module]; bad {
+			continue
+		}
+		if existing, seen := versions[module]; seen && existing != version {
+			delete(versions, module)
+			ambiguous[module] = struct{}{}
+			continue
+		}
+		versions[module] = version
+	}
+	return versions
+}
+
+func snapshotModuleDigests(snapshot regapi.State) map[string]string {
+	digests := make(map[string]string)
+	ambiguous := make(map[string]struct{})
+	for _, entry := range snapshot {
+		module := entryModule(entry)
+		digest := moduleDigest(entry)
+		if module == "" || digest == "" {
+			continue
+		}
+		if _, bad := ambiguous[module]; bad {
+			continue
+		}
+		if existing, seen := digests[module]; seen && !strings.EqualFold(existing, digest) {
+			delete(digests, module)
+			ambiguous[module] = struct{}{}
+			continue
+		}
+		digests[module] = digest
+	}
+	return digests
+}
+
+func entryModule(entry regapi.Entry) string {
+	if entry.Meta == nil {
+		return ""
+	}
+	if v, ok := entry.Meta[metaModuleKey]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func moduleVersion(entry regapi.Entry) string {
+	if entry.Meta == nil {
+		return ""
+	}
+	if v, ok := entry.Meta[metaModuleVersionKey]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func moduleDigest(entry regapi.Entry) string {
+	if entry.Meta == nil {
+		return ""
+	}
+	if v, ok := entry.Meta[metaModuleDigestKey]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func markModuleMeta(entry regapi.Entry, moduleName, moduleVersion string) regapi.Entry {
+	meta := entry.Meta
+	if meta == nil {
+		meta = attrs.NewBag()
+	} else {
+		meta = attrs.NewBagFrom(meta)
+	}
+	existingModule := strings.TrimSpace(meta.GetString(metaModuleKey, ""))
+	if existingModule == "" {
+		meta.Set(metaModuleKey, moduleName)
+		if moduleVersion != "" {
+			meta.Set(metaModuleVersionKey, moduleVersion)
+		}
+	} else if existingModule == moduleName && moduleVersion != "" && meta.GetString(metaModuleVersionKey, "") == "" {
+		meta.Set(metaModuleVersionKey, moduleVersion)
+	}
+	entry.Meta = meta
+	return entry
+}
+
+func markModuleIdentity(entry regapi.Entry, moduleName, moduleVersion, digest string) regapi.Entry {
+	entry = markModuleMeta(entry, moduleName, moduleVersion)
+	if entryModule(entry) != moduleName || digest == "" {
+		return entry
+	}
+	meta := attrs.NewBagFrom(entry.Meta)
+	meta.Set(metaModuleDigestKey, digest)
+	entry.Meta = meta
+	return entry
+}
+
+func markModuleIdentityForGraph(
+	entry regapi.Entry,
+	moduleName string,
+	moduleVersion string,
+	digest string,
+	namespaceOwners map[string]moduleOwner,
+	entryOwners map[string]moduleOwner,
+) regapi.Entry {
+	if entryModule(entry) != "" {
+		return markModuleIdentity(entry, moduleName, moduleVersion, digest)
+	}
+	if owner, ok := entryOwners[idKey(entry.ID)]; ok && owner.name != "" {
+		if owner.name == moduleName {
+			return markModuleIdentity(entry, moduleName, moduleVersion, digest)
+		}
+		return markModuleIdentity(entry, owner.name, owner.version, owner.digest)
+	}
+	if owner, ok := namespaceOwners[entry.ID.NS]; ok && owner.name != "" {
+		return markModuleIdentity(entry, owner.name, owner.version, owner.digest)
+	}
+	return markModuleIdentity(entry, moduleName, moduleVersion, digest)
+}
+
+func markModuleMetaForGraph(
+	entry regapi.Entry,
+	moduleName string,
+	moduleVersion string,
+	namespaceOwners map[string]moduleOwner,
+	entryOwners map[string]moduleOwner,
+) regapi.Entry {
+	if entryModule(entry) != "" {
+		return markModuleMeta(entry, moduleName, moduleVersion)
+	}
+	if owner, ok := entryOwners[idKey(entry.ID)]; ok && owner.name != "" {
+		if owner.name == moduleName {
+			return markModuleMeta(entry, moduleName, moduleVersion)
+		}
+		return markModuleMeta(entry, owner.name, owner.version)
+	}
+	if owner, ok := namespaceOwners[entry.ID.NS]; ok && owner.name != "" {
+		return markModuleMeta(entry, owner.name, owner.version)
+	}
+	return markModuleMeta(entry, moduleName, moduleVersion)
+}

--- a/boot/deps/hub/operation_planner.go
+++ b/boot/deps/hub/operation_planner.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"reflect"
+	"strings"
+
+	regapi "github.com/wippyai/runtime/api/registry"
+)
+
+func entriesEqual(a, b regapi.Entry) bool {
+	if !idsEqual(a.ID, b.ID) || a.Kind != b.Kind || a.DependencyRoot != b.DependencyRoot {
+		return false
+	}
+	if !reflect.DeepEqual(a.Meta, b.Meta) {
+		return false
+	}
+	switch {
+	case a.Data == nil && b.Data == nil:
+		return true
+	case a.Data == nil || b.Data == nil:
+		return false
+	}
+	if a.Data.Format() != b.Data.Format() {
+		return false
+	}
+	return reflect.DeepEqual(a.Data.Data(), b.Data.Data())
+}
+
+type operationPlanOptions struct {
+	controlledModules map[string]struct{}
+	mutableModules    map[string]struct{}
+	originalKey       string
+}
+
+type operationPlanner struct {
+	resolver regapi.DependencyResolver
+}
+
+func (p operationPlanner) plan(current regapi.State, desired []regapi.Entry, opts operationPlanOptions) ([]regapi.Operation, error) {
+	currentByID := make(map[string]regapi.Entry, len(current))
+	for _, entry := range current {
+		currentByID[idKey(entry.ID)] = entry
+	}
+
+	desiredByID := make(map[string]regapi.Entry, len(desired))
+	for _, entry := range desired {
+		desiredByID[idKey(entry.ID)] = entry
+	}
+
+	ops := make([]regapi.Operation, 0)
+	originalKey := opts.originalKey
+	for key, entry := range desiredByID {
+		if key == originalKey {
+			continue
+		}
+		if existing, ok := currentByID[key]; ok {
+			if entryConflict(existing, entry) {
+				return nil, NewDependencyEntryConflictError(entry.ID.String(), entryModule(existing), entryModule(entry))
+			}
+			if !entriesEqual(existing, entry) {
+				if existing.Kind != entry.Kind {
+					ops = append(ops,
+						regapi.Operation{Kind: regapi.EntryDelete, Entry: existing},
+						regapi.Operation{Kind: regapi.EntryCreate, Entry: entry},
+					)
+					continue
+				}
+				if preserveImmutableResidentEntry(existing, entry, opts.mutableModules) {
+					continue
+				}
+				ops = append(ops, regapi.Operation{Kind: regapi.EntryUpdate, Entry: entry})
+			}
+		} else {
+			ops = append(ops, regapi.Operation{Kind: regapi.EntryCreate, Entry: entry})
+		}
+	}
+
+	for key, entry := range currentByID {
+		if key == originalKey {
+			continue
+		}
+		if _, ok := desiredByID[key]; ok {
+			continue
+		}
+		if module := entryModule(entry); module != "" {
+			if opts.controlledModules != nil {
+				if _, ok := opts.controlledModules[module]; !ok {
+					continue
+				}
+			}
+			if hasLiveDependent(entry.ID, currentByID, desiredByID, opts.controlledModules, p.resolver) {
+				continue
+			}
+			ops = append(ops, regapi.Operation{Kind: regapi.EntryDelete, Entry: regapi.Entry{ID: entry.ID}})
+		}
+	}
+
+	return ops, nil
+}
+
+func hasLiveDependent(
+	target regapi.ID,
+	currentByID map[string]regapi.Entry,
+	desiredByID map[string]regapi.Entry,
+	controlledModules map[string]struct{},
+	resolver regapi.DependencyResolver,
+) bool {
+	if resolver == nil {
+		return false
+	}
+	universe := dependencyEntryUniverse(currentByID)
+	targetKey := idKey(target)
+	for key, current := range currentByID {
+		if key == targetKey {
+			continue
+		}
+		check := current
+		if desired, ok := desiredByID[key]; ok {
+			check = desired
+		} else if missingDesiredEntryWillBeDeleted(current, controlledModules) {
+			continue
+		}
+		if entryDependsOn(check, target, universe, resolver) {
+			return true
+		}
+	}
+	return false
+}
+
+func missingDesiredEntryWillBeDeleted(entry regapi.Entry, controlledModules map[string]struct{}) bool {
+	module := entryModule(entry)
+	if module == "" {
+		return false
+	}
+	if controlledModules == nil {
+		return true
+	}
+	_, ok := controlledModules[module]
+	return ok
+}
+
+type dependencyEntryUniverseView struct {
+	groups map[string][]regapi.ID
+	ns     map[string][]regapi.ID
+}
+
+func dependencyEntryUniverse(entries map[string]regapi.Entry) dependencyEntryUniverseView {
+	universe := dependencyEntryUniverseView{
+		groups: make(map[string][]regapi.ID),
+		ns:     make(map[string][]regapi.ID),
+	}
+	for _, entry := range entries {
+		for _, group := range entry.Meta.GetSlice(regapi.TagGroups) {
+			universe.groups[group] = append(universe.groups[group], entry.ID)
+		}
+		if entry.ID.NS != "" {
+			universe.ns[entry.ID.NS] = append(universe.ns[entry.ID.NS], entry.ID)
+		}
+	}
+	return universe
+}
+
+func entryDependsOn(entry regapi.Entry, target regapi.ID, universe dependencyEntryUniverseView, resolver regapi.DependencyResolver) bool {
+	dependencies := entry.Meta.GetSlice(regapi.TagDependsOn)
+	dependencies = append(dependencies, resolver.Extract(entry)...)
+	for _, dep := range dependencies {
+		switch depType, value := parseDependencyRef(dep); depType {
+		case "direct":
+			if resolveDependencyRef(entry.ID.NS, value) == target {
+				return true
+			}
+		case "group":
+			for _, id := range universe.groups[value] {
+				if id == target {
+					return true
+				}
+			}
+		case "namespace":
+			for _, id := range universe.ns[value] {
+				if id == target {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func parseDependencyRef(dep string) (depType string, value string) {
+	if strings.HasPrefix(dep, "group:") {
+		return "group", strings.TrimPrefix(dep, "group:")
+	}
+	if strings.HasPrefix(dep, "ns:") {
+		return "namespace", strings.TrimPrefix(dep, "ns:")
+	}
+	return "direct", dep
+}
+
+func resolveDependencyRef(sourceNS string, dep string) regapi.ID {
+	if strings.Contains(dep, ":") {
+		return regapi.ParseID(dep)
+	}
+	return regapi.NewID(sourceNS, dep)
+}
+
+// preserveImmutableResidentEntry prevents metadata normalization from
+// rewriting an installed artifact that was not selected as mutable.
+func preserveImmutableResidentEntry(existing, desired regapi.Entry, mutableModules map[string]struct{}) bool {
+	if mutableModules == nil {
+		return false
+	}
+	if existing.DependencyRoot != desired.DependencyRoot {
+		return false
+	}
+	module := entryModule(desired)
+	if module == "" || module != entryModule(existing) {
+		return false
+	}
+	if _, mutable := mutableModules[module]; mutable {
+		return false
+	}
+	existingVersion := moduleVersion(existing)
+	desiredVersion := moduleVersion(desired)
+	if existingVersion != "" && desiredVersion != "" && existingVersion != desiredVersion {
+		return false
+	}
+	return true
+}
+
+func entryConflict(existing, desired regapi.Entry) bool {
+	desiredModule := entryModule(desired)
+	if desiredModule == "" {
+		return false
+	}
+	existingModule := entryModule(existing)
+	return existingModule == "" || existingModule != desiredModule
+}

--- a/boot/deps/hub/operation_planner_test.go
+++ b/boot/deps/hub/operation_planner_test.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	regtop "github.com/wippyai/runtime/system/registry/topology"
+)
+
+func TestOperationPlanner_MutableArtifactBoundary(t *testing.T) {
+	base := plannerTestEntry("service", "acme/service", "v1.0.0", "sha256:old", "resident")
+
+	tests := []struct {
+		name      string
+		mutate    func(regapi.Entry) regapi.Entry
+		wantKinds []string
+		mutable   bool
+		wantError bool
+	}{
+		{
+			name: "identical",
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				return entry
+			},
+		},
+		{
+			name: "immutable digest metadata drift",
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Meta.Set(metaModuleDigestKey, "sha256:new")
+				return entry
+			},
+		},
+		{
+			name:    "mutable digest metadata drift",
+			mutable: true,
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Meta.Set(metaModuleDigestKey, "sha256:new")
+				return entry
+			},
+			wantKinds: []string{regapi.EntryUpdate},
+		},
+		{
+			name: "immutable data normalization",
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Data = payload.New(map[string]any{"value": "normalized"})
+				return entry
+			},
+		},
+		{
+			name:    "mutable host data drift",
+			mutable: true,
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Data = payload.New(map[string]any{"value": "changed"})
+				return entry
+			},
+			wantKinds: []string{regapi.EntryUpdate},
+		},
+		{
+			name: "version change remains effective",
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Meta.Set(metaModuleVersionKey, "v2.0.0")
+				return entry
+			},
+			wantKinds: []string{regapi.EntryUpdate},
+		},
+		{
+			name: "owner conflict remains effective",
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Meta.Set(metaModuleKey, "other/service")
+				return entry
+			},
+			wantError: true,
+		},
+		{
+			name: "kind change remains effective",
+			mutate: func(entry regapi.Entry) regapi.Entry {
+				entry.Kind = "other.kind"
+				return entry
+			},
+			wantKinds: []string{regapi.EntryDelete, regapi.EntryCreate},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := clonePlannerTestEntry(base)
+			desired := tt.mutate(clonePlannerTestEntry(current))
+			mutable := map[string]struct{}{}
+			if tt.mutable {
+				mutable[entryModule(desired)] = struct{}{}
+			}
+
+			ops, err := (operationPlanner{}).plan(regapi.State{current}, []regapi.Entry{desired}, operationPlanOptions{
+				controlledModules: map[string]struct{}{"acme/service": {}},
+				mutableModules:    mutable,
+			})
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, ops, len(tt.wantKinds))
+			for i, kind := range tt.wantKinds {
+				assert.Equal(t, kind, ops[i].Kind)
+			}
+		})
+	}
+}
+
+func TestOperationPlanner_DependencyRootTransitionsRemainEffective(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		from bool
+		to   bool
+	}{
+		{name: "promotion", from: false, to: true},
+		{name: "demotion", from: true, to: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			current := plannerTestEntry(regapi.NamespaceDependency, "acme/deployment", "v1.0.0", "sha256:a", "root")
+			current.DependencyRoot = test.from
+			desired := clonePlannerTestEntry(current)
+			desired.DependencyRoot = test.to
+
+			ops, err := (operationPlanner{}).plan(regapi.State{current}, []regapi.Entry{desired}, operationPlanOptions{
+				controlledModules: map[string]struct{}{"acme/deployment": {}},
+				mutableModules:    map[string]struct{}{},
+			})
+			require.NoError(t, err)
+			require.Len(t, ops, 1)
+			assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
+			assert.Equal(t, test.to, ops[0].Entry.DependencyRoot)
+		})
+	}
+}
+
+func TestOperationPlanner_NilMutableSetUsesNormalDiff(t *testing.T) {
+	current := plannerTestEntry("service", "acme/service", "v1.0.0", "sha256:old", "same")
+	desired := clonePlannerTestEntry(current)
+	desired.Meta.Set(metaModuleDigestKey, "sha256:new")
+
+	ops, err := (operationPlanner{}).plan(regapi.State{current}, []regapi.Entry{desired}, operationPlanOptions{})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
+}
+
+func TestOperationPlanner_ControlledDeletionBoundary(t *testing.T) {
+	controlled := plannerTestEntry("service", "acme/controlled", "v1.0.0", "sha256:a", "controlled")
+	unrelated := plannerTestEntry("service", "acme/unrelated", "v1.0.0", "sha256:b", "unrelated")
+	unrelated.ID = regapi.NewID("other", "service")
+	host := regapi.Entry{ID: regapi.NewID("app", "host"), Kind: "service", Data: payload.New("host")}
+
+	ops, err := (operationPlanner{}).plan(regapi.State{controlled, unrelated, host}, nil, operationPlanOptions{
+		controlledModules: map[string]struct{}{"acme/controlled": {}},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, regapi.EntryDelete, ops[0].Kind)
+	assert.Equal(t, controlled.ID, ops[0].Entry.ID)
+}
+
+func TestOperationPlanner_LiveDependentRetainsControlledEntry(t *testing.T) {
+	target := plannerTestEntry("library", "acme/library", "v1.0.0", "sha256:a", "target")
+	dependent := regapi.Entry{
+		ID:   regapi.NewID(target.ID.NS, "dependent"),
+		Kind: "service",
+		Meta: attrs.NewBagFrom(map[string]any{regapi.TagDependsOn: []string{target.ID.Name}}),
+		Data: payload.New("dependent"),
+	}
+
+	ops, err := (operationPlanner{resolver: regtop.NewResolver()}).plan(
+		regapi.State{target, dependent},
+		[]regapi.Entry{dependent},
+		operationPlanOptions{controlledModules: map[string]struct{}{"acme/library": {}}},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, ops)
+}
+
+func TestOperationPlanner_PlanConvergesAndIsIdempotent(t *testing.T) {
+	const entryCount = 4
+	for currentMask := 0; currentMask < 1<<entryCount; currentMask++ {
+		for desiredMask := 0; desiredMask < 1<<entryCount; desiredMask++ {
+			name := fmt.Sprintf("current_%02d_desired_%02d", currentMask, desiredMask)
+			t.Run(name, func(t *testing.T) {
+				current := make(regapi.State, 0, entryCount)
+				desired := make([]regapi.Entry, 0, entryCount)
+				controlled := make(map[string]struct{}, entryCount)
+				for i := 0; i < entryCount; i++ {
+					module := fmt.Sprintf("acme/module-%d", i)
+					controlled[module] = struct{}{}
+					if currentMask&(1<<i) != 0 {
+						entry := plannerTestEntry("service", module, "v1.0.0", fmt.Sprintf("sha256:current-%d", i), fmt.Sprintf("current-%d", i))
+						entry.ID = regapi.NewID("test", fmt.Sprintf("entry_%d", i))
+						current = append(current, entry)
+					}
+					if desiredMask&(1<<i) != 0 {
+						entry := plannerTestEntry("service", module, "v1.0.0", fmt.Sprintf("sha256:desired-%d", i), fmt.Sprintf("desired-%d", i))
+						entry.ID = regapi.NewID("test", fmt.Sprintf("entry_%d", i))
+						desired = append(desired, entry)
+					}
+				}
+
+				planner := operationPlanner{}
+				opts := operationPlanOptions{controlledModules: controlled, mutableModules: controlled}
+				ops, err := planner.plan(current, desired, opts)
+				require.NoError(t, err)
+				got := applyPlannerOperations(current, ops)
+				assertPlannerStatesEqual(t, desired, got)
+
+				next, err := planner.plan(got, desired, opts)
+				require.NoError(t, err)
+				assert.Empty(t, next)
+			})
+		}
+	}
+}
+
+func plannerTestEntry(kind regapi.Kind, module, version, digest, value string) regapi.Entry {
+	return regapi.Entry{
+		ID:   regapi.NewID("test", "entry"),
+		Kind: kind,
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        module,
+			metaModuleVersionKey: version,
+			metaModuleDigestKey:  digest,
+		}),
+		Data: payload.New(map[string]any{"value": value}),
+	}
+}
+
+func clonePlannerTestEntry(entry regapi.Entry) regapi.Entry {
+	entry.Meta = attrs.NewBagFrom(entry.Meta)
+	if entry.Data != nil {
+		if data, ok := entry.Data.Data().(map[string]any); ok {
+			copyData := make(map[string]any, len(data))
+			for key, value := range data {
+				copyData[key] = value
+			}
+			entry.Data = payload.New(copyData)
+		}
+	}
+	return entry
+}
+
+func applyPlannerOperations(current regapi.State, ops []regapi.Operation) regapi.State {
+	entries := make(map[string]regapi.Entry, len(current)+len(ops))
+	for _, entry := range current {
+		entries[idKey(entry.ID)] = entry
+	}
+	for _, op := range ops {
+		switch op.Kind {
+		case regapi.EntryCreate, regapi.EntryUpdate:
+			entries[idKey(op.Entry.ID)] = op.Entry
+		case regapi.EntryDelete:
+			delete(entries, idKey(op.Entry.ID))
+		}
+	}
+	result := make(regapi.State, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, entry)
+	}
+	return result
+}
+
+func assertPlannerStatesEqual(t *testing.T, want []regapi.Entry, got regapi.State) {
+	t.Helper()
+	require.Len(t, got, len(want))
+	gotByID := entriesByID(got)
+	for _, entry := range want {
+		actual, ok := gotByID[idKey(entry.ID)]
+		require.True(t, ok, "missing entry %s", entry.ID)
+		assert.Equal(t, entry, actual, "entry %s differs", entry.ID)
+	}
+}

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -422,6 +422,7 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 	if l.data.Directories.Src != "" {
 		paths = append(paths, ModuleLoadPath{
 			Path: ResolveLockPath(lockDir, l.data.Directories.Src),
+			Root: true,
 		})
 	}
 

--- a/boot/deps/lock/module_load_paths_test.go
+++ b/boot/deps/lock/module_load_paths_test.go
@@ -40,8 +40,8 @@ func TestLock_GetModuleLoadPaths(t *testing.T) {
 			t.Fatalf("path count = %d, want 3", len(paths))
 		}
 
-		if got := paths[0]; got.Path != filepath.Join(tmpDir, "app") || got.Module != "" || got.Version != "" {
-			t.Fatalf("src path = %+v, want app path with empty module/version", got)
+		if got := paths[0]; got.Path != filepath.Join(tmpDir, "app") || got.Module != "" || got.Version != "" || !got.Root {
+			t.Fatalf("src path = %+v, want root app path with empty module/version", got)
 		}
 
 		if got := paths[1]; got.Path != filepath.Join(tmpDir, "local/users") || got.SourceRoot != filepath.Join(tmpDir, "local/users") || got.Module != "userspace/users" || got.Version != "" {

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -356,12 +356,12 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 			}
 		}
 
-		if mp.Module != "" {
-			for i := range loaded {
+		for i := range loaded {
+			if mp.Module != "" {
 				loaded[i] = markModuleMeta(loaded[i], mp.Module, mp.Version)
-				if mp.Root && loaded[i].Kind == regapi.NamespaceDependency {
-					loaded[i].DependencyRoot = true
-				}
+			}
+			if mp.Root && loaded[i].Kind == regapi.NamespaceDependency {
+				loaded[i].DependencyRoot = true
 			}
 		}
 

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -243,6 +243,39 @@ entries:
 	}
 }
 
+func TestLoadEntriesFromModuleLoadPathsMarksUnownedAppSourceDependencyRoot(t *testing.T) {
+	ctx := setupTestContext(t)
+	appDir := t.TempDir()
+	manifest := `version: "1.0"
+namespace: custom.dependencies
+entries:
+  - name: search
+    kind: ns.dependency
+    component: acme/search
+    version: "*"
+`
+	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{{
+		Path: appDir,
+		Root: true,
+	}}, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("entries = %d, want 1", len(loaded))
+	}
+	if !loaded[0].DependencyRoot {
+		t.Fatal("application source dependency was not marked as a deployment root")
+	}
+	if got := loaded[0].Meta.GetString("module", ""); got != "" {
+		t.Fatalf("application source ownership = %q, want empty", got)
+	}
+}
+
 func TestLoadEntriesFromPathsSingleWapp(t *testing.T) {
 	ctx := setupTestContext(t)
 	logger := zap.NewNop()


### PR DESCRIPTION
## Summary

- separate dependency-control closure, module provenance, and operation planning from the dependency handler
- distinguish deployment package ownership from dependency graph authority during expand and stored-resolution reconciliation
- preserve application-owned roots, policies, environment, and UI entries during rollback while removing departing dependency modules
- unregister departing embedded packs from the live graph
- treat DependencyRoot promotion and demotion as semantic registry changes

## Regression coverage

- owned deployment roots seed their declared dependency graph without granting control over the deployment package
- current, target, and desired graphs compose into one bounded reconciliation authority
- ApplyVersion removes a departing module and embedded pack, preserves deployment-owned entries, and allows a follow-up install
- immutable artifact normalization remains quiet while real host data drift is restored once
- operation planning is covered for controlled deletion, live dependents, mutable boundaries, root transitions, convergence, and idempotence

## Validation

- go test ./... -count=1
- go test -race ./boot/deps/hub ./system/registry/... -count=1
- make lint
- supported local Kickside: Knowledge, KB10 migrations, and Webscout install successfully
- deliberate no-FTS local Kickside: KB10 migration fails, registry rolls back, admin/Keeper remain available, governance stays running, and Webscout installs afterward

Process-host hot-update semantics are intentionally not included and will be handled in a separate PR.