### PR TITLE
fix(deps): preserve root application dependency topology

### DIFF
--- a/boot/build/stages/errors.go
+++ b/boot/build/stages/errors.go
@@ -68,12 +68,6 @@ func NewDecodeDependencyError(entryID string, cause error) apierror.Error {
 	return apierror.New(apierror.Internal, fmt.Sprintf("failed to decode dependency %s", entryID)).WithCause(cause)
 }
 
-func NewInvalidDependencyComponentError(entryID, component string, cause error) apierror.Error {
-	return apierror.New(apierror.Invalid, fmt.Sprintf("invalid dependency component %s", component)).
-		WithDetails(attrs.NewBagFrom(map[string]any{"entry_id": entryID, "component": component})).
-		WithCause(cause)
-}
-
 func NewRequirementError(requirementName, namespace string, cause error) apierror.Error {
 	return apierror.New(apierror.Internal, fmt.Sprintf("requirement %s in namespace %s failed", requirementName, namespace)).WithCause(cause)
 }

--- a/boot/build/stages/linking.go
+++ b/boot/build/stages/linking.go
@@ -290,7 +290,7 @@ func normalizeBindings(
 		owned := ownedAddressIndex(dep, reqIDs, requirements)
 
 		for _, param := range dep.definition.Parameters {
-			for _, reqID := range resolveParameter(param.Name, owned) {
+			for _, reqID := range resolveParameter(param.Name, requirements, owned) {
 				bindings[reqID] = append(bindings[reqID], binding{
 					value:         param.Value,
 					dependencyID:  depID,
@@ -346,14 +346,22 @@ func ownedAddressIndex(
 }
 
 // resolveParameter maps a single parameter name to the set of concrete
-// requirement ids it addresses. Both bare names and full ids resolve only
-// through the dependency's owned index, so a dependency cannot configure a
-// requirement outside its referenced module. A name that addresses nothing
+// requirement ids it addresses. A canonical ns:name is already a complete
+// registry address and selects that exact requirement. A bare name uses the
+// dependency component's declared namespace index. Package identities are
+// never converted into registry namespaces. A name that addresses nothing
 // returns an empty set.
 func resolveParameter(
 	name string,
+	requirements map[string]decodedRequirement,
 	owned map[string][]string,
 ) []string {
+	if strings.Contains(name, ":") {
+		if _, exists := requirements[name]; exists {
+			return []string{name}
+		}
+		return nil
+	}
 	return owned[name]
 }
 

--- a/boot/build/stages/linking.go
+++ b/boot/build/stages/linking.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wippyai/runtime/api/logs"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
-	"github.com/wippyai/runtime/boot/deps/graph"
 	"github.com/wippyai/runtime/system/entry"
 	"go.uber.org/zap"
 )
@@ -139,7 +138,12 @@ func (s *linkStage) Execute(ctx context.Context, entries *[]registry.Entry) erro
 		}
 	}
 
-	dependencies, err := s.collectDependencies(ctx, transcoder, entries)
+	moduleNamespaces, err := declaredModuleNamespaces(*entries)
+	if err != nil {
+		return err
+	}
+
+	dependencies, err := s.collectDependencies(ctx, transcoder, entries, moduleNamespaces)
 	if err != nil {
 		return err
 	}
@@ -194,7 +198,12 @@ func (s *linkStage) shouldFailUnresolvedRequirement(req decodedRequirement) bool
 	return true
 }
 
-func (s *linkStage) collectDependencies(ctx context.Context, transcoder payload.Transcoder, entries *[]registry.Entry) (map[string]decodedDependency, error) {
+func (s *linkStage) collectDependencies(
+	ctx context.Context,
+	transcoder payload.Transcoder,
+	entries *[]registry.Entry,
+	moduleNamespaces map[string]string,
+) (map[string]decodedDependency, error) {
 	source := *entries
 	if s.explicitDeps {
 		source = s.dependencyEntries
@@ -210,16 +219,19 @@ func (s *linkStage) collectDependencies(ctx context.Context, transcoder payload.
 		if err != nil {
 			return nil, NewDecodeDependencyError(e.ID.String(), err)
 		}
-		moduleNamespace, err := componentToNamespace(def.Component)
-		if err != nil {
-			return nil, NewInvalidDependencyComponentError(e.ID.String(), def.Component, err)
+		ownedNamespace := moduleNamespaces[def.Component]
+		if ownedNamespace == "" && len(def.Parameters) > 0 && loadedModule(*entries, def.Component) {
+			return nil, fmt.Errorf(
+				"dependency %s cannot bind parameters for component %s: loaded module has no ns.definition root namespace",
+				e.ID.String(),
+				def.Component,
+			)
 		}
 
 		dependencies[e.ID.String()] = decodedDependency{
-			definition:      def,
-			moduleNamespace: moduleNamespace,
-			component:       def.Component,
-			transitive:      requirementModuleFromEntry(e) != "" && !e.DependencyRoot,
+			definition:     def,
+			ownedNamespace: ownedNamespace,
+			transitive:     requirementModuleFromEntry(e) != "" && !e.DependencyRoot,
 		}
 	}
 
@@ -232,28 +244,19 @@ type decodedRequirement struct {
 }
 
 type decodedDependency struct {
-	definition      *DependencyDefinition
-	moduleNamespace string
-	component       string
+	definition     *DependencyDefinition
+	ownedNamespace string
 	// transitive marks a dependency injected by a package, as opposed to an
 	// explicitly selected deployment root. Ownership and root provenance are
 	// independent for published application modules.
 	transitive bool
 }
 
-// owns reports whether a dependency addresses a requirement. Dotted namespaces
-// are globally scoped and must live in the dependency component namespace or one
-// of its child namespaces. The meta.module bridge is kept only for legacy
-// one-segment alias namespaces such as "telegram".
+// owns reports whether a dependency addresses a requirement. A module owns its
+// declared ns.definition namespace and its children. Package names never
+// participate in registry namespace ownership.
 func (d decodedDependency) owns(req decodedRequirement) bool {
-	if req.entry.ID.NS == d.moduleNamespace || strings.HasPrefix(req.entry.ID.NS, d.moduleNamespace+".") {
-		return true
-	}
-	if !isLegacyAliasNamespace(req.entry.ID.NS) {
-		return false
-	}
-	module := requirementModuleFromEntry(req.entry)
-	return module != "" && module == d.component
+	return req.entry.ID.NS == d.ownedNamespace || strings.HasPrefix(req.entry.ID.NS, d.ownedNamespace+".")
 }
 
 // binding records one dependency parameter resolved to a single concrete
@@ -271,10 +274,10 @@ type binding struct {
 // normalizeBindings maps every dependency parameter to the set of concrete
 // requirement ids it addresses, grouped by requirement id. A bare parameter
 // fans out through the dependency's owned addressing index to every owned
-// requirement of that bare name; a full ns:name parameter addresses the exact
-// requirement id when one exists, otherwise fans out through the owned index.
-// A parameter addressing nothing is dropped. Iteration is sorted so the result
-// is independent of entry ordering.
+// requirement of that bare name; a full ns:name parameter addresses that exact
+// requirement only when it belongs to the referenced module. A parameter
+// addressing nothing is dropped. Iteration is sorted so the result is
+// independent of entry ordering.
 func normalizeBindings(
 	requirements map[string]decodedRequirement,
 	dependencies map[string]decodedDependency,
@@ -287,7 +290,7 @@ func normalizeBindings(
 		owned := ownedAddressIndex(dep, reqIDs, requirements)
 
 		for _, param := range dep.definition.Parameters {
-			for _, reqID := range resolveParameter(param.Name, requirements, owned) {
+			for _, reqID := range resolveParameter(param.Name, owned) {
 				bindings[reqID] = append(bindings[reqID], binding{
 					value:         param.Value,
 					dependencyID:  depID,
@@ -314,7 +317,7 @@ func normalizeBindings(
 
 // ownedAddressIndex maps each address key a dependency accepts to the concrete
 // requirement ids it fans out to. Every owned requirement registers under both
-// its bare name and its module-qualified moduleNS:name form. Two or more owned
+// its bare name and its canonical registry id. Two or more owned
 // requirements sharing one bare name is the fan-out set: a bare parameter of
 // that name feeds its value to all of them. A given requirement id appears at
 // most once per key.
@@ -331,7 +334,7 @@ func ownedAddressIndex(
 		}
 		keys := []string{
 			req.entry.ID.Name,
-			dep.moduleNamespace + ":" + req.entry.ID.Name,
+			reqID,
 		}
 		for _, key := range keys {
 			if !containsID(owned[key], reqID) {
@@ -343,20 +346,14 @@ func ownedAddressIndex(
 }
 
 // resolveParameter maps a single parameter name to the set of concrete
-// requirement ids it addresses. A full ns:name addresses the exact requirement
-// id when one exists, bypassing the owned index. Otherwise the name fans out
-// through the dependency's owned index to every owned requirement of that name.
-// A name that addresses nothing returns an empty set.
+// requirement ids it addresses. Both bare names and full ids resolve only
+// through the dependency's owned index, so a dependency cannot configure a
+// requirement outside its referenced module. A name that addresses nothing
+// returns an empty set.
 func resolveParameter(
 	name string,
-	requirements map[string]decodedRequirement,
 	owned map[string][]string,
 ) []string {
-	if strings.Contains(name, ":") {
-		if _, exact := requirements[name]; exact {
-			return []string{name}
-		}
-	}
 	return owned[name]
 }
 
@@ -531,10 +528,6 @@ func (s *linkStage) findTargetEntries(
 	return results
 }
 
-func isLegacyAliasNamespace(ns string) bool {
-	return ns != "" && !strings.Contains(ns, ".")
-}
-
 func requirementModuleFromEntry(entry registry.Entry) string {
 	if entry.Meta == nil {
 		return ""
@@ -545,10 +538,53 @@ func requirementModuleFromEntry(entry registry.Entry) string {
 	return ""
 }
 
-func componentToNamespace(component string) (string, error) {
-	name, err := graph.ParseName(component)
-	if err != nil {
-		return "", err
+func loadedModule(entries []registry.Entry, module string) bool {
+	for _, entry := range entries {
+		if requirementModuleFromEntry(entry) == module {
+			return true
+		}
 	}
-	return name.Organization + "." + name.Module, nil
+	return false
+}
+
+// declaredModuleNamespaces returns the canonical registry namespace exported
+// by each loaded module. Publishing requires exactly one ns.definition per
+// module, and the loader records the containing module on that entry. This is
+// the authoritative bridge between a Hub component name (org/module) and its
+// registry namespace; neither spelling nor pluralization is inferred.
+func declaredModuleNamespaces(entries []registry.Entry) (map[string]string, error) {
+	namespaces := make(map[string]string)
+	owners := make(map[string]string)
+	for _, entry := range entries {
+		if entry.Kind != registry.NamespaceDefinition {
+			continue
+		}
+		module := requirementModuleFromEntry(entry)
+		if module == "" {
+			continue
+		}
+		namespace := strings.TrimSpace(entry.ID.NS)
+		if namespace == "" {
+			continue
+		}
+		if existing := namespaces[module]; existing != "" && existing != namespace {
+			return nil, fmt.Errorf(
+				"module %s declares multiple namespaces: %s and %s",
+				module,
+				existing,
+				namespace,
+			)
+		}
+		if owner := owners[namespace]; owner != "" && owner != module {
+			return nil, fmt.Errorf(
+				"namespace %s is declared by multiple modules: %s and %s",
+				namespace,
+				owner,
+				module,
+			)
+		}
+		namespaces[module] = namespace
+		owners[namespace] = module
+	}
+	return namespaces, nil
 }

--- a/boot/build/stages/linking_declared_namespace_test.go
+++ b/boot/build/stages/linking_declared_namespace_test.go
@@ -25,7 +25,7 @@ func TestLinkUsesDeclaredModuleNamespace(t *testing.T) {
 		{name: "bare name", parameter: "router", want: "app:configured"},
 		{name: "canonical requirement id", parameter: "identity.account.api:router", want: "app:configured"},
 		{name: "package-derived namespace is not an address", parameter: "example.accounts:router", want: "app:default"},
-		{name: "foreign requirement id is not an address", parameter: "analytics.report:router", want: "app:default"},
+		{name: "unknown canonical requirement id is not an address", parameter: "analytics.report:router", want: "app:default"},
 	}
 
 	for _, tt := range tests {
@@ -41,6 +41,34 @@ func TestLinkUsesDeclaredModuleNamespace(t *testing.T) {
 			assert.Equal(t, tt.want, target.Meta["router"])
 		})
 	}
+}
+
+func TestLinkCanonicalRequirementAddressDoesNotInferOwnership(t *testing.T) {
+	ctx, _ := setupTestContext()
+	entries := []registry.Entry{
+		moduleDefinition(fixtureComponent, fixtureNamespace),
+		dependencyEntry(fixtureComponent, "workflow.scheduler:process_host", "app:processes"),
+		requirementEntry(fixtureComponent, "workflow.scheduler", "process_host", "app:scheduler", "app:default"),
+		targetEntry("scheduler"),
+	}
+
+	err := Link().Execute(ctx, &entries)
+	require.NoError(t, err)
+	assert.Equal(t, "app:processes", findEntry(entries, "app", "scheduler").Meta["router"])
+}
+
+func TestLinkBareRequirementDoesNotEscapeDeclaredNamespace(t *testing.T) {
+	ctx, _ := setupTestContext()
+	entries := []registry.Entry{
+		moduleDefinition(fixtureComponent, fixtureNamespace),
+		dependencyEntry(fixtureComponent, "process_host", "app:processes"),
+		requirementEntry(fixtureComponent, "workflow.scheduler", "process_host", "app:scheduler", "app:default"),
+		targetEntry("scheduler"),
+	}
+
+	err := Link().Execute(ctx, &entries)
+	require.NoError(t, err)
+	assert.Equal(t, "app:default", findEntry(entries, "app", "scheduler").Meta["router"])
 }
 
 func TestLinkDeclaredNamespaceOwnsChildrenOnly(t *testing.T) {

--- a/boot/build/stages/linking_declared_namespace_test.go
+++ b/boot/build/stages/linking_declared_namespace_test.go
@@ -85,9 +85,10 @@ func TestLinkAllowsUnloadedDependencyDuringSourceBuild(t *testing.T) {
 
 func TestLinkRejectsConflictingModuleDefinitions(t *testing.T) {
 	tests := []struct {
-		name    string
+		name string
+		want string
+
 		entries []registry.Entry
-		want    string
 	}{
 		{
 			name: "one module declares two roots",

--- a/boot/build/stages/linking_declared_namespace_test.go
+++ b/boot/build/stages/linking_declared_namespace_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package stages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+const (
+	fixtureComponent = "example/accounts"
+	fixtureNamespace = "identity.account"
+)
+
+func TestLinkUsesDeclaredModuleNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		parameter string
+		want      string
+	}{
+		{name: "bare name", parameter: "router", want: "app:configured"},
+		{name: "canonical requirement id", parameter: "identity.account.api:router", want: "app:configured"},
+		{name: "package-derived namespace is not an address", parameter: "example.accounts:router", want: "app:default"},
+		{name: "foreign requirement id is not an address", parameter: "analytics.report:router", want: "app:default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := setupTestContext()
+			entries := declaredNamespaceFixture(tt.parameter)
+
+			err := Link().Execute(ctx, &entries)
+			require.NoError(t, err)
+
+			target := findEntry(entries, "app", "endpoint")
+			require.NotNil(t, target)
+			assert.Equal(t, tt.want, target.Meta["router"])
+		})
+	}
+}
+
+func TestLinkDeclaredNamespaceOwnsChildrenOnly(t *testing.T) {
+	ctx, _ := setupTestContext()
+	entries := []registry.Entry{
+		moduleDefinition(fixtureComponent, fixtureNamespace),
+		moduleDefinition("example/reports", "analytics.report"),
+		dependencyEntry(fixtureComponent, "identity.account.api:router", "app:account"),
+		requirementEntry(fixtureComponent, "identity.account.api", "router", "app:account_endpoint", "app:default"),
+		requirementEntry("example/reports", "analytics.report", "router", "app:report_endpoint", "app:report_default"),
+		targetEntry("account_endpoint"),
+		targetEntry("report_endpoint"),
+	}
+
+	err := Link().Execute(ctx, &entries)
+	require.NoError(t, err)
+	assert.Equal(t, "app:account", findEntry(entries, "app", "account_endpoint").Meta["router"])
+	assert.Equal(t, "app:report_default", findEntry(entries, "app", "report_endpoint").Meta["router"])
+}
+
+func TestLinkRejectsLoadedModuleWithoutDefinition(t *testing.T) {
+	ctx, _ := setupTestContext()
+	entries := []registry.Entry{
+		dependencyEntry(fixtureComponent, "router", "app:configured"),
+		requirementEntry(fixtureComponent, fixtureNamespace, "router", "app:endpoint", "app:default"),
+		targetEntry("endpoint"),
+	}
+
+	err := Link().Execute(ctx, &entries)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "loaded module has no ns.definition root namespace")
+}
+
+func TestLinkAllowsUnloadedDependencyDuringSourceBuild(t *testing.T) {
+	ctx, _ := setupTestContext()
+	entries := []registry.Entry{
+		dependencyEntry(fixtureComponent, "router", "app:configured"),
+	}
+
+	require.NoError(t, Link().Execute(ctx, &entries))
+}
+
+func TestLinkRejectsConflictingModuleDefinitions(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []registry.Entry
+		want    string
+	}{
+		{
+			name: "one module declares two roots",
+			entries: []registry.Entry{
+				moduleDefinition(fixtureComponent, fixtureNamespace),
+				moduleDefinition(fixtureComponent, "identity.profile"),
+			},
+			want: "declares multiple namespaces",
+		},
+		{
+			name: "two modules declare one root",
+			entries: []registry.Entry{
+				moduleDefinition(fixtureComponent, fixtureNamespace),
+				moduleDefinition("example/profiles", fixtureNamespace),
+			},
+			want: "declared by multiple modules",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := setupTestContext()
+			err := Link().Execute(ctx, &tt.entries)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func declaredNamespaceFixture(parameter string) []registry.Entry {
+	return []registry.Entry{
+		moduleDefinition(fixtureComponent, fixtureNamespace),
+		dependencyEntry(fixtureComponent, parameter, "app:configured"),
+		requirementEntry(fixtureComponent, "identity.account.api", "router", "app:endpoint", "app:default"),
+		targetEntry("endpoint"),
+	}
+}
+
+func moduleDefinition(component, namespace string) registry.Entry {
+	return registry.Entry{
+		ID:   registry.NewID(namespace, "definition"),
+		Kind: registry.NamespaceDefinition,
+		Meta: map[string]any{"module": component},
+	}
+}
+
+func dependencyEntry(component, parameter string, value any) registry.Entry {
+	return registry.Entry{
+		ID:   registry.NewID("app.dependencies", "module"),
+		Kind: registry.NamespaceDependency,
+		Data: payload.New(map[string]any{
+			"component": component,
+			"parameters": []any{
+				map[string]any{"name": parameter, "value": value},
+			},
+		}),
+	}
+}
+
+func requirementEntry(component, namespace, name, target string, defaultValue any) registry.Entry {
+	return registry.Entry{
+		ID:   registry.NewID(namespace, name),
+		Kind: registry.NamespaceRequirement,
+		Meta: map[string]any{"module": component},
+		Data: payload.New(map[string]any{
+			"default": defaultValue,
+			"targets": []any{
+				map[string]any{"entry": target, "path": ".meta.router"},
+			},
+		}),
+	}
+}
+
+func targetEntry(name string) registry.Entry {
+	return registry.Entry{
+		ID:   registry.NewID("app", name),
+		Kind: "http.endpoint",
+		Meta: map[string]any{},
+		Data: payload.New(map[string]any{}),
+	}
+}

--- a/boot/build/stages/linking_test.go
+++ b/boot/build/stages/linking_test.go
@@ -5,10 +5,12 @@ package stages
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
@@ -39,7 +41,7 @@ func TestLink_WithDefault(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify value was set
@@ -86,7 +88,7 @@ func TestLink_FromDependency(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify dependency parameter was used
@@ -150,7 +152,7 @@ func TestLink_ExplicitDependenciesOverride(t *testing.T) {
 	}
 
 	stage := Link(WithDependencies(explicitDeps))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "vendor.module", "service")
@@ -210,7 +212,7 @@ func TestLink_ConflictError(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	// Linking stage now logs warnings instead of returning errors
 	require.NoError(t, err)
 }
@@ -266,113 +268,12 @@ func TestLink_ModuleScopedParameters(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "vendor.a", "endpoint")
 	require.NotNil(t, target)
 	assert.Equal(t, "app:router_a", target.Meta["router"])
-}
-
-func TestLink_BareParameterMatchesLegacyRequirementModuleMeta(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app", "__dependency.telegram"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "butschster/telegram",
-				"parameters": []any{
-					map[string]any{
-						"name":  "env_storage",
-						"value": "app.env:file",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "env_storage"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{
-				"module": "butschster/telegram",
-			},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{
-						"entry": "telegram:webhook_url",
-						"path":  ".storage",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "webhook_url"),
-			Kind: "env.variable",
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	target := findEntry(entries, "telegram", "webhook_url")
-	require.NotNil(t, target)
-	data := target.Data.Data().(map[string]any)
-	assert.Equal(t, "app.env:file", data["storage"])
-}
-
-func TestLink_BareParameterDoesNotMatchDottedAliasRequirementModuleMeta(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app", "__dependency.dataflow"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "wippy/dataflow",
-				"parameters": []any{
-					map[string]any{
-						"name":  "target_db",
-						"value": "app:db",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("userspace.dataflow", "target_db"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{
-				"module": "wippy/dataflow",
-			},
-			Data: payload.New(map[string]any{
-				"default": "default:db",
-				"targets": []any{
-					map[string]any{
-						"entry": "app:db",
-						"path":  ".file",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("app", "db"),
-			Kind: "db.sql.sqlite",
-			Data: payload.New(map[string]any{
-				"file": ":memory:",
-			}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	target := findEntry(entries, "app", "db")
-	require.NotNil(t, target)
-	data := target.Data.Data().(map[string]any)
-	assert.Equal(t, "default:db", data["file"])
 }
 
 func TestLink_BareParameterDoesNotCrossDottedModuleMeta(t *testing.T) {
@@ -439,13 +340,13 @@ func TestLink_BareParameterDoesNotCrossDottedModuleMeta(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target1 := findEntry(entries, "app", "db1")
 	require.NotNil(t, target1)
 	data1 := target1.Data.Data().(map[string]any)
-	assert.Equal(t, ":memory1:", data1["file"])
+	assert.Equal(t, "app:db", data1["file"])
 
 	target2 := findEntry(entries, "app", "db2")
 	require.NotNil(t, target2)
@@ -496,7 +397,7 @@ func TestLink_BareParametersWithSameNameAreScopedToDependencyComponent(t *testin
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"wippy/views"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "wippy.views", "pages_endpoint")
@@ -554,7 +455,7 @@ func TestLink_DuplicateDependencyParametersForSameRequirementConflict(t *testing
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"wippy/bootloader"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "parameter conflict")
 	assert.ErrorContains(t, err, "env_storage=app.env:store")
@@ -600,200 +501,11 @@ func TestLink_FullAndBareParametersForSameRequirementConflict(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"wippy/views"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "parameter conflict")
 	assert.ErrorContains(t, err, "api_router=app:api.views")
 	assert.ErrorContains(t, err, "api_router=app:api")
-}
-
-func TestLink_FullIDParameterName(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app", "__dependency.telegram"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "butschster/telegram",
-				"parameters": []any{
-					map[string]any{
-						"name":  "telegram:env_storage",
-						"value": "app:env_file",
-					},
-					map[string]any{
-						"name":  "telegram:webhook_router",
-						"value": "app:router",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "env_storage"),
-			Kind: registry.NamespaceRequirement,
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{
-						"entry": "telegram:bot_token",
-						"path":  ".storage",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "webhook_router"),
-			Kind: registry.NamespaceRequirement,
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{
-						"entry": "telegram.handler:webhook_endpoint",
-						"path":  ".meta.router",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "bot_token"),
-			Kind: "env.variable",
-			Data: payload.New(map[string]any{}),
-		},
-		{
-			ID:   registry.NewID("telegram.handler", "webhook_endpoint"),
-			Kind: "http.endpoint",
-			Meta: map[string]any{},
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	// Storage set via data path
-	botToken := findEntry(entries, "telegram", "bot_token")
-	require.NotNil(t, botToken)
-	data := botToken.Data.Data().(map[string]any)
-	assert.Equal(t, "app:env_file", data["storage"])
-
-	// Router set via meta path
-	endpoint := findEntry(entries, "telegram.handler", "webhook_endpoint")
-	require.NotNil(t, endpoint)
-	assert.Equal(t, "app:router", endpoint.Meta["router"])
-}
-
-func TestLink_ComponentNamespaceFullIDParameterName(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app", "__dependency.telegram"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "butschster/telegram",
-				"parameters": []any{
-					map[string]any{
-						"name":  "butschster.telegram:env_storage",
-						"value": "app.env:file",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "env_storage"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{
-				"module": "butschster/telegram",
-			},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{
-						"entry": "telegram:webhook_url",
-						"path":  ".storage",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "webhook_url"),
-			Kind: "env.variable",
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	webhookURL := findEntry(entries, "telegram", "webhook_url")
-	require.NotNil(t, webhookURL)
-	data := webhookURL.Data.Data().(map[string]any)
-	assert.Equal(t, "app.env:file", data["storage"])
-}
-
-func TestLink_DottedNamespaceRequirementIgnoresForeignModuleMetaParameters(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app", "dep.keeper"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "keeper/keeper",
-				"parameters": []any{
-					map[string]any{
-						"name":  "keeper:api_router",
-						"value": "app:api.public",
-					},
-					map[string]any{
-						"name":  "api_router",
-						"value": "app:api",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("app.deps", "views"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "wippy/views",
-				"parameters": []any{
-					map[string]any{
-						"name":  "wippy.views:api_router",
-						"value": "app:api.views",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("wippy.views", "api_router"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{
-				"module": "keeper/keeper",
-			},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{
-						"entry": "wippy.views.api:list_components.endpoint",
-						"path":  ".meta.router",
-					},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("wippy.views.api", "list_components.endpoint"),
-			Kind: "http.endpoint",
-			Meta: map[string]any{},
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	endpoint := findEntry(entries, "wippy.views.api", "list_components.endpoint")
-	require.NotNil(t, endpoint)
-	assert.Equal(t, "app:api.views", endpoint.Meta["router"])
 }
 
 func TestLink_FullyQualifiedParameterDoesNotCrossRequirementNamespace(t *testing.T) {
@@ -867,7 +579,7 @@ func TestLink_FullyQualifiedParameterDoesNotCrossRequirementNamespace(t *testing
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	facadeEndpoint := findEntry(entries, "wippy.facade", "facade_endpoint")
@@ -934,7 +646,7 @@ func TestLink_SameBareNameOwnedRequirementsResolveByFullID(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"kickside/core"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	proj := findEntry(entries, "kickside.core.projections", "proj_endpoint")
@@ -999,72 +711,7 @@ func TestLink_BareNameFansOutToAllOwnedRequirements(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"kickside/core"}))
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	proj := findEntry(entries, "kickside.core.projections", "proj_endpoint")
-	require.NotNil(t, proj)
-	assert.Equal(t, "app:router", proj.Meta["router"])
-
-	ret := findEntry(entries, "kickside.core.retention", "ret_endpoint")
-	require.NotNil(t, ret)
-	assert.Equal(t, "app:router", ret.Meta["router"])
-}
-
-// TestLink_ModuleQualifiedNameFansOutToAllOwnedRequirements verifies that a
-// module-qualified parameter (moduleNamespace:name, not a full requirement
-// id) fans out through the owned addressing index the same way a bare name
-// does, when it does not exact-match an entry in requirements.
-func TestLink_ModuleQualifiedNameFansOutToAllOwnedRequirements(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app.deps", "core"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "kickside/core",
-				"parameters": []any{
-					map[string]any{"name": "kickside.core:api_router", "value": "app:router"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("kickside.core.projections", "api_router"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{"module": "kickside/core"},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{"entry": "proj_endpoint", "path": ".meta.router"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("kickside.core.retention", "api_router"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{"module": "kickside/core"},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{"entry": "ret_endpoint", "path": ".meta.router"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("kickside.core.projections", "proj_endpoint"),
-			Kind: "http.endpoint",
-			Meta: map[string]any{},
-			Data: payload.New(map[string]any{}),
-		},
-		{
-			ID:   registry.NewID("kickside.core.retention", "ret_endpoint"),
-			Kind: "http.endpoint",
-			Meta: map[string]any{},
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link(WithStrictRequirementModules([]string{"kickside/core"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	proj := findEntry(entries, "kickside.core.projections", "proj_endpoint")
@@ -1143,7 +790,7 @@ func TestLink_ThreeWayBareNameFansOut(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"kickside/core"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	for _, tc := range []struct{ ns, entry string }{
@@ -1215,7 +862,7 @@ func TestLink_BareFanOutWithConflictingFullIDValueFails(t *testing.T) {
 		entries := build("app:other")
 
 		stage := Link(WithStrictRequirementModules([]string{"kickside/core"}))
-		err := stage.Execute(ctx, &entries)
+		err := executeLinkFixture(ctx, &entries, stage)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "parameter conflict")
 		assert.ErrorContains(t, err, "api_router=app:router")
@@ -1232,7 +879,7 @@ func TestLink_BareFanOutWithConflictingFullIDValueFails(t *testing.T) {
 		entries := build("app:router")
 
 		stage := Link(WithStrictRequirementModules([]string{"kickside/core"}))
-		err := stage.Execute(ctx, &entries)
+		err := executeLinkFixture(ctx, &entries, stage)
 		require.NoError(t, err)
 
 		proj := findEntry(entries, "kickside.core.projections", "proj_endpoint")
@@ -1269,7 +916,7 @@ func TestLink_NoValueError(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	// Linking stage now logs warnings instead of returning errors
 	require.NoError(t, err)
 }
@@ -1298,7 +945,7 @@ func TestLink_StrictRequirementsFailsOnMissingValue(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirements())
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.ErrorContains(t, err, "unresolved requirements")
 }
 
@@ -1307,22 +954,10 @@ func TestLink_StrictRequirementsFailsOnMissingTarget(t *testing.T) {
 
 	entries := []registry.Entry{
 		{
-			ID:   registry.NewID("app", "__dependency.telegram"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "butschster/telegram",
-				"parameters": []any{
-					map[string]any{
-						"name":  "telegram:webhook_router",
-						"value": "app:api",
-					},
-				},
-			}),
-		},
-		{
 			ID:   registry.NewID("telegram", "webhook_router"),
 			Kind: registry.NamespaceRequirement,
 			Data: payload.New(map[string]any{
+				"default": "app:api",
 				"targets": []any{
 					map[string]any{
 						"entry": "telegram.handler:webhook_endpoint",
@@ -1342,7 +977,7 @@ func TestLink_StrictRequirementsFailsOnMissingTarget(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirements())
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.ErrorContains(t, err, "unresolved requirements")
 	require.ErrorContains(t, err, "telegram.handler:webhook_endpoint")
 }
@@ -1388,7 +1023,7 @@ func TestLink_StrictRequirementModulesIgnoresUnrelatedRequirements(t *testing.T)
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"acme/module"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	endpoint := findEntry(entries, "acme.module", "endpoint")
@@ -1415,7 +1050,7 @@ func TestLink_StrictRequirementModulesEmptyScopeDoesNotFailAppRequirements(t *te
 	}
 
 	stage := Link(WithStrictRequirementModules(nil))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 }
 
@@ -1446,7 +1081,7 @@ func TestLink_AppendOperator(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify value was appended
@@ -1482,7 +1117,7 @@ func TestLink_SetValue(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify value was set
@@ -1517,7 +1152,7 @@ func TestLink_EmptyEntryError(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	// Linking stage now logs warnings instead of returning errors
 	require.NoError(t, err)
 }
@@ -1547,7 +1182,7 @@ func TestLink_CrossNamespace(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify value was set in different namespace
@@ -1592,7 +1227,7 @@ func TestLink_MultipleTargets(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify both targets were updated
@@ -1633,7 +1268,7 @@ func TestLink_BarePath(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify bare path was treated as data.default
@@ -1669,7 +1304,7 @@ func TestLink_MetaPath(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify meta field was set
@@ -1716,7 +1351,7 @@ func TestLink_MultipleRequirements(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	// Verify both requirements were applied
@@ -1754,7 +1389,7 @@ func TestLink_EmptyDefaultResolvesUnderStrict(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"acme/module"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	endpoint := findEntry(entries, "acme.module", "endpoint")
@@ -1798,7 +1433,7 @@ func TestLink_EmptyProvidedValueResolvesUnderStrict(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"vendor/module"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 }
 
@@ -1830,7 +1465,7 @@ func TestLink_IntDefaultLandsAsInt(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "test", "service")
@@ -1872,7 +1507,7 @@ func TestLink_StringDefaultStaysString(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "test", "service")
@@ -1915,7 +1550,7 @@ func TestLink_BoolAndFloatDefaults(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "test", "service")
@@ -1958,7 +1593,7 @@ func TestLink_TypedDependencyParameter(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "vendor.module", "service")
@@ -2011,7 +1646,7 @@ func TestLink_TypedParameterSameValueNoConflict(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"vendor/module"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "vendor.module", "service")
@@ -2065,7 +1700,7 @@ func TestLink_TypedParameterConflictLeavesUnresolved(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"vendor/module"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "workers=4")
 	assert.ErrorContains(t, err, "workers=8")
@@ -2102,7 +1737,7 @@ func TestLink_NullDefaultLeavesMandatory(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirements())
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.ErrorContains(t, err, "unresolved requirements")
 }
 
@@ -2133,7 +1768,7 @@ func TestLink_PlaceholderDefaultPassesThroughUntouched(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "test", "service")
@@ -2169,7 +1804,7 @@ func TestLink_AppendTypedValue(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	target := findEntry(entries, "test", "service")
@@ -2227,7 +1862,7 @@ func TestLink_BareParameterResolvesWithinOwnModule(t *testing.T) {
 	}
 
 	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	service := findEntry(entries, "vendor.alpha", "service")
@@ -2237,67 +1872,6 @@ func TestLink_BareParameterResolvesWithinOwnModule(t *testing.T) {
 	beta := findEntry(entries, "vendor.beta", "beta_service")
 	require.NotNil(t, beta)
 	assert.Equal(t, "beta-default", beta.Data.Data().(map[string]any)["token"])
-}
-
-// TestLink_FullParameterResolvesExactRequirementNotOwned verifies that a full
-// ns:name parameter resolves to the exact registry requirement id even when the
-// dependency also owns a same-named requirement under its module namespace.
-func TestLink_FullParameterResolvesExactRequirementNotOwned(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app.deps", "alpha"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "vendor/alpha",
-				"parameters": []any{
-					map[string]any{"name": "shared:token", "value": "exact-token"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("vendor.alpha", "token"),
-			Kind: registry.NamespaceRequirement,
-			Data: payload.New(map[string]any{
-				"default": "owned-default",
-				"targets": []any{
-					map[string]any{"entry": "service", "path": ".token"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("shared", "token"),
-			Kind: registry.NamespaceRequirement,
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{"entry": "shared:service", "path": ".token"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("vendor.alpha", "service"),
-			Kind: "process.lua",
-			Data: payload.New(map[string]any{}),
-		},
-		{
-			ID:   registry.NewID("shared", "service"),
-			Kind: "process.lua",
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	shared := findEntry(entries, "shared", "service")
-	require.NotNil(t, shared)
-	assert.Equal(t, "exact-token", shared.Data.Data().(map[string]any)["token"])
-
-	owned := findEntry(entries, "vendor.alpha", "service")
-	require.NotNil(t, owned)
-	assert.Equal(t, "owned-default", owned.Data.Data().(map[string]any)["token"])
 }
 
 // TestLink_NormalizationDeterministicAcrossShuffledOrderings verifies that the
@@ -2343,74 +1917,12 @@ func TestLink_NormalizationDeterministicAcrossShuffledOrderings(t *testing.T) {
 		for i, idx := range order {
 			entries[i] = base[idx]
 		}
-		err := Link().Execute(ctx, &entries)
+		err := executeLinkFixture(ctx, &entries, Link())
 		require.NoError(t, err)
 		service := findEntry(entries, "vendor.alpha", "service")
 		require.NotNil(t, service)
 		assert.Equal(t, "alpha-token", service.Data.Data().(map[string]any)["token"])
 	}
-}
-
-// TestLink_BareNameFansOutAcrossLegacyOwnershipForms verifies fan-out when a
-// dependency owns two same-bare-named requirements through both ownership
-// forms: one by living in the component's module namespace, one by a legacy
-// one-segment meta.module alias. The bare parameter feeds its value to both.
-func TestLink_BareNameFansOutAcrossLegacyOwnershipForms(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app.deps", "alpha"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "vendor/alpha",
-				"parameters": []any{
-					map[string]any{"name": "token", "value": "some-token"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("vendor.alpha", "token"),
-			Kind: registry.NamespaceRequirement,
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{"entry": "service", "path": ".token"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("extra", "token"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{"module": "vendor/alpha"},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{"entry": "extra:service", "path": ".token"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("vendor.alpha", "service"),
-			Kind: "process.lua",
-			Data: payload.New(map[string]any{}),
-		},
-		{
-			ID:   registry.NewID("extra", "service"),
-			Kind: "process.lua",
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	service := findEntry(entries, "vendor.alpha", "service")
-	require.NotNil(t, service)
-	assert.Equal(t, "some-token", service.Data.Data().(map[string]any)["token"])
-
-	extra := findEntry(entries, "extra", "service")
-	require.NotNil(t, extra)
-	assert.Equal(t, "some-token", extra.Data.Data().(map[string]any)["token"])
 }
 
 // TestLink_TwoRequirementsSameTargetApplyDeterministically verifies that when
@@ -2457,7 +1969,7 @@ func TestLink_TwoRequirementsSameTargetApplyDeterministically(t *testing.T) {
 		for i, idx := range order {
 			entries[i] = base[idx]
 		}
-		err := Link().Execute(ctx, &entries)
+		err := executeLinkFixture(ctx, &entries, Link())
 		require.NoError(t, err)
 		service := findEntry(entries, "test", "service")
 		require.NotNil(t, service)
@@ -2514,63 +2026,7 @@ func TestLink_RootParameterBeatsTransitiveBareAliasSpelling(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"butschster/telegram"}))
-	err := stage.Execute(ctx, &entries)
-	require.NoError(t, err)
-
-	botToken := findEntry(entries, "telegram", "bot_token")
-	require.NotNil(t, botToken)
-	data := botToken.Data.Data().(map[string]any)
-	assert.Equal(t, "app:root_env", data["storage"])
-}
-
-// TestLink_RootParameterBeatsTransitiveComponentNamespaceAliasSpelling verifies
-// the same precedence when the transitive dependency addresses the requirement
-// via its component-namespace-qualified alias rather than the requirement's own
-// registry namespace.
-func TestLink_RootParameterBeatsTransitiveComponentNamespaceAliasSpelling(t *testing.T) {
-	ctx, _ := setupTestContext()
-
-	entries := []registry.Entry{
-		{
-			ID:   registry.NewID("app.deps", "telegram_root"),
-			Kind: registry.NamespaceDependency,
-			Data: payload.New(map[string]any{
-				"component": "butschster/telegram",
-				"parameters": []any{
-					map[string]any{"name": "telegram:env_storage", "value": "app:root_env"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("app", "dep.telegram"),
-			Kind: registry.NamespaceDependency,
-			Meta: map[string]any{"module": "wippy/migration"},
-			Data: payload.New(map[string]any{
-				"component": "butschster/telegram",
-				"parameters": []any{
-					map[string]any{"name": "butschster.telegram:env_storage", "value": "app:transitive_env"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "env_storage"),
-			Kind: registry.NamespaceRequirement,
-			Meta: map[string]any{"module": "butschster/telegram"},
-			Data: payload.New(map[string]any{
-				"targets": []any{
-					map[string]any{"entry": "telegram:bot_token", "path": ".storage"},
-				},
-			}),
-		},
-		{
-			ID:   registry.NewID("telegram", "bot_token"),
-			Kind: "env.variable",
-			Data: payload.New(map[string]any{}),
-		},
-	}
-
-	stage := Link()
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.NoError(t, err)
 
 	botToken := findEntry(entries, "telegram", "bot_token")
@@ -2627,7 +2083,7 @@ func TestLink_TransitiveOnlyDuplicateForSameRequirementConflicts(t *testing.T) {
 	}
 
 	stage := Link(WithStrictRequirementModules([]string{"butschster/telegram"}))
-	err := stage.Execute(ctx, &entries)
+	err := executeLinkFixture(ctx, &entries, stage)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "parameter conflict")
 	assert.ErrorContains(t, err, "env_storage=app:env_a")
@@ -2641,6 +2097,77 @@ func TestLink_TransitiveOnlyDuplicateForSameRequirementConflicts(t *testing.T) {
 }
 
 // Helper functions
+
+// executeLinkFixture supplies the artifact boundary that production loaders
+// attach before Link executes. Older value-resolution tests construct flattened
+// registry slices directly; namespace-contract tests build definitions
+// explicitly and call Execute without this helper.
+func executeLinkFixture(ctx context.Context, entries *[]registry.Entry, stage boot.Stage) error {
+	definitions := make(map[string]struct{})
+	for _, entry := range *entries {
+		if entry.Kind != registry.NamespaceDefinition {
+			continue
+		}
+		if module := requirementModuleFromEntry(entry); module != "" {
+			definitions[module] = struct{}{}
+		}
+	}
+
+	components := make(map[string]struct{})
+	for _, entry := range *entries {
+		if entry.Kind != registry.NamespaceDependency {
+			continue
+		}
+		data, ok := entry.Data.Data().(map[string]any)
+		if !ok {
+			continue
+		}
+		component, _ := data["component"].(string)
+		if component != "" {
+			components[component] = struct{}{}
+		}
+	}
+
+	for component := range components {
+		if _, exists := definitions[component]; exists {
+			continue
+		}
+		namespace := fixtureModuleNamespace(*entries, component)
+		*entries = append(*entries, registry.Entry{
+			ID:   registry.NewID(namespace, "definition"),
+			Kind: registry.NamespaceDefinition,
+			Meta: map[string]any{"module": component},
+		})
+	}
+	return stage.Execute(ctx, entries)
+}
+
+func fixtureModuleNamespace(entries []registry.Entry, component string) string {
+	var namespaces []string
+	for _, entry := range entries {
+		if entry.Kind == registry.NamespaceRequirement && requirementModuleFromEntry(entry) == component {
+			namespaces = append(namespaces, entry.ID.NS)
+		}
+	}
+	if len(namespaces) == 0 {
+		return strings.ReplaceAll(component, "/", ".")
+	}
+
+	parts := strings.Split(namespaces[0], ".")
+	for _, namespace := range namespaces[1:] {
+		candidate := strings.Split(namespace, ".")
+		limit := len(parts)
+		if len(candidate) < limit {
+			limit = len(candidate)
+		}
+		common := 0
+		for common < limit && parts[common] == candidate[common] {
+			common++
+		}
+		parts = parts[:common]
+	}
+	return strings.Join(parts, ".")
+}
 
 type mockTranscoder struct{}
 

--- a/boot/deps/config/source_fs.go
+++ b/boot/deps/config/source_fs.go
@@ -33,7 +33,63 @@ func SourcePrefix(moduleRoot, loadRoot string) string {
 // translation here prevents publish, install, update, and restart from each
 // inventing subtly different exclusion behavior.
 func NewSourceFS(base fs.FS, config *ModuleConfig, moduleRoot, loadRoot string) fs.FS {
-	return config.FilterSourceFS(base, SourcePrefix(moduleRoot, loadRoot))
+	return config.FilterSourceFS(&sourceBoundaryFS{base: base}, SourcePrefix(moduleRoot, loadRoot))
+}
+
+// sourceBoundaryFS hides runtime-owned state from module source traversal.
+// A replacement rooted at a working directory may contain .wippy caches and
+// unpacked dependencies; those files are not part of the replacement module.
+// The boundary is relative to base so a module stored beneath a parent .wippy
+// directory remains readable while nested runtime state does not.
+type sourceBoundaryFS struct {
+	base fs.FS
+}
+
+func (f *sourceBoundaryFS) Open(name string) (fs.File, error) {
+	if isRuntimeStatePath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return f.base.Open(name)
+}
+
+func (f *sourceBoundaryFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if isRuntimeStatePath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	entries, err := fs.ReadDir(f.base, name)
+	if err != nil {
+		return nil, err
+	}
+	visible := make([]fs.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !isRuntimeStatePath(path.Join(name, entry.Name())) {
+			visible = append(visible, entry)
+		}
+	}
+	return visible, nil
+}
+
+func (f *sourceBoundaryFS) ReadFile(name string) ([]byte, error) {
+	if isRuntimeStatePath(name) {
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
+	}
+	return fs.ReadFile(f.base, name)
+}
+
+func (f *sourceBoundaryFS) Stat(name string) (fs.FileInfo, error) {
+	if isRuntimeStatePath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	}
+	return fs.Stat(f.base, name)
+}
+
+func isRuntimeStatePath(name string) bool {
+	for _, segment := range strings.Split(cleanSourcePath(name), "/") {
+		if segment == ".wippy" {
+			return true
+		}
+	}
+	return false
 }
 
 // FilterSourceFS returns a view of base that hides paths excluded by the

--- a/boot/deps/config/source_fs_test.go
+++ b/boot/deps/config/source_fs_test.go
@@ -64,3 +64,28 @@ func TestSourcePrefix(t *testing.T) {
 	assert.Equal(t, "src/components", SourcePrefix(root, filepath.Join(root, "src", "components")))
 	assert.Empty(t, SourcePrefix(root, root+"-sibling"))
 }
+
+func TestNewSourceFSHidesNestedRuntimeState(t *testing.T) {
+	base := fstest.MapFS{
+		".wippy.yaml":                           {Data: []byte("application")},
+		"src/_index.yaml":                       {Data: []byte("source")},
+		"src/.wippy/vendor/example/_index.yaml": {Data: []byte("dependency")},
+	}
+
+	filtered := NewSourceFS(base, nil, ".", ".")
+	var paths []string
+	require.NoError(t, fs.WalkDir(filtered, ".", func(name string, _ fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		paths = append(paths, name)
+		return nil
+	}))
+
+	assert.Equal(t, []string{
+		".",
+		".wippy.yaml",
+		"src",
+		"src/_index.yaml",
+	}, paths)
+	_, err := fs.Stat(filtered, "src/.wippy/vendor/example/_index.yaml")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}

--- a/boot/deps/hub/dependency_boot_test.go
+++ b/boot/deps/hub/dependency_boot_test.go
@@ -334,13 +334,14 @@ func TestDependencyHandler_ApplyVersionReconciliationSemantics(t *testing.T) {
 		for _, transition := range runner.transitions {
 			rollbackOps = append(rollbackOps, transition...)
 		}
-		require.Len(t, rollbackOps, 2, "rollback must remove only the departing root and module entry")
-		deleted := make(map[regapi.ID]struct{}, len(rollbackOps))
+		deleted := make(map[regapi.ID]struct{}, 2)
 		for _, op := range rollbackOps {
-			require.Equal(t, regapi.EntryDelete, op.Kind)
-			deleted[op.Entry.ID] = struct{}{}
 			require.NotEqual(t, hostID, op.Entry.ID)
+			if op.Kind == regapi.EntryDelete {
+				deleted[op.Entry.ID] = struct{}{}
+			}
 		}
+		require.Len(t, deleted, 2, "rollback must delete only the departing root and module entry")
 		require.Contains(t, deleted, addonRoot.ID)
 		require.Contains(t, deleted, regapi.NewID("acme.addon", "service"))
 		_, err = reg.GetEntry(regapi.NewID("app.security", "admin_all_access"))

--- a/boot/deps/hub/dependency_control.go
+++ b/boot/deps/hub/dependency_control.go
@@ -10,9 +10,9 @@ import (
 )
 
 func isRootDependency(entry regapi.Entry) bool {
-	// DependencyRoot is authoritative for every current source and pack ingest
-	// path. The ownership fallback is retained only so registries persisted
-	// before dependency_root was introduced remain upgradeable.
+	// Deployment ingestion marks source-owned roots explicitly. A dependency
+	// authored through the registry API has no module owner and is a user overlay
+	// root. Module-owned declarations without root provenance are transitive.
 	return entry.Kind == regapi.NamespaceDependency && (entry.DependencyRoot || entryModule(entry) == "")
 }
 

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1755,6 +1755,7 @@ func (h *DependencyHandler) loadModuleEntries(ctx context.Context, modules []Res
 
 	for _, mod := range modules {
 		moduleName := mod.Org + "/" + mod.Name
+		deploymentRootModule := h.lock != nil && h.lock.IsRootModule(moduleName)
 		moduleEntries, staged, err := h.loadEntriesForModulePlan(ctx, transcoder, mod)
 		if err != nil {
 			_ = plan.cleanup()
@@ -1762,6 +1763,15 @@ func (h *DependencyHandler) loadModuleEntries(ctx context.Context, modules []Res
 		}
 		plan.add(staged)
 		for i := range moduleEntries {
+			// Cold boot marks dependency declarations from the selected root
+			// application as deployment roots. Loading that same application
+			// through a live Hub update must produce the identical topology;
+			// otherwise the update silently turns its application dependencies
+			// into transitive module entries and the next update loses their
+			// host bindings.
+			if deploymentRootModule && moduleEntries[i].Kind == regapi.NamespaceDependency {
+				moduleEntries[i].DependencyRoot = true
+			}
 			if keep, ok := preserveHostSnapshotEntry(moduleEntries[i], moduleName, snapshotByID, installedRoots); ok {
 				moduleEntries[i] = keep
 				continue

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -776,9 +776,9 @@ func (h *DependencyHandler) ReconcileResolution(
 }
 
 // changedDependencyParameterModules returns the modules whose authored root
-// parameters differ across a history transition. A root parameter normally
-// configures its own component. Fully-qualified requirement IDs may address a
-// requirement in another module, so those owners are included as well.
+// parameters differ across a history transition. Dependency parameters belong
+// to the referenced component's declared namespace and cannot mutate another
+// module, including through a fully qualified requirement ID.
 func changedDependencyParameterModules(
 	ctx context.Context,
 	current regapi.State,
@@ -834,22 +834,6 @@ func changedDependencyParameterModules(
 			}
 			if item.definition.Component != "" {
 				changed[item.definition.Component] = struct{}{}
-			}
-			for _, parameter := range item.definition.Parameters {
-				if !strings.Contains(parameter.Name, ":") {
-					continue
-				}
-				requirementID := regapi.ParseID(parameter.Name)
-				for _, state := range []regapi.State{current, target} {
-					for _, entry := range state {
-						if entry.ID != requirementID || entry.Kind != regapi.NamespaceRequirement {
-							continue
-						}
-						if module := entryModule(entry); module != "" {
-							changed[module] = struct{}{}
-						}
-					}
-				}
 			}
 		}
 	}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -248,17 +248,10 @@ func (h *DependencyHandler) expand(
 		desiredDepEntries = append(desiredDepEntries, dep.entry)
 	}
 
-	var resolved []ResolvedModule
 	desiredRoots := dependencyDefinitions(desiredDeps)
-	if len(desiredRoots) > 0 {
-		var err error
-		resolved, err = h.resolveModules(ctx, desiredRoots, lockedVersions)
-		if err != nil {
-			return regapi.DirectiveResult{}, err
-		}
-		if err = h.completeResolvedModuleIdentities(ctx, resolved); err != nil {
-			return regapi.DirectiveResult{}, err
-		}
+	resolved, err := h.resolveEffectiveModules(ctx, desiredRoots, lockedVersions)
+	if err != nil {
+		return regapi.DirectiveResult{}, err
 	}
 	for _, ref := range refDeps {
 		selected, ok := selectedModuleVersion(resolved, ref.definition.Component)
@@ -559,14 +552,7 @@ func (h *DependencyHandler) refreshResolvedModules(
 			}
 		}
 	}
-	resolved, err := h.resolveModules(ctx, dependencyDefinitions(desiredDeps), lockedVersions)
-	if err != nil {
-		return nil, err
-	}
-	if err = h.completeResolvedModuleIdentities(ctx, resolved); err != nil {
-		return nil, err
-	}
-	return resolved, nil
+	return h.resolveEffectiveModules(ctx, dependencyDefinitions(desiredDeps), lockedVersions)
 }
 
 // ReconcileResolution materializes a previously selected graph. An unchanged
@@ -1343,6 +1329,50 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 	}
 
 	return result.Modules, nil
+}
+
+// resolveEffectiveModules returns the complete module selection controlled by
+// the current deployment plus authored registry roots. Lock-selected root
+// modules are implicit deployment inputs: a history overlay may replace one,
+// but removing that overlay must reveal the locked root again rather than
+// uninstalling the deployment itself.
+func (h *DependencyHandler) resolveEffectiveModules(
+	ctx context.Context,
+	deps []DependencyDefinition,
+	lockedVersions map[string]string,
+) ([]ResolvedModule, error) {
+	resolved, err := h.resolveModules(ctx, deps, lockedVersions)
+	if err != nil {
+		return nil, err
+	}
+	selected := make(map[string]struct{}, len(resolved))
+	for _, mod := range resolved {
+		selected[mod.Org+"/"+mod.Name] = struct{}{}
+	}
+	if h.lock != nil {
+		for _, locked := range h.lock.GetModules() {
+			if !locked.Root || locked.Name == "" || locked.Version == "" {
+				continue
+			}
+			if _, exists := selected[locked.Name]; exists {
+				continue
+			}
+			name, parseErr := graph.ParseName(locked.Name)
+			if parseErr != nil {
+				return nil, NewDependencyResolutionError(parseErr)
+			}
+			resolved = append(resolved, ResolvedModule{
+				Org: name.Organization, Name: name.Module,
+				Version: locked.Version, VersionID: locked.Version,
+				Digest: locked.Hash,
+			})
+			selected[locked.Name] = struct{}{}
+		}
+	}
+	if err := h.completeResolvedModuleIdentities(ctx, resolved); err != nil {
+		return nil, err
+	}
+	return resolved, nil
 }
 
 func validateModuleArtifactIdentity(name graph.Name, version, digest string) error {

--- a/boot/deps/hub/dependency_handler_edge_test.go
+++ b/boot/deps/hub/dependency_handler_edge_test.go
@@ -185,6 +185,10 @@ func TestIsRootDependencyKeepsOwnershipSeparate(t *testing.T) {
 	transitive := root
 	transitive.DependencyRoot = false
 	assert.False(t, isRootDependency(transitive))
+
+	unowned := transitive
+	unowned.Meta = nil
+	assert.True(t, isRootDependency(unowned), "registry-authored dependencies are user overlay roots")
 }
 
 // --- markModuleMeta ---

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -3375,10 +3375,10 @@ func buildWappBytes(t *testing.T, entries []wapp.Entry) []byte {
 func completeArtifactFixture(entries []wapp.Entry) []wapp.Entry {
 	hasRequirement := false
 	for _, entry := range entries {
-		if entry.Kind == string(regapi.NamespaceDefinition) {
+		if entry.Kind == regapi.NamespaceDefinition {
 			return entries
 		}
-		if entry.Kind == string(regapi.NamespaceRequirement) {
+		if entry.Kind == regapi.NamespaceRequirement {
 			hasRequirement = true
 		}
 	}
@@ -3388,7 +3388,7 @@ func completeArtifactFixture(entries []wapp.Entry) []wapp.Entry {
 	completed := append([]wapp.Entry(nil), entries...)
 	completed = append(completed, wapp.Entry{
 		ID:   wapp.NewID(entries[0].ID.Namespace, "definition"),
-		Kind: string(regapi.NamespaceDefinition),
+		Kind: regapi.NamespaceDefinition,
 	})
 	return completed
 }

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -1367,15 +1367,6 @@ func TestDependencyHandler_Expand_RootParametersOverrideModuleOwnedTransitivePar
 				"parameters":[{"name":"wippy.views:api_router","value":"app:api.views"}]
 			}`, payload.JSON),
 		},
-		{
-			ID:   regapi.NewID("app.deps", "kickside_ui"),
-			Kind: regapi.NamespaceDependency,
-			Data: payload.NewPayload(`{
-				"component":"kickside/ui",
-				"version":"v1.0.0",
-				"parameters":[{"name":"api_router","value":"app:api"}]
-			}`, payload.JSON),
-		},
 	}
 	rootDep := regapi.Entry{
 		ID:   regapi.NewID("app.deps", "sessions"),
@@ -1957,23 +1948,23 @@ func TestDependencyHandler_Expand_RejectsNewModuleClaimingExistingHostEntry(t *t
 	assert.Equal(t, "kickside/security", apiErr.Details().GetString("desired_module", ""))
 }
 
-func TestDependencyHandler_Expand_AppliesCanonicalComponentParametersToAliasNamespaceRequirements(t *testing.T) {
+func TestDependencyHandler_Expand_AppliesCanonicalParametersToDeclaredNamespace(t *testing.T) {
 	ctx := newTestContext()
 	tmpDir := t.TempDir()
 	vendorDir := filepath.Join(tmpDir, "vendor")
 
-	writeWapp(t, filepath.Join(vendorDir, "butschster", "telegram-0.3.0.wapp"), []wapp.Entry{
+	writeWapp(t, filepath.Join(vendorDir, "example", "accounts-0.3.0.wapp"), []wapp.Entry{
 		{
-			ID:   wapp.NewID("telegram", "env_storage"),
+			ID:   wapp.NewID("identity.account", "env_storage"),
 			Kind: regapi.NamespaceRequirement,
 			Data: map[string]any{
 				"targets": []any{
-					map[string]any{"entry": "telegram:webhook_url", "path": ".storage"},
+					map[string]any{"entry": "identity.account:callback_url", "path": ".storage"},
 				},
 			},
 		},
 		{
-			ID:   wapp.NewID("telegram", "webhook_url"),
+			ID:   wapp.NewID("identity.account", "callback_url"),
 			Kind: "env.variable",
 			Data: map[string]any{},
 		},
@@ -1995,12 +1986,12 @@ func TestDependencyHandler_Expand_AppliesCanonicalComponentParametersToAliasName
 	require.NoError(t, err)
 
 	rootDep := regapi.Entry{
-		ID:   regapi.NewID("app.deps", "telegram"),
+		ID:   regapi.NewID("app.deps", "accounts"),
 		Kind: regapi.NamespaceDependency,
 		Data: payload.NewPayload(`{
-			"component":"butschster/telegram",
+			"component":"example/accounts",
 			"version":"0.3.0",
-			"parameters":[{"name":"butschster.telegram:env_storage","value":"app.env:file"}]
+			"parameters":[{"name":"identity.account:env_storage","value":"app.env:file"}]
 		}`, payload.JSON),
 	}
 
@@ -2008,17 +1999,17 @@ func TestDependencyHandler_Expand_AppliesCanonicalComponentParametersToAliasName
 	require.NoError(t, err)
 	assert.True(t, result.Applied)
 
-	var webhookURL *regapi.Entry
+	var callbackURL *regapi.Entry
 	for _, scoped := range result.Additional {
 		op := scoped.Operation
-		if op.Kind == regapi.EntryCreate && op.Entry.ID == regapi.NewID("telegram", "webhook_url") {
+		if op.Kind == regapi.EntryCreate && op.Entry.ID == regapi.NewID("identity.account", "callback_url") {
 			entry := op.Entry
-			webhookURL = &entry
+			callbackURL = &entry
 			break
 		}
 	}
-	require.NotNil(t, webhookURL, "expected module env.variable to be created")
-	data, ok := webhookURL.Data.Data().(map[string]any)
+	require.NotNil(t, callbackURL, "expected module env.variable to be created")
+	data, ok := callbackURL.Data.Data().(map[string]any)
 	require.True(t, ok, "created env.variable data must be a map")
 	assert.Equal(t, "app.env:file", data["storage"])
 }
@@ -2032,24 +2023,24 @@ func TestDependencyHandler_Expand_FailsBeforeRegistryApplyWhenRequirementTargetI
 	require.NoError(t, err)
 	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "."})
 	lockObj.SetOptions(lock.Options{UnpackModules: true})
-	lockObj.SetModule(lock.Module{Name: "butschster/telegram", Version: "0.3.0"})
+	lockObj.SetModule(lock.Module{Name: "example/accounts", Version: "0.3.0"})
 	require.NoError(t, lockObj.Write())
 
-	writeWapp(t, filepath.Join(vendorDir, "butschster", "telegram-0.3.0.wapp"), []wapp.Entry{
+	writeWapp(t, filepath.Join(vendorDir, "example", "accounts-0.3.0.wapp"), []wapp.Entry{
 		{
-			ID:   wapp.NewID("telegram", "webhook_router"),
+			ID:   wapp.NewID("identity.account", "public_router"),
 			Kind: regapi.NamespaceRequirement,
 			Data: map[string]any{
 				"targets": []any{
-					map[string]any{"entry": "telegram.handler:webhook_endpoint", "path": ".meta.router"},
+					map[string]any{"entry": "identity.account.api:login_endpoint", "path": ".meta.router"},
 				},
 			},
 		},
 		{
-			ID:   wapp.NewID("telegram.handler", "webhook.endpoint"),
+			ID:   wapp.NewID("identity.account.api", "login.endpoint"),
 			Kind: "http.endpoint",
-			Meta: map[string]any{"router": "telegram:router"},
-			Data: map[string]any{"method": "POST", "path": "/webhook"},
+			Meta: map[string]any{"router": "identity.account:router"},
+			Data: map[string]any{"method": "POST", "path": "/login"},
 		},
 	})
 
@@ -2070,21 +2061,21 @@ func TestDependencyHandler_Expand_FailsBeforeRegistryApplyWhenRequirementTargetI
 	require.NoError(t, err)
 
 	rootDep := regapi.Entry{
-		ID:   regapi.NewID("app.deps", "telegram"),
+		ID:   regapi.NewID("app.deps", "accounts"),
 		Kind: regapi.NamespaceDependency,
 		Data: payload.NewPayload(`{
-			"component":"butschster/telegram",
+			"component":"example/accounts",
 			"version":"0.3.0",
-			"parameters":[{"name":"butschster.telegram:webhook_router","value":"app:api"}]
+			"parameters":[{"name":"identity.account:public_router","value":"app:api"}]
 		}`, payload.JSON),
 	}
 
 	result, err := handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryCreate, Entry: rootDep}, nil)
 	require.ErrorContains(t, err, "dependency pipeline failed")
-	require.ErrorContains(t, err, "telegram.handler:webhook_endpoint")
+	require.ErrorContains(t, err, "identity.account.api:login_endpoint")
 	assert.False(t, result.Applied)
 	assert.Empty(t, result.Additional)
-	staging, globErr := filepath.Glob(filepath.Join(vendorDir, "butschster", ".telegram.stage-*"))
+	staging, globErr := filepath.Glob(filepath.Join(vendorDir, "example", ".accounts.stage-*"))
 	require.NoError(t, globErr)
 	assert.Empty(t, staging, "planning errors must remove private extracted trees")
 }
@@ -3371,8 +3362,33 @@ func mustReadFile(t *testing.T, path string) []byte {
 
 func buildWappBytes(t *testing.T, entries []wapp.Entry) []byte {
 	t.Helper()
+	entries = completeArtifactFixture(entries)
 	var buf bytes.Buffer
 	writer := wapp.NewWriter()
 	require.NoError(t, writer.PackEntries(wapp.Metadata{}, entries, &buf))
 	return buf.Bytes()
+}
+
+// completeArtifactFixture gives compact artifact fixtures the same mandatory
+// root definition as a published module. Tests that exercise namespace
+// semantics provide their definition explicitly.
+func completeArtifactFixture(entries []wapp.Entry) []wapp.Entry {
+	hasRequirement := false
+	for _, entry := range entries {
+		if entry.Kind == string(regapi.NamespaceDefinition) {
+			return entries
+		}
+		if entry.Kind == string(regapi.NamespaceRequirement) {
+			hasRequirement = true
+		}
+	}
+	if !hasRequirement || len(entries) == 0 || entries[0].ID.Namespace == "" {
+		return entries
+	}
+	completed := append([]wapp.Entry(nil), entries...)
+	completed = append(completed, wapp.Entry{
+		ID:   wapp.NewID(entries[0].ID.Namespace, "definition"),
+		Kind: string(regapi.NamespaceDefinition),
+	})
+	return completed
 }

--- a/boot/deps/hub/dependency_handler_uninstall_repro_test.go
+++ b/boot/deps/hub/dependency_handler_uninstall_repro_test.go
@@ -21,7 +21,7 @@ import (
 // mcpServerWappEntries mirrors the real butschster/mcp-server layout: entries
 // live in the "mcp" namespace (not org.module), three SSE endpoints default to
 // router app:api.public at /mcp, and a module-owned ns.requirement relocates
-// their meta.router. Installing with param butschster.mcp-server:router=app:api
+// their meta.router. Installing with the canonical param mcp:router=app:api
 // moves them off app:api.public so they stop colliding with the host's own
 // public MCP endpoint on that router.
 func mcpServerWappEntries() []wapp.Entry {
@@ -66,6 +66,11 @@ func installedMcpSnapshotEntries(routerValue string) []regapi.Entry {
 	}
 	return []regapi.Entry{
 		{
+			ID:   regapi.NewID("mcp", "definition"),
+			Kind: regapi.NamespaceDefinition,
+			Meta: attrs.NewBagFrom(mod),
+		},
+		{
 			ID:   regapi.NewID("mcp", "router"),
 			Kind: regapi.NamespaceRequirement,
 			Meta: attrs.NewBagFrom(mod),
@@ -81,7 +86,7 @@ func mcpRootDep() regapi.Entry {
 	return regapi.Entry{
 		ID:   regapi.NewID("app.deps", "mcp-server"),
 		Kind: regapi.NamespaceDependency,
-		Data: payload.NewPayload(`{"component":"butschster/mcp-server","version":"1.6.2","parameters":[{"name":"butschster.mcp-server:router","value":"app:api"}]}`, payload.JSON),
+		Data: payload.NewPayload(`{"component":"butschster/mcp-server","version":"1.6.2","parameters":[{"name":"mcp:router","value":"app:api"}]}`, payload.JSON),
 	}
 }
 
@@ -165,7 +170,7 @@ func TestReproDeleteUnrelatedRootPreservesMcpRouterParam(t *testing.T) {
 	dummyRoot := regapi.Entry{
 		ID:   regapi.NewID("app.deps", "dummy"),
 		Kind: regapi.NamespaceDependency,
-		Data: payload.NewPayload(`{"component":"wippy/dummy","version":"v1.0.0","parameters":[{"name":"wippy.dummy:router_req","value":"app:api"}]}`, payload.JSON),
+		Data: payload.NewPayload(`{"component":"wippy/dummy","version":"v1.0.0","parameters":[{"name":"dummy:router_req","value":"app:api"}]}`, payload.JSON),
 	}
 	dummyReq := regapi.Entry{
 		ID:   regapi.NewID("dummy", "router_req"),

--- a/boot/deps/hub/deployment_baseline.go
+++ b/boot/deps/hub/deployment_baseline.go
@@ -81,9 +81,10 @@ func (h *DependencyHandler) deploymentBaselineDigest(
 	})
 
 	data, err := json.Marshal(struct {
+		Model   string           `json:"model"`
 		Modules []lockedModule   `json:"modules"`
 		Roots   []deploymentRoot `json:"roots"`
-	}{Modules: modules, Roots: roots})
+	}{Model: "deployment-overlay-v1", Modules: modules, Roots: roots})
 	if err != nil {
 		return "", fmt.Errorf("encode deployment dependency baseline: %w", err)
 	}

--- a/boot/deps/hub/reference_fold_hardening_test.go
+++ b/boot/deps/hub/reference_fold_hardening_test.go
@@ -482,7 +482,8 @@ func TestReconcile_ParameterDisagreementBootsThenConflictsOnNextOperation(t *tes
 	root := paramRoot("app.deps:a", "acme/a", "v1.0.0", map[string]any{"db": "app:db"})
 	disagreeing := paramRoot("acme.pkg:__dependency.acme.a", "acme/a", ">=1.0.0", map[string]any{"db": "other:db"})
 	moduleEntry := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
-	state := regapi.State{root, disagreeing, moduleEntry}
+	moduleDefinition := hardeningModuleDefinition("acme.a", "acme/a", "v1.0.0")
+	state := regapi.State{root, disagreeing, moduleDefinition, moduleEntry}
 
 	transcoder := payload.GetTranscoder(ctx)
 	baseline, err := handler.deploymentBaselineDigest(ctx, state, transcoder)

--- a/boot/deps/hub/reference_param_drift_test.go
+++ b/boot/deps/hub/reference_param_drift_test.go
@@ -35,7 +35,8 @@ func TestReconcile_ParameterDriftOnControllerStillBoots(t *testing.T) {
 	root := paramRoot("app.deps:a", "acme/a", "v1.0.0", map[string]any{"db": "app:db"})
 	reference := paramRoot("acme.pkg:__dependency.acme.a", "acme/a", ">=1.0.0", map[string]any{"db": "app:db"})
 	moduleEntry := hardeningModuleEntry("acme.a:entry", "acme/a", "v1.0.0")
-	recordedState := regapi.State{root, reference, moduleEntry}
+	moduleDefinition := hardeningModuleDefinition("acme.a", "acme/a", "v1.0.0")
+	recordedState := regapi.State{root, reference, moduleDefinition, moduleEntry}
 
 	transcoder := payload.GetTranscoder(ctx)
 	baseline, err := handler.deploymentBaselineDigest(ctx, recordedState, transcoder)
@@ -46,7 +47,7 @@ func TestReconcile_ParameterDriftOnControllerStillBoots(t *testing.T) {
 
 	// ...then the controller's parameters change on disk.
 	driftedRoot := paramRoot("app.deps:a", "acme/a", "v1.0.0", map[string]any{"db": "other:db"})
-	driftedState := regapi.State{driftedRoot, reference, moduleEntry}
+	driftedState := regapi.State{driftedRoot, reference, moduleDefinition, moduleEntry}
 
 	result, err := handler.ReconcileResolution(ctx, driftedState, driftedState, resolution)
 	require.NoError(t, err, "parameter drift must not wedge reconciliation")

--- a/boot/deps/hub/resolution_hardening_test.go
+++ b/boot/deps/hub/resolution_hardening_test.go
@@ -76,6 +76,18 @@ func hardeningModuleEntry(id, module, version string) regapi.Entry {
 	}
 }
 
+func hardeningModuleDefinition(namespace, module, version string) regapi.Entry {
+	return regapi.Entry{
+		ID:   regapi.NewID(namespace, "definition"),
+		Kind: regapi.NamespaceDefinition,
+		Meta: attrs.NewBagFrom(map[string]any{
+			metaModuleKey:        module,
+			metaModuleVersionKey: version,
+			metaModuleDigestKey:  hardeningDigest,
+		}),
+	}
+}
+
 func hardeningResolution(roots ...regapi.Entry) *regapi.DependencyResolution {
 	desired := make([]desiredDependency, 0, len(roots))
 	modules := make([]ResolvedModule, 0, len(roots))

--- a/boot/deps/hub/root_application_update_test.go
+++ b/boot/deps/hub/root_application_update_test.go
@@ -189,7 +189,9 @@ modules:
 	for i := range workerEntries {
 		workerEntries[i] = markModuleIdentity(workerEntries[i], "acme/worker", "v1.0.0", digests[selection{"acme/worker", "v1.0.0"}])
 	}
-	baseline := append(v1AppEntries, workerEntries...)
+	baseline := make(regapi.State, 0, len(v1AppEntries)+len(workerEntries))
+	baseline = append(baseline, v1AppEntries...)
+	baseline = append(baseline, workerEntries...)
 	v0 := version.FromParent(nil, regapi.RootVersion)
 	require.NoError(t, reg.LoadState(ctx, baseline, v0))
 	v0Resolution, err := history.GetDependencyResolution(v0)

--- a/boot/deps/hub/root_application_update_test.go
+++ b/boot/deps/hub/root_application_update_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	registryimpl "github.com/wippyai/runtime/system/registry"
+	regexp "github.com/wippyai/runtime/system/registry/expansion"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
 	"github.com/wippyai/runtime/system/registry/topology"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
@@ -29,9 +33,19 @@ func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t
 	// Root provenance is selected by the lock graph, not by an app.deps naming
 	// convention. Use deliberately arbitrary managed namespaces in this proof.
 	workerRootID := regapi.NewID("workspace.modules", "worker")
+	adminPolicyID := regapi.NewID("deployment.security", "admin")
 	artifacts := map[selection][]byte{
+		{"acme/app", "v1.0.0"}: buildWappBytes(t, []wapp.Entry{
+			{ID: wapp.NewID("acme.app", "service"), Kind: "service", Data: map[string]any{"version": "v1"}},
+			{ID: wapp.NewID(adminPolicyID.NS, adminPolicyID.Name), Kind: "security.policy", Data: map[string]any{"allow": true}},
+			{ID: wapp.NewID(workerRootID.NS, workerRootID.Name), Kind: regapi.NamespaceDependency,
+				Data: map[string]any{
+					"component": "acme/worker", "version": "v1.0.0",
+					"parameters": []any{map[string]any{"name": "acme.worker:router", "value": "app:api"}},
+				}},
+		}),
 		{"acme/app", "v2.0.0"}: buildWappBytes(t, []wapp.Entry{
-			{ID: wapp.NewID("acme.app", "service"), Kind: "service"},
+			{ID: wapp.NewID("acme.app", "service"), Kind: "service", Data: map[string]any{"version": "v2"}},
 			{ID: wapp.NewID(workerRootID.NS, workerRootID.Name), Kind: regapi.NamespaceDependency,
 				Data: map[string]any{
 					"component": "acme/worker", "version": "v1.0.0",
@@ -47,16 +61,25 @@ func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t
 		sum := sha256.Sum256(artifact)
 		digests[selected] = "sha256:" + hex.EncodeToString(sum[:])
 	}
+	require.NoError(t, os.MkdirAll(filepath.Join(vendorDir, "acme"), 0o755))
+	for _, selected := range []selection{{"acme/app", "v1.0.0"}, {"acme/worker", "v1.0.0"}} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(vendorDir, "acme", selected.module[len("acme/"):]+"-"+selected.version+".wapp"),
+			artifacts[selected],
+			0o600,
+		))
+	}
 	require.NoError(t, os.WriteFile(lockPath, []byte(fmt.Sprintf(`directories:
   modules: vendor
 modules:
   - name: acme/app
     version: v1.0.0
+    hash: %s
     root: true
   - name: acme/worker
     version: v1.0.0
     hash: %s
-`, digests[selection{"acme/worker", "v1.0.0"}])), 0o600))
+`, digests[selection{"acme/app", "v1.0.0"}], digests[selection{"acme/worker", "v1.0.0"}])), 0o600))
 
 	hubClient := &fakeHub{
 		getManifest: func(_ context.Context, org, module, constraint string) (*ModuleManifest, error) {
@@ -135,4 +158,96 @@ modules:
 	require.NotNil(t, nestedUpdate, "root package update must replace its nested dependency declaration")
 	require.True(t, nestedUpdate.Entry.DependencyRoot,
 		"dependencies declared by the selected root application must remain deployment roots")
+
+	// Exercise the real root self-update shape. The deployment root is selected
+	// by wippy.lock and therefore has no synthetic registry dependency at v0.
+	// A live update creates an overlay dependency for the same component; undo
+	// must reveal the locked package and all of its entries again.
+	history := historymem.New()
+	runner := &bootRecordingRunner{}
+	reg := registryimpl.NewRegistry(
+		history,
+		runner,
+		topology.NewStateBuilder(zap.NewNop(), handler.resolver),
+		handler.resolver,
+		zap.NewNop(),
+		registryimpl.WithKindDirective(
+			regapi.NamespaceDependency,
+			regexp.NewDependencyDirective(handler.Expand).WithResolutionTransition(handler.ReconcileResolution),
+		),
+	)
+	v1AppEntries, err := loadEntriesFromWappBytesForTest(artifacts[selection{"acme/app", "v1.0.0"}])
+	require.NoError(t, err)
+	for i := range v1AppEntries {
+		v1AppEntries[i] = markModuleIdentity(v1AppEntries[i], "acme/app", "v1.0.0", digests[selection{"acme/app", "v1.0.0"}])
+		if v1AppEntries[i].Kind == regapi.NamespaceDependency {
+			v1AppEntries[i].DependencyRoot = true
+		}
+	}
+	workerEntries, err := loadEntriesFromWappBytesForTest(artifacts[selection{"acme/worker", "v1.0.0"}])
+	require.NoError(t, err)
+	for i := range workerEntries {
+		workerEntries[i] = markModuleIdentity(workerEntries[i], "acme/worker", "v1.0.0", digests[selection{"acme/worker", "v1.0.0"}])
+	}
+	baseline := append(v1AppEntries, workerEntries...)
+	v0 := version.FromParent(nil, regapi.RootVersion)
+	require.NoError(t, reg.LoadState(ctx, baseline, v0))
+	v0Resolution, err := history.GetDependencyResolution(v0)
+	require.NoError(t, err)
+	require.Equal(t, "v1.0.0", resolutionModuleVersion(v0Resolution, "acme/app"),
+		"the durable baseline graph must include its lock-selected root module")
+
+	overlayRoot := regapi.Entry{
+		ID: regapi.NewID("deployment.packages", "application"), Kind: regapi.NamespaceDependency,
+		Data: payload.New(map[string]any{"component": "acme/app", "version": "v2.0.0"}),
+	}
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: overlayRoot}})
+	require.NoError(t, err)
+	service, err := reg.GetEntry(regapi.NewID("acme.app", "service"))
+	require.NoError(t, err)
+	require.Equal(t, "v2.0.0", moduleVersion(service))
+	_, err = reg.GetEntry(adminPolicyID)
+	require.Error(t, err, "v2 fixture deliberately removes the v1 policy")
+
+	require.NoError(t, reg.ApplyVersion(ctx, v0))
+	service, err = reg.GetEntry(regapi.NewID("acme.app", "service"))
+	require.NoError(t, err)
+	require.Equal(t, "v1.0.0", moduleVersion(service))
+	_, err = reg.GetEntry(adminPolicyID)
+	require.NoError(t, err, "undo must reveal every entry from the locked root package")
+	_, err = reg.GetEntry(overlayRoot.ID)
+	require.Error(t, err)
+
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	service, err = reg.GetEntry(regapi.NewID("acme.app", "service"))
+	require.NoError(t, err)
+	require.Equal(t, "v2.0.0", moduleVersion(service))
+	_, err = reg.GetEntry(adminPolicyID)
+	require.Error(t, err)
+}
+
+func loadEntriesFromWappBytesForTest(data []byte) ([]regapi.Entry, error) {
+	file, err := os.CreateTemp("", "root-application-*.wapp")
+	if err != nil {
+		return nil, err
+	}
+	path := file.Name()
+	defer os.Remove(path)
+	if _, err = file.Write(data); err != nil {
+		file.Close()
+		return nil, err
+	}
+	if err = file.Close(); err != nil {
+		return nil, err
+	}
+	return loadEntriesFromWapp(path)
+}
+
+func resolutionModuleVersion(resolution *regapi.DependencyResolution, module string) string {
+	for _, selected := range resolution.Modules {
+		if selected.Name == module {
+			return selected.Version
+		}
+	}
+	return ""
 }

--- a/boot/deps/hub/root_application_update_test.go
+++ b/boot/deps/hub/root_application_update_test.go
@@ -26,7 +26,9 @@ func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t
 	vendorDir := filepath.Join(tmpDir, "vendor")
 
 	type selection struct{ module, version string }
-	workerRootID := regapi.NewID("app.deps", "worker")
+	// Root provenance is selected by the lock graph, not by an app.deps naming
+	// convention. Use deliberately arbitrary managed namespaces in this proof.
+	workerRootID := regapi.NewID("workspace.modules", "worker")
 	artifacts := map[selection][]byte{
 		{"acme/app", "v2.0.0"}: buildWappBytes(t, []wapp.Entry{
 			{ID: wapp.NewID("acme.app", "service"), Kind: "service"},
@@ -99,7 +101,7 @@ modules:
 	require.NoError(t, err)
 
 	appRoot := regapi.Entry{
-		ID: regapi.NewID("app.deps", "app"), Kind: regapi.NamespaceDependency, DependencyRoot: true,
+		ID: regapi.NewID("deployment.packages", "app"), Kind: regapi.NamespaceDependency, DependencyRoot: true,
 		Data: payload.New(map[string]any{"component": "acme/app", "version": "v1.0.0"}),
 	}
 	workerRoot := markModuleIdentity(regapi.Entry{

--- a/boot/deps/hub/root_application_update_test.go
+++ b/boot/deps/hub/root_application_update_test.go
@@ -36,6 +36,7 @@ func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t
 	adminPolicyID := regapi.NewID("deployment.security", "admin")
 	artifacts := map[selection][]byte{
 		{"acme/app", "v1.0.0"}: buildWappBytes(t, []wapp.Entry{
+			{ID: wapp.NewID("acme.app", "definition"), Kind: regapi.NamespaceDefinition},
 			{ID: wapp.NewID("acme.app", "service"), Kind: "service", Data: map[string]any{"version": "v1"}},
 			{ID: wapp.NewID(adminPolicyID.NS, adminPolicyID.Name), Kind: "security.policy", Data: map[string]any{"allow": true}},
 			{ID: wapp.NewID(workerRootID.NS, workerRootID.Name), Kind: regapi.NamespaceDependency,
@@ -45,6 +46,7 @@ func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t
 				}},
 		}),
 		{"acme/app", "v2.0.0"}: buildWappBytes(t, []wapp.Entry{
+			{ID: wapp.NewID("acme.app", "definition"), Kind: regapi.NamespaceDefinition},
 			{ID: wapp.NewID("acme.app", "service"), Kind: "service", Data: map[string]any{"version": "v2"}},
 			{ID: wapp.NewID(workerRootID.NS, workerRootID.Name), Kind: regapi.NamespaceDependency,
 				Data: map[string]any{
@@ -52,9 +54,10 @@ func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t
 					"parameters": []any{map[string]any{"name": "acme.worker:router", "value": "app:api"}},
 				}},
 		}),
-		{"acme/worker", "v1.0.0"}: buildWappBytes(t, []wapp.Entry{{
-			ID: wapp.NewID("acme.worker", "service"), Kind: "service",
-		}}),
+		{"acme/worker", "v1.0.0"}: buildWappBytes(t, []wapp.Entry{
+			{ID: wapp.NewID("acme.worker", "definition"), Kind: regapi.NamespaceDefinition},
+			{ID: wapp.NewID("acme.worker", "service"), Kind: "service"},
+		}),
 	}
 	digests := make(map[selection]string, len(artifacts))
 	for selected, artifact := range artifacts {
@@ -137,8 +140,12 @@ modules:
 	snapshot := regapi.State{
 		appRoot,
 		workerRoot,
+		markModuleIdentity(regapi.Entry{ID: regapi.NewID("acme.app", "definition"), Kind: regapi.NamespaceDefinition},
+			"acme/app", "v1.0.0", "sha256:old-app"),
 		markModuleIdentity(regapi.Entry{ID: regapi.NewID("acme.app", "service"), Kind: "service"},
 			"acme/app", "v1.0.0", "sha256:old-app"),
+		markModuleIdentity(regapi.Entry{ID: regapi.NewID("acme.worker", "definition"), Kind: regapi.NamespaceDefinition},
+			"acme/worker", "v1.0.0", digests[selection{"acme/worker", "v1.0.0"}]),
 		markModuleIdentity(regapi.Entry{ID: regapi.NewID("acme.worker", "service"), Kind: "service"},
 			"acme/worker", "v1.0.0", digests[selection{"acme/worker", "v1.0.0"}]),
 	}

--- a/boot/deps/hub/root_application_update_test.go
+++ b/boot/deps/hub/root_application_update_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+func TestDependencyHandler_RootApplicationUpdatePreservesNestedDependencyRoots(t *testing.T) {
+	ctx := newTestContext()
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	vendorDir := filepath.Join(tmpDir, "vendor")
+
+	type selection struct{ module, version string }
+	workerRootID := regapi.NewID("app.deps", "worker")
+	artifacts := map[selection][]byte{
+		{"acme/app", "v2.0.0"}: buildWappBytes(t, []wapp.Entry{
+			{ID: wapp.NewID("acme.app", "service"), Kind: "service"},
+			{ID: wapp.NewID(workerRootID.NS, workerRootID.Name), Kind: regapi.NamespaceDependency,
+				Data: map[string]any{
+					"component": "acme/worker", "version": "v1.0.0",
+					"parameters": []any{map[string]any{"name": "acme.worker:router", "value": "app:api"}},
+				}},
+		}),
+		{"acme/worker", "v1.0.0"}: buildWappBytes(t, []wapp.Entry{{
+			ID: wapp.NewID("acme.worker", "service"), Kind: "service",
+		}}),
+	}
+	digests := make(map[selection]string, len(artifacts))
+	for selected, artifact := range artifacts {
+		sum := sha256.Sum256(artifact)
+		digests[selected] = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	require.NoError(t, os.WriteFile(lockPath, []byte(fmt.Sprintf(`directories:
+  modules: vendor
+modules:
+  - name: acme/app
+    version: v1.0.0
+    root: true
+  - name: acme/worker
+    version: v1.0.0
+    hash: %s
+`, digests[selection{"acme/worker", "v1.0.0"}])), 0o600))
+
+	hubClient := &fakeHub{
+		getManifest: func(_ context.Context, org, module, constraint string) (*ModuleManifest, error) {
+			selected := selection{module: org + "/" + module, version: constraint}
+			artifact, ok := artifacts[selected]
+			if !ok {
+				return nil, fmt.Errorf("unexpected manifest %s@%s", selected.module, selected.version)
+			}
+			manifest := &ModuleManifest{
+				Org: org, Name: module, Version: constraint, VersionID: constraint,
+				Digest: digests[selected], SizeBytes: uint64(len(artifact)),
+				URL: "memory://" + module + "@" + constraint,
+			}
+			if selected.module == "acme/app" {
+				manifest.Dependencies = []ManifestDep{{
+					Org: "acme", Name: "worker", Version: "v1.0.0", Constraint: "v1.0.0",
+					Digest: digests[selection{"acme/worker", "v1.0.0"}],
+				}}
+			}
+			return manifest, nil
+		},
+		downloadFile: func(_ context.Context, url, destination string) error {
+			var selected selection
+			switch url {
+			case "memory://app@v2.0.0":
+				selected = selection{"acme/app", "v2.0.0"}
+			case "memory://worker@v1.0.0":
+				selected = selection{"acme/worker", "v1.0.0"}
+			default:
+				return fmt.Errorf("unexpected download %s", url)
+			}
+			if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(destination, artifacts[selected], 0o600)
+		},
+	}
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub: hubClient, Logger: zap.NewNop(), Resolver: topology.NewResolver(),
+		LockPath: lockPath, VendorDir: vendorDir,
+	})
+	require.NoError(t, err)
+
+	appRoot := regapi.Entry{
+		ID: regapi.NewID("app.deps", "app"), Kind: regapi.NamespaceDependency, DependencyRoot: true,
+		Data: payload.New(map[string]any{"component": "acme/app", "version": "v1.0.0"}),
+	}
+	workerRoot := markModuleIdentity(regapi.Entry{
+		ID: workerRootID, Kind: regapi.NamespaceDependency, DependencyRoot: true,
+		Data: payload.New(map[string]any{
+			"component": "acme/worker", "version": "v1.0.0",
+			"parameters": []any{map[string]any{"name": "acme.worker:router", "value": "app:api"}},
+		}),
+	}, "acme/app", "v1.0.0", "sha256:old-app")
+	snapshot := regapi.State{
+		appRoot,
+		workerRoot,
+		markModuleIdentity(regapi.Entry{ID: regapi.NewID("acme.app", "service"), Kind: "service"},
+			"acme/app", "v1.0.0", "sha256:old-app"),
+		markModuleIdentity(regapi.Entry{ID: regapi.NewID("acme.worker", "service"), Kind: "service"},
+			"acme/worker", "v1.0.0", digests[selection{"acme/worker", "v1.0.0"}]),
+	}
+	updatedRoot := appRoot
+	updatedRoot.Data = payload.New(map[string]any{"component": "acme/app", "version": "v2.0.0"})
+	result, err := handler.Expand(ctx, regapi.Operation{Kind: regapi.EntryUpdate, Entry: updatedRoot}, snapshot)
+	require.NoError(t, err)
+
+	var nestedUpdate *regapi.Operation
+	for i := range result.Additional {
+		if result.Additional[i].Operation.Entry.ID == workerRootID {
+			op := result.Additional[i].Operation
+			nestedUpdate = &op
+			break
+		}
+	}
+	require.NotNil(t, nestedUpdate, "root package update must replace its nested dependency declaration")
+	require.True(t, nestedUpdate.Entry.DependencyRoot,
+		"dependencies declared by the selected root application must remain deployment roots")
+}

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/boot"
 	contextapi "github.com/wippyai/runtime/api/context"
 	logapi "github.com/wippyai/runtime/api/logs"
@@ -273,6 +275,98 @@ entries:
 	}
 	if got := loaded[0].Meta.GetString("module", ""); got != "" {
 		t.Fatalf("application source ownership = %q, want empty", got)
+	}
+}
+
+func TestLoadEntriesFromModuleLoadPathsLinksDeclaredNamespaceForPackedAndUnpackedModules(t *testing.T) {
+	ctx := setupTestContext(t)
+	tmpDir := t.TempDir()
+	logger := zap.NewNop()
+
+	appDir := filepath.Join(tmpDir, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	appYAML := `version: "1.0"
+namespace: app.dependencies
+entries:
+  - name: accounts
+    kind: ns.dependency
+    component: example/accounts
+    parameters:
+      - name: public_router
+        value: app:api.public
+`
+	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(appYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	moduleDir := filepath.Join(tmpDir, "accounts")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	moduleYAML := `version: "1.0"
+namespace: identity.account
+entries:
+  - name: definition
+    kind: ns.definition
+  - name: public_router
+    kind: ns.requirement
+    targets:
+      - entry: login.endpoint
+        path: meta.router
+  - name: login.endpoint
+    kind: http.endpoint
+    meta:
+      router: unresolved
+`
+	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(moduleYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	packedPath := createTestWappFile(t, tmpDir, "accounts", []wapp.Entry{
+		{ID: wapp.NewID("identity.account", "definition"), Kind: "ns.definition"},
+		{
+			ID:   wapp.NewID("identity.account", "public_router"),
+			Kind: "ns.requirement",
+			Data: map[string]any{
+				"targets": []any{
+					map[string]any{"entry": "login.endpoint", "path": "meta.router"},
+				},
+			},
+		},
+		{
+			ID:   wapp.NewID("identity.account", "login.endpoint"),
+			Kind: "http.endpoint",
+			Meta: wapp.Metadata{"router": "unresolved"},
+		},
+	})
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "unpacked directory", path: moduleDir},
+		{name: "packed archive", path: packedPath},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loaded, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+				{Path: appDir},
+				{Path: tt.path, Module: "example/accounts", Version: "1.0.0"},
+			}, logger)
+			require.NoError(t, err)
+
+			var endpoint *regapi.Entry
+			for i := range loaded {
+				if loaded[i].ID.String() == "identity.account:login.endpoint" {
+					endpoint = &loaded[i]
+					break
+				}
+			}
+			require.NotNil(t, endpoint)
+			assert.Equal(t, "app:api.public", endpoint.Meta.GetString("router", ""))
+		})
 	}
 }
 
@@ -725,86 +819,6 @@ func TestLoadEntriesFromPathsMultipleWappsWithDifferentKinds(t *testing.T) {
 	}
 	if kinds["myapp:run"] != "process.lua" {
 		t.Errorf("myapp:run kind = %v, want process.lua", kinds["myapp:run"])
-	}
-}
-
-func TestLoadEntriesFromModuleLoadPaths_ResolvesLegacyAliasRequirementByModuleMeta(t *testing.T) {
-	ctx := setupTestContext(t)
-	logger := zap.NewNop()
-	tmpDir := t.TempDir()
-
-	moduleDir := filepath.Join(tmpDir, "module")
-	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
-		t.Fatalf("mkdir module dir: %v", err)
-	}
-	moduleYAML := `version: "1.0"
-namespace: userspace
-entries:
-  - name: public_router
-    kind: ns.requirement
-    targets:
-      - entry: login.endpoint
-        path: meta.router
-  - name: login.endpoint
-    kind: http.endpoint
-    meta:
-      router: public_router
-`
-	if err := os.WriteFile(filepath.Join(moduleDir, "_index.yaml"), []byte(moduleYAML), 0o644); err != nil {
-		t.Fatalf("write module _index.yaml: %v", err)
-	}
-
-	appDir := filepath.Join(tmpDir, "app")
-	if err := os.MkdirAll(appDir, 0o755); err != nil {
-		t.Fatalf("mkdir app dir: %v", err)
-	}
-	appYAML := `version: "1.0"
-namespace: app.deps
-entries:
-  - name: users
-    kind: ns.dependency
-    component: userspace/users
-    parameters:
-      - name: public_router
-        value: app:api.public
-`
-	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(appYAML), 0o644); err != nil {
-		t.Fatalf("write app _index.yaml: %v", err)
-	}
-
-	flatEntries, err := LoadEntriesFromPaths(ctx, []string{appDir, moduleDir}, logger)
-	if err != nil {
-		t.Fatalf("LoadEntriesFromPaths failed: %v", err)
-	}
-
-	routerFlat := ""
-	for _, entry := range flatEntries {
-		if entry.ID.String() != "userspace:login.endpoint" {
-			continue
-		}
-		routerFlat = entry.Meta.GetString("router", "")
-	}
-	if routerFlat != "public_router" {
-		t.Fatalf("flat load router = %q, want unresolved alias", routerFlat)
-	}
-
-	moduleAwareEntries, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
-		{Path: appDir},
-		{Path: moduleDir, Module: "userspace/users", Version: "1.0.0"},
-	}, logger)
-	if err != nil {
-		t.Fatalf("LoadEntriesFromModuleLoadPaths failed: %v", err)
-	}
-
-	routerResolved := ""
-	for _, entry := range moduleAwareEntries {
-		if entry.ID.String() != "userspace:login.endpoint" {
-			continue
-		}
-		routerResolved = entry.Meta.GetString("router", "")
-	}
-	if routerResolved != "app:api.public" {
-		t.Fatalf("module-aware load router = %q, want app:api.public", routerResolved)
 	}
 }
 
@@ -1443,16 +1457,21 @@ func TestNormalizeEntries_PreLinkOverrideAffectsRequirementDefaults(t *testing.T
 func TestNormalizeEntries_PostLinkOverrideWinsFinalValue(t *testing.T) {
 	ctx := setupTestContext(t)
 	cfg := boot.NewConfig(boot.WithSection("override", map[string]any{
-		"userspace.user:login.endpoint:meta.router": "app:api.final",
+		"identity.account:login.endpoint:meta.router": "app:api.final",
 	}))
 	ctx = boot.WithConfig(ctx, cfg)
 
 	items := []regapi.Entry{
 		{
-			ID:   regapi.NewID("app.deps", "users"),
+			ID:   regapi.NewID("identity.account", "definition"),
+			Kind: regapi.NamespaceDefinition,
+			Meta: map[string]any{"module": "example/accounts"},
+		},
+		{
+			ID:   regapi.NewID("app.deps", "accounts"),
 			Kind: regapi.NamespaceDependency,
 			Data: payload.New(map[string]any{
-				"component": "userspace/users",
+				"component": "example/accounts",
 				"parameters": []any{
 					map[string]any{
 						"name":  "public_router",
@@ -1462,8 +1481,9 @@ func TestNormalizeEntries_PostLinkOverrideWinsFinalValue(t *testing.T) {
 			}),
 		},
 		{
-			ID:   regapi.NewID("userspace.user", "public_router"),
+			ID:   regapi.NewID("identity.account", "public_router"),
 			Kind: regapi.NamespaceRequirement,
+			Meta: map[string]any{"module": "example/accounts"},
 			Data: payload.New(map[string]any{
 				"targets": []any{
 					map[string]any{
@@ -1474,11 +1494,11 @@ func TestNormalizeEntries_PostLinkOverrideWinsFinalValue(t *testing.T) {
 			}),
 		},
 		{
-			ID:   regapi.NewID("userspace.user", "login.endpoint"),
+			ID:   regapi.NewID("identity.account", "login.endpoint"),
 			Kind: "http.endpoint",
 			Meta: map[string]any{
 				"router": "public_router",
-				"module": "userspace/users",
+				"module": "example/accounts",
 			},
 			Data: payload.New(map[string]any{
 				"path":   "/user/token",
@@ -1494,7 +1514,7 @@ func TestNormalizeEntries_PostLinkOverrideWinsFinalValue(t *testing.T) {
 
 	got := ""
 	for _, entry := range items {
-		if entry.ID.String() == "userspace.user:login.endpoint" {
+		if entry.ID.String() == "identity.account:login.endpoint" {
 			got = entry.Meta.GetString("router", "")
 			break
 		}

--- a/cmd/wippy/cmd/load_entries_test.go
+++ b/cmd/wippy/cmd/load_entries_test.go
@@ -28,13 +28,13 @@ func TestLoadEntriesFromLockPaths_NilLock(t *testing.T) {
 	}
 }
 
-func TestLoadEntriesFromLockPaths_ResolvesLegacyAliasRequirementByModuleMeta(t *testing.T) {
+func TestLoadEntriesFromLockPaths_ResolvesDeclaredModuleNamespace(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	logger := zap.NewNop()
 	tmpDir := t.TempDir()
 
 	appDir := filepath.Join(tmpDir, "app")
-	moduleDir := filepath.Join(tmpDir, ".wippy", "vendor", "userspace", "users")
+	moduleDir := filepath.Join(tmpDir, ".wippy", "vendor", "example", "accounts")
 
 	if err := os.MkdirAll(appDir, 0o755); err != nil {
 		t.Fatalf("mkdir app dir: %v", err)
@@ -46,9 +46,9 @@ func TestLoadEntriesFromLockPaths_ResolvesLegacyAliasRequirementByModuleMeta(t *
 	appYAML := `version: "1.0"
 namespace: app.deps
 entries:
-  - name: users
+  - name: accounts
     kind: ns.dependency
-    component: userspace/users
+    component: example/accounts
     parameters:
       - name: public_router
         value: app:api.public
@@ -58,8 +58,10 @@ entries:
 	}
 
 	moduleYAML := `version: "1.0"
-namespace: userspace
+namespace: identity.account
 entries:
+  - name: definition
+    kind: ns.definition
   - name: public_router
     kind: ns.requirement
     targets:
@@ -84,7 +86,7 @@ entries:
 		Src:     "app",
 	})
 	lockObj.SetModule(lock.Module{
-		Name:    "userspace/users",
+		Name:    "example/accounts",
 		Version: "v1.0.0",
 	})
 	if err := lockObj.Write(); err != nil {
@@ -100,7 +102,7 @@ entries:
 	module := ""
 	moduleVersion := ""
 	for _, entry := range loaded {
-		if entry.ID.String() != "userspace:login.endpoint" {
+		if entry.ID.String() != "identity.account:login.endpoint" {
 			continue
 		}
 		router = entry.Meta.GetString("router", "")
@@ -111,8 +113,8 @@ entries:
 	if router != "app:api.public" {
 		t.Fatalf("router = %q, want app:api.public", router)
 	}
-	if module != "userspace/users" {
-		t.Fatalf("module = %q, want userspace/users", module)
+	if module != "example/accounts" {
+		t.Fatalf("module = %q, want example/accounts", module)
 	}
 	if moduleVersion != "v1.0.0" {
 		t.Fatalf("module_version = %q, want v1.0.0", moduleVersion)

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -35,6 +35,7 @@ type Reg struct {
 	stateIndex        map[registry.ID]int
 	depIndex          *topology.DepIndex
 	log               *zap.Logger
+	baseline          registry.State
 	state             registry.State
 	versionNum        atomic.Uint64
 	applyMu           sync.Mutex
@@ -354,16 +355,14 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	if err != nil {
 		return err
 	}
+	targetState, err := r.stateAtVersion(ctx, targetVersion)
+	if err != nil {
+		return err
+	}
 
 	r.log.Debug("resolving version transition",
 		zap.Uint("from", currentVersionID),
 		zap.Uint("to", targetVersion.ID()))
-
-	changeset, err := r.collectTransitionChangesets(baseVersion, targetVersion)
-	if err != nil {
-		return err
-	}
-	canonicalizeChangeSetIDs(changeset)
 
 	var (
 		allOps           registry.ChangeSet
@@ -385,8 +384,7 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			return NewExpandChangesError(errors.New("stored dependency resolution has no configured reconciler"))
 		}
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
-		stateMap := topology.NewStateMap(snapshot)
-		applyStateOperations(stateMap, changeset)
+		stateMap := topology.NewStateMap(targetState)
 		reconciled := false
 		for _, directive := range r.directivesByKind[registry.NamespaceDependency] {
 			result, ok, reconcileErr := reconcileStoredResolution(ctx, directive, snapshot, topology.StateMapToSlice(stateMap), targetResolution)
@@ -426,80 +424,54 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		}
 	} else if len(r.directivesByKind) > 0 {
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
-
-		plan, err := planner.Expand(ctx, changeset, snapshot)
-		if err != nil {
-			return NewExpandChangesError(err)
+		stateMap := topology.NewStateMap(targetState)
+		declarations := topology.StateMapToSlice(stateMap)
+		for _, entry := range declarations {
+			if targetResolution != nil && entry.Kind == registry.NamespaceDependency {
+				continue // One dependency expansion resolves the complete root graph.
+			}
+			if len(r.directivesByKind[entry.Kind]) == 0 {
+				continue
+			}
+			intermediate := topology.StateMapToSlice(stateMap)
+			plan, expandErr := planner.Expand(ctx, registry.ChangeSet{{Kind: registry.EntryUpdate, Entry: entry}}, intermediate)
+			if expandErr != nil {
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewExpandChangesError(expandErr)
+			}
+			if !plan.Expanded {
+				continue
+			}
+			plan.Ops, expandErr = planner.SortOps(intermediate, plan.Ops)
+			if expandErr != nil {
+				planner.RollbackEffects(ctx, plan.Effects)
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewSortChangesError(expandErr)
+			}
+			ops, _ := plan.SplitScopes()
+			prepared, prepareErr := planner.PrepareEffects(ctx, plan.Effects)
+			if prepareErr != nil {
+				planner.RollbackEffects(ctx, prepared)
+				planner.RollbackEffects(ctx, preparedEff)
+				return NewPrepareEffectsError(prepareErr)
+			}
+			preparedEff = append(preparedEff, prepared...)
+			if plan.Resolution != nil {
+				targetResolution = plan.Resolution.Canonical()
+			}
+			applyStateOperations(stateMap, ops)
 		}
-
-		plan.Ops, err = planner.SortOps(snapshot, plan.Ops)
-		if err != nil {
-			planner.RollbackEffects(ctx, plan.Effects)
-			return NewSortChangesError(err)
-		}
-
-		allOps, _ = plan.SplitScopes()
-		if plan.Resolution != nil {
-			targetResolution = plan.Resolution.Canonical()
-		}
-		preparedEff, err = planner.PrepareEffects(ctx, plan.Effects)
+		allOps, err = r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
 		if err != nil {
 			planner.RollbackEffects(ctx, preparedEff)
-			return NewPrepareEffectsError(err)
-		}
-
-		// A legacy target may change only unrelated declarations even though its
-		// final state still contains dependency roots. Resolve that final root set
-		// once so the target can be checkpointed instead of inheriting whatever
-		// derived modules happen to be present in the source state.
-		if targetResolution == nil {
-			stateMap := topology.NewStateMap(snapshot)
-			applyStateOperations(stateMap, allOps)
-			declarations := topology.StateMapToSlice(stateMap)
-			for _, entry := range declarations {
-				if entry.Kind != registry.NamespaceDependency {
-					continue
-				}
-				intermediate := topology.StateMapToSlice(stateMap)
-				rootPlan, expandErr := planner.Expand(ctx, registry.ChangeSet{{Kind: registry.EntryUpdate, Entry: entry}}, intermediate)
-				if expandErr != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-					return NewExpandChangesError(expandErr)
-				}
-				if rootPlan.Resolution == nil {
-					planner.RollbackEffects(ctx, rootPlan.Effects)
-					continue
-				}
-				rootPlan.Ops, expandErr = planner.SortOps(intermediate, rootPlan.Ops)
-				if expandErr != nil {
-					planner.RollbackEffects(ctx, rootPlan.Effects)
-					planner.RollbackEffects(ctx, preparedEff)
-					return NewSortChangesError(expandErr)
-				}
-				rootOps, _ := rootPlan.SplitScopes()
-				rootPrepared, prepareErr := planner.PrepareEffects(ctx, rootPlan.Effects)
-				if prepareErr != nil {
-					planner.RollbackEffects(ctx, rootPrepared)
-					planner.RollbackEffects(ctx, preparedEff)
-					return NewPrepareEffectsError(prepareErr)
-				}
-				preparedEff = append(preparedEff, rootPrepared...)
-				applyStateOperations(stateMap, rootOps)
-				targetResolution = rootPlan.Resolution.Canonical()
-				allOps, expandErr = r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
-				if expandErr != nil {
-					planner.RollbackEffects(ctx, preparedEff)
-					return NewComputeTransitionError(expandErr)
-				}
-				break
-			}
+			return NewComputeTransitionError(err)
 		}
 	} else {
-		sorted, err := r.builder.SortChangeSet(snapshot, changeset)
+		delta, err := r.builder.BuildDelta(snapshot, targetState)
 		if err != nil {
-			return NewSortChangesError(err)
+			return NewComputeTransitionError(err)
 		}
-		allOps = sorted
+		allOps = delta
 	}
 
 	resolutionHeadCAS, supportsAtomicResolutionHead := r.history.(registry.ResolutionHeadCASHistory)
@@ -598,6 +570,42 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 	return nil
 }
 
+// stateAtVersion composes the immutable deployment baseline with the authored
+// history at target. Live version selection must use the same authority model
+// as cold boot; reversing operations against the expanded resident state can
+// otherwise delete baseline entries hidden by an overlay.
+func (r *Reg) stateAtVersion(ctx context.Context, target registry.Version) (registry.State, error) {
+	stateMap := topology.NewStateMap(r.baseline)
+	if target == nil || target.ID() == registry.RootVersion {
+		return topology.StateMapToSlice(stateMap), nil
+	}
+	apply := func(changes registry.ChangeSet) error {
+		canonicalizeChangeSetIDs(changes)
+		applyStateOperations(stateMap, changes)
+		return nil
+	}
+	if replayer, ok := r.history.(registry.ChangeSetReplayer); ok {
+		if err := replayer.ReplayChanges(ctx, target, apply); err != nil {
+			return nil, NewGetChangesetError(target.ID(), err)
+		}
+		return topology.StateMapToSlice(stateMap), nil
+	}
+	var lineage []registry.Version
+	for current := target; current != nil && current.ID() > registry.RootVersion; current = current.Previous() {
+		lineage = append(lineage, current)
+	}
+	for i := len(lineage) - 1; i >= 0; i-- {
+		changes, err := r.history.Get(lineage[i])
+		if err != nil {
+			return nil, NewGetChangesetError(lineage[i].ID(), err)
+		}
+		if err := apply(changes); err != nil {
+			return nil, err
+		}
+	}
+	return topology.StateMapToSlice(stateMap), nil
+}
+
 func compareAndSetHistoryHead(history registry.History, expected, target registry.Version) error {
 	if expected == nil {
 		return history.SetHead(target)
@@ -627,59 +635,6 @@ func (r *Reg) findStoredVersion(v registry.Version) (registry.Version, error) {
 		}
 	}
 	return nil, NewVersionNotFoundError(v.ID())
-}
-
-// collectTransitionChangesets builds a source-to-target transition from parent
-// edges. Numeric version IDs are allocation order only; they do not tell us
-// whether two versions are ancestors or siblings on different branches.
-func (r *Reg) collectTransitionChangesets(source, target registry.Version) (registry.ChangeSet, error) {
-	if source == nil || target == nil {
-		return nil, NewComputePathError(0, 0, ErrNoCommonAncestor)
-	}
-
-	sourceAncestors := make(map[uint]registry.Version)
-	for current := source; current != nil; current = current.Previous() {
-		sourceAncestors[current.ID()] = current
-	}
-
-	var (
-		commonAncestor registry.Version
-		targetTail     []registry.Version
-	)
-	for current := target; current != nil; current = current.Previous() {
-		if ancestor, ok := sourceAncestors[current.ID()]; ok {
-			commonAncestor = ancestor
-			break
-		}
-		targetTail = append(targetTail, current)
-	}
-	if commonAncestor == nil {
-		return nil, NewComputePathError(source.ID(), target.ID(), ErrNoCommonAncestor)
-	}
-
-	changesets := make([]registry.ChangeSet, 0, len(targetTail)+1)
-	for current := source; current != nil && current.ID() != commonAncestor.ID(); current = current.Previous() {
-		cs, err := r.history.Get(current)
-		if err != nil {
-			return nil, NewGetChangesetError(current.ID(), err)
-		}
-		canonicalizeChangeSetIDs(cs)
-		reversed, err := r.builder.ReverseChangeset(cs)
-		if err != nil {
-			return nil, NewReverseChangesetError(err)
-		}
-		changesets = append(changesets, reversed)
-	}
-	for i := len(targetTail) - 1; i >= 0; i-- {
-		cs, err := r.history.Get(targetTail[i])
-		if err != nil {
-			return nil, NewGetChangesetError(targetTail[i].ID(), err)
-		}
-		canonicalizeChangeSetIDs(cs)
-		changesets = append(changesets, cs)
-	}
-
-	return r.builder.SquashChangesets(changesets), nil
 }
 
 func (r *Reg) collectBackwardChangesets(path []registry.Version, targetVersion registry.Version) (registry.ChangeSet, error) {
@@ -959,6 +914,7 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	}
 
 	r.state = newState
+	r.baseline = append(registry.State(nil), baseline...)
 	r.rebuildIndex()
 	r.rebuildDepIndex()
 	r.currentVersion = targetVersion

--- a/system/registry/version_transition_test.go
+++ b/system/registry/version_transition_test.go
@@ -76,6 +76,91 @@ func (f directiveFunc) Expand(ctx context.Context, op registry.Operation, snap r
 	return f(ctx, op, snap)
 }
 
+type baselineOverlayDirective struct {
+	policyID registry.ID
+}
+
+func (d baselineOverlayDirective) Expand(_ context.Context, op registry.Operation, snapshot registry.State) (registry.DirectiveResult, error) {
+	resolution := (&registry.DependencyResolution{InputDigest: "sha256:test"}).Canonical()
+	result := registry.DirectiveResult{Applied: true, Resolution: resolution}
+	if op.Kind != registry.EntryDelete {
+		for _, entry := range snapshot {
+			if entry.ID == d.policyID {
+				result.Additional = append(result.Additional, registry.ScopedOperation{
+					Operation: registry.Operation{Kind: registry.EntryDelete, Entry: entry},
+					Scope:     registry.ScopeBaseline,
+				})
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (d baselineOverlayDirective) ReconcileResolutionTransition(
+	_ context.Context,
+	_ registry.State,
+	target registry.State,
+	resolution *registry.DependencyResolution,
+) (registry.DirectiveResult, error) {
+	result := registry.DirectiveResult{Applied: true, Resolution: resolution}
+	for _, entry := range target {
+		if entry.Kind != registry.NamespaceDependency {
+			continue
+		}
+		for _, candidate := range target {
+			if candidate.ID == d.policyID {
+				result.Additional = append(result.Additional, registry.ScopedOperation{
+					Operation: registry.Operation{Kind: registry.EntryDelete, Entry: candidate},
+					Scope:     registry.ScopeBaseline,
+				})
+				return result, nil
+			}
+		}
+	}
+	return result, nil
+}
+
+func TestApplyVersion_ComposesTargetHistoryOverImmutableBaseline(t *testing.T) {
+	ctx := context.Background()
+	history := historymem.New()
+	runner := NewTestRunner()
+	policyID := registry.NewID("deployment.security", "admin")
+	directive := baselineOverlayDirective{policyID: policyID}
+	reg := NewRegistry(
+		history,
+		runner,
+		topology.NewStateBuilder(zap.NewNop(), nil),
+		nil,
+		zap.NewNop(),
+		WithKindDirective(registry.NamespaceDependency, directive),
+	)
+	baseline := registry.State{{ID: policyID, Kind: "security.policy", Data: payload.New(true)}}
+	v0 := version.FromParent(nil, registry.RootVersion)
+	require.NoError(t, reg.LoadState(ctx, baseline, v0))
+
+	overlay := registry.Entry{
+		ID: registry.NewID("workspace.packages", "application"), Kind: registry.NamespaceDependency,
+		Data: payload.New(map[string]any{"component": "acme/application", "version": "v2.0.0"}),
+	}
+	v1, err := reg.Apply(ctx, registry.ChangeSet{{Kind: registry.EntryCreate, Entry: overlay}})
+	require.NoError(t, err)
+	_, err = reg.GetEntry(policyID)
+	require.Error(t, err, "fixture overlay must hide the deployment policy")
+
+	require.NoError(t, reg.ApplyVersion(ctx, v0))
+	_, err = reg.GetEntry(policyID)
+	require.NoError(t, err, "undo must reveal the immutable deployment baseline")
+	_, err = reg.GetEntry(overlay.ID)
+	require.Error(t, err)
+
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	_, err = reg.GetEntry(policyID)
+	require.Error(t, err, "redo must reapply the overlay-derived state")
+	_, err = reg.GetEntry(overlay.ID)
+	require.NoError(t, err)
+}
+
 func TestApplyVersion_ForwardWithSquashing(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.NewNop()


### PR DESCRIPTION
## Summary

- preserve explicit deployment-root and user-overlay dependency authority across application updates, rollback, and restart
- compose every version transition from the deployment baseline plus the selected history resolution
- bind dependency parameters through each package's declared `ns.definition` root instead of deriving namespaces from package names
- treat a fully-qualified `namespace:name` parameter as an exact registry requirement address
- keep unpacked/local module loading inside its source boundary by excluding nested `.wippy` runtime state

## Semantic model

- `component` identifies an artifact (`org/module`); it is not a registry namespace.
- The artifact's single root `ns.definition` declares the namespace used for bare requirement parameters.
- Fully-qualified requirement IDs are exact addresses and can intentionally wire another package's public requirement.
- `DependencyRoot` and the persisted resolution graph determine deployment ownership. No namespace, including `app.deps`, is hard-coded as a root.
- Root application entries, user-authored overlay roots, and transitive module entries retain separate provenance.
- Packed modules, unpacked modules, local replacements, live updates, and cold restart use the same source and linking rules.

## Root causes fixed

The live Hub loader previously reloaded root-application dependency declarations as module-owned transitives, stripping root authority. Historical transitions could then compose against stale intermediate graphs instead of the current deployment baseline.

The linker also inferred registry namespaces from package spelling. That breaks valid packages such as a plural artifact exporting a singular namespace and cannot support deliberately unrelated package/namespace names.

Finally, a local replacement rooted at a workspace directory could recursively ingest `.wippy/vendor` as if those dependencies belonged to the replacement module.

## Verification

- `go test ./... -count=1`
- `make lint`
- exact candidate binary: `nightly-20260719-75810d1-9-g8ce6cae21`
- PostgreSQL Kickside history restored at head v7 with 42 roots and 44 resolved modules; HTTP returned 200 after cold restart
- real unpacked `userspace/users` package resolved through its declared `userspace.user:definition` namespace
- focused coverage includes root application update, downgrade/undo/redo, restart replay, user overlays, arbitrary namespaces, exact cross-namespace parameters, packed/unpacked provenance, and nested `.wippy` exclusion

This supersedes #503. Its application-takeover exception is neither needed nor permitted by this model; #502 and #503 remain closed.
