### PR TITLE
feat(publish): preserve application runtime config in packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,18 @@ non-workspace runtime profiles are published from its `wippy.yaml` manifest:
 publish:
   profiles:
     include: [production]
+  runtime:
+    sections: [security, registry, override]
+    vars: [public_url]
 ```
+
+Published runtime configuration is application-owned. The selected sections
+and any variables they or the published profiles reference are carried into the
+application pack as defaults. Variable references are followed transitively.
+Use `publish.runtime.vars` only for intentionally public defaults which are not
+otherwise referenced; unlisted variables are not packaged. Publisher
+environment references and machine-local `boot`, `extensions`, and `workspace`
+sections are rejected.
 
 Existing `replacements:` in `wippy.lock` remain readable for compatibility but
 emit a deprecation warning. Move them to any runtime configuration file; new

--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -59,6 +59,7 @@ type PublishProfilesConfig struct {
 type PublishRuntimeConfig struct {
 	Source   string   `yaml:"source,omitempty"`
 	Sections []string `yaml:"sections,omitempty"`
+	Vars     []string `yaml:"vars,omitempty"`
 }
 
 func Load(dir string) (*ModuleConfig, error) {
@@ -174,8 +175,9 @@ func (c *ModuleConfig) ValidateForLabel() error {
 }
 
 func (c *ModuleConfig) validatePublishOwnership() error {
-	if len(c.Publish.Runtime.Sections) > 0 && c.Type != "application" {
-		return fmt.Errorf("publish.runtime.sections is application-owned and requires type: application")
+	runtime := c.Publish.Runtime
+	if (len(runtime.Sections) > 0 || len(runtime.Vars) > 0 || strings.TrimSpace(runtime.Source) != "") && c.Type != "application" {
+		return fmt.Errorf("publish.runtime is application-owned and requires type: application")
 	}
 	return nil
 }

--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -44,12 +44,21 @@ type ModuleConfig struct {
 
 type PublishConfig struct {
 	Profiles PublishProfilesConfig `yaml:"profiles,omitempty"`
+	Runtime  PublishRuntimeConfig  `yaml:"runtime,omitempty"`
 }
 
 type PublishProfilesConfig struct {
 	Enabled *bool    `yaml:"enabled,omitempty"`
 	Source  string   `yaml:"source,omitempty"`
 	Include []string `yaml:"include,omitempty"`
+}
+
+// PublishRuntimeConfig selects application runtime sections to carry as pack
+// defaults. Sections are opt-in because runtime configuration may contain
+// credentials and machine-local paths which must not become package metadata.
+type PublishRuntimeConfig struct {
+	Source   string   `yaml:"source,omitempty"`
+	Sections []string `yaml:"sections,omitempty"`
 }
 
 func Load(dir string) (*ModuleConfig, error) {
@@ -118,6 +127,9 @@ func (c *ModuleConfig) Validate() error {
 	if err := ValidateModuleType(c.Type); err != nil {
 		return err
 	}
+	if err := c.validatePublishOwnership(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -154,7 +166,17 @@ func (c *ModuleConfig) ValidateForLabel() error {
 	if err := ValidateModuleType(c.Type); err != nil {
 		return err
 	}
+	if err := c.validatePublishOwnership(); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func (c *ModuleConfig) validatePublishOwnership() error {
+	if len(c.Publish.Runtime.Sections) > 0 && c.Type != "application" {
+		return fmt.Errorf("publish.runtime.sections is application-owned and requires type: application")
+	}
 	return nil
 }
 

--- a/boot/deps/config/config_test.go
+++ b/boot/deps/config/config_test.go
@@ -324,6 +324,7 @@ publish:
   runtime:
     source: config/runtime.yaml
     sections: [security, registry, override]
+    vars: [public_url]
 `
 	require.NoError(t, os.WriteFile(filepath.Join(dir, DefaultConfigFile), []byte(content), 0o644))
 
@@ -331,9 +332,10 @@ publish:
 	require.NoError(t, err)
 	assert.Equal(t, "config/runtime.yaml", cfg.Publish.Runtime.Source)
 	assert.Equal(t, []string{"security", "registry", "override"}, cfg.Publish.Runtime.Sections)
+	assert.Equal(t, []string{"public_url"}, cfg.Publish.Runtime.Vars)
 }
 
-func TestValidate_PublishRuntimeSectionsAreApplicationOnly(t *testing.T) {
+func TestValidate_PublishRuntimeIsApplicationOnly(t *testing.T) {
 	for _, moduleType := range []string{"", "library", "agent", "plugin"} {
 		t.Run("reject_"+moduleType, func(t *testing.T) {
 			cfg := ModuleConfig{
@@ -341,7 +343,7 @@ func TestValidate_PublishRuntimeSectionsAreApplicationOnly(t *testing.T) {
 				ModuleName:   "module",
 				Type:         moduleType,
 				Publish: PublishConfig{Runtime: PublishRuntimeConfig{
-					Sections: []string{"security"},
+					Vars: []string{"public_url"},
 				}},
 			}
 			err := cfg.Validate()
@@ -356,6 +358,7 @@ func TestValidate_PublishRuntimeSectionsAreApplicationOnly(t *testing.T) {
 		Type:         "application",
 		Publish: PublishConfig{Runtime: PublishRuntimeConfig{
 			Sections: []string{"security", "registry"},
+			Vars:     []string{"public_url"},
 		}},
 	}
 	require.NoError(t, cfg.Validate())

--- a/boot/deps/config/config_test.go
+++ b/boot/deps/config/config_test.go
@@ -315,6 +315,53 @@ publish:
 	assert.Equal(t, []string{"production", "staging"}, cfg.Publish.Profiles.Include)
 }
 
+func TestLoad_WithPublishRuntimeSections(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+organization: myorg
+module: mymod
+publish:
+  runtime:
+    source: config/runtime.yaml
+    sections: [security, registry, override]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DefaultConfigFile), []byte(content), 0o644))
+
+	cfg, err := Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "config/runtime.yaml", cfg.Publish.Runtime.Source)
+	assert.Equal(t, []string{"security", "registry", "override"}, cfg.Publish.Runtime.Sections)
+}
+
+func TestValidate_PublishRuntimeSectionsAreApplicationOnly(t *testing.T) {
+	for _, moduleType := range []string{"", "library", "agent", "plugin"} {
+		t.Run("reject_"+moduleType, func(t *testing.T) {
+			cfg := ModuleConfig{
+				Organization: "acme",
+				ModuleName:   "module",
+				Type:         moduleType,
+				Publish: PublishConfig{Runtime: PublishRuntimeConfig{
+					Sections: []string{"security"},
+				}},
+			}
+			err := cfg.Validate()
+			require.ErrorContains(t, err, "requires type: application")
+			require.ErrorContains(t, cfg.ValidateForLabel(), "requires type: application")
+		})
+	}
+
+	cfg := ModuleConfig{
+		Organization: "acme",
+		ModuleName:   "app",
+		Type:         "application",
+		Publish: PublishConfig{Runtime: PublishRuntimeConfig{
+			Sections: []string{"security", "registry"},
+		}},
+	}
+	require.NoError(t, cfg.Validate())
+	require.NoError(t, cfg.ValidateForLabel())
+}
+
 func TestLoad_WithExplicitEmptyPublishProfileInclude(t *testing.T) {
 	dir := t.TempDir()
 	content := `

--- a/cmd/internal/bootconfig/load.go
+++ b/cmd/internal/bootconfig/load.go
@@ -26,7 +26,7 @@ func LoadFiles(paths []string) (boot.Config, error) {
 		if path == "" {
 			return nil, fmt.Errorf("load config file: path is empty")
 		}
-		cfg, err := load(path, true)
+		cfg, err := load(path, true, true)
 		if err != nil {
 			return nil, fmt.Errorf("load config file %s: %w", path, err)
 		}
@@ -36,10 +36,17 @@ func LoadFiles(paths []string) (boot.Config, error) {
 }
 
 func Load(path string) (boot.Config, error) {
-	return load(path, false)
+	return load(path, false, true)
 }
 
-func load(path string, required bool) (boot.Config, error) {
+// LoadForPublish reads declared configuration without expanding references to
+// the publisher's environment. Package metadata must be derived from source,
+// never from machine-local values present while the package is built.
+func LoadForPublish(path string) (boot.Config, error) {
+	return load(path, false, false)
+}
+
+func load(path string, required, resolveEnv bool) (boot.Config, error) {
 	if path == "" {
 		return nil, nil //nolint:nilnil // empty path means no config
 	}
@@ -60,8 +67,10 @@ func load(path string, required bool) (boot.Config, error) {
 	if err := validateVersion(cfg.Version); err != nil {
 		return nil, err
 	}
-	if err := resolveOSEnvRefs(cfg.Sections); err != nil {
-		return nil, err
+	if resolveEnv {
+		if err := resolveOSEnvRefs(cfg.Sections); err != nil {
+			return nil, err
+		}
 	}
 
 	return buildBootConfig(cfg.Sections)

--- a/cmd/internal/bootconfig/load_test.go
+++ b/cmd/internal/bootconfig/load_test.go
@@ -229,6 +229,22 @@ registry:
 		assert.Equal(t, "wippy_registry", registryCfg.GetString("history_schema", ""))
 	})
 
+	t.Run("publish load never reads the publisher environment", func(t *testing.T) {
+		t.Setenv("WIPPY_TEST_PUBLISH_SECRET", "must-not-enter-pack-metadata")
+		yamlContent := `version: "1.0"
+registry:
+  history_dsn: ${env:WIPPY_TEST_PUBLISH_SECRET}
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "test.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0o600))
+
+		cfg, err := LoadForPublish(configPath)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "${env:WIPPY_TEST_PUBLISH_SECRET}", cfg.GetString("registry.history_dsn", ""))
+	})
+
 	t.Run("keeps profile variables for later profile resolution", func(t *testing.T) {
 		yamlContent := `version: "1.0"
 vars:

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -521,7 +521,7 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		}
 		metadata[trimmed] = value
 	}
-	if err := addPublishedRuntimeProfileMetadata(metadata, srcDir, cfg.Publish.Profiles); err != nil {
+	if err := addPublishedRuntimeMetadata(metadata, srcDir, cfg.Publish); err != nil {
 		return nil, NewPublishConfigError(err)
 	}
 

--- a/cmd/wippy/cmd/publish_profiles.go
+++ b/cmd/wippy/cmd/publish_profiles.go
@@ -4,41 +4,27 @@ package cmd
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/boot/deps/config"
-	"github.com/wippyai/runtime/cmd/internal/bootconfig"
 )
 
-const (
-	publishRuntimeMetadataKey         = "runtime"
-	publishRuntimeProfilesMetadataKey = "profiles"
-	publishRuntimeVarsMetadataKey     = "vars"
-)
-
+// addPublishedRuntimeProfileMetadata retains the focused helper used by
+// callers and tests which only configure profile publication.
 func addPublishedRuntimeProfileMetadata(metadata attrs.Bag, configDir string, profileCfg config.PublishProfilesConfig) error {
-	if hasNestedRuntimeMetadata(metadata, publishRuntimeProfilesMetadataKey) {
-		return fmt.Errorf("wippy.yaml metadata.runtime.profiles is not supported; declare publishable profiles in .wippy.yaml or publish.profiles.source")
-	}
+	return addPublishedRuntimeMetadata(metadata, configDir, config.PublishConfig{Profiles: profileCfg})
+}
 
+func collectPublishedRuntimeProfiles(dst *publishedRuntimeConfig, configDir string, profileCfg config.PublishProfilesConfig) error {
 	if profileCfg.Enabled != nil && !*profileCfg.Enabled {
 		return nil
 	}
 
-	source := strings.TrimSpace(profileCfg.Source)
-	if source == "" {
-		source = defaultConfigFile
-	}
-	if !filepath.IsAbs(source) {
-		source = filepath.Join(configDir, source)
-	}
-
-	cfg, err := bootconfig.Load(source)
+	cfg, source, err := loadPublishRuntimeSource(configDir, profileCfg.Source)
 	if err != nil {
-		return fmt.Errorf("load runtime profile source %s: %w", source, err)
+		return err
 	}
 	if cfg == nil {
 		return nil
@@ -51,22 +37,11 @@ func addPublishedRuntimeProfileMetadata(metadata attrs.Bag, configDir string, pr
 	if len(profiles) == 0 {
 		return nil
 	}
-
-	if hasNestedRuntimeMetadata(metadata, publishRuntimeVarsMetadataKey) {
-		return fmt.Errorf("runtime vars are defined in both %s and wippy.yaml metadata; keep profile variables in the profile source", source)
+	if path, found := findPublishEnvReference(profiles, publishRuntimeProfilesMetadataKey); found {
+		return fmt.Errorf("runtime setting %s references the publisher environment; use a runtime variable or an entry *_env setting instead", path)
 	}
-
-	runtime, err := runtimeMetadataMap(metadata)
-	if err != nil {
-		return err
-	}
-	runtime[publishRuntimeProfilesMetadataKey] = profiles
-
-	vars := runtimeSectionFromConfig(cfg, publishRuntimeVarsMetadataKey)
-	if len(vars) > 0 {
-		runtime[publishRuntimeVarsMetadataKey] = vars
-	}
-
+	dst.profiles = profiles
+	mergePublishedVars(dst.vars, runtimeSectionFromConfig(cfg, publishRuntimeVarsMetadataKey), source)
 	return nil
 }
 
@@ -134,73 +109,4 @@ func runtimeProfilesFromConfig(cfg boot.Config, include []string) (map[string]an
 		profiles[name] = profile
 	}
 	return profiles, nil
-}
-
-func runtimeSectionFromConfig(cfg boot.Config, section string) map[string]any {
-	values := make(map[string]any)
-	if cfg == nil {
-		return values
-	}
-
-	prefix := section + "."
-	for _, key := range cfg.Keys() {
-		if !strings.HasPrefix(key, prefix) {
-			continue
-		}
-		value, _ := cfg.Get(key)
-		values[strings.TrimPrefix(key, prefix)] = value
-	}
-	return values
-}
-
-func runtimeMetadataMap(metadata attrs.Bag) (map[string]any, error) {
-	if metadata == nil {
-		return nil, fmt.Errorf("metadata bag is nil")
-	}
-
-	raw, exists := metadata[publishRuntimeMetadataKey]
-	if !exists {
-		runtime := make(map[string]any)
-		metadata[publishRuntimeMetadataKey] = runtime
-		return runtime, nil
-	}
-
-	switch typed := raw.(type) {
-	case map[string]any:
-		return typed, nil
-	case attrs.Bag:
-		runtime := map[string]any(typed)
-		metadata[publishRuntimeMetadataKey] = runtime
-		return runtime, nil
-	default:
-		return nil, fmt.Errorf("wippy.yaml metadata.runtime must be a map when publishing runtime profiles")
-	}
-}
-
-func hasNestedRuntimeMetadata(metadata attrs.Bag, nestedKey string) bool {
-	if metadata == nil {
-		return false
-	}
-
-	dotted := publishRuntimeMetadataKey + "." + nestedKey
-	for key := range metadata {
-		if key == dotted || strings.HasPrefix(key, dotted+".") {
-			return true
-		}
-	}
-
-	raw, exists := metadata[publishRuntimeMetadataKey]
-	if !exists {
-		return false
-	}
-	switch typed := raw.(type) {
-	case map[string]any:
-		_, exists = typed[nestedKey]
-		return exists
-	case attrs.Bag:
-		_, exists = typed[nestedKey]
-		return exists
-	default:
-		return false
-	}
 }

--- a/cmd/wippy/cmd/publish_profiles_test.go
+++ b/cmd/wippy/cmd/publish_profiles_test.go
@@ -26,6 +26,7 @@ profiles:
       db_host: db.internal
     override:
       "app:db:kind": db.sql.postgres
+      "app:db:host": "${db_host}"
     disable:
       namespaces:
         add:
@@ -60,6 +61,142 @@ profiles:
 	require.Equal(t, "db.sql.postgres", prodOverride["app:db:kind"])
 	prodDisable := requireMap(t, prod["disable"])
 	require.Equal(t, []any{"app.dev.**"}, prodDisable["namespaces.add"])
+}
+
+func TestAddPublishedRuntimeMetadataExportsSelectedBaseConfigAndProfiles(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+security:
+  strict_mode: true
+registry:
+  enable_history: true
+  dispatch_internal_kinds:
+    - registry.entry
+    - ns.requirement
+vars:
+  port: 8085
+  signing_key: must-never-be-packed
+override:
+  "app:gateway:addr": ":${port}"
+profiles:
+  local:
+    override:
+      "app:gateway:addr": ":18085"
+workspace:
+  replacements:
+    acme/http: ../http
+secrets:
+  signing_key: must-never-be-packed
+`)
+
+	metadata := attrs.Bag{}
+	disabled := false
+	require.NoError(t, addPublishedRuntimeMetadata(metadata, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{
+			Sections: []string{"security", "registry", "override"},
+		},
+		Profiles: config.PublishProfilesConfig{Enabled: &disabled},
+	}))
+
+	runtime := requireMap(t, metadata["runtime"])
+	require.Equal(t, true, requireMap(t, runtime["security"])["strict_mode"])
+	registry := requireMap(t, runtime["registry"])
+	require.Equal(t, true, registry["enable_history"])
+	require.Equal(t, []any{"registry.entry", "ns.requirement"}, registry["dispatch_internal_kinds"])
+	require.Equal(t, ":${port}", requireMap(t, runtime["override"])["app:gateway:addr"])
+	require.Equal(t, 8085, requireMap(t, runtime["vars"])["port"])
+	require.NotContains(t, requireMap(t, runtime["vars"]), "signing_key")
+	require.NotContains(t, runtime, "profiles")
+	require.NotContains(t, runtime, "workspace")
+	require.NotContains(t, runtime, "secrets")
+}
+
+func TestAddPublishedRuntimeMetadataRejectsMachineLocalSections(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+workspace:
+  replacements:
+    acme/http: ../http
+`)
+
+	err := addPublishedRuntimeMetadata(attrs.Bag{}, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Sections: []string{"workspace"}},
+	})
+	require.ErrorContains(t, err, `runtime section "workspace" is machine-local`)
+}
+
+func TestAddPublishedRuntimeMetadataNeverResolvesPublisherSecrets(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("WIPPY_PUBLISH_TEST_SECRET", "publisher-secret-value")
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+vars:
+  history_dsn: ${env:WIPPY_PUBLISH_TEST_SECRET}
+registry:
+  history_dsn: ${history_dsn}
+`)
+
+	metadata := attrs.Bag{}
+	err := addPublishedRuntimeMetadata(metadata, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Sections: []string{"registry"}},
+	})
+	require.ErrorContains(t, err, "vars.history_dsn references the publisher environment")
+	require.NotContains(t, err.Error(), "publisher-secret-value")
+	require.NotContains(t, metadata, "runtime")
+}
+
+func TestAddPublishedRuntimeMetadataRejectsUndefinedReferencedVariable(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+override:
+  "app:gateway:addr": ":${missing_port}"
+`)
+
+	err := addPublishedRuntimeMetadata(attrs.Bag{}, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Sections: []string{"override"}},
+	})
+	require.ErrorContains(t, err, `published runtime sections references undefined runtime variable "missing_port"`)
+}
+
+func TestAddPublishedRuntimeProfileMetadataPreservesLegacyBaseVariables(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+vars:
+  public_host: localhost
+  public_timeout: 30s
+profiles:
+  local:
+    override:
+      "app:db:host": "${public_host}"
+`)
+
+	metadata := attrs.Bag{}
+	require.NoError(t, addPublishedRuntimeProfileMetadata(metadata, dir, config.PublishProfilesConfig{}))
+	vars := requireMap(t, requireMap(t, metadata["runtime"])["vars"])
+	require.Equal(t, "localhost", vars["public_host"])
+	require.Equal(t, "30s", vars["public_timeout"])
+}
+
+func TestAddPublishedRuntimeMetadataRequiresExplicitSectionAllowList(t *testing.T) {
+	err := addPublishedRuntimeMetadata(attrs.Bag{}, t.TempDir(), config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Source: "config/runtime.yaml"},
+	})
+	require.ErrorContains(t, err, "requires an explicit publish.runtime.sections allow-list")
+}
+
+func TestAddPublishedRuntimeMetadataRejectsAmbiguousSectionMetadata(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+security:
+  strict_mode: true
+`)
+	metadata := attrs.Bag{"runtime": map[string]any{
+		"security": map[string]any{"strict_mode": false},
+	}}
+
+	err := addPublishedRuntimeMetadata(metadata, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Sections: []string{"security"}},
+	})
+	require.ErrorContains(t, err, `runtime section "security" is defined in both`)
 }
 
 func TestAddPublishedRuntimeProfileMetadataUsesConfiguredSource(t *testing.T) {

--- a/cmd/wippy/cmd/publish_profiles_test.go
+++ b/cmd/wippy/cmd/publish_profiles_test.go
@@ -46,8 +46,7 @@ profiles:
 	runtime := requireMap(t, metadata["runtime"])
 	require.Equal(t, map[string]any{"level": "info"}, requireMap(t, runtime["logger"]))
 
-	vars := requireMap(t, runtime["vars"])
-	require.Equal(t, "localhost", vars["db_host"])
+	require.NotContains(t, runtime, "vars", "profile-local variables must not cause unrelated base variables to be published")
 
 	profiles := requireMap(t, runtime["profiles"])
 	local := requireMap(t, profiles["local"])
@@ -157,7 +156,7 @@ override:
 	require.ErrorContains(t, err, `published runtime sections references undefined runtime variable "missing_port"`)
 }
 
-func TestAddPublishedRuntimeProfileMetadataPreservesLegacyBaseVariables(t *testing.T) {
+func TestAddPublishedRuntimeProfileMetadataExportsOnlyReferencedBaseVariables(t *testing.T) {
 	dir := t.TempDir()
 	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
 vars:
@@ -173,14 +172,73 @@ profiles:
 	require.NoError(t, addPublishedRuntimeProfileMetadata(metadata, dir, config.PublishProfilesConfig{}))
 	vars := requireMap(t, requireMap(t, metadata["runtime"])["vars"])
 	require.Equal(t, "localhost", vars["public_host"])
-	require.Equal(t, "30s", vars["public_timeout"])
+	require.NotContains(t, vars, "public_timeout")
 }
 
-func TestAddPublishedRuntimeMetadataRequiresExplicitSectionAllowList(t *testing.T) {
+func TestAddPublishedRuntimeMetadataProfileVariablesSelectBaseDependenciesTransitively(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+vars:
+  public_host: localhost
+  public_url: "http://${public_host}:8085"
+  signing_key: must-never-be-packed
+profiles:
+  local:
+    vars:
+      api_url: "${public_url}/api"
+    override:
+      "app.env:defaults:values.PUBLIC_API_URL": "${api_url}"
+`)
+
+	metadata := attrs.Bag{}
+	require.NoError(t, addPublishedRuntimeProfileMetadata(metadata, dir, config.PublishProfilesConfig{}))
+	runtime := requireMap(t, metadata["runtime"])
+	vars := requireMap(t, runtime["vars"])
+	require.Equal(t, "localhost", vars["public_host"])
+	require.Equal(t, "http://${public_host}:8085", vars["public_url"])
+	require.NotContains(t, vars, "signing_key")
+
+	local := requireMap(t, requireMap(t, runtime["profiles"])["local"])
+	require.Equal(t, "${public_url}/api", requireMap(t, local["vars"])["api_url"])
+}
+
+func TestAddPublishedRuntimeMetadataExportsExplicitPublicVariables(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+vars:
+  public_host: localhost
+  public_url: "http://${public_host}:8085"
+  signing_key: must-never-be-packed
+`)
+
+	metadata := attrs.Bag{}
+	require.NoError(t, addPublishedRuntimeMetadata(metadata, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Vars: []string{"public_url"}},
+	}))
+	vars := requireMap(t, requireMap(t, metadata["runtime"])["vars"])
+	require.Equal(t, "localhost", vars["public_host"])
+	require.Equal(t, "http://${public_host}:8085", vars["public_url"])
+	require.NotContains(t, vars, "signing_key")
+}
+
+func TestAddPublishedRuntimeMetadataRejectsUnknownExplicitVariable(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeProfileConfig(t, dir, `.wippy.yaml`, `version: "1.0"
+vars:
+  public_url: http://localhost:8085
+`)
+
+	err := addPublishedRuntimeMetadata(attrs.Bag{}, dir, config.PublishConfig{
+		Runtime: config.PublishRuntimeConfig{Vars: []string{"missing"}},
+	})
+	require.ErrorContains(t, err, `publish runtime variable "missing" not found`)
+}
+
+func TestAddPublishedRuntimeMetadataRequiresExplicitAllowList(t *testing.T) {
 	err := addPublishedRuntimeMetadata(attrs.Bag{}, t.TempDir(), config.PublishConfig{
 		Runtime: config.PublishRuntimeConfig{Source: "config/runtime.yaml"},
 	})
-	require.ErrorContains(t, err, "requires an explicit publish.runtime.sections allow-list")
+	require.ErrorContains(t, err, "requires an explicit sections or vars allow-list")
 }
 
 func TestAddPublishedRuntimeMetadataRejectsAmbiguousSectionMetadata(t *testing.T) {

--- a/cmd/wippy/cmd/publish_runtime.go
+++ b/cmd/wippy/cmd/publish_runtime.go
@@ -32,9 +32,10 @@ var nonPublishableRuntimeSections = map[string]struct{}{
 }
 
 type publishedRuntimeConfig struct {
-	sections map[string]map[string]any
-	profiles map[string]any
-	vars     map[string]publishedRuntimeVar
+	sections     map[string]map[string]any
+	profiles     map[string]any
+	vars         map[string]publishedRuntimeVar
+	explicitVars []string
 }
 
 type publishedRuntimeVar struct {
@@ -59,7 +60,7 @@ func addPublishedRuntimeMetadata(metadata attrs.Bag, configDir string, publishCf
 	if err := collectPublishedRuntimeProfiles(&collected, configDir, publishCfg.Profiles); err != nil {
 		return err
 	}
-	if len(collected.sections) == 0 && len(collected.profiles) == 0 {
+	if len(collected.sections) == 0 && len(collected.profiles) == 0 && len(collected.explicitVars) == 0 {
 		return nil
 	}
 	vars, err := publishedRuntimeVars(collected)
@@ -93,33 +94,20 @@ func addPublishedRuntimeMetadata(metadata attrs.Bag, configDir string, publishCf
 }
 
 func publishedRuntimeVars(collected publishedRuntimeConfig) (map[string]any, error) {
-	// Profile publication predates section publication and intentionally exposes
-	// base vars so destination-local config can reference those public defaults.
-	// Keep that contract, but read source literally and reject environment refs.
-	if len(collected.profiles) > 0 {
-		return allPublishedVars(collected.vars)
+	selected, err := referencedPublishedVars(collected.vars, collected.sections, collected.profiles)
+	if err != nil {
+		return nil, err
 	}
-	return referencedPublishedVars(collected.vars, collected.sections, nil)
-}
-
-func allPublishedVars(available map[string]publishedRuntimeVar) (map[string]any, error) {
-	selected := make(map[string]any, len(available))
-	for name, variable := range available {
-		if variable.conflictSource != "" {
-			return nil, fmt.Errorf("runtime variable %q has conflicting values in %s and %s", name, variable.source, variable.conflictSource)
-		}
-		if path, found := findPublishEnvReference(variable.value, publishRuntimeVarsMetadataKey+"."+name); found {
-			return nil, fmt.Errorf("runtime setting %s references the publisher environment; use a public default or omit it", path)
-		}
-		selected[name] = variable.value
+	if err := selectNamedPublishedVars(collected.vars, collected.explicitVars, "publish.runtime.vars", selected); err != nil {
+		return nil, err
 	}
 	return selected, nil
 }
 
 func collectPublishedRuntimeSections(dst *publishedRuntimeConfig, configDir string, runtimeCfg config.PublishRuntimeConfig) error {
-	if runtimeCfg.Sections == nil {
+	if len(runtimeCfg.Sections) == 0 && len(runtimeCfg.Vars) == 0 {
 		if strings.TrimSpace(runtimeCfg.Source) != "" {
-			return fmt.Errorf("publish.runtime.source requires an explicit publish.runtime.sections allow-list")
+			return fmt.Errorf("publish.runtime.source requires an explicit sections or vars allow-list")
 		}
 		return nil
 	}
@@ -128,7 +116,7 @@ func collectPublishedRuntimeSections(dst *publishedRuntimeConfig, configDir stri
 	if err != nil {
 		return err
 	}
-	if cfg == nil && len(runtimeCfg.Sections) > 0 {
+	if cfg == nil {
 		return fmt.Errorf("runtime publish source %s does not exist", source)
 	}
 
@@ -159,8 +147,22 @@ func collectPublishedRuntimeSections(dst *publishedRuntimeConfig, configDir stri
 		dst.sections[section] = values
 	}
 
-	if len(dst.sections) > 0 {
-		mergePublishedVars(dst.vars, runtimeSectionFromConfig(cfg, publishRuntimeVarsMetadataKey), source)
+	vars := runtimeSectionFromConfig(cfg, publishRuntimeVarsMetadataKey)
+	mergePublishedVars(dst.vars, vars, source)
+	seenVars := make(map[string]struct{}, len(runtimeCfg.Vars))
+	for _, rawName := range runtimeCfg.Vars {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return fmt.Errorf("publish.runtime.vars contains an empty variable name")
+		}
+		if _, duplicate := seenVars[name]; duplicate {
+			continue
+		}
+		seenVars[name] = struct{}{}
+		if _, exists := vars[name]; !exists {
+			return fmt.Errorf("publish runtime variable %q not found in %s", name, source)
+		}
+		dst.explicitVars = append(dst.explicitVars, name)
 	}
 	return nil
 }
@@ -222,6 +224,18 @@ func referencedPublishedVars(available map[string]publishedRuntimeVar, sections 
 func selectReferencedVars(available map[string]publishedRuntimeVar, local map[string]any, values any, context string, selected map[string]any) error {
 	pending := make(map[string]struct{})
 	collectPublishVarReferences(values, pending)
+	return selectPendingPublishedVars(available, local, pending, context, selected)
+}
+
+func selectNamedPublishedVars(available map[string]publishedRuntimeVar, names []string, context string, selected map[string]any) error {
+	pending := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		pending[name] = struct{}{}
+	}
+	return selectPendingPublishedVars(available, nil, pending, context, selected)
+}
+
+func selectPendingPublishedVars(available map[string]publishedRuntimeVar, local map[string]any, pending map[string]struct{}, context string, selected map[string]any) error {
 	resolved := make(map[string]struct{})
 	for len(pending) > 0 {
 		name := firstSortedKey(pending)

--- a/cmd/wippy/cmd/publish_runtime.go
+++ b/cmd/wippy/cmd/publish_runtime.go
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/boot/deps/config"
+	"github.com/wippyai/runtime/cmd/internal/bootconfig"
+)
+
+const (
+	publishRuntimeMetadataKey         = "runtime"
+	publishRuntimeProfilesMetadataKey = "profiles"
+	publishRuntimeVarsMetadataKey     = "vars"
+)
+
+var publishEnvReference = regexp.MustCompile(`\$\{env:[A-Za-z_][A-Za-z0-9_]*\}`)
+var publishVarReference = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+var nonPublishableRuntimeSections = map[string]struct{}{
+	"boot":       {}, // derived by the runtime for the destination workspace
+	"extensions": {}, // native extension paths belong to the build machine
+	"workspace":  {}, // replacements and source roots belong to the workspace
+}
+
+type publishedRuntimeConfig struct {
+	sections map[string]map[string]any
+	profiles map[string]any
+	vars     map[string]publishedRuntimeVar
+}
+
+type publishedRuntimeVar struct {
+	value          any
+	source         string
+	conflictSource string
+}
+
+func addPublishedRuntimeMetadata(metadata attrs.Bag, configDir string, publishCfg config.PublishConfig) error {
+	if hasNestedRuntimeMetadata(metadata, publishRuntimeProfilesMetadataKey) {
+		return fmt.Errorf("wippy.yaml metadata.runtime.profiles is not supported; declare publishable profiles in .wippy.yaml or publish.profiles.source")
+	}
+
+	collected := publishedRuntimeConfig{
+		sections: make(map[string]map[string]any),
+		vars:     make(map[string]publishedRuntimeVar),
+	}
+
+	if err := collectPublishedRuntimeSections(&collected, configDir, publishCfg.Runtime); err != nil {
+		return err
+	}
+	if err := collectPublishedRuntimeProfiles(&collected, configDir, publishCfg.Profiles); err != nil {
+		return err
+	}
+	if len(collected.sections) == 0 && len(collected.profiles) == 0 {
+		return nil
+	}
+	vars, err := publishedRuntimeVars(collected)
+	if err != nil {
+		return err
+	}
+
+	for section := range collected.sections {
+		if hasNestedRuntimeMetadata(metadata, section) {
+			return fmt.Errorf("runtime section %q is defined in both publish.runtime.sections and wippy.yaml metadata", section)
+		}
+	}
+	if len(vars) > 0 && hasNestedRuntimeMetadata(metadata, publishRuntimeVarsMetadataKey) {
+		return fmt.Errorf("runtime vars are defined in both the runtime source and wippy.yaml metadata")
+	}
+
+	runtime, err := runtimeMetadataMap(metadata)
+	if err != nil {
+		return err
+	}
+	for section, values := range collected.sections {
+		runtime[section] = values
+	}
+	if len(collected.profiles) > 0 {
+		runtime[publishRuntimeProfilesMetadataKey] = collected.profiles
+	}
+	if len(vars) > 0 {
+		runtime[publishRuntimeVarsMetadataKey] = vars
+	}
+	return nil
+}
+
+func publishedRuntimeVars(collected publishedRuntimeConfig) (map[string]any, error) {
+	// Profile publication predates section publication and intentionally exposes
+	// base vars so destination-local config can reference those public defaults.
+	// Keep that contract, but read source literally and reject environment refs.
+	if len(collected.profiles) > 0 {
+		return allPublishedVars(collected.vars)
+	}
+	return referencedPublishedVars(collected.vars, collected.sections, nil)
+}
+
+func allPublishedVars(available map[string]publishedRuntimeVar) (map[string]any, error) {
+	selected := make(map[string]any, len(available))
+	for name, variable := range available {
+		if variable.conflictSource != "" {
+			return nil, fmt.Errorf("runtime variable %q has conflicting values in %s and %s", name, variable.source, variable.conflictSource)
+		}
+		if path, found := findPublishEnvReference(variable.value, publishRuntimeVarsMetadataKey+"."+name); found {
+			return nil, fmt.Errorf("runtime setting %s references the publisher environment; use a public default or omit it", path)
+		}
+		selected[name] = variable.value
+	}
+	return selected, nil
+}
+
+func collectPublishedRuntimeSections(dst *publishedRuntimeConfig, configDir string, runtimeCfg config.PublishRuntimeConfig) error {
+	if runtimeCfg.Sections == nil {
+		if strings.TrimSpace(runtimeCfg.Source) != "" {
+			return fmt.Errorf("publish.runtime.source requires an explicit publish.runtime.sections allow-list")
+		}
+		return nil
+	}
+
+	cfg, source, err := loadPublishRuntimeSource(configDir, runtimeCfg.Source)
+	if err != nil {
+		return err
+	}
+	if cfg == nil && len(runtimeCfg.Sections) > 0 {
+		return fmt.Errorf("runtime publish source %s does not exist", source)
+	}
+
+	seen := make(map[string]struct{}, len(runtimeCfg.Sections))
+	for _, rawSection := range runtimeCfg.Sections {
+		section := strings.TrimSpace(rawSection)
+		if section == "" || strings.Contains(section, ".") {
+			return fmt.Errorf("publish.runtime.sections contains invalid top-level section %q", rawSection)
+		}
+		if _, reserved := nonPublishableRuntimeSections[section]; reserved {
+			return fmt.Errorf("runtime section %q is machine-local and cannot be published", section)
+		}
+		if section == publishRuntimeProfilesMetadataKey || section == publishRuntimeVarsMetadataKey || section == "version" {
+			return fmt.Errorf("runtime section %q has dedicated publication semantics and cannot be listed in publish.runtime.sections", section)
+		}
+		if _, duplicate := seen[section]; duplicate {
+			continue
+		}
+		seen[section] = struct{}{}
+
+		values := runtimeSectionFromConfig(cfg, section)
+		if len(values) == 0 {
+			return fmt.Errorf("publish runtime section %q not found in %s", section, source)
+		}
+		if path, found := findPublishEnvReference(values, section); found {
+			return fmt.Errorf("runtime setting %s references the publisher environment; use a runtime variable or an entry *_env setting instead", path)
+		}
+		dst.sections[section] = values
+	}
+
+	if len(dst.sections) > 0 {
+		mergePublishedVars(dst.vars, runtimeSectionFromConfig(cfg, publishRuntimeVarsMetadataKey), source)
+	}
+	return nil
+}
+
+func loadPublishRuntimeSource(configDir, configured string) (boot.Config, string, error) {
+	source := strings.TrimSpace(configured)
+	if source == "" {
+		source = defaultConfigFile
+	}
+	if !filepath.IsAbs(source) {
+		source = filepath.Join(configDir, source)
+	}
+
+	cfg, err := bootconfig.LoadForPublish(source)
+	if err != nil {
+		return nil, source, fmt.Errorf("load runtime publish source %s: %w", source, err)
+	}
+	return cfg, source, nil
+}
+
+func mergePublishedVars(dst map[string]publishedRuntimeVar, values map[string]any, source string) {
+	for key, value := range values {
+		existing, exists := dst[key]
+		if !exists {
+			dst[key] = publishedRuntimeVar{value: value, source: source}
+			continue
+		}
+		if !reflect.DeepEqual(existing.value, value) {
+			existing.conflictSource = source
+			dst[key] = existing
+		}
+	}
+}
+
+func referencedPublishedVars(available map[string]publishedRuntimeVar, sections map[string]map[string]any, profiles map[string]any) (map[string]any, error) {
+	selected := make(map[string]any)
+	if err := selectReferencedVars(available, nil, sections, "published runtime sections", selected); err != nil {
+		return nil, err
+	}
+
+	profileNames := make([]string, 0, len(profiles))
+	for name := range profiles {
+		profileNames = append(profileNames, name)
+	}
+	sort.Strings(profileNames)
+	for _, name := range profileNames {
+		profile, ok := profiles[name].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("published profile %q has invalid type %T", name, profiles[name])
+		}
+		profileVars, _ := profile[publishRuntimeVarsMetadataKey].(map[string]any)
+		if err := selectReferencedVars(available, profileVars, profile, "profile "+name, selected); err != nil {
+			return nil, err
+		}
+	}
+	return selected, nil
+}
+
+func selectReferencedVars(available map[string]publishedRuntimeVar, local map[string]any, values any, context string, selected map[string]any) error {
+	pending := make(map[string]struct{})
+	collectPublishVarReferences(values, pending)
+	resolved := make(map[string]struct{})
+	for len(pending) > 0 {
+		name := firstSortedKey(pending)
+		delete(pending, name)
+		if _, exists := resolved[name]; exists {
+			continue
+		}
+		resolved[name] = struct{}{}
+
+		if value, exists := local[name]; exists {
+			if path, found := findPublishEnvReference(value, context+".vars."+name); found {
+				return fmt.Errorf("runtime setting %s references the publisher environment; use a public default or omit it", path)
+			}
+			collectPublishVarReferences(value, pending)
+			continue
+		}
+		variable, exists := available[name]
+		if !exists {
+			return fmt.Errorf("%s references undefined runtime variable %q", context, name)
+		}
+		if variable.conflictSource != "" {
+			return fmt.Errorf("runtime variable %q has conflicting values in %s and %s", name, variable.source, variable.conflictSource)
+		}
+		if path, found := findPublishEnvReference(variable.value, publishRuntimeVarsMetadataKey+"."+name); found {
+			return fmt.Errorf("runtime setting %s references the publisher environment; use a public default or omit it", path)
+		}
+		selected[name] = variable.value
+		collectPublishVarReferences(variable.value, pending)
+	}
+	return nil
+}
+
+func firstSortedKey(values map[string]struct{}) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys[0]
+}
+
+func collectPublishVarReferences(value any, dst map[string]struct{}) {
+	switch typed := value.(type) {
+	case string:
+		for _, match := range publishVarReference.FindAllStringSubmatch(typed, -1) {
+			if len(match) == 2 && !strings.HasPrefix(match[1], "env:") {
+				dst[match[1]] = struct{}{}
+			}
+		}
+	case map[string]any:
+		for _, nested := range typed {
+			collectPublishVarReferences(nested, dst)
+		}
+	case map[string]map[string]any:
+		for _, nested := range typed {
+			collectPublishVarReferences(nested, dst)
+		}
+	case map[any]any:
+		for _, nested := range typed {
+			collectPublishVarReferences(nested, dst)
+		}
+	case []any:
+		for _, nested := range typed {
+			collectPublishVarReferences(nested, dst)
+		}
+	}
+}
+
+func findPublishEnvReference(value any, path string) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		return path, publishEnvReference.MatchString(typed)
+	case map[string]any:
+		for key, nested := range typed {
+			if foundPath, found := findPublishEnvReference(nested, path+"."+key); found {
+				return foundPath, true
+			}
+		}
+	case map[any]any:
+		for key, nested := range typed {
+			if foundPath, found := findPublishEnvReference(nested, fmt.Sprintf("%s.%v", path, key)); found {
+				return foundPath, true
+			}
+		}
+	case []any:
+		for idx, nested := range typed {
+			if foundPath, found := findPublishEnvReference(nested, fmt.Sprintf("%s[%d]", path, idx)); found {
+				return foundPath, true
+			}
+		}
+	}
+	return "", false
+}
+
+func runtimeSectionFromConfig(cfg boot.Config, section string) map[string]any {
+	values := make(map[string]any)
+	if cfg == nil {
+		return values
+	}
+
+	prefix := section + "."
+	for _, key := range cfg.Keys() {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		value, _ := cfg.Get(key)
+		values[strings.TrimPrefix(key, prefix)] = value
+	}
+	return values
+}
+
+func runtimeMetadataMap(metadata attrs.Bag) (map[string]any, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("metadata bag is nil")
+	}
+
+	raw, exists := metadata[publishRuntimeMetadataKey]
+	if !exists {
+		runtime := make(map[string]any)
+		metadata[publishRuntimeMetadataKey] = runtime
+		return runtime, nil
+	}
+
+	switch typed := raw.(type) {
+	case map[string]any:
+		return typed, nil
+	case attrs.Bag:
+		runtime := map[string]any(typed)
+		metadata[publishRuntimeMetadataKey] = runtime
+		return runtime, nil
+	default:
+		return nil, fmt.Errorf("wippy.yaml metadata.runtime must be a map when publishing runtime configuration")
+	}
+}
+
+func hasNestedRuntimeMetadata(metadata attrs.Bag, nestedKey string) bool {
+	if metadata == nil {
+		return false
+	}
+
+	dotted := publishRuntimeMetadataKey + "." + nestedKey
+	for key := range metadata {
+		if key == dotted || strings.HasPrefix(key, dotted+".") {
+			return true
+		}
+	}
+
+	raw, exists := metadata[publishRuntimeMetadataKey]
+	if !exists {
+		return false
+	}
+	switch typed := raw.(type) {
+	case map[string]any:
+		_, exists = typed[nestedKey]
+		return exists
+	case attrs.Bag:
+		_, exists = typed[nestedKey]
+		return exists
+	default:
+		return false
+	}
+}

--- a/cmd/wippy/cmd/run_pack_metadata.go
+++ b/cmd/wippy/cmd/run_pack_metadata.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/wippyai/runtime/api/boot"
-	"github.com/wippyai/runtime/cmd/internal/bootconfig"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
@@ -37,31 +36,15 @@ func loadPackRuntimeDefaults(packPath string, logger *zap.Logger) (boot.Config, 
 	return runtimeConfigFromPackMetadata(metadata, logger), nil
 }
 
-// loadPackRuntimeDefaultsFromFiles reads and merges runtime defaults from pack files.
-// Later packs override earlier ones for overlapping keys.
+// loadPackRuntimeDefaultsFromFiles reads runtime defaults from the application
+// pack only. Dependency packs contribute registry entries and resources, but
+// never configure the host application.
 func loadPackRuntimeDefaultsFromFiles(packFiles []string, logger *zap.Logger) (boot.Config, error) {
-	var merged boot.Config
-
 	mainPackIndex := lastWappPackIndex(packFiles)
-	for idx, packPath := range packFiles {
-		if !hasWappExtension(packPath) {
-			continue
-		}
-
-		cfg, err := loadPackRuntimeDefaults(packPath, logger)
-		if err != nil {
-			return nil, err
-		}
-		if idx != mainPackIndex {
-			cfg = withoutAppRuntimeProfileConfig(cfg)
-		}
-
-		if cfg != nil {
-			merged = bootconfig.Merge(merged, cfg)
-		}
+	if mainPackIndex < 0 {
+		return nil, nil //nolint:nilnil // no pack means no packed defaults
 	}
-
-	return merged, nil
+	return loadPackRuntimeDefaults(packFiles[mainPackIndex], logger)
 }
 
 func lastWappPackIndex(packFiles []string) int {
@@ -71,36 +54,6 @@ func lastWappPackIndex(packFiles []string) int {
 		}
 	}
 	return -1
-}
-
-func withoutAppRuntimeProfileConfig(cfg boot.Config) boot.Config {
-	if cfg == nil {
-		return nil
-	}
-
-	sections := make(map[string]map[string]any)
-	for _, key := range cfg.Keys() {
-		section, subkey, ok := strings.Cut(key, ".")
-		if !ok || section == "" || subkey == "" || section == "profiles" || section == "vars" {
-			continue
-		}
-
-		if sections[section] == nil {
-			sections[section] = make(map[string]any)
-		}
-		value, _ := cfg.Get(key)
-		sections[section][subkey] = value
-	}
-
-	if len(sections) == 0 {
-		return nil
-	}
-
-	opts := make([]boot.ConfigOption, 0, len(sections))
-	for section, values := range sections {
-		opts = append(opts, boot.WithSection(section, values))
-	}
-	return boot.NewConfig(opts...)
 }
 
 // runtimeConfigFromPackMetadata extracts runtime.* metadata keys and builds a boot config.
@@ -114,7 +67,7 @@ func runtimeConfigFromPackMetadata(metadata wapp.Metadata, logger *zap.Logger) b
 	for key, val := range metadata {
 		switch {
 		case key == "runtime":
-			flattenRuntimeMetadata(flatRuntime, "", val)
+			flattenRuntimeMetadata(flatRuntime, "", val, false)
 		case strings.HasPrefix(key, runtimeMetadataPrefix):
 			runtimeKey := strings.Trim(strings.TrimPrefix(key, runtimeMetadataPrefix), ".")
 			if runtimeKey == "" {
@@ -141,7 +94,7 @@ func runtimeConfigFromPackMetadata(metadata wapp.Metadata, logger *zap.Logger) b
 		if sections[section] == nil {
 			sections[section] = make(map[string]any)
 		}
-		sections[section][subKey] = normalizeRuntimeMetadataValue(val)
+		sections[section][subKey] = val
 	}
 
 	if len(sections) == 0 {
@@ -156,7 +109,7 @@ func runtimeConfigFromPackMetadata(metadata wapp.Metadata, logger *zap.Logger) b
 	return boot.NewConfig(opts...)
 }
 
-func flattenRuntimeMetadata(dst map[string]any, prefix string, value any) {
+func flattenRuntimeMetadata(dst map[string]any, prefix string, value any, normalize bool) {
 	switch typed := value.(type) {
 	case map[string]any:
 		for key, nested := range typed {
@@ -167,7 +120,7 @@ func flattenRuntimeMetadata(dst map[string]any, prefix string, value any) {
 			if prefix != "" {
 				next = prefix + "." + key
 			}
-			flattenRuntimeMetadata(dst, next, nested)
+			flattenRuntimeMetadata(dst, next, nested, normalize)
 		}
 	case map[any]any:
 		for key, nested := range typed {
@@ -179,11 +132,14 @@ func flattenRuntimeMetadata(dst map[string]any, prefix string, value any) {
 			if prefix != "" {
 				next = prefix + "." + strKey
 			}
-			flattenRuntimeMetadata(dst, next, nested)
+			flattenRuntimeMetadata(dst, next, nested, normalize)
 		}
 	default:
 		if prefix != "" {
-			dst[prefix] = normalizeRuntimeMetadataValue(value)
+			if normalize {
+				value = normalizeRuntimeMetadataValue(value)
+			}
+			dst[prefix] = value
 		}
 	}
 }

--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -25,7 +25,7 @@ func TestRuntimeConfigFromPackMetadata_DottedKeys(t *testing.T) {
 	require.Equal(t, "debug", cfg.GetString("logger.level", ""))
 }
 
-func TestRuntimeConfigFromPackMetadata_NestedRuntimeMap(t *testing.T) {
+func TestRuntimeConfigFromPackMetadata_NestedRuntimeMapPreservesScalarTypes(t *testing.T) {
 	cfg := runtimeConfigFromPackMetadata(wapp.Metadata{
 		"runtime": map[string]any{
 			"lsp": map[string]any{
@@ -33,13 +33,21 @@ func TestRuntimeConfigFromPackMetadata_NestedRuntimeMap(t *testing.T) {
 			},
 			"logger": map[string]any{
 				"encoding": "console",
+				"label":    "  padded  ",
+			},
+			"vars": map[string]any{
+				"port":    "5432",
+				"enabled": "false",
 			},
 		},
 	}, zap.NewNop())
 
 	require.NotNil(t, cfg)
-	require.True(t, cfg.GetBool("lsp.enabled", false))
+	require.Equal(t, "true", cfg.GetString("lsp.enabled", ""))
 	require.Equal(t, "console", cfg.GetString("logger.encoding", ""))
+	require.Equal(t, "  padded  ", cfg.GetString("logger.label", ""))
+	require.Equal(t, "5432", cfg.GetString("vars.port", ""))
+	require.Equal(t, "false", cfg.GetString("vars.enabled", ""))
 }
 
 func TestRuntimeConfigFromPackMetadata_PreservesProfiles(t *testing.T) {
@@ -68,28 +76,30 @@ func TestRuntimeConfigFromPackMetadata_PreservesProfiles(t *testing.T) {
 	require.Equal(t, []any{"kickside.research.**"}, namespaces)
 }
 
-func TestLoadPackRuntimeDefaultsFromFiles_MergeOrder(t *testing.T) {
+func TestLoadPackRuntimeDefaultsFromFiles_UsesOnlyMainPack(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	basePack := filepath.Join(tmpDir, "base.wapp")
-	require.NoError(t, writeTestPack(basePack, wapp.Metadata{
-		"runtime.lsp.enabled":  true,
-		"runtime.logger.level": "info",
+	dependencyPack := filepath.Join(tmpDir, "dependency.wapp")
+	require.NoError(t, writeTestPack(dependencyPack, wapp.Metadata{
+		"runtime.security.strict_mode": false,
+		"runtime.logger.level":         "dependency",
 	}))
 
-	overridePack := filepath.Join(tmpDir, "override.wapp")
-	require.NoError(t, writeTestPack(overridePack, wapp.Metadata{
-		"runtime.lsp.enabled": false,
+	mainPack := filepath.Join(tmpDir, "main.wapp")
+	require.NoError(t, writeTestPack(mainPack, wapp.Metadata{
+		"runtime.security.strict_mode":  true,
+		"runtime.registry.history_type": "memory",
 	}))
 
-	cfg, err := loadPackRuntimeDefaultsFromFiles([]string{basePack, overridePack}, zap.NewNop())
+	cfg, err := loadPackRuntimeDefaultsFromFiles([]string{dependencyPack, mainPack}, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
-	require.False(t, cfg.GetBool("lsp.enabled", true))
-	require.Equal(t, "info", cfg.GetString("logger.level", ""))
+	require.True(t, cfg.GetBool("security.strict_mode", false))
+	require.Equal(t, "memory", cfg.GetString("registry.history_type", ""))
+	require.Equal(t, "", cfg.GetString("logger.level", ""))
 }
 
-func TestLoadPackRuntimeDefaultsFromFiles_ProfileConfigComesOnlyFromMainPack(t *testing.T) {
+func TestLoadPackRuntimeDefaultsFromFiles_DependencyCannotContributeConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	depPack := filepath.Join(tmpDir, "dep.wapp")
@@ -108,7 +118,7 @@ func TestLoadPackRuntimeDefaultsFromFiles_ProfileConfigComesOnlyFromMainPack(t *
 	cfg, err := loadPackRuntimeDefaultsFromFiles([]string{depPack, mainPack}, zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
-	require.Equal(t, "info", cfg.GetString("logger.level", ""))
+	require.Equal(t, "", cfg.GetString("logger.level", ""))
 	require.Equal(t, "", cfg.GetString("vars.dep_only", ""))
 	require.Equal(t, "kept", cfg.GetString("vars.main_only", ""))
 	require.Equal(t, "", cfg.GetString("profiles.dep.override.app:db:kind", ""))

--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
@@ -123,6 +125,85 @@ func TestLoadPackRuntimeDefaultsFromFiles_DependencyCannotContributeConfig(t *te
 	require.Equal(t, "kept", cfg.GetString("vars.main_only", ""))
 	require.Equal(t, "", cfg.GetString("profiles.dep.override.app:db:kind", ""))
 	require.Equal(t, "db.sql.postgres", cfg.GetString("profiles.main.override.app:db:kind", ""))
+}
+
+func TestPublishedApplicationRuntimeConfigSurvivesPackRoundTripWithoutLocalConfig(t *testing.T) {
+	publisherDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(publisherDir, "wippy.yaml"), []byte(`
+organization: kickside
+module: kickside
+type: application
+publish:
+  runtime:
+    sections:
+      - security
+      - registry
+      - override
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(publisherDir, ".wippy.yaml"), []byte(`
+version: "1.0"
+security:
+  strict_mode: true
+registry:
+  enable_history: true
+  history_type: sqlite
+  history_path: ./.wippy/registry.db
+  event_wait_timeout: 120s
+vars:
+  public_url: http://localhost:8085
+override:
+  "app.env:defaults:values.PUBLIC_API_URL": "${public_url}"
+`), 0o600))
+
+	manifest, err := config.Load(publisherDir)
+	require.NoError(t, err)
+	require.NoError(t, manifest.Validate())
+
+	metadata := attrs.Bag{}
+	require.NoError(t, addPublishedRuntimeMetadata(metadata, publisherDir, manifest.Publish))
+
+	packDir := t.TempDir()
+	dependencyPack := filepath.Join(packDir, "dependency.wapp")
+	require.NoError(t, writeTestPack(dependencyPack, wapp.Metadata{
+		"runtime": map[string]any{
+			"security": map[string]any{"strict_mode": false},
+			"registry": map[string]any{"history_type": "memory"},
+			"logger":   map[string]any{"level": "dependency-must-not-leak"},
+		},
+	}))
+	applicationPack := filepath.Join(packDir, "application.wapp")
+	require.NoError(t, writeTestPack(applicationPack, wapp.Metadata(metadata)))
+
+	packDefaults, err := loadPackRuntimeDefaultsFromFiles(
+		[]string{dependencyPack, applicationPack},
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+
+	destinationDir := t.TempDir()
+	previousDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(destinationDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(previousDir)) })
+	setTestConfigFiles(t)
+
+	previousProfiler := profiler
+	profiler = false
+	t.Cleanup(func() { profiler = previousProfiler })
+
+	effective, err := loadRuntimeConfigWithDefaults(nil, zap.NewNop(), packDefaults)
+	require.NoError(t, err)
+	require.True(t, effective.GetBool("security.strict_mode", false))
+	require.True(t, effective.GetBool("registry.enable_history", false))
+	require.Equal(t, "sqlite", effective.GetString("registry.history_type", ""))
+	require.Equal(t, "./.wippy/registry.db", effective.GetString("registry.history_path", ""))
+	require.Equal(t, "120s", effective.GetString("registry.event_wait_timeout", ""))
+	require.Equal(t, "http://localhost:8085", effective.GetString("vars.public_url", ""))
+	require.Equal(
+		t, "http://localhost:8085",
+		effective.GetString("override.app.env:defaults:values.PUBLIC_API_URL", ""),
+	)
+	require.Equal(t, "", effective.GetString("logger.level", ""))
 }
 
 func writeTestPack(path string, metadata wapp.Metadata) error {

--- a/cmd/wippy/cmd/run_test.go
+++ b/cmd/wippy/cmd/run_test.go
@@ -355,3 +355,66 @@ profiles:
 	require.NoError(t, err)
 	require.Equal(t, "db.sql.file", cfg.GetString("override.app:db:kind", ""))
 }
+
+func TestLoadRuntimeConfig_PackedApplicationParityAndLocalPrecedence(t *testing.T) {
+	tempDir := t.TempDir()
+	cfgPath := filepath.Join(tempDir, "wippy.yaml")
+	cfgBody := []byte(`version: "1.0"
+registry:
+  event_wait_timeout: 30s
+override:
+  "app:local:enabled": true
+profiles:
+  production:
+    vars:
+      port: 19000
+    registry:
+      history_type: local-postgres
+`)
+	require.NoError(t, os.WriteFile(cfgPath, cfgBody, 0o644))
+
+	prevProfiler := profiler
+	setTestConfigFiles(t, cfgPath)
+	profiler = false
+	t.Cleanup(func() { profiler = prevProfiler })
+
+	runtimeDefaults := boot.NewConfig(
+		boot.WithSection("security", map[string]any{
+			"strict_mode": true,
+		}),
+		boot.WithSection("registry", map[string]any{
+			"history_type":            "memory",
+			"dispatch_internal_kinds": []any{"registry.entry", "ns.requirement"},
+		}),
+		boot.WithSection("vars", map[string]any{
+			"port": 8085,
+		}),
+		boot.WithSection("override", map[string]any{
+			"app:gateway:addr": ":${port}",
+		}),
+		boot.WithSection("profiles", map[string]any{
+			"production.vars.port":             18085,
+			"production.registry.history_type": "pack-postgres",
+		}),
+	)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringArray("profile", nil, "")
+	require.NoError(t, cmd.Flags().Set("profile", "production"))
+
+	cfg, err := loadRuntimeConfigWithDefaults(cmd, zap.NewNop(), runtimeDefaults)
+	require.NoError(t, err)
+	require.True(t, cfg.GetBool("security.strict_mode", false))
+	require.Equal(t, []any{"registry.entry", "ns.requirement"}, mustConfigValue(t, cfg, "registry.dispatch_internal_kinds"))
+	require.Equal(t, "30s", cfg.GetString("registry.event_wait_timeout", ""))
+	require.Equal(t, "local-postgres", cfg.GetString("registry.history_type", ""))
+	require.Equal(t, ":19000", cfg.GetString("override.app:gateway:addr", ""))
+	require.True(t, cfg.GetBool("override.app:local:enabled", false))
+}
+
+func mustConfigValue(t *testing.T, cfg boot.Config, key string) any {
+	t.Helper()
+	value, ok := cfg.Get(key)
+	require.Truef(t, ok, "missing config value %s", key)
+	return value
+}


### PR DESCRIPTION
## Summary

- add an application-only `publish.runtime.sections` allow-list that copies declared base runtime sections from a source `.wippy.yaml` into pack metadata
- publish only variables referenced by selected sections or published profiles, following references transitively; unreferenced variables are excluded by default
- add `publish.runtime.vars` as an explicit allow-list for intentionally public defaults that are not otherwise referenced
- derive metadata from unresolved source so publisher environment values are never expanded, reject `${env:...}` in exported configuration, and categorically reject machine-local `boot`, `extensions`, and `workspace` sections
- make the main application pack the sole authority for host runtime defaults; dependency packs cannot configure the host
- preserve exact scalar types for nested runtime metadata while retaining legacy coercion for dotted `runtime.*` metadata

## Runtime precedence

Lowest to highest:

1. main application pack defaults
2. runtime built-in defaults
3. destination-local config files, in declared order
4. selected profiles
5. CLI/runtime overrides

Dependency-pack runtime metadata is ignored.

## Application manifest

Applications opt in without duplicating values:

```yaml
type: application
publish:
  runtime:
    source: .wippy.yaml
    sections:
      - security
      - registry
      - override
    vars:
      - public_url
```

`source` defaults to `.wippy.yaml`. Referenced variables do not need to be listed in `vars`; that list is only for deliberately public, otherwise-unreferenced defaults. Literal credentials and other unrelated variables stay out of the pack. Runtime publication is rejected for library, agent, and plugin packages.

## Validation

- targeted config, profile, CLI, and pack round-trip tests
- race detector on `boot/deps/config`, `cmd/internal/bootconfig`, and `cmd/wippy/cmd`
- `go vet` on the affected packages
- complete `go test ./... -count=1`: all affected packages passed; the run hit the pre-existing `service/exec/native` output-capture flakes in `MegaCommand` and `Stderr`
- both flaky native tests then passed 20/20 isolated repetitions

The PR remains open for application-level retesting and is not approved for merge yet.
