### PR TITLE
fix(run): make Hub deployments restart offline

### DIFF
--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -177,7 +177,15 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 
 	logger.Info("initializing runtime", zap.String("memory_limit", formatBytes(memLimit)))
 
-	cfg, err := loadRuntimeConfig(cmd, logger)
+	// A Hub deployment is restarted from wippy.lock, without resolving the Hub
+	// reference again. Its selected root pack is therefore the same authority
+	// for published runtime defaults as it was on the first run.
+	runtimeDefaults, err := loadLockRootRuntimeDefaults(defaultLockFile, logger)
+	if err != nil {
+		logger.Error("failed to load deployment runtime defaults", zap.Error(err))
+		return err
+	}
+	cfg, err := loadRuntimeConfigWithDefaults(cmd, logger, runtimeDefaults)
 	if err != nil {
 		logger.Error("failed to resolve runtime config", zap.Error(err))
 		return err

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -327,7 +327,7 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 
 		isRoot := m.Org == org && m.Name == module
 		if err := updateLockFile(moduleName, m.Version, m.Digest, isRoot); err != nil {
-			fmt.Printf("%s Warning: could not update lock file for %s: %v\n", dimStyle.Render(""), moduleName, err)
+			return nil, err
 		}
 
 		// A Hub reference is a deployment bootstrap, not a disposable cache run.

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 	bootpkg "github.com/wippyai/runtime/boot"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
+	"github.com/wippyai/runtime/boot/deps/graph"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	"github.com/wippyai/runtime/cmd/internal/banner"
@@ -328,6 +330,14 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 			fmt.Printf("%s Warning: could not update lock file for %s: %v\n", dimStyle.Render(""), moduleName, err)
 		}
 
+		// A Hub reference is a deployment bootstrap, not a disposable cache run.
+		// Materialize every verified pack under the lock's vendor directory so a
+		// subsequent bare `wippy run` is fully local and uses the exact lock graph.
+		packPath, err = materializeHubRunPack(packPath, moduleName, m.Version, m.Digest, m.SizeBytes)
+		if err != nil {
+			return nil, err
+		}
+
 		if m.Org == org && m.Name == module {
 			mainPackPath = packPath
 		} else {
@@ -343,6 +353,70 @@ func downloadHubModule(ctx context.Context, ref string, registryURL string) ([]s
 
 	fmt.Println()
 	return packPaths, nil
+}
+
+func materializeHubRunPack(sourcePath, moduleName, version, digest string, size uint64) (string, error) {
+	lockObj, err := lock.New(defaultLockFile)
+	if err != nil {
+		return "", fmt.Errorf("load deployment lock: %w", err)
+	}
+	name, err := graph.ParseName(moduleName)
+	if err != nil {
+		return "", fmt.Errorf("invalid resolved module %q: %w", moduleName, err)
+	}
+	lockDir := filepath.Dir(lockObj.Path())
+	vendorDir := lock.ResolveLockPath(lockDir, lockObj.GetVendorPath())
+	destination := filepath.Join(vendorDir, lock.WappPath(name, version))
+	if filepath.Clean(sourcePath) == filepath.Clean(destination) {
+		return destination, nil
+	}
+	if err := hub.VerifyDownloadedArtifact(destination, digest, size); err == nil {
+		return destination, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("verify installed %s@%s: %w", moduleName, version, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return "", fmt.Errorf("create deployment vendor directory: %w", err)
+	}
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("open cached %s@%s: %w", moduleName, version, err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(destination), ".hub-run-pack-*")
+	if err != nil {
+		_ = source.Close()
+		return "", fmt.Errorf("stage %s@%s: %w", moduleName, version, err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		_ = source.Close()
+		_ = tmp.Close()
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := io.Copy(tmp, source); err != nil {
+		return "", fmt.Errorf("copy %s@%s into deployment: %w", moduleName, version, err)
+	}
+	if err := source.Close(); err != nil {
+		return "", fmt.Errorf("close cached %s@%s: %w", moduleName, version, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", fmt.Errorf("sync staged %s@%s: %w", moduleName, version, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close staged %s@%s: %w", moduleName, version, err)
+	}
+	if err := hub.VerifyDownloadedArtifact(tmpPath, digest, size); err != nil {
+		return "", fmt.Errorf("verify staged %s@%s: %w", moduleName, version, err)
+	}
+	if err := os.Rename(tmpPath, destination); err != nil {
+		return "", fmt.Errorf("install %s@%s: %w", moduleName, version, err)
+	}
+	committed = true
+	return destination, nil
 }
 
 func ensureHubPackCached(ctx context.Context, client hubPackDownloader, m hub.ResolvedModule, packPath, moduleName, registryURL string) error {

--- a/cmd/wippy/cmd/run_pack_metadata.go
+++ b/cmd/wippy/cmd/run_pack_metadata.go
@@ -37,8 +37,18 @@ func loadLockRootRuntimeDefaults(lockPath string, logger *zap.Logger) (boot.Conf
 		if loadPath.Module != root || !loadPath.Root {
 			continue
 		}
-		if !strings.EqualFold(filepath.Ext(loadPath.Path), ".wapp") {
+		info, statErr := os.Stat(loadPath.Path)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				return nil, fmt.Errorf("selected deployment root %s is not installed; run wippy install", root)
+			}
+			return nil, fmt.Errorf("inspect selected deployment root %s: %w", root, statErr)
+		}
+		if info.IsDir() {
 			return nil, nil
+		}
+		if !info.Mode().IsRegular() || !strings.EqualFold(filepath.Ext(loadPath.Path), ".wapp") {
+			return nil, fmt.Errorf("selected deployment root %s has unsupported artifact %s", root, loadPath.Path)
 		}
 		return loadPackRuntimeDefaults(loadPath.Path, logger)
 	}

--- a/cmd/wippy/cmd/run_pack_metadata.go
+++ b/cmd/wippy/cmd/run_pack_metadata.go
@@ -5,15 +5,45 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/boot/deps/lock"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
 
 const runtimeMetadataPrefix = "runtime."
+
+// loadLockRootRuntimeDefaults reads published host configuration from the
+// selected deployment root. Hub bootstrap and offline lock restart therefore
+// share one configuration authority; dependency packs never configure the host.
+func loadLockRootRuntimeDefaults(lockPath string, logger *zap.Logger) (boot.Config, error) {
+	lockObj, err := lock.New(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("load deployment lock %s: %w", lockPath, err)
+	}
+	roots := lockObj.GetRootModules()
+	if len(roots) == 0 {
+		return nil, nil
+	}
+	if len(roots) != 1 {
+		return nil, fmt.Errorf("deployment lock must select exactly one root module")
+	}
+	root := roots[0]
+	for _, loadPath := range lockObj.GetModuleLoadPaths() {
+		if loadPath.Module != root || !loadPath.Root {
+			continue
+		}
+		if !strings.EqualFold(filepath.Ext(loadPath.Path), ".wapp") {
+			return nil, nil
+		}
+		return loadPackRuntimeDefaults(loadPath.Path, logger)
+	}
+	return nil, fmt.Errorf("selected deployment root %s is not installed; run wippy install", root)
+}
 
 // loadPackRuntimeDefaults reads runtime defaults from a single pack metadata.
 func loadPackRuntimeDefaults(packPath string, logger *zap.Logger) (boot.Config, error) {

--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -44,6 +44,17 @@ func TestLoadLockRootRuntimeDefaults(t *testing.T) {
 	require.True(t, resolved.GetBool("registry.enabled", false))
 }
 
+func TestLoadLockRootRuntimeDefaultsRejectsMissingSelectedPack(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), defaultLockFile)
+	lockObj, err := lock.New(lockPath)
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{Name: "acme/app", Version: "1.2.3", Root: true})
+	require.NoError(t, lockObj.Write())
+
+	_, err = loadLockRootRuntimeDefaults(lockPath, zap.NewNop())
+	require.ErrorContains(t, err, "selected deployment root acme/app is not installed")
+}
+
 func TestMaterializeHubRunPackInstallsExactLockArtifact(t *testing.T) {
 	projectDir := t.TempDir()
 	previousDir, err := os.Getwd()

--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,10 +12,67 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/boot/deps/config"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/runtime/cmd/internal/bootconfig"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
+
+func TestLoadLockRootRuntimeDefaults(t *testing.T) {
+	projectDir := t.TempDir()
+	lockPath := filepath.Join(projectDir, defaultLockFile)
+	lockObj, err := lock.New(lockPath)
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{Name: "acme/app", Version: "1.2.3", Root: true})
+	require.NoError(t, lockObj.Write())
+
+	packPath := filepath.Join(projectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(packPath), 0o755))
+	require.NoError(t, writeTestPack(packPath, wapp.Metadata{
+		"runtime.profiles.postgres.registry.history_type": "postgres",
+		"runtime.profiles.postgres.registry.enabled":      true,
+	}))
+
+	defaults, err := loadLockRootRuntimeDefaults(lockPath, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, defaults)
+	resolved, err := configForProfile(defaults, "postgres")
+	require.NoError(t, err)
+	require.Equal(t, "postgres", resolved.GetString("registry.history_type", ""))
+	require.True(t, resolved.GetBool("registry.enabled", false))
+}
+
+func TestMaterializeHubRunPackInstallsExactLockArtifact(t *testing.T) {
+	projectDir := t.TempDir()
+	previousDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(projectDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(previousDir)) })
+
+	source := filepath.Join(t.TempDir(), "app.wapp")
+	require.NoError(t, writeTestPack(source, wapp.Metadata{"name": "app"}))
+	content, err := os.ReadFile(source)
+	require.NoError(t, err)
+	sum := sha256.Sum256(content)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	destination, err := materializeHubRunPack(source, "acme/app", "1.2.3", digest, uint64(len(content)))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(projectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), destination)
+	installed, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	require.Equal(t, content, installed)
+
+	second, err := materializeHubRunPack(source, "acme/app", "1.2.3", digest, uint64(len(content)))
+	require.NoError(t, err)
+	require.Equal(t, destination, second)
+}
+
+func configForProfile(defaults boot.Config, profile string) (boot.Config, error) {
+	return bootconfig.ApplyProfiles(defaults, []string{profile})
+}
 
 func TestRuntimeConfigFromPackMetadata_DottedKeys(t *testing.T) {
 	cfg := runtimeConfigFromPackMetadata(wapp.Metadata{


### PR DESCRIPTION
## Summary

- materialize every verified Hub-run pack under the project-local vendor directory recorded by `wippy.lock`
- run the first launch from those exact local artifacts instead of the disposable global cache paths
- load published runtime defaults and named profiles from the lock-selected root pack during bare `wippy run`

## Root cause

`wippy run org/module@version` wrote `wippy.lock` while leaving downloaded packs only in the global cache. Bare `wippy run` later loaded the lock vendor directory, where those artifacts did not exist. It also resolved configuration without the selected root pack metadata, so named profiles from a published application failed before entry loading.

## Contract

A Hub reference bootstraps a local deployment. Once the lock is written, that deployment restarts from the exact locked project-local artifacts without Hub resolution or download. The single lock-selected root pack is the only package allowed to contribute published host runtime defaults; dependency packs cannot configure the host.

There is no version scan, namespace convention, or cache fallback.

## Verification

- `go test ./cmd/wippy/cmd -count=1`
- unit coverage for exact artifact materialization and lock-root profile loading
- PostgreSQL Hub boot → live root package update → bare offline restart lifecycle (in progress on the stacked release candidate)