### PR TITLE
fix(registry): preserve module provenance on updates

### DIFF
--- a/boot/deps/hub/root_application_update_test.go
+++ b/boot/deps/hub/root_application_update_test.go
@@ -206,6 +206,20 @@ modules:
 	require.Equal(t, "v1.0.0", resolutionModuleVersion(v0Resolution, "acme/app"),
 		"the durable baseline graph must include its lock-selected root module")
 
+	// Keeper updates dependency data and intentionally omits loader-owned
+	// provenance. The registry must retain that provenance in both live state
+	// and history; otherwise the next sibling/root update compares an ownerless
+	// declaration with the root application's materialized entry and conflicts.
+	installedWorker, err := reg.GetEntry(workerRootID)
+	require.NoError(t, err)
+	workerUpdate := installedWorker
+	workerUpdate.Meta = nil
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: workerUpdate}})
+	require.NoError(t, err)
+	installedWorker, err = reg.GetEntry(workerRootID)
+	require.NoError(t, err)
+	require.Equal(t, "acme/app", entryModule(installedWorker))
+
 	overlayRoot := regapi.Entry{
 		ID: regapi.NewID("deployment.packages", "application"), Kind: regapi.NamespaceDependency,
 		Data: payload.New(map[string]any{"component": "acme/app", "version": "v2.0.0"}),

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/internal/version"
 	regexp "github.com/wippyai/runtime/system/registry/expansion"
@@ -165,6 +166,7 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 	baseVersion = r.currentVersion
 	resolution = r.currentResolution
 	r.mu.RUnlock()
+	changes = preserveManagedEntryMetadata(changes, snapshot)
 
 	if len(r.directivesByKind) > 0 {
 		planner = regexp.NewPlanner(r.directivesByKind, r.resolver, r.log.Named("expansion"))
@@ -310,6 +312,48 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 		}
 	}
 	return r.currentVersion, nil
+}
+
+// preserveManagedEntryMetadata keeps registry-owned provenance stable when a
+// caller updates an entry's declarative data. These fields are attached by the
+// module loader and dependency linker; omitting them from an update payload
+// must not turn an installed entry into an unowned host entry.
+func preserveManagedEntryMetadata(changes registry.ChangeSet, snapshot registry.State) registry.ChangeSet {
+	const (
+		moduleKey        = "module"
+		moduleVersionKey = "module_version"
+		moduleDigestKey  = "module_digest"
+	)
+	managedKeys := [...]string{moduleKey, moduleVersionKey, moduleDigestKey}
+	state := make(registry.StateMap, len(snapshot)+len(changes))
+	for _, entry := range snapshot {
+		state[entry.ID] = entry
+	}
+	for i := range changes {
+		op := &changes[i]
+		switch op.Kind {
+		case registry.EntryCreate:
+			state[op.Entry.ID] = op.Entry
+		case registry.EntryUpdate:
+			existing, ok := state[op.Entry.ID]
+			if ok {
+				meta := attrs.NewBagFrom(op.Entry.Meta)
+				for _, key := range managedKeys {
+					if _, supplied := meta[key]; supplied {
+						continue
+					}
+					if value, present := existing.Meta[key]; present {
+						meta[key] = value
+					}
+				}
+				op.Entry.Meta = meta
+			}
+			state[op.Entry.ID] = op.Entry
+		case registry.EntryDelete:
+			delete(state, op.Entry.ID)
+		}
+	}
+	return changes
 }
 
 // patchDepIndex folds committed ops back into the inverse-dependency index so

--- a/system/registry/registry_test.go
+++ b/system/registry/registry_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/boot/loader"
@@ -31,6 +32,32 @@ import (
 	historynil "github.com/wippyai/runtime/system/registry/history/nil"
 	"github.com/wippyai/runtime/system/registry/topology"
 )
+
+func TestPreserveManagedEntryMetadata(t *testing.T) {
+	id := registry.NewID("app.deps", "core")
+	snapshot := registry.State{{
+		ID: id, Kind: registry.NamespaceDependency,
+		Meta: attrs.NewBagFrom(map[string]any{
+			"module": "acme/app", "module_version": "1.0.0", "module_digest": "sha256:old", "title": "Old",
+		}),
+		Data: payload.New(map[string]any{"component": "acme/core", "version": "1.0.0"}),
+	}}
+	changes := registry.ChangeSet{{
+		Kind: registry.EntryUpdate,
+		Entry: registry.Entry{
+			ID: id, Kind: registry.NamespaceDependency,
+			Meta: attrs.NewBagFrom(map[string]any{"title": "New"}),
+			Data: payload.New(map[string]any{"component": "acme/core", "version": "2.0.0"}),
+		},
+	}}
+
+	got := preserveManagedEntryMetadata(changes, snapshot)
+	require.Len(t, got, 1)
+	require.Equal(t, "acme/app", got[0].Entry.Meta.GetString("module", ""))
+	require.Equal(t, "1.0.0", got[0].Entry.Meta.GetString("module_version", ""))
+	require.Equal(t, "sha256:old", got[0].Entry.Meta.GetString("module_digest", ""))
+	require.Equal(t, "New", got[0].Entry.Meta.GetString("title", ""))
+}
 
 // MockRunner is a mock implementation of the registry.process interface for testing.
 type MockRunner struct {


### PR DESCRIPTION
## Summary

- preserve registry-managed `module`, `module_version`, and `module_digest` metadata when an `entry.update` omits those fields
- preserve provenance against a rolling state for multi-operation changesets
- cover the real sequential root-update shape in the root application lifecycle test

## Root cause

PR #504 correctly made the lock-selected root application participate in dependency reconciliation. That exposed an inconsistent update shape: cold loading attributes root application entries to the root module, but Keeper's dependency update payload intentionally contains only declarative dependency data and no loader-managed metadata.

The first root dependency update therefore replaced an entry such as `app.deps:kickside_hub` with an ownerless copy. The next sibling update re-materialized the root application, produced the correctly owned entry, and failed with:

```
entry "app.deps:kickside_hub" conflicts: owned by "", wanted by "kickside/kickside"
```

Registry-managed provenance is not user-authored entry data. Omitting it from an update must preserve the existing values. Explicitly supplied metadata remains authoritative, so real ownership conflicts are still rejected.

## Verification

- `go test ./system/registry/...`
- `go test ./boot/deps/hub/...`
- fresh Kickside application from Hub using the patched binary
- Hub `0.1.38 -> 0.1.37`, then Core `0.1.28 -> 0.1.27`
- Hub and Core updated back in the opposite sibling sequence
- root application `0.1.100 -> 0.1.99 -> 0.1.100`
- server restart with root overlay persisted
- after restart, a Hub update followed by a Core update both succeeded

This PR contains no package, Keeper, WASM, or application changes.
