### PR TITLE
fix(supervisor): name the failing service in start/stop errors

### DIFF
--- a/system/supervisor/errors.go
+++ b/system/supervisor/errors.go
@@ -56,7 +56,12 @@ func NewStopError(err error) apierror.Error {
 }
 
 func NewServiceStartError(serviceID string, err error) apierror.Error {
-	return apierror.New(apierror.Internal, "failed to start service").
+	message := "failed to start service"
+	if serviceID != "" {
+		message += " " + serviceID
+	}
+
+	return apierror.New(apierror.Internal, message).
 		WithRetryable(apierror.True).
 		WithDetails(attrs.NewBagFrom(map[string]any{"service_id": serviceID, "cause": err.Error()})).
 		WithCause(err)
@@ -74,7 +79,12 @@ func NewServiceBlockedError(serviceID string, blockers []string) apierror.Error 
 }
 
 func NewServiceStopError(serviceID string, err error) apierror.Error {
-	return apierror.New(apierror.Internal, "failed to stop service").
+	message := "failed to stop service"
+	if serviceID != "" {
+		message += " " + serviceID
+	}
+
+	return apierror.New(apierror.Internal, message).
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{"service_id": serviceID, "cause": err.Error()})).
 		WithCause(err)


### PR DESCRIPTION
apierror's Error() renders only "message: cause"; the details bag is never in the string. NewServiceStartError/NewServiceStopError kept the service id only in that bag, so a failed start or stop read "failed to stop service: <cause>" with no way to tell which service — and TestStressSequencerWithFailures, which asserts the error names the failing service, failed deterministically.

Fold the id into the message, as NewServiceBlockedError already does. The error now names the service, in the string an operator actually sees.

## Testing
- `WIPPY_STRESS_TESTS=1 go test -race ./system/supervisor/` — green (`TestStressSequencerWithFailures` now passes).