### PR TITLE
fix(deps): adopt active application roots on live update

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -343,9 +343,10 @@ func (h *DependencyHandler) expand(
 	}
 
 	additional, err := (operationPlanner{resolver: h.resolver}).plan(snapshot, combined, operationPlanOptions{
-		originalKey:       idKey(op.Entry.ID),
-		controlledModules: controlledModules,
-		mutableModules:    mutableModules,
+		originalKey:           idKey(op.Entry.ID),
+		controlledModules:     controlledModules,
+		mutableModules:        mutableModules,
+		deploymentRootModules: h.deploymentRootModules(),
 	})
 	if err != nil {
 		return regapi.DirectiveResult{}, err
@@ -756,8 +757,9 @@ func (h *DependencyHandler) ReconcileResolution(
 	// and restart unrelated services during undo/redo (including the governance
 	// worker itself).
 	additional, err := (operationPlanner{resolver: h.resolver}).plan(target, combined, operationPlanOptions{
-		controlledModules: controlled,
-		mutableModules:    mutable,
+		controlledModules:     controlled,
+		mutableModules:        mutable,
+		deploymentRootModules: h.deploymentRootModules(),
 	})
 	if err != nil {
 		return regapi.DirectiveResult{}, err
@@ -1704,6 +1706,13 @@ func stringSet(values []string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func (h *DependencyHandler) deploymentRootModules() map[string]struct{} {
+	if h == nil || h.lock == nil {
+		return nil
+	}
+	return stringSet(h.lock.GetRootModules())
 }
 
 func sortedSetKeys(values map[string]struct{}) []string {

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -1957,6 +1957,89 @@ func TestDependencyHandler_Expand_RejectsNewModuleClaimingExistingHostEntry(t *t
 	assert.Equal(t, "kickside/security", apiErr.Details().GetString("desired_module", ""))
 }
 
+func TestDependencyHandler_Expand_ActiveApplicationAdoptsDeploymentRootDependencies(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	vendorDir := filepath.Join(tmpDir, ".wippy")
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+modules:
+  - name: acme/application
+    version: v1.0.0
+    root: true
+  - name: acme/service
+    version: v1.0.0
+`), 0o600))
+
+	writeWapp(t, filepath.Join(vendorDir, "acme", "application-v2.0.0.wapp"), []wapp.Entry{{
+		ID: wapp.NewID("app.deps", "service"), Kind: regapi.NamespaceDependency,
+		Data: map[string]any{"component": "acme/service", "version": "v2.0.0"},
+	}, {
+		ID: wapp.NewID("app", "gateway"), Kind: "http.service",
+		Data: map[string]any{"generation": "v2"},
+	}})
+	writeWapp(t, filepath.Join(vendorDir, "acme", "service-v2.0.0.wapp"), []wapp.Entry{{
+		ID: wapp.NewID("acme.service", "worker"), Kind: "service",
+		Data: map[string]any{"generation": "v2"},
+	}})
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: &fakeHub{getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			manifest := &ModuleManifest{Org: org, Name: module, Version: "v2.0.0"}
+			if module == "application" {
+				manifest.Dependencies = []ManifestDep{{Org: "acme", Name: "service", Version: "v2.0.0"}}
+			}
+			return manifest, nil
+		}},
+		Logger: zap.NewNop(), LockPath: lockPath, VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	deploymentDependency := regapi.Entry{
+		ID: regapi.NewID("app.deps", "service"), Kind: regapi.NamespaceDependency,
+		DependencyRoot: true,
+		Data:           payload.New(map[string]any{"component": "acme/service", "version": "v2.0.0"}),
+	}
+	applicationEntry := regapi.Entry{
+		ID: regapi.NewID("app", "gateway"), Kind: "http.service",
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey: "acme/application", metaModuleVersionKey: "v1.0.0",
+		}),
+		Data: payload.New(map[string]any{"generation": "v1"}),
+	}
+	serviceEntry := regapi.Entry{
+		ID: regapi.NewID("acme.service", "worker"), Kind: "service",
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey: "acme/service", metaModuleVersionKey: "v1.0.0",
+		}),
+		Data: payload.New(map[string]any{"generation": "v1"}),
+	}
+	applicationRoot := regapi.Entry{
+		ID: regapi.NewID("app.deps", "application"), Kind: regapi.NamespaceDependency,
+		Data: payload.New(map[string]any{"component": "acme/application", "version": "v2.0.0"}),
+	}
+
+	result, err := handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryCreate, Entry: applicationRoot}, regapi.State{
+		deploymentDependency, applicationEntry, serviceEntry,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+
+	var adopted *regapi.Entry
+	for _, scoped := range result.Additional {
+		if scoped.Operation.Kind == regapi.EntryUpdate && idsEqual(scoped.Operation.Entry.ID, deploymentDependency.ID) {
+			entry := scoped.Operation.Entry
+			adopted = &entry
+			break
+		}
+	}
+	require.NotNil(t, adopted)
+	assert.Equal(t, "acme/application", entryModule(*adopted))
+	assert.Equal(t, "v2.0.0", moduleVersion(*adopted))
+	assert.False(t, adopted.DependencyRoot)
+}
+
 func TestDependencyHandler_Expand_AppliesCanonicalComponentParametersToAliasNamespaceRequirements(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()

--- a/boot/deps/hub/operation_planner.go
+++ b/boot/deps/hub/operation_planner.go
@@ -29,9 +29,10 @@ func entriesEqual(a, b regapi.Entry) bool {
 }
 
 type operationPlanOptions struct {
-	controlledModules map[string]struct{}
-	mutableModules    map[string]struct{}
-	originalKey       string
+	controlledModules     map[string]struct{}
+	mutableModules        map[string]struct{}
+	deploymentRootModules map[string]struct{}
+	originalKey           string
 }
 
 type operationPlanner struct {
@@ -56,7 +57,7 @@ func (p operationPlanner) plan(current regapi.State, desired []regapi.Entry, opt
 			continue
 		}
 		if existing, ok := currentByID[key]; ok {
-			if entryConflict(existing, entry) {
+			if entryConflictForPlan(existing, entry, opts) {
 				return nil, NewDependencyEntryConflictError(entry.ID.String(), entryModule(existing), entryModule(entry))
 			}
 			if !entriesEqual(existing, entry) {
@@ -236,4 +237,29 @@ func entryConflict(existing, desired regapi.Entry) bool {
 	}
 	existingModule := entryModule(existing)
 	return existingModule == "" || existingModule != desiredModule
+}
+
+func entryConflictForPlan(existing, desired regapi.Entry, opts operationPlanOptions) bool {
+	if !entryConflict(existing, desired) {
+		return false
+	}
+
+	// A published deployment root is initially loaded as the application
+	// baseline. Its authored dependency declarations are deliberately unowned
+	// even though the rest of the package keeps module provenance. A prior
+	// direct update of one of those declarations may also clear DependencyRoot,
+	// so transient root provenance cannot be the authority check. When that same
+	// active application is installed as a history root for an in-place update,
+	// it may adopt only unowned dependency IDs that its new artifact actually
+	// declares. This is not a general host-entry takeover: ordinary host entries
+	// and any package other than a root selected by the deployment lock still
+	// conflict.
+	desiredModule := entryModule(desired)
+	if _, activeRoot := opts.deploymentRootModules[desiredModule]; !activeRoot {
+		return true
+	}
+	return entryModule(existing) != "" ||
+		existing.Kind != regapi.NamespaceDependency ||
+		desired.Kind != regapi.NamespaceDependency ||
+		desired.DependencyRoot
 }

--- a/boot/deps/hub/operation_planner_test.go
+++ b/boot/deps/hub/operation_planner_test.go
@@ -141,6 +141,114 @@ func TestOperationPlanner_DependencyRootTransitionsRemainEffective(t *testing.T)
 	}
 }
 
+func TestOperationPlanner_ActiveApplicationAdoptsOnlyDeploymentRootDeclarations(t *testing.T) {
+	const application = "acme/application"
+	current := regapi.Entry{
+		ID:             regapi.NewID("app.deps", "service"),
+		Kind:           regapi.NamespaceDependency,
+		DependencyRoot: true,
+		Data:           payload.New(map[string]any{"component": "acme/service", "version": "*"}),
+	}
+	desired := clonePlannerTestEntry(current)
+	desired.DependencyRoot = false
+	desired.Meta = attrs.NewBagFrom(map[string]any{
+		metaModuleKey:        application,
+		metaModuleVersionKey: "v2.0.0",
+		metaModuleDigestKey:  "sha256:new",
+	})
+	desired.Data = payload.New(map[string]any{"component": "acme/service", "version": ">=v2.0.0"})
+
+	ops, err := (operationPlanner{}).plan(regapi.State{current}, []regapi.Entry{desired}, operationPlanOptions{
+		controlledModules:     map[string]struct{}{application: {}},
+		mutableModules:        map[string]struct{}{application: {}},
+		deploymentRootModules: map[string]struct{}{application: {}},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
+	assert.Equal(t, desired, ops[0].Entry)
+}
+
+func TestOperationPlanner_ActiveApplicationAdoptsPreviouslyUpdatedDependencyDeclaration(t *testing.T) {
+	const application = "acme/application"
+	current := regapi.Entry{
+		ID:   regapi.NewID("app.deps", "service"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.New(map[string]any{"component": "acme/service", "version": ">=v1.0.0"}),
+	}
+	desired := clonePlannerTestEntry(current)
+	desired.Meta = attrs.NewBagFrom(map[string]any{metaModuleKey: application})
+	desired.Data = payload.New(map[string]any{"component": "acme/service", "version": ">=v2.0.0"})
+
+	ops, err := (operationPlanner{}).plan(regapi.State{current}, []regapi.Entry{desired}, operationPlanOptions{
+		deploymentRootModules: map[string]struct{}{application: {}},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, regapi.EntryUpdate, ops[0].Kind)
+	assert.Equal(t, application, entryModule(ops[0].Entry))
+}
+
+func TestOperationPlanner_ApplicationAdoptionBoundaryRejectsOtherClaims(t *testing.T) {
+	const application = "acme/application"
+	baseCurrent := regapi.Entry{
+		ID:             regapi.NewID("app.deps", "service"),
+		Kind:           regapi.NamespaceDependency,
+		DependencyRoot: true,
+		Data:           payload.New(map[string]any{"component": "acme/service", "version": "*"}),
+	}
+	baseDesired := clonePlannerTestEntry(baseCurrent)
+	baseDesired.DependencyRoot = false
+	baseDesired.Meta = attrs.NewBagFrom(map[string]any{metaModuleKey: application})
+
+	tests := []struct {
+		mutate func(*regapi.Entry, *regapi.Entry)
+		roots  map[string]struct{}
+		name   string
+	}{
+		{
+			name:  "package is not the active deployment root",
+			roots: map[string]struct{}{"acme/other": {}},
+		},
+		{
+			name: "ordinary unowned host entry",
+			mutate: func(current, desired *regapi.Entry) {
+				current.Kind = "http.service"
+				desired.Kind = "http.service"
+			},
+			roots: map[string]struct{}{application: {}},
+		},
+		{
+			name: "declaration remains a deployment root",
+			mutate: func(_, desired *regapi.Entry) {
+				desired.DependencyRoot = true
+			},
+			roots: map[string]struct{}{application: {}},
+		},
+		{
+			name: "declaration belongs to another module",
+			mutate: func(current, _ *regapi.Entry) {
+				current.Meta = attrs.NewBagFrom(map[string]any{metaModuleKey: "acme/owner"})
+			},
+			roots: map[string]struct{}{application: {}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			current := clonePlannerTestEntry(baseCurrent)
+			desired := clonePlannerTestEntry(baseDesired)
+			if test.mutate != nil {
+				test.mutate(&current, &desired)
+			}
+			_, err := (operationPlanner{}).plan(regapi.State{current}, []regapi.Entry{desired}, operationPlanOptions{
+				deploymentRootModules: test.roots,
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestOperationPlanner_NilMutableSetUsesNormalDiff(t *testing.T) {
 	current := plannerTestEntry("service", "acme/service", "v1.0.0", "sha256:old", "same")
 	desired := clonePlannerTestEntry(current)


### PR DESCRIPTION
## Problem

Installing an updated root application through Hub fails when its published artifact redeclares deployment-root dependencies. Those declarations are intentionally unowned in the boot baseline, so the generic ownership conflict check rejects the application that originally authored them.

## Change

- pass the active deployment-root module set from the lock into operation planning
- allow only an active root application to adopt an unowned `ns.dependency` entry that its own desired artifact declares
- keep conflicts for ordinary host entries, non-root packages, other module owners, and declarations that remain dependency roots
- apply the same rule during normal expansion and resolution reconciliation

## Compatibility / risk

This does not change resolution, lock format, or general registry ownership. The only changed case is an unowned dependency declaration with the same ID as a declaration in an actively booted root application. A customized unowned declaration with that exact ID will now be replaced by the application update; unrelated unowned entries remain protected.

## Verification

- `go test ./...`
- PostgreSQL Kickside production-tag boot restored 64 roots
- real Hub UI updated `kickside/kickside` from 0.1.89 to 0.1.95 without process restart
- running PID remained unchanged and System UI returned HTTP 200
