### PR TITLE
fix(host): update process workers without restart

### DIFF
--- a/service/host/errors.go
+++ b/service/host/errors.go
@@ -26,3 +26,22 @@ func NewUnsupportedEntryKindError(kind registry.Kind) apierror.Error {
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{"kind": kind}))
 }
+
+func NewHostNotFoundError(id registry.ID) apierror.Error {
+	return apierror.New(apierror.NotFound, "process host not found").
+		WithRetryable(apierror.False).
+		WithDetails(attrs.NewBagFrom(map[string]any{"id": id.String()}))
+}
+
+func NewUnsupportedHostUpdateError(fields []string) apierror.Error {
+	return apierror.New(apierror.Conflict, "process host update requires unsupported runtime changes").
+		WithRetryable(apierror.False).
+		WithDetails(attrs.NewBagFrom(map[string]any{"fields": fields}))
+}
+
+func NewResizeWorkersError(cause error) apierror.Error {
+	return apierror.New(apierror.Conflict, "failed to resize process host workers").
+		WithRetryable(apierror.False).
+		WithDetails(attrs.NewBagFrom(map[string]any{"cause": cause.Error()})).
+		WithCause(cause)
+}

--- a/service/host/host.go
+++ b/service/host/host.go
@@ -6,6 +6,7 @@ package host
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
@@ -30,16 +31,17 @@ func WithPIDRegistry(reg topology.PIDRegistry) Option {
 
 // Host implements process.Host using the actor scheduler.
 type Host struct {
-	factory   process.Factory
-	pidGen    process.PIDGenerator
-	pidReg    topology.PIDRegistry
-	ctx       context.Context
-	cfg       *hostapi.EntryConfig
-	log       *zap.Logger
-	scheduler *actor.Scheduler
-	id        registry.ID
-	running   atomic.Bool
-	shutdown  atomic.Bool
+	factory     process.Factory
+	pidGen      process.PIDGenerator
+	pidReg      topology.PIDRegistry
+	ctx         context.Context
+	cfg         *hostapi.EntryConfig
+	log         *zap.Logger
+	scheduler   *actor.Scheduler
+	id          registry.ID
+	lifecycleMu sync.Mutex
+	running     atomic.Bool
+	shutdown    atomic.Bool
 }
 
 // NewHost creates a new host with actor scheduler.
@@ -175,6 +177,11 @@ func (h *Host) Send(pkg *relay.Package) error {
 
 // Start implements supervisor.Service.
 func (h *Host) Start(ctx context.Context) (<-chan any, error) {
+	h.lifecycleMu.Lock()
+	defer h.lifecycleMu.Unlock()
+	if h.shutdown.Load() {
+		return nil, ErrHostShuttingDown
+	}
 	if h.running.Swap(true) {
 		return nil, ErrHostAlreadyRunning
 	}
@@ -188,11 +195,18 @@ func (h *Host) Start(ctx context.Context) (<-chan any, error) {
 
 // Stop implements supervisor.Service.
 func (h *Host) Stop(ctx context.Context) error {
-	if !h.running.Swap(false) {
+	h.lifecycleMu.Lock()
+	wasRunning := h.running.Swap(false)
+	h.shutdown.Store(true)
+	h.lifecycleMu.Unlock()
+
+	// Publish the terminal host state before draining the scheduler. Draining
+	// may wait for a process step or invoke lifecycle callbacks; Start and live
+	// Update must reject during that wait instead of blocking behind it.
+	if !wasRunning {
 		return nil
 	}
 
-	h.shutdown.Store(true)
 	h.log.Info("host stopping", zap.String("id", h.id.String()))
 
 	h.scheduler.Stop(ctx)

--- a/service/host/host.go
+++ b/service/host/host.go
@@ -31,17 +31,21 @@ func WithPIDRegistry(reg topology.PIDRegistry) Option {
 
 // Host implements process.Host using the actor scheduler.
 type Host struct {
-	factory     process.Factory
-	pidGen      process.PIDGenerator
-	pidReg      topology.PIDRegistry
-	ctx         context.Context
-	cfg         *hostapi.EntryConfig
-	log         *zap.Logger
-	scheduler   *actor.Scheduler
-	id          registry.ID
-	lifecycleMu sync.Mutex
-	running     atomic.Bool
-	shutdown    atomic.Bool
+	factory   process.Factory
+	pidGen    process.PIDGenerator
+	pidReg    topology.PIDRegistry
+	ctx       context.Context
+	cfg       *hostapi.EntryConfig
+	log       *zap.Logger
+	scheduler *actor.Scheduler
+	id        registry.ID
+	// affinityManaged is fixed when the host is built. Manager affinity changes
+	// apply only to subsequently created hosts and must not change which live
+	// updates an existing scheduler can accept.
+	affinityManaged bool
+	lifecycleMu     sync.Mutex
+	running         atomic.Bool
+	shutdown        atomic.Bool
 }
 
 // NewHost creates a new host with actor scheduler.

--- a/service/host/host_test.go
+++ b/service/host/host_test.go
@@ -249,7 +249,12 @@ func TestHost_StopNotRunning(t *testing.T) {
 	th := newTestHost()
 
 	err := th.host.Stop(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	assert.False(t, th.host.running.Load())
+	assert.True(t, th.host.shutdown.Load())
+
+	_, err = th.host.Start(ctxWithAppContext())
+	assert.ErrorIs(t, err, ErrHostShuttingDown)
 }
 
 func TestHost_StopIdempotent(t *testing.T) {

--- a/service/host/manager.go
+++ b/service/host/manager.go
@@ -32,6 +32,7 @@ type Manager struct {
 	log             *zap.Logger
 	hosts           map[registry.ID]*Host
 	actorAffinity   affinity.Set
+	mutationMu      sync.Mutex
 	mu              sync.RWMutex
 }
 
@@ -39,7 +40,9 @@ type Manager struct {
 // sizes the worker pool to it, keeping actor execution on cores reserved away
 // from WASM. Empty (the default) leaves scheduling unpinned. Call before Add.
 func (m *Manager) SetActorAffinity(set affinity.Set) {
-	m.actorAffinity = set
+	m.mutationMu.Lock()
+	m.actorAffinity = append(affinity.Set(nil), set...)
+	m.mutationMu.Unlock()
 }
 
 // NewManager creates a new host manager.
@@ -67,6 +70,8 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 	if err != nil {
 		return NewDecodeConfigError(err)
 	}
+	m.mutationMu.Lock()
+	defer m.mutationMu.Unlock()
 
 	h := NewHost(entry.ID, cfg, nil, m.factory, m.pidGen, m.log)
 
@@ -119,10 +124,35 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 	if entry.Kind != hostapi.Host {
 		return NewUnsupportedEntryKindError(entry.Kind)
 	}
-	if err := m.Delete(ctx, entry); err != nil {
+
+	// Validate the complete replacement before looking up or mutating the live
+	// host. A malformed registry update must never take a healthy executor down.
+	cfg, err := entryutil.DecodeEntryConfig[hostapi.EntryConfig](ctx, m.dtt, entry)
+	if err != nil {
+		return NewDecodeConfigError(err)
+	}
+
+	m.mutationMu.Lock()
+	defer m.mutationMu.Unlock()
+
+	m.mu.RLock()
+	h, ok := m.hosts[entry.ID]
+	m.mu.RUnlock()
+	if !ok {
+		return NewHostNotFoundError(entry.ID)
+	}
+
+	changed, err := h.updateConfig(cfg, len(m.actorAffinity) > 0)
+	if err != nil {
 		return err
 	}
-	return m.Add(ctx, entry)
+	if !changed {
+		return nil
+	}
+	m.log.Info("host workers resized",
+		zap.String("id", entry.ID.String()),
+		zap.Int("workers", cfg.HostConfig.Workers))
+	return nil
 }
 
 // Delete implements registry.EntryListener.
@@ -130,6 +160,8 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 	if entry.Kind != hostapi.Host {
 		return NewUnsupportedEntryKindError(entry.Kind)
 	}
+	m.mutationMu.Lock()
+	defer m.mutationMu.Unlock()
 	m.mu.Lock()
 	h, ok := m.hosts[entry.ID]
 	if !ok {

--- a/service/host/manager.go
+++ b/service/host/manager.go
@@ -89,6 +89,7 @@ func (m *Manager) Add(ctx context.Context, entry registry.Entry) error {
 	}
 	if len(m.actorAffinity) > 0 {
 		opts = append(opts, actor.WithWorkers(len(m.actorAffinity)), actor.WithThreadPin(m.actorAffinity))
+		h.affinityManaged = true
 	}
 
 	scheduler := actor.NewScheduler(m.commandRegistry, opts...)
@@ -142,7 +143,7 @@ func (m *Manager) Update(ctx context.Context, entry registry.Entry) error {
 		return NewHostNotFoundError(entry.ID)
 	}
 
-	changed, err := h.updateConfig(cfg, len(m.actorAffinity) > 0)
+	changed, err := h.updateConfig(cfg, h.affinityManaged)
 	if err != nil {
 		return err
 	}
@@ -161,11 +162,11 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 		return NewUnsupportedEntryKindError(entry.Kind)
 	}
 	m.mutationMu.Lock()
-	defer m.mutationMu.Unlock()
 	m.mu.Lock()
 	h, ok := m.hosts[entry.ID]
 	if !ok {
 		m.mu.Unlock()
+		m.mutationMu.Unlock()
 		return nil
 	}
 	delete(m.hosts, entry.ID)
@@ -182,7 +183,11 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 		Kind:   relay.HostDelete,
 		Path:   entry.ID.String(),
 	})
+	m.mutationMu.Unlock()
 
+	// The host is no longer discoverable and its unregister events are ordered
+	// before any replacement Add. Draining can now proceed without blocking
+	// unrelated manager mutations for the scheduler shutdown timeout.
 	if err := h.Stop(ctx); err != nil {
 		m.log.Error("failed to stop host", zap.Error(err))
 	}

--- a/service/host/manager_test.go
+++ b/service/host/manager_test.go
@@ -260,6 +260,65 @@ func TestManager_Delete_StopsHost(t *testing.T) {
 	assert.False(t, h.running.Load())
 }
 
+func TestManager_DeleteDoesNotBlockUnrelatedMutationWhileHostDrains(t *testing.T) {
+	mgr, _ := newTestManagerWithBus(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	mgr.factory = &mockFactory{proc: &mockProcess{stepFunc: func(_ []process.Event, out *process.StepOutput) error {
+		close(entered)
+		<-release
+		out.Done(nil)
+		return nil
+	}}}
+
+	deletingID := registry.NewID("test", "deleting")
+	processCtx := process.WithLifecycleRegistry(ctxWithAppContext(), processSystem.NewLifecycleRegistry())
+	require.NoError(t, mgr.Add(processCtx, makeHostEntry(deletingID)))
+	deleting := mgr.hosts[deletingID]
+	_, err := deleting.Start(processCtx)
+	require.NoError(t, err)
+	_, err = deleting.Run(ctxWithAppContext(), &process.Start{Source: registry.NewID("test", "proc")})
+	require.NoError(t, err)
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("process did not enter gated step")
+	}
+
+	deleteDone := make(chan error, 1)
+	deleteFinished := make(chan struct{})
+	go func() {
+		deleteDone <- mgr.Delete(context.Background(), makeHostEntry(deletingID))
+		close(deleteFinished)
+	}()
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		select {
+		case <-deleteFinished:
+		case <-time.After(time.Second):
+		}
+	})
+	require.Eventually(t, func() bool {
+		_, ok := mgr.GetHost(deletingID.String())
+		return !ok
+	}, time.Second, time.Millisecond)
+
+	newID := registry.NewID("test", "new")
+	addDone := make(chan error, 1)
+	go func() { addDone <- mgr.Add(context.Background(), makeHostEntry(newID)) }()
+	select {
+	case err := <-addDone:
+		require.NoError(t, err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("unrelated Add blocked behind draining host")
+	}
+	t.Cleanup(func() { require.NoError(t, mgr.Delete(context.Background(), makeHostEntry(newID))) })
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-deleteDone)
+}
+
 // --- Manager Update Tests ---
 
 func TestManager_UpdateEquivalentEffectiveConfigIsNoOp(t *testing.T) {
@@ -456,6 +515,30 @@ func TestManager_UpdateRejectsWorkerChangeManagedByAffinity(t *testing.T) {
 	assert.Equal(t, []string{"host.workers"}, hostErr.Details().GetSlice("fields"))
 	assert.Same(t, config, h.cfg)
 	assert.EqualValues(t, 3, h.scheduler.Stats()["workers"])
+	assert.Empty(t, bus.snapshot())
+}
+
+func TestManager_AffinityChangeAppliesOnlyToNewHosts(t *testing.T) {
+	mgr, bus := newTestManagerWithBus(t)
+	existingID := registry.NewID("test", "existing")
+	require.NoError(t, mgr.Add(context.Background(), makeHostEntry(existingID)))
+	existing := mgr.hosts[existingID]
+
+	mgr.SetActorAffinity(affinity.Set{0, 1, 2})
+	newID := registry.NewID("test", "new")
+	require.NoError(t, mgr.Add(context.Background(), makeHostEntry(newID)))
+	newHost := mgr.hosts[newID]
+	bus.reset()
+
+	require.NoError(t, mgr.Update(context.Background(), makeConfiguredHostEntry(existingID, 4, 1024, 256, nil)))
+	assert.EqualValues(t, 4, existing.scheduler.Stats()["workers"])
+
+	err := mgr.Update(context.Background(), makeConfiguredHostEntry(newID, 4, 1024, 256, nil))
+	require.Error(t, err)
+	var hostErr apierror.Error
+	require.ErrorAs(t, err, &hostErr)
+	assert.Equal(t, []string{"host.workers"}, hostErr.Details().GetSlice("fields"))
+	assert.EqualValues(t, 3, newHost.scheduler.Stats()["workers"])
 	assert.Empty(t, bus.snapshot())
 }
 

--- a/service/host/manager_test.go
+++ b/service/host/manager_test.go
@@ -5,13 +5,16 @@ package host
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/attrs"
 	dispatcherapi "github.com/wippyai/runtime/api/dispatcher"
 	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/process"
@@ -19,9 +22,10 @@ import (
 	"github.com/wippyai/runtime/api/runtime"
 	"github.com/wippyai/runtime/api/service/host"
 	"github.com/wippyai/runtime/internal/uniqid"
-	"github.com/wippyai/runtime/system/eventbus"
 	payloadSystem "github.com/wippyai/runtime/system/payload"
 	"github.com/wippyai/runtime/system/payload/json"
+	processSystem "github.com/wippyai/runtime/system/process"
+	"github.com/wippyai/runtime/system/scheduler/affinity"
 	"go.uber.org/zap"
 )
 
@@ -37,28 +41,75 @@ func (m *mockCommandRegistry) Has(_ dispatcherapi.CommandID) bool {
 	return false
 }
 
-func newTestManager(_ *testing.T) *Manager {
-	bus := eventbus.NewBus()
+type recordingEventBus struct {
+	events []event.Event
+	mu     sync.Mutex
+}
+
+func (b *recordingEventBus) Subscribe(context.Context, event.System, chan<- event.Event) (event.SubscriberID, error) {
+	return "test", nil
+}
+
+func (b *recordingEventBus) SubscribeP(context.Context, event.System, event.Kind, chan<- event.Event) (event.SubscriberID, error) {
+	return "test", nil
+}
+
+func (b *recordingEventBus) Unsubscribe(context.Context, event.SubscriberID) {}
+
+func (b *recordingEventBus) Send(_ context.Context, evt event.Event) {
+	b.mu.Lock()
+	b.events = append(b.events, evt)
+	b.mu.Unlock()
+}
+
+func (b *recordingEventBus) reset() {
+	b.mu.Lock()
+	b.events = nil
+	b.mu.Unlock()
+}
+
+func (b *recordingEventBus) snapshot() []event.Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]event.Event(nil), b.events...)
+}
+
+func newTestManagerWithBus(_ *testing.T) (*Manager, *recordingEventBus) {
+	bus := &recordingEventBus{}
 	dtt := payloadSystem.GlobalTranscoder()
 	json.Register(dtt)
 	cmdReg := &mockCommandRegistry{}
 	factory := &mockFactory{proc: &mockProcess{}}
 	pidGen := uniqid.NewPIDGenerator(uniqid.NewGenerator(), "test-node")
 	log := zap.NewNop()
-	return NewManager(bus, dtt, cmdReg, factory, pidGen, log)
+	return NewManager(bus, dtt, cmdReg, factory, pidGen, log), bus
+}
+
+func newTestManager(t *testing.T) *Manager {
+	mgr, _ := newTestManagerWithBus(t)
+	return mgr
 }
 
 func makeHostEntry(id registry.ID) registry.Entry {
+	return makeConfiguredHostEntry(id, 2, 1024, 256, nil)
+}
+
+func makeConfiguredHostEntry(id registry.ID, workers, queueSize, localQueueSize int, lifecycle map[string]any) registry.Entry {
+	data := map[string]any{
+		"host": map[string]any{
+			"workers":          workers,
+			"queue_size":       queueSize,
+			"local_queue_size": localQueueSize,
+		},
+	}
+	if lifecycle != nil {
+		data["lifecycle"] = lifecycle
+	}
 	return registry.Entry{
 		ID:   id,
 		Kind: host.Host,
 		Meta: attrs.NewBag(),
-		Data: payload.New(map[string]any{
-			"host": map[string]any{
-				"workers":    2,
-				"queue_size": 1024,
-			},
-		}),
+		Data: payload.New(data),
 	}
 }
 
@@ -211,20 +262,36 @@ func TestManager_Delete_StopsHost(t *testing.T) {
 
 // --- Manager Update Tests ---
 
-func TestManager_Update(t *testing.T) {
-	mgr := newTestManager(t)
-	entry := makeHostEntry(registry.NewID("test", "host1"))
+func TestManager_UpdateEquivalentEffectiveConfigIsNoOp(t *testing.T) {
+	mgr, bus := newTestManagerWithBus(t)
+	id := registry.NewID("test", "host1")
+	entry := makeConfiguredHostEntry(id, 2, 1024, 256, map[string]any{
+		"requires": []any{"test:db", "test:cache"},
+	})
+	require.NoError(t, mgr.Add(context.Background(), entry))
 
-	err := mgr.Add(context.Background(), entry)
+	h := mgr.hosts[id]
+	scheduler := h.scheduler
+	config := h.cfg
+	_, err := h.Start(ctxWithAppContext())
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, h.Stop(context.Background())) })
+	bus.reset()
 
-	err = mgr.Update(context.Background(), entry)
-	require.NoError(t, err)
+	// Explicit defaults, dependency alias/order differences, and registry
+	// metadata are all equivalent to the effective resident configuration.
+	updated := makeConfiguredHostEntry(id, 2, 1024, 256, map[string]any{
+		"depends_on": []any{"test:cache", "test:db", "test:db"},
+	})
+	updated.Meta = attrs.NewBagFrom(map[string]any{"title": "renamed host"})
+	require.NoError(t, mgr.Update(context.Background(), updated))
 
-	mgr.mu.RLock()
-	_, ok := mgr.hosts[entry.ID]
-	mgr.mu.RUnlock()
-	assert.True(t, ok)
+	assert.Same(t, h, mgr.hosts[id])
+	assert.Same(t, scheduler, h.scheduler)
+	assert.Same(t, config, h.cfg, "a no-op must not publish a replacement config snapshot")
+	assert.True(t, h.running.Load())
+	assert.EqualValues(t, 2, h.scheduler.Stats()["workers"])
+	assert.Empty(t, bus.snapshot(), "an effective no-op must emit no lifecycle or relay events")
 }
 
 func TestManager_Update_InvalidKind(t *testing.T) {
@@ -247,25 +314,32 @@ func TestManager_Update_InvalidKind(t *testing.T) {
 }
 
 func TestManager_Update_NonExistent(t *testing.T) {
-	mgr := newTestManager(t)
+	mgr, bus := newTestManagerWithBus(t)
 	entry := makeHostEntry(registry.NewID("test", "host1"))
 
-	// Update on non-existent should add
 	err := mgr.Update(context.Background(), entry)
-	require.NoError(t, err)
+	require.Error(t, err)
+	var hostErr apierror.Error
+	require.ErrorAs(t, err, &hostErr)
+	assert.Equal(t, apierror.NotFound, hostErr.Kind())
 
 	mgr.mu.RLock()
 	_, ok := mgr.hosts[entry.ID]
 	mgr.mu.RUnlock()
-	assert.True(t, ok)
+	assert.False(t, ok, "an update must not resurrect an absent host")
+	assert.Empty(t, bus.snapshot())
 }
 
 func TestManager_Update_DecodeError(t *testing.T) {
-	mgr := newTestManager(t)
+	mgr, bus := newTestManagerWithBus(t)
 
 	// First add a valid host
 	validEntry := makeHostEntry(registry.NewID("test", "host1"))
 	require.NoError(t, mgr.Add(context.Background(), validEntry))
+	h := mgr.hosts[validEntry.ID]
+	config := h.cfg
+	scheduler := h.scheduler
+	bus.reset()
 
 	// Then try to update with invalid data
 	invalidEntry := registry.Entry{
@@ -277,6 +351,260 @@ func TestManager_Update_DecodeError(t *testing.T) {
 
 	err := mgr.Update(context.Background(), invalidEntry)
 	require.Error(t, err)
+	assert.Same(t, h, mgr.hosts[validEntry.ID])
+	assert.Same(t, scheduler, h.scheduler)
+	assert.Same(t, config, h.cfg)
+	assert.Empty(t, bus.snapshot(), "decode failure must occur before live host mutation")
+}
+
+func TestManager_UpdateResizesWorkersWithoutLifecycleEvents(t *testing.T) {
+	mgr, bus := newTestManagerWithBus(t)
+	id := registry.NewID("test", "host1")
+	require.NoError(t, mgr.Add(context.Background(), makeHostEntry(id)))
+	h := mgr.hosts[id]
+	scheduler := h.scheduler
+	_, err := h.Start(ctxWithAppContext())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, h.Stop(context.Background())) })
+	bus.reset()
+
+	for _, workers := range []int{4, 1} {
+		require.NoError(t, mgr.Update(context.Background(), makeConfiguredHostEntry(id, workers, 1024, 256, nil)))
+		assert.Same(t, h, mgr.hosts[id])
+		assert.Same(t, scheduler, h.scheduler)
+		assert.True(t, h.running.Load())
+		assert.Equal(t, workers, h.cfg.HostConfig.Workers)
+		assert.EqualValues(t, workers, h.scheduler.Stats()["workers"])
+	}
+	assert.Empty(t, bus.snapshot(), "worker resize must not unregister or replace the host")
+}
+
+func TestManager_UpdateRejectsUnsupportedChangesAtomically(t *testing.T) {
+	tests := []struct {
+		name   string
+		entry  func(registry.ID) registry.Entry
+		fields []string
+	}{
+		{
+			name: "global queue capacity",
+			entry: func(id registry.ID) registry.Entry {
+				return makeConfiguredHostEntry(id, 2, 2048, 256, nil)
+			},
+			fields: []string{"host.queue_size"},
+		},
+		{
+			name: "local queue capacity",
+			entry: func(id registry.ID) registry.Entry {
+				return makeConfiguredHostEntry(id, 2, 1024, 512, nil)
+			},
+			fields: []string{"host.local_queue_size"},
+		},
+		{
+			name: "lifecycle",
+			entry: func(id registry.ID) registry.Entry {
+				return makeConfiguredHostEntry(id, 2, 1024, 256, map[string]any{"auto_start": true})
+			},
+			fields: []string{"lifecycle"},
+		},
+		{
+			name: "supported and unsupported fields together",
+			entry: func(id registry.ID) registry.Entry {
+				return makeConfiguredHostEntry(id, 4, 2048, 512, nil)
+			},
+			fields: []string{"host.queue_size", "host.local_queue_size"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, bus := newTestManagerWithBus(t)
+			id := registry.NewID("test", "host1")
+			require.NoError(t, mgr.Add(context.Background(), makeHostEntry(id)))
+			h := mgr.hosts[id]
+			config := h.cfg
+			scheduler := h.scheduler
+			bus.reset()
+
+			err := mgr.Update(context.Background(), tt.entry(id))
+			require.Error(t, err)
+			var hostErr apierror.Error
+			require.ErrorAs(t, err, &hostErr)
+			assert.Equal(t, apierror.Conflict, hostErr.Kind())
+			assert.Equal(t, tt.fields, hostErr.Details().GetSlice("fields"))
+			assert.Same(t, h, mgr.hosts[id])
+			assert.Same(t, scheduler, h.scheduler)
+			assert.Same(t, config, h.cfg)
+			assert.EqualValues(t, 2, h.scheduler.Stats()["workers"], "mixed update must not partially resize")
+			assert.Empty(t, bus.snapshot())
+		})
+	}
+}
+
+func TestManager_UpdateRejectsWorkerChangeManagedByAffinity(t *testing.T) {
+	mgr, bus := newTestManagerWithBus(t)
+	mgr.SetActorAffinity(affinity.Set{0, 1, 2})
+	id := registry.NewID("test", "host1")
+	require.NoError(t, mgr.Add(context.Background(), makeHostEntry(id)))
+	h := mgr.hosts[id]
+	config := h.cfg
+	bus.reset()
+
+	err := mgr.Update(context.Background(), makeConfiguredHostEntry(id, 4, 1024, 256, nil))
+	require.Error(t, err)
+	var hostErr apierror.Error
+	require.ErrorAs(t, err, &hostErr)
+	assert.Equal(t, []string{"host.workers"}, hostErr.Details().GetSlice("fields"))
+	assert.Same(t, config, h.cfg)
+	assert.EqualValues(t, 3, h.scheduler.Stats()["workers"])
+	assert.Empty(t, bus.snapshot())
+}
+
+func TestManager_UpdateAfterStopDoesNotPublishConfig(t *testing.T) {
+	mgr, bus := newTestManagerWithBus(t)
+	id := registry.NewID("test", "host1")
+	require.NoError(t, mgr.Add(context.Background(), makeHostEntry(id)))
+	h := mgr.hosts[id]
+	config := h.cfg
+	_, err := h.Start(ctxWithAppContext())
+	require.NoError(t, err)
+	require.NoError(t, h.Stop(context.Background()))
+	bus.reset()
+
+	err = mgr.Update(context.Background(), makeConfiguredHostEntry(id, 4, 1024, 256, nil))
+	require.ErrorIs(t, err, ErrHostShuttingDown)
+	assert.Same(t, config, h.cfg)
+	assert.Empty(t, bus.snapshot())
+}
+
+func TestManager_UpdateDuringStopRejectsPromptly(t *testing.T) {
+	mgr, bus := newTestManagerWithBus(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	mgr.factory = &mockFactory{proc: &mockProcess{stepFunc: func(_ []process.Event, out *process.StepOutput) error {
+		close(entered)
+		<-release
+		out.Done(nil)
+		return nil
+	}}}
+
+	id := registry.NewID("test", "host1")
+	processCtx := process.WithLifecycleRegistry(ctxWithAppContext(), processSystem.NewLifecycleRegistry())
+	require.NoError(t, mgr.Add(processCtx, makeHostEntry(id)))
+	h := mgr.hosts[id]
+	config := h.cfg
+	_, err := h.Start(processCtx)
+	require.NoError(t, err)
+	_, err = h.Run(ctxWithAppContext(), &process.Start{Source: registry.NewID("test", "proc")})
+	require.NoError(t, err)
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("process did not enter gated step")
+	}
+
+	stopDone := make(chan error, 1)
+	stopFinished := make(chan struct{})
+	go func() {
+		stopDone <- h.Stop(context.Background())
+		close(stopFinished)
+	}()
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		select {
+		case <-stopFinished:
+		case <-time.After(time.Second):
+		}
+	})
+	require.Eventually(t, h.shutdown.Load, time.Second, time.Millisecond)
+	assert.False(t, h.running.Load())
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned while the process step was gated: %v", err)
+	default:
+	}
+	bus.reset()
+
+	updateDone := make(chan error, 1)
+	go func() {
+		updateDone <- mgr.Update(context.Background(), makeConfiguredHostEntry(id, 4, 1024, 256, nil))
+	}()
+	select {
+	case err := <-updateDone:
+		require.ErrorIs(t, err, ErrHostShuttingDown)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Update blocked behind the scheduler drain")
+	}
+	assert.Same(t, config, h.cfg)
+	assert.Empty(t, bus.snapshot())
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Update caused gated Stop to return: %v", err)
+	default:
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-stopDone)
+}
+
+func TestManager_WorkerShrinkPublishesWithoutBlockingHostLookup(t *testing.T) {
+	mgr, _ := newTestManagerWithBus(t)
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	mgr.factory = &mockFactory{proc: &mockProcess{stepFunc: func(_ []process.Event, out *process.StepOutput) error {
+		entered <- struct{}{}
+		<-release
+		out.Done(nil)
+		return nil
+	}}}
+	id := registry.NewID("test", "host1")
+	processCtx := process.WithLifecycleRegistry(ctxWithAppContext(), processSystem.NewLifecycleRegistry())
+	require.NoError(t, mgr.Add(processCtx, makeHostEntry(id)))
+	h := mgr.hosts[id]
+	_, err := h.Start(processCtx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		_ = h.Stop(context.Background())
+	})
+	_, err = h.Run(ctxWithAppContext(), &process.Start{Source: registry.NewID("test", "proc")})
+	require.NoError(t, err)
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not enter gated step")
+	}
+
+	resizeDone := make(chan error, 1)
+	go func() {
+		resizeDone <- mgr.Update(context.Background(), makeConfiguredHostEntry(id, 1, 1024, 256, nil))
+	}()
+	select {
+	case err := <-resizeDone:
+		require.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("shrink waited for a retiring worker")
+	}
+	assert.Equal(t, 1, h.cfg.HostConfig.Workers)
+	assert.EqualValues(t, 1, h.scheduler.Stats()["workers"])
+
+	lookupDone := make(chan bool, 1)
+	go func() {
+		got, ok := mgr.GetHost(id.String())
+		lookupDone <- ok && got == h
+	}()
+	select {
+	case ok := <-lookupDone:
+		assert.True(t, ok)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("GetHost blocked behind a worker shrink")
+	}
+
+	close(release)
 }
 
 // --- Manager GetHost Tests ---

--- a/service/host/update.go
+++ b/service/host/update.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package host
+
+import (
+	"reflect"
+	"sort"
+
+	hostapi "github.com/wippyai/runtime/api/service/host"
+	"github.com/wippyai/runtime/api/supervisor"
+)
+
+// updateConfig applies the supported live subset atomically with Host
+// Start/Stop. The returned bool reports whether scheduler state changed.
+func (h *Host) updateConfig(desired *hostapi.EntryConfig, affinityManaged bool) (bool, error) {
+	h.lifecycleMu.Lock()
+	defer h.lifecycleMu.Unlock()
+
+	if h.shutdown.Load() {
+		return false, ErrHostShuttingDown
+	}
+	unsupported := unsupportedHostUpdateFields(h.cfg, desired, affinityManaged)
+	if len(unsupported) > 0 {
+		return false, NewUnsupportedHostUpdateError(unsupported)
+	}
+	if h.cfg.HostConfig.Workers == desired.HostConfig.Workers {
+		return false, nil
+	}
+	if err := h.scheduler.ResizeWorkers(desired.HostConfig.Workers); err != nil {
+		return false, NewResizeWorkersError(err)
+	}
+
+	// Config snapshots are immutable after publication. A failed resize leaves
+	// both the scheduler and this pointer at the previous effective config.
+	h.cfg = desired
+	return true, nil
+}
+
+func unsupportedHostUpdateFields(current, desired *hostapi.EntryConfig, affinityManaged bool) []string {
+	fields := make([]string, 0, 4)
+	if !reflect.DeepEqual(canonicalLifecycle(current.Lifecycle), canonicalLifecycle(desired.Lifecycle)) {
+		fields = append(fields, "lifecycle")
+	}
+	if current.HostConfig.QueueSize != desired.HostConfig.QueueSize {
+		fields = append(fields, "host.queue_size")
+	}
+	if current.HostConfig.LocalQueueSize != desired.HostConfig.LocalQueueSize {
+		fields = append(fields, "host.local_queue_size")
+	}
+	if affinityManaged && current.HostConfig.Workers != desired.HostConfig.Workers {
+		fields = append(fields, "host.workers")
+	}
+	return fields
+}
+
+func canonicalLifecycle(cfg supervisor.LifecycleConfig) supervisor.LifecycleConfig {
+	cfg.InitDefaults()
+	seen := make(map[string]struct{}, len(cfg.Requires)+len(cfg.DependsOn))
+	required := make([]string, 0, len(cfg.Requires)+len(cfg.DependsOn))
+	for _, dependency := range append(append([]string(nil), cfg.Requires...), cfg.DependsOn...) {
+		if _, exists := seen[dependency]; exists {
+			continue
+		}
+		seen[dependency] = struct{}{}
+		required = append(required, dependency)
+	}
+	sort.Strings(required)
+	cfg.Requires = required
+	cfg.DependsOn = nil
+	return cfg
+}

--- a/system/scheduler/actor/benchmark_test.go
+++ b/system/scheduler/actor/benchmark_test.go
@@ -216,7 +216,7 @@ func BenchmarkManyYieldsPerExecute(b *testing.B) {
 // BenchmarkWorkerExecute measures raw worker.executeOne performance.
 func BenchmarkWorkerExecute(b *testing.B) {
 	sched := newTestScheduler(1)
-	worker := sched.workers[0]
+	worker := sched.workerSnapshot()[0]
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/system/scheduler/actor/edge_cases_test.go
+++ b/system/scheduler/actor/edge_cases_test.go
@@ -732,7 +732,7 @@ func TestWorkerStealEmpty(t *testing.T) {
 	sched := newTestScheduler(4)
 	// Don't start, just test steal logic
 
-	w := sched.workers[0]
+	w := sched.workerSnapshot()[0]
 	proc := w.steal()
 	if proc != nil {
 		t.Fatal("expected nil from empty steal")

--- a/system/scheduler/actor/resize_test.go
+++ b/system/scheduler/actor/resize_test.go
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package actor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/payload"
+	pidapi "github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+)
+
+type resizeGateProcess struct {
+	entered chan struct{}
+	release chan struct{}
+	steps   atomic.Int32
+}
+
+func (p *resizeGateProcess) Init(context.Context, string, payload.Payloads) error { return nil }
+
+func (p *resizeGateProcess) Step(_ []process.Event, out *process.StepOutput) error {
+	if p.steps.Add(1) == 1 {
+		close(p.entered)
+		<-p.release
+		out.Continue()
+		return nil
+	}
+	out.Done(nil)
+	return nil
+}
+
+func (*resizeGateProcess) Send(*relay.Package) error { return nil }
+func (*resizeGateProcess) Close()                    {}
+
+type resizeImmediateProcess struct{}
+
+func (*resizeImmediateProcess) Init(context.Context, string, payload.Payloads) error { return nil }
+func (*resizeImmediateProcess) Step(_ []process.Event, out *process.StepOutput) error {
+	out.Done(nil)
+	return nil
+}
+func (*resizeImmediateProcess) Send(*relay.Package) error { return nil }
+func (*resizeImmediateProcess) Close()                    {}
+
+type resizeFromStepProcess struct {
+	scheduler *Scheduler
+	result    chan error
+}
+
+func (*resizeFromStepProcess) Init(context.Context, string, payload.Payloads) error { return nil }
+func (p *resizeFromStepProcess) Step(_ []process.Event, out *process.StepOutput) error {
+	p.result <- p.scheduler.ResizeWorkers(1)
+	out.Done(nil)
+	return nil
+}
+func (*resizeFromStepProcess) Send(*relay.Package) error { return nil }
+func (*resizeFromStepProcess) Close()                    {}
+
+func releaseResizeGate(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+
+func TestSchedulerResizeBeforeStartAndNoOp(t *testing.T) {
+	sched := newTestScheduler(1)
+	global := sched.global
+	original := sched.workerSnapshot()[0]
+
+	if err := sched.ResizeWorkers(4); err != nil {
+		t.Fatalf("grow before start: %v", err)
+	}
+	if got := sched.workerSnapshot(); len(got) != 4 || got[0] != original {
+		t.Fatalf("grow replaced existing workers: len=%d", len(got))
+	}
+	if err := sched.ResizeWorkers(2); err != nil {
+		t.Fatalf("shrink before start: %v", err)
+	}
+	before := sched.workerSnapshot()
+	if err := sched.ResizeWorkers(2); err != nil {
+		t.Fatalf("no-op resize: %v", err)
+	}
+	after := sched.workerSnapshot()
+	if len(after) != 2 || after[0] != before[0] || after[1] != before[1] {
+		t.Fatal("no-op resize changed worker identity")
+	}
+	if sched.global != global {
+		t.Fatal("resize replaced the global queue")
+	}
+
+	sched.Start()
+	defer testStopScheduler(sched)
+	if _, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "prestart-resize"}, &resizeImmediateProcess{}, "", nil); err != nil {
+		t.Fatalf("submit after pre-start resize: %v", err)
+	}
+	waitFor(t, func() bool { return sched.processorCount.Load() == 0 })
+}
+
+func TestSchedulerResizeRejectsInvalidAndStopped(t *testing.T) {
+	sched := newTestScheduler(1)
+	if err := sched.ResizeWorkers(0); !errors.Is(err, ErrInvalidWorkerCount) {
+		t.Fatalf("zero workers: got %v", err)
+	}
+	if err := sched.ResizeWorkers(-1); !errors.Is(err, ErrInvalidWorkerCount) {
+		t.Fatalf("negative workers: got %v", err)
+	}
+	sched.Start()
+	testStopScheduler(sched)
+	if err := sched.ResizeWorkers(2); !errors.Is(err, process.ErrSchedulerStopping) {
+		t.Fatalf("resize after stop: got %v", err)
+	}
+}
+
+func TestSchedulerResizeRejectsWhileStopping(t *testing.T) {
+	sched := newTestScheduler(1)
+	gate := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
+	defer releaseResizeGate(gate.release)
+	if _, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "stop-gate"}, gate, "", nil); err != nil {
+		t.Fatal(err)
+	}
+	sched.Start()
+	select {
+	case <-gate.entered:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not enter blocking step")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		sched.Stop(ctx)
+		close(stopDone)
+	}()
+	waitFor(t, func() bool { return sched.stopping.Load() })
+
+	started := time.Now()
+	if err := sched.ResizeWorkers(2); !errors.Is(err, process.ErrSchedulerStopping) {
+		t.Fatalf("resize while stopping: got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("resize waited behind Stop instead of rejecting: %v", elapsed)
+	}
+	releaseResizeGate(gate.release)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not complete")
+	}
+}
+
+func TestSchedulerDoesNotRouteToRetiredWorker(t *testing.T) {
+	sched := newTestScheduler(2)
+	retired := sched.workerSnapshot()[1]
+	if err := sched.ResizeWorkers(1); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := acquireProcessor()
+	defer releaseProcessor(proc)
+	proc.lastWorker.Store(1)
+	sched.injectOrGlobal(proc)
+	if got := sched.global.Pop(); got != proc {
+		t.Fatal("processor affinity to retired worker did not fall back to global queue")
+	}
+	if got := retired.inject.Pop(); got != nil {
+		t.Fatal("processor was routed into retired worker inject queue")
+	}
+	if got := proc.lastWorker.Load(); got != noWorkerAffinity {
+		t.Fatalf("retired affinity was not cleared: %d", got)
+	}
+}
+
+func TestSchedulerGrowReusesRetiredWorkerIDs(t *testing.T) {
+	sched := newTestScheduler(3)
+	retired := append([]*Worker(nil), sched.workerSnapshot()[1:]...)
+	if err := sched.ResizeWorkers(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := sched.ResizeWorkers(3); err != nil {
+		t.Fatal(err)
+	}
+	workers := sched.workerSnapshot()
+	for id := 1; id < 3; id++ {
+		if workers[id].id != id {
+			t.Fatalf("worker %d has ID %d", id, workers[id].id)
+		}
+		if workers[id] == retired[id-1] {
+			t.Fatalf("worker ID %d reused retired worker instance", id)
+		}
+	}
+}
+
+func TestSchedulerShrinkFromRetiringWorkerDoesNotDeadlock(t *testing.T) {
+	sched := newTestScheduler(2)
+	retiring := sched.workerSnapshot()[1]
+	proc := &resizeFromStepProcess{scheduler: sched, result: make(chan error, 1)}
+	submitted, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "self-shrink"}, proc, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if popped := sched.global.Pop(); popped != submitted {
+		t.Fatal("submitted processor was not in global queue")
+	}
+	sched.workerSnapshot()[1].inject.Push(submitted)
+	sched.Start()
+	defer testStopScheduler(sched)
+
+	select {
+	case err := <-proc.result:
+		if err != nil {
+			t.Fatalf("worker-triggered shrink: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker deadlocked while retiring itself")
+	}
+	if got := len(sched.workerSnapshot()); got != 1 {
+		t.Fatalf("active workers: got %d", got)
+	}
+	select {
+	case <-retiring.done:
+	case <-time.After(time.Second):
+		t.Fatal("self-retiring worker did not exit")
+	}
+	waitFor(t, func() bool { return sched.retiredExecuted.Load() >= 1 })
+}
+
+func TestSchedulerImmediateRegrowRoutesToPublishedWorker(t *testing.T) {
+	completed := make(chan string, 3)
+	lifecycle := &testLifecycle{onComplete: func(_ context.Context, pid pidapi.PID, _ *runtime.Result) {
+		completed <- pid.UniqID
+	}}
+	sched := newTestSchedulerWithLifecycle(2, lifecycle)
+	workers := sched.workerSnapshot()
+	oldWorkerOne := workers[1]
+
+	gateZero := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
+	gateOne := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
+	for id, item := range []struct {
+		gate *resizeGateProcess
+		pid  string
+	}{{gateZero, "regrow-gate-0"}, {gateOne, "regrow-gate-1"}} {
+		proc, err := sched.Submit(context.Background(), pidapi.PID{UniqID: item.pid}, item.gate, "", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if popped := sched.global.Pop(); popped != proc {
+			t.Fatal("gate processor was not in global queue")
+		}
+		workers[id].inject.Push(proc)
+	}
+	sched.Start()
+	defer testStopScheduler(sched)
+	defer releaseResizeGate(gateZero.release)
+	defer releaseResizeGate(gateOne.release)
+	for id, entered := range []chan struct{}{gateZero.entered, gateOne.entered} {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatalf("worker %d did not enter gate", id)
+		}
+	}
+
+	if err := sched.ResizeWorkers(1); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-oldWorkerOne.done:
+		t.Fatal("blocked retiring worker exited before its current step finished")
+	default:
+	}
+
+	queued, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "regrow-routed"}, &resizeImmediateProcess{}, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if popped := sched.global.Pop(); popped != queued {
+		t.Fatal("queued processor was not in global queue")
+	}
+	queued.lastWorker.Store(1)
+	if err := sched.ResizeWorkers(2); err != nil {
+		t.Fatal(err)
+	}
+	newWorkerOne := sched.workerSnapshot()[1]
+	if newWorkerOne.id != oldWorkerOne.id || newWorkerOne == oldWorkerOne {
+		t.Fatal("regrow did not create a distinct worker with the reusable ID")
+	}
+	sched.injectOrGlobal(queued)
+	select {
+	case id := <-completed:
+		if id != "regrow-routed" {
+			t.Fatalf("unexpected completion before gates released: %s", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("affine work did not route through the newly published worker")
+	}
+	select {
+	case <-oldWorkerOne.done:
+		t.Fatal("old same-ID worker unexpectedly left its blocked step")
+	default:
+	}
+
+	releaseResizeGate(gateOne.release)
+	select {
+	case <-oldWorkerOne.done:
+	case <-time.After(time.Second):
+		t.Fatal("old same-ID worker did not retire after its step finished")
+	}
+	releaseResizeGate(gateZero.release)
+}
+
+func TestSchedulerGrowRunsQueuedWorkWithoutReplacingState(t *testing.T) {
+	var quickCompleted atomic.Int32
+	lifecycle := &testLifecycle{onComplete: func(_ context.Context, pid pidapi.PID, _ *runtime.Result) {
+		if pid.UniqID != "grow-blocker" {
+			quickCompleted.Add(1)
+		}
+	}}
+	sched := newTestSchedulerWithLifecycle(1, lifecycle)
+	global := sched.global
+	firstWorker := sched.workerSnapshot()[0]
+	sched.Start()
+	defer testStopScheduler(sched)
+
+	gate := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
+	defer releaseResizeGate(gate.release)
+	if _, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "grow-blocker"}, gate, "", nil); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-gate.entered:
+	case <-time.After(time.Second):
+		t.Fatal("initial worker did not enter blocking step")
+	}
+
+	const quick = 24
+	for i := 0; i < quick; i++ {
+		id := pidapi.PID{UniqID: fmt.Sprintf("grow-quick-%d", i)}
+		if _, err := sched.Submit(context.Background(), id, &resizeImmediateProcess{}, "", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := sched.ResizeWorkers(3); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { return quickCompleted.Load() == quick })
+	if sched.global != global || sched.workerSnapshot()[0] != firstWorker {
+		t.Fatal("grow replaced scheduler state or existing worker")
+	}
+	releaseResizeGate(gate.release)
+}
+
+func TestSchedulerShrinkFinishesCurrentStepAndHandsOffContinuation(t *testing.T) {
+	completed := make(chan string, 2)
+	lifecycle := &testLifecycle{onComplete: func(_ context.Context, pid pidapi.PID, _ *runtime.Result) {
+		if pid.UniqID != "shrink-survivor-gate" {
+			completed <- pid.UniqID
+		}
+	}}
+	sched := newTestSchedulerWithLifecycle(2, lifecycle)
+	workers := sched.workerSnapshot()
+	survivorGate := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
+	gate := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
+	var proc *Processor
+	for id, item := range []struct {
+		pid  string
+		gate *resizeGateProcess
+	}{{"shrink-survivor-gate", survivorGate}, {"shrink-gate", gate}} {
+		submitted, err := sched.Submit(context.Background(), pidapi.PID{UniqID: item.pid}, item.gate, "", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if popped := sched.global.Pop(); popped != submitted {
+			t.Fatal("gate processor was not in global queue")
+		}
+		workers[id].inject.Push(submitted)
+		if id == 1 {
+			proc = submitted
+		}
+	}
+	retiring := workers[1]
+	sched.Start()
+	defer testStopScheduler(sched)
+	defer releaseResizeGate(gate.release)
+	defer releaseResizeGate(survivorGate.release)
+
+	for id, entered := range []chan struct{}{survivorGate.entered, gate.entered} {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatalf("worker %d did not enter gate", id)
+		}
+	}
+	queued, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "shrink-injected"}, &resizeImmediateProcess{}, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if popped := sched.global.Pop(); popped != queued {
+		t.Fatal("injected processor was not in global queue")
+	}
+	queued.lastWorker.Store(1)
+	if !sched.workerSnapshot()[1].injectProcessor(queued) {
+		t.Fatal("could not queue processor on active worker")
+	}
+
+	started := time.Now()
+	if err := sched.ResizeWorkers(1); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("shrink waited for retiring worker: %v", elapsed)
+	}
+	if stored, ok := sched.byPID.Load(proc.pid.String()); !ok || stored != proc {
+		t.Fatal("resize removed or replaced the live processor")
+	}
+	if stored, ok := sched.byPID.Load(queued.pid.String()); !ok || stored != queued {
+		t.Fatal("resize removed or replaced the injected processor")
+	}
+	releaseResizeGate(gate.release)
+	select {
+	case <-retiring.done:
+	case <-time.After(time.Second):
+		t.Fatal("retiring worker did not finish its step and hand off queues")
+	}
+	releaseResizeGate(survivorGate.release)
+	if got := len(sched.workerSnapshot()); got != 1 {
+		t.Fatalf("active workers: got %d", got)
+	}
+	wantCompleted := map[string]bool{"shrink-gate": false, "shrink-injected": false}
+	for range wantCompleted {
+		select {
+		case id := <-completed:
+			if _, ok := wantCompleted[id]; !ok {
+				t.Fatalf("unexpected process completed: %s", id)
+			}
+			wantCompleted[id] = true
+		case <-time.After(time.Second):
+			t.Fatal("retired worker queues were not handed to the remaining worker")
+		}
+	}
+	for id, done := range wantCompleted {
+		if !done {
+			t.Fatalf("process did not complete after handoff: %s", id)
+		}
+	}
+	if gate.steps.Load() != 2 {
+		t.Fatalf("process steps: got %d, want 2", gate.steps.Load())
+	}
+}
+
+func TestSchedulerConcurrentResizeAndSubmit(t *testing.T) {
+	var completed atomic.Int32
+	lifecycle := &testLifecycle{onComplete: func(context.Context, pidapi.PID, *runtime.Result) {
+		completed.Add(1)
+	}}
+	sched := newTestSchedulerWithLifecycle(3, lifecycle)
+	sched.Start()
+	defer testStopScheduler(sched)
+
+	const submissions = 200
+	var wg sync.WaitGroup
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for i := 0; i < 40; i++ {
+				target := 1 + ((i + offset) % 8)
+				if err := sched.ResizeWorkers(target); err != nil {
+					t.Errorf("resize to %d: %v", target, err)
+					return
+				}
+				_ = sched.Stats()
+				_ = sched.WorkerStats()
+			}
+		}(r)
+	}
+	for i := 0; i < submissions; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := pidapi.PID{UniqID: fmt.Sprintf("concurrent-%d", i)}
+			if _, err := sched.Submit(context.Background(), id, &CounterProcess{}, "", testInput(3)); err != nil {
+				t.Errorf("submit %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if err := sched.ResizeWorkers(4); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { return completed.Load() == submissions })
+	if sched.processorCount.Load() != 0 {
+		t.Fatalf("processors remained after resize stress: %d", sched.processorCount.Load())
+	}
+}

--- a/system/scheduler/actor/resize_test.go
+++ b/system/scheduler/actor/resize_test.go
@@ -373,9 +373,9 @@ func TestSchedulerShrinkFinishesCurrentStepAndHandsOffContinuation(t *testing.T)
 	gate := &resizeGateProcess{entered: make(chan struct{}), release: make(chan struct{})}
 	var proc *Processor
 	for id, item := range []struct {
-		pid  string
 		gate *resizeGateProcess
-	}{{"shrink-survivor-gate", survivorGate}, {"shrink-gate", gate}} {
+		pid  string
+	}{{survivorGate, "shrink-survivor-gate"}, {gate, "shrink-gate"}} {
 		submitted, err := sched.Submit(context.Background(), pidapi.PID{UniqID: item.pid}, item.gate, "", nil)
 		if err != nil {
 			t.Fatal(err)

--- a/system/scheduler/actor/scheduler.go
+++ b/system/scheduler/actor/scheduler.go
@@ -27,7 +27,7 @@ type Option func(*Scheduler)
 func WithWorkers(n int) Option {
 	return func(s *Scheduler) {
 		if n > 0 {
-			s.numWorkers = n
+			s.initialWorkers = n
 		}
 	}
 }
@@ -68,29 +68,33 @@ func WithMaxProcesses(maxProcs int64) Option {
 }
 
 type Scheduler struct {
-	lifecycle      process.Lifecycle
-	registry       dispatcher.Registry
-	global         *Queue
-	drainCh        chan struct{}
-	byQueue        sync.Map
-	byPID          sync.Map
-	workers        []*Worker
-	pinSet         affinity.Set
-	wg             sync.WaitGroup
-	numWorkers     int
-	maxProcesses   int64
-	localQueueSize int
-	processorCount atomic.Int64
-	queueSize      int
-	nextID         atomic.Uint64
-	stopping       atomic.Bool
-	collectStats   atomic.Bool
+	lifecycle       process.Lifecycle
+	registry        dispatcher.Registry
+	global          *Queue
+	drainCh         chan struct{}
+	byQueue         sync.Map
+	byPID           sync.Map
+	workers         atomic.Pointer[workerSet]
+	pinSet          affinity.Set
+	wg              sync.WaitGroup
+	controlMu       sync.Mutex
+	initialWorkers  int
+	maxProcesses    int64
+	localQueueSize  int
+	processorCount  atomic.Int64
+	retiredExecuted atomic.Uint64
+	retiredStolen   atomic.Uint64
+	queueSize       int
+	nextID          atomic.Uint64
+	stopping        atomic.Bool
+	collectStats    atomic.Bool
+	started         bool
 }
 
 func NewScheduler(registry dispatcher.Registry, opts ...Option) *Scheduler {
 	s := &Scheduler{
 		registry:       registry,
-		numWorkers:     goruntime.GOMAXPROCS(0),
+		initialWorkers: goruntime.GOMAXPROCS(0),
 		queueSize:      1024,
 		localQueueSize: 256,
 	}
@@ -101,11 +105,11 @@ func NewScheduler(registry dispatcher.Registry, opts ...Option) *Scheduler {
 
 	s.global = NewQueue(s.queueSize)
 	s.drainCh = make(chan struct{}, 1)
-	s.workers = make([]*Worker, s.numWorkers)
-
-	for i := range s.workers {
-		s.workers[i] = newWorker(i, s)
+	workers := make([]*Worker, s.initialWorkers)
+	for i := range workers {
+		workers[i] = newWorker(i, s)
 	}
+	s.storeWorkers(workers)
 
 	return s
 }
@@ -114,26 +118,17 @@ func (s *Scheduler) getHandler(cmd dispatcher.Command) dispatcher.Handler {
 	return s.registry.Get(cmd.CmdID())
 }
 
-func (s *Scheduler) Start() {
-	for _, w := range s.workers {
-		s.wg.Add(1)
-		go func(worker *Worker) {
-			defer s.wg.Done()
-			if len(s.pinSet) > 0 {
-				goruntime.LockOSThread()
-				defer goruntime.UnlockOSThread()
-				_ = affinity.Apply(s.pinSet)
-			}
-			worker.run()
-		}(w)
-	}
-}
-
 // Stop gracefully shuts down the scheduler.
 // Sends cancel events and waits for processes to complete or context deadline.
 func (s *Scheduler) Stop(ctx context.Context) {
-	// Set stopping first - prevents new submissions and pool release
-	s.stopping.Store(true)
+	// Publish the terminal state while serialized with Start and Resize, then
+	// release the control lock before lifecycle callbacks and worker waits.
+	s.controlMu.Lock()
+	if s.stopping.Swap(true) {
+		s.controlMu.Unlock()
+		return
+	}
+	s.controlMu.Unlock()
 
 	// Push cancel event directly to each processor's queue.
 	// Safe because stopping=true prevents pool release.
@@ -199,7 +194,7 @@ func (s *Scheduler) Stop(ctx context.Context) {
 }
 
 func (s *Scheduler) wakeAny() {
-	for _, w := range s.workers {
+	for _, w := range s.workerSnapshot() {
 		if w.signal() {
 			return
 		}
@@ -207,20 +202,23 @@ func (s *Scheduler) wakeAny() {
 }
 
 func (s *Scheduler) wakeAll() {
-	for _, w := range s.workers {
+	for _, w := range s.workerSnapshot() {
 		_ = w.signal()
 	}
 }
 
 func (s *Scheduler) injectOrGlobal(proc *Processor) {
 	workerID := proc.lastWorker.Load()
-	if workerID >= 0 && int(workerID) < len(s.workers) {
-		s.workers[workerID].inject.Push(proc)
-		s.workers[workerID].signal()
-	} else {
-		s.global.Push(proc)
-		s.wakeAny()
+	workers := s.workerSnapshot()
+	if workerID >= 0 && int(workerID) < len(workers) {
+		worker := workers[workerID]
+		if worker.injectProcessor(proc) {
+			return
+		}
 	}
+	proc.lastWorker.Store(noWorkerAffinity)
+	s.global.Push(proc)
+	s.wakeAny()
 }
 
 // WakeProcessor implements process.YieldScheduler.
@@ -477,8 +475,10 @@ func (s *Scheduler) deliverToProc(proc *Processor, gen uint64, pkg *relay.Packag
 func (s *Scheduler) Stats() map[string]uint64 {
 	stats := make(map[string]uint64, 8)
 
-	var executed, stolen uint64
-	for _, w := range s.workers {
+	executed := s.retiredExecuted.Load()
+	stolen := s.retiredStolen.Load()
+	workers := s.workerSnapshot()
+	for _, w := range workers {
 		executed += w.executed.Load()
 		stolen += w.stolen.Load()
 	}
@@ -489,15 +489,16 @@ func (s *Scheduler) Stats() map[string]uint64 {
 	stats["executed"] = executed
 	stats["stolen"] = stolen
 	stats["global_queue"] = uint64(max(0, s.global.Len()))
-	stats["workers"] = uint64(len(s.workers))
+	stats["workers"] = uint64(len(workers))
 	stats["processes"] = processCount
 
 	return stats
 }
 
 func (s *Scheduler) WorkerStats() []map[string]uint64 {
-	result := make([]map[string]uint64, len(s.workers))
-	for i, w := range s.workers {
+	workers := s.workerSnapshot()
+	result := make([]map[string]uint64, len(workers))
+	for i, w := range workers {
 		result[i] = map[string]uint64{
 			"executed":    w.executed.Load(),
 			"stolen":      w.stolen.Load(),

--- a/system/scheduler/actor/scheduler_workers.go
+++ b/system/scheduler/actor/scheduler_workers.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package actor
+
+import (
+	"errors"
+	goruntime "runtime"
+
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/system/scheduler/affinity"
+)
+
+// ErrInvalidWorkerCount is returned when a resize would leave the scheduler
+// without an execution worker.
+var ErrInvalidWorkerCount = errors.New("worker count must be greater than zero")
+
+// workerSet is immutable after publication. Readers can retain a snapshot
+// without locking while a concurrent resize publishes its successor.
+type workerSet struct {
+	active []*Worker
+}
+
+func (s *Scheduler) Start() {
+	s.controlMu.Lock()
+	defer s.controlMu.Unlock()
+
+	if s.started || s.stopping.Load() {
+		return
+	}
+	s.started = true
+	for _, w := range s.workerSnapshot() {
+		s.startWorker(w)
+	}
+}
+
+// ResizeWorkers changes scheduler execution capacity without replacing the
+// scheduler or any processors. Growing appends workers. Shrinking first removes
+// the highest-numbered workers from routing; each then finishes its current
+// step, hands queued work to the global queue, and exits asynchronously.
+func (s *Scheduler) ResizeWorkers(target int) error {
+	if target <= 0 {
+		return ErrInvalidWorkerCount
+	}
+	if s.stopping.Load() {
+		return process.ErrSchedulerStopping
+	}
+
+	s.controlMu.Lock()
+	defer s.controlMu.Unlock()
+
+	if s.stopping.Load() {
+		return process.ErrSchedulerStopping
+	}
+
+	current := s.workerSnapshot()
+	if target == len(current) {
+		return nil
+	}
+	if target > len(current) {
+		s.growWorkers(current, target)
+		return nil
+	}
+	s.shrinkWorkers(current, target)
+	return nil
+}
+
+func (s *Scheduler) growWorkers(current []*Worker, target int) {
+	resized := append([]*Worker(nil), current...)
+	added := make([]*Worker, 0, target-len(current))
+	for id := len(current); id < target; id++ {
+		// IDs are indexes in the published worker set, not global worker
+		// identities. A same-ID predecessor may still be finishing retirement,
+		// but it is absent from routing and owns a distinct done channel.
+		w := newWorker(id, s)
+		resized = append(resized, w)
+		added = append(added, w)
+	}
+	s.storeWorkers(resized)
+	if s.started {
+		for _, w := range added {
+			s.startWorker(w)
+		}
+	}
+	s.wakeAll()
+}
+
+func (s *Scheduler) shrinkWorkers(current []*Worker, target int) {
+	active := append([]*Worker(nil), current[:target]...)
+	retiring := append([]*Worker(nil), current[target:]...)
+
+	// Publish the smaller routing set before retirement. A sender that already
+	// holds the old snapshot is synchronized by Worker.retire, while all later
+	// senders immediately fall back to the global queue.
+	s.storeWorkers(active)
+	for _, w := range retiring {
+		w.retire()
+	}
+	if !s.started {
+		s.collectRetiredStats(retiring)
+		return
+	}
+	go s.awaitRetiredWorkers(retiring)
+}
+
+func (s *Scheduler) awaitRetiredWorkers(retiring []*Worker) {
+	for _, w := range retiring {
+		<-w.done
+	}
+	s.collectRetiredStats(retiring)
+}
+
+func (s *Scheduler) collectRetiredStats(retiring []*Worker) {
+	for _, w := range retiring {
+		s.retiredExecuted.Add(w.executed.Load())
+		s.retiredStolen.Add(w.stolen.Load())
+	}
+}
+
+func (s *Scheduler) startWorker(w *Worker) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		defer close(w.done)
+		if len(s.pinSet) > 0 {
+			goruntime.LockOSThread()
+			defer goruntime.UnlockOSThread()
+			_ = affinity.Apply(s.pinSet)
+		}
+		w.run()
+	}()
+}
+
+func (s *Scheduler) workerSnapshot() []*Worker {
+	set := s.workers.Load()
+	if set == nil {
+		return nil
+	}
+	return set.active
+}
+
+func (s *Scheduler) storeWorkers(workers []*Worker) {
+	s.workers.Store(&workerSet{active: workers})
+}

--- a/system/scheduler/actor/worker.go
+++ b/system/scheduler/actor/worker.go
@@ -22,11 +22,14 @@ type Worker struct {
 	inject    *InjectQueue
 	scheduler *Scheduler
 	parkCond  *sync.Cond
+	done      chan struct{}
+	parkMu    sync.Mutex
+	routeMu   sync.Mutex
 	id        int
 	executed  atomic.Uint64
 	stolen    atomic.Uint64
-	parkMu    sync.Mutex
 	notified  atomic.Bool
+	retiring  atomic.Bool
 }
 
 func newWorker(id int, s *Scheduler) *Worker {
@@ -35,6 +38,7 @@ func newWorker(id int, s *Scheduler) *Worker {
 		scheduler: s,
 		local:     NewDeque(s.localQueueSize),
 		inject:    NewInjectQueue(),
+		done:      make(chan struct{}),
 	}
 	w.parkCond = sync.NewCond(&w.parkMu)
 	return w
@@ -45,7 +49,16 @@ func (w *Worker) run() {
 	spins := 0
 
 	for {
+		if w.retiring.Load() {
+			w.handoffQueuedWork()
+			return
+		}
 		if proc := w.findWork(); proc != nil {
+			if w.retiring.Load() {
+				w.handoff(proc)
+				w.handoffQueuedWork()
+				return
+			}
 			spins = 0
 			w.executeOne(proc)
 			w.executed.Add(1)
@@ -68,6 +81,10 @@ func (w *Worker) run() {
 
 		spins = 0
 		w.park()
+		if w.retiring.Load() {
+			w.handoffQueuedWork()
+			return
+		}
 		if s.stopping.Load() {
 			w.drain()
 			return
@@ -75,10 +92,55 @@ func (w *Worker) run() {
 	}
 }
 
+func (w *Worker) retire() {
+	w.routeMu.Lock()
+	w.retiring.Store(true)
+	w.routeMu.Unlock()
+	w.signal()
+}
+
+func (w *Worker) injectProcessor(proc *Processor) bool {
+	w.routeMu.Lock()
+	defer w.routeMu.Unlock()
+	if w.retiring.Load() {
+		return false
+	}
+	w.inject.Push(proc)
+	w.signal()
+	return true
+}
+
+func (w *Worker) handoffQueuedWork() {
+	for {
+		proc := w.local.Pop()
+		if proc == nil {
+			break
+		}
+		w.handoff(proc)
+	}
+	for {
+		proc := w.inject.Pop()
+		if proc == nil {
+			break
+		}
+		w.handoff(proc)
+	}
+	w.scheduler.wakeAll()
+}
+
+func (w *Worker) handoff(proc *Processor) {
+	proc.lastWorker.Store(noWorkerAffinity)
+	w.scheduler.global.Push(proc)
+}
+
 func (w *Worker) park() {
 	s := w.scheduler
 	w.parkMu.Lock()
 	for {
+		if w.retiring.Load() {
+			w.parkMu.Unlock()
+			return
+		}
 		if proc := w.findWork(); proc != nil {
 			shouldWake := s.global.Len() > 0
 			w.parkMu.Unlock()
@@ -157,7 +219,7 @@ func (w *Worker) findWork() *Processor {
 }
 
 func (w *Worker) steal() *Processor {
-	workers := w.scheduler.workers
+	workers := w.scheduler.workerSnapshot()
 	n := len(workers)
 	if n <= 1 {
 		return nil


### PR DESCRIPTION
## Summary

- replace destructive `process.host` update (`Delete` + `Add`) with semantic in-place updates
- treat equivalent config and metadata-only changes as strict no-ops
- resize scheduler workers without replacing the host, scheduler, queues, or live processes
- reject queue-capacity, lifecycle, and affinity-owned worker changes before mutation
- make worker shrink safe through atomic routing snapshots, retirement handoff, and asynchronous completion

## Runtime semantics

- malformed updates are validated before the live host is touched
- updates of absent hosts return `NotFound` instead of implicitly adding them
- worker grow/shrink preserves the existing host, scheduler, PIDs, process queues, and relay/supervisor registration
- shrink removes retiring workers from routing before they finish their current step and hand queued work to the global queue
- stop/update transitions publish terminal state before draining, without holding lifecycle/control locks across callbacks or worker waits

Queue sizes remain construction-time capacity hints, and supervisor lifecycle configuration does not yet have a live-update contract. Changes to those fields are therefore rejected rather than silently accepted.

## Validation

- `make lint`
- `go test ./... -count=1`
- `go test -race ./service/host ./system/scheduler/actor -count=1`
- focused resize, self-retirement, immediate-regrow, and concurrent-resize race suites (100 repetitions)
- clean Kickside Hub install with the dependency reconciliation branch: expected KB10/FTS5 migration failure rolled back cleanly; Keeper remained running; a subsequent Webscout install succeeded

This PR is intentionally separate from #491 and does not include dependency reconciliation changes.
