### PR TITLE
fix(deps): resolve unversioned replacements against hub releases

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1568,11 +1568,10 @@ func validModuleIdentifier(value string) bool {
 	return true
 }
 
-// replacementManifestProvider resolves locally-replaced modules from their lock
-// replacement instead of the Hub. A replaced module's source of truth is local,
-// so it must never be re-fetched from the Hub during live changeset expansion —
-// otherwise installing any module fails when an already-installed, locally-sourced
-// module is absent from the Hub. Non-replaced modules delegate to the base provider.
+// replacementManifestProvider loads entries and declared dependencies from a
+// local replacement tree. A replacement with no explicit source version still
+// delegates release availability to the Hub; a satisfying lock avoids that call.
+// Non-replaced modules delegate to the base provider.
 type replacementManifestProvider struct {
 	base           ManifestProvider
 	handler        *DependencyHandler
@@ -1580,32 +1579,50 @@ type replacementManifestProvider struct {
 	lockedDigests  map[string]string
 }
 
-func (p *replacementManifestProvider) replacedVersion(name, constraint string) string {
-	if version := p.lockedVersions[name]; version != "" {
-		return version
-	}
+// replacementVersion returns the version whose local source tree should be
+// loaded. An explicit source version is authoritative. Otherwise the resolver's
+// exact selection is authoritative; the lock is only a checkpoint for requests
+// that do not already name a selected release.
+func (p *replacementManifestProvider) replacementVersion(name, constraint string) string {
 	if version := p.handler.replacementModuleVersion(name); version != "" {
 		return version
 	}
-	return strings.TrimPrefix(constraint, "@")
+	if isExactModuleVersion(constraint) {
+		return constraint
+	}
+	return p.lockedVersions[name]
+}
+
+func isExactModuleVersion(value string) bool {
+	_, err := hubsemver.ParseVersion(strings.TrimSpace(value))
+	return err == nil
 }
 
 func (p *replacementManifestProvider) GetManifest(ctx context.Context, org, module, constraint string) (*ModuleManifest, error) {
 	name := org + "/" + module
 	if path, ok := p.handler.replacementPath(name); ok {
-		if version := p.replacedVersion(name, constraint); version != "" {
-			dependencies, err := p.localReplacementDependencies(ctx, path)
+		version := p.replacementVersion(name, constraint)
+		if version == "" {
+			// Labels do not identify a concrete release. Ask the Hub only to
+			// resolve the label, then keep the local replacement tree as the
+			// content and dependency source of truth.
+			manifest, err := p.base.GetManifest(ctx, org, module, constraint)
 			if err != nil {
 				return nil, err
 			}
-			return &ModuleManifest{
-				Org:          org,
-				Name:         module,
-				Version:      version,
-				Digest:       p.lockedDigests[name+"@"+version],
-				Dependencies: dependencies,
-			}, nil
+			version = manifest.Version
 		}
+		dependencies, err := p.localReplacementDependencies(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		return &ModuleManifest{
+			Org:          org,
+			Name:         module,
+			Version:      version,
+			Digest:       p.lockedDigests[name+"@"+version],
+			Dependencies: dependencies,
+		}, nil
 	}
 	return p.base.GetManifest(ctx, org, module, constraint)
 }
@@ -1699,9 +1716,13 @@ func loadReplacementEntries(
 func (p *replacementManifestProvider) ListAllVersions(ctx context.Context, org, module string) ([]VersionInfo, error) {
 	name := org + "/" + module
 	if _, ok := p.handler.replacementPath(name); ok {
-		if version := p.replacedVersion(name, ""); version != "" {
+		// An explicit source version is the complete candidate set. Without
+		// one, the local tree supplies bytes but the Hub remains authoritative
+		// for which released versions are available to satisfy live ranges.
+		if version := p.handler.replacementModuleVersion(name); version != "" {
 			return []VersionInfo{{Version: version}}, nil
 		}
+		return p.base.ListAllVersions(ctx, org, module)
 	}
 	return p.base.ListAllVersions(ctx, org, module)
 }

--- a/boot/deps/hub/replacement_version_selection_test.go
+++ b/boot/deps/hub/replacement_version_selection_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
+)
+
+const replacementCRMSpec = "spiralscout/crm"
+
+func newReplacementProvider(t *testing.T, version string, base ManifestProvider, locked string) *replacementManifestProvider {
+	t.Helper()
+
+	path := t.TempDir()
+	if version != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(path, "wippy.yaml"), []byte("version: "+version+"\n"), 0o600))
+	}
+
+	return &replacementManifestProvider{
+		base: base,
+		handler: &DependencyHandler{
+			logger: zap.NewNop(),
+			replacements: map[string]lock.Replacement{
+				replacementCRMSpec: {From: replacementCRMSpec, To: path},
+			},
+		},
+		lockedVersions: map[string]string{replacementCRMSpec: locked},
+	}
+}
+
+func crmReplacementRoots(constraints ...string) []DependencySpec {
+	roots := make([]DependencySpec, 0, len(constraints))
+	for _, constraint := range constraints {
+		roots = append(roots, DependencySpec{Org: "spiralscout", Name: "crm", Constraint: constraint})
+	}
+	return roots
+}
+
+func TestReplacementManifestProvider_UnversionedSourceUsesHubCandidatesWhenLockDoesNotSatisfy(t *testing.T) {
+	base := newFakeProvider()
+	base.addModule("spiralscout", "crm", "0.1.44")
+	base.addModule("spiralscout", "crm", "0.1.49")
+	provider := newReplacementProvider(t, "", base, "0.1.44")
+
+	result, err := Resolve(newTestContext(), provider, crmReplacementRoots("*", ">=0.1.17", ">=0.1.49"), &ResolveOptions{
+		LockedVersions: map[string]string{replacementCRMSpec: "0.1.44"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Modules, 1)
+	assert.Equal(t, "0.1.49", result.Modules[0].Version)
+	assert.Equal(t, 1, base.listAllVersion[replacementCRMSpec])
+	assert.Zero(t, base.getManifest[replacementCRMSpec], "the local source supplies the resolved manifest")
+}
+
+func TestReplacementManifestProvider_LockRemainsAuthoritativeWhenItSatisfies(t *testing.T) {
+	base := newFakeProvider()
+	base.addModule("spiralscout", "crm", "0.1.44")
+	base.addModule("spiralscout", "crm", "0.1.49")
+	provider := newReplacementProvider(t, "", base, "0.1.44")
+
+	result, err := Resolve(newTestContext(), provider, crmReplacementRoots("*", ">=0.1.17"), &ResolveOptions{
+		LockedVersions: map[string]string{replacementCRMSpec: "0.1.44"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Modules, 1)
+	assert.Equal(t, "0.1.44", result.Modules[0].Version)
+	assert.Zero(t, base.listAllVersion[replacementCRMSpec], "a satisfying lock must not resolve through the Hub")
+	assert.Zero(t, base.getManifest[replacementCRMSpec])
+}
+
+func TestReplacementManifestProvider_ExplicitSourceVersionDoesNotDelegateCandidates(t *testing.T) {
+	base := newFakeProvider()
+	base.addModule("spiralscout", "crm", "0.1.44")
+	base.addModule("spiralscout", "crm", "0.1.49")
+	provider := newReplacementProvider(t, "0.1.44", base, "0.1.44")
+
+	result, err := Resolve(newTestContext(), provider, crmReplacementRoots(">=0.1.49"), &ResolveOptions{
+		LockedVersions: map[string]string{replacementCRMSpec: "0.1.44"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Modules)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Message, "no available version of spiralscout/crm")
+	assert.NotContains(t, result.Errors[0].Message, "conflicting version constraints")
+	assert.Zero(t, base.listAllVersion[replacementCRMSpec], "an explicit local version is authoritative")
+	assert.Zero(t, base.getManifest[replacementCRMSpec])
+}
+
+func TestReplacementManifestProvider_UnversionedSourceUsesHubCandidatesForSelection(t *testing.T) {
+	base := newFakeProvider()
+	base.addModule("spiralscout", "crm", "0.1.44")
+	base.addModule("spiralscout", "crm", "0.1.48")
+	provider := newReplacementProvider(t, "", base, "0.1.44")
+
+	result, err := Resolve(context.Background(), provider, crmReplacementRoots(">=0.1.17", ">=0.1.49"), &ResolveOptions{
+		LockedVersions: map[string]string{replacementCRMSpec: "0.1.44"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Modules)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Message, "no available version of spiralscout/crm")
+	assert.Contains(t, result.Errors[0].Message, ">=0.1.17")
+	assert.Contains(t, result.Errors[0].Message, ">=0.1.49")
+	assert.NotContains(t, result.Errors[0].Message, "conflicting version constraints")
+}

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -417,7 +417,7 @@ func (r *resolver) resolveIntersection(ctx context.Context, org, name string, co
 	for _, c := range constraints {
 		p, err := semver.ParseConstraint(c)
 		if err != nil {
-			return "", fmt.Errorf("invalid constraint %q: %w", c, err)
+			return "", fmt.Errorf("%w: %q", errConstraintsIncompatible, c)
 		}
 		parsed = append(parsed, p)
 	}

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -66,10 +66,14 @@ func Resolve(ctx context.Context, provider ManifestProvider, roots []DependencyS
 	}, nil
 }
 
-// errConstraintsIncompatible marks a live constraint set that no available
-// version can satisfy simultaneously. The resolver reports it as a conflict
-// error naming the module and every requester.
+// errConstraintsIncompatible marks constraints that cannot be interpreted
+// together (for example, a label mixed with a semantic-version range).
 var errConstraintsIncompatible = errors.New("constraints incompatible")
+
+// errNoAvailableVersion marks a valid live constraint set for which the
+// provider has no published candidate. This is deliberately distinct from an
+// incompatible constraint expression: a newer release may make it resolvable.
+var errNoAvailableVersion = errors.New("no available version satisfies constraints")
 
 // resolver resolves a dependency graph to a fixpoint. Every constraint and every
 // dependency edge is tagged with its source (a root slot or a parent@version), so
@@ -394,7 +398,8 @@ func (r *resolver) resolveVersion(ctx context.Context, org, name string, live []
 }
 
 // resolveIntersection selects the highest available version satisfying every
-// constraint, or errConstraintsIncompatible when none does.
+// constraint, or errNoAvailableVersion when the provider has no matching
+// candidate.
 //
 // The constraints are matched individually rather than concatenated into one
 // string and reparsed: the parser caps a constraint at maxConstraintParts, a
@@ -447,7 +452,7 @@ func (r *resolver) resolveIntersection(ctx context.Context, org, name string, co
 		return best.Version, nil
 	}
 
-	return "", errConstraintsIncompatible
+	return "", errNoAvailableVersion
 }
 
 // matchesAll reports whether a version satisfies every constraint.
@@ -494,6 +499,15 @@ func (r *resolver) resolutionError(key string, live []string, err error) Resolut
 			Message:    r.conflictMessage(key),
 		}
 	}
+	if errors.Is(err, errNoAvailableVersion) {
+		return ResolutionError{
+			Err:        err,
+			Org:        org,
+			Name:       name,
+			Constraint: strings.Join(live, ", "),
+			Message:    r.availabilityMessage(key),
+		}
+	}
 	return ResolutionError{
 		Err:        err,
 		Org:        org,
@@ -503,9 +517,19 @@ func (r *resolver) resolutionError(key string, live []string, err error) Resolut
 	}
 }
 
+// availabilityMessage names the module and each requester whose valid ranges
+// need a release the provider does not currently offer.
+func (r *resolver) availabilityMessage(key string) string {
+	return r.demandMessage(key, "no available version of")
+}
+
 // conflictMessage names the module and each requester's constraint in deterministic
 // order.
 func (r *resolver) conflictMessage(key string) string {
+	return r.demandMessage(key, "conflicting version constraints for")
+}
+
+func (r *resolver) demandMessage(key, prefix string) string {
 	type demand struct {
 		source     string
 		constraint string
@@ -522,7 +546,7 @@ func (r *resolver) conflictMessage(key string) string {
 	})
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "conflicting version constraints for %s: ", key)
+	fmt.Fprintf(&b, "%s %s: ", prefix, key)
 	for i, d := range demands {
 		if i > 0 {
 			b.WriteString(", ")
@@ -691,7 +715,7 @@ func (r *resolver) resolveConstraint(ctx context.Context, org, name, constraint 
 
 	best, err := parsed.FindBestMatch(semverVersions)
 	if err != nil {
-		return "", fmt.Errorf("no version matching %q", constraint)
+		return "", fmt.Errorf("%w: %s", errNoAvailableVersion, constraint)
 	}
 
 	for _, iv := range indexed {

--- a/boot/deps/hub/resolve_test.go
+++ b/boot/deps/hub/resolve_test.go
@@ -787,13 +787,17 @@ func TestResolve_LabelWithDivergentSemverConflicts(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	hasConflict := false
+	var conflict *ResolutionError
 	for _, e := range result.Errors {
 		if e.Name == "x" {
-			hasConflict = true
+			conflict = &e
+			break
 		}
 	}
-	assert.True(t, hasConflict, "label vs divergent semver is not deterministically intersectable")
+	require.NotNil(t, conflict, "label vs divergent semver is not deterministically intersectable")
+	assert.Contains(t, conflict.Message, "conflicting version constraints for acme/x")
+	assert.Contains(t, conflict.Message, "@latest")
+	assert.Contains(t, conflict.Message, "^1.0.0")
 }
 
 func TestResolve_MaxDepthEnforcedAgainstLiveDepthAfterRetraction(t *testing.T) {

--- a/boot/deps/hub/resolve_test.go
+++ b/boot/deps/hub/resolve_test.go
@@ -328,7 +328,8 @@ func TestResolve_NoMatchingVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.Modules)
 	require.Len(t, result.Errors, 1)
-	assert.Contains(t, result.Errors[0].Message, "no version matching")
+	assert.Contains(t, result.Errors[0].Message, "no available version of acme/lib")
+	assert.NotContains(t, result.Errors[0].Message, "conflicting version constraints")
 }
 
 func TestResolve_PartialSuccess(t *testing.T) {
@@ -1141,9 +1142,9 @@ func TestResolve_ManyParentsWithCompatibleRanges(t *testing.T) {
 	t.Fatal("wippy/dataflow was not resolved at all")
 }
 
-// A genuinely unsatisfiable set must still be reported as a conflict: matching
-// each constraint individually must not turn an incompatibility into a resolve.
-func TestResolve_IncompatibleRangesStillConflict(t *testing.T) {
+// A valid but unsatisfied range set is an availability failure, not a parser
+// conflict. Publishing a compatible release may make it resolvable.
+func TestResolve_IncompatibleRangesReportAvailability(t *testing.T) {
 	p := newFakeProvider()
 	p.addModule("acme", "alpha", "1.0.0", ManifestDep{
 		Org: "wippy", Name: "dataflow", Version: "0.4.31", Constraint: ">=v0.4.10 <v0.5.0",
@@ -1161,6 +1162,7 @@ func TestResolve_IncompatibleRangesStillConflict(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, result.Errors, "no version satisfies both ranges; this must conflict")
-	assert.Contains(t, result.Errors[0].Message, "conflicting version constraints")
+	require.NotEmpty(t, result.Errors, "no version satisfies both ranges")
+	assert.Contains(t, result.Errors[0].Message, "no available version of wippy/dataflow")
+	assert.NotContains(t, result.Errors[0].Message, "conflicting version constraints")
 }


### PR DESCRIPTION
## Summary
- keep a satisfying deployment lock authoritative for local replacements
- let an unversioned local replacement use Hub release candidates when the live graph needs a newer compatible version
- keep local source entries and dependencies authoritative, while labeling the local manifest with the resolver-selected exact release
- distinguish a valid range set with no available release from a constraint-expression conflict

## Regression coverage
- stale `0.1.44` lock plus `>=0.1.49` selects `0.1.49` from Hub candidates while loading the local source
- satisfying lock makes no Hub candidate request
- explicit local source version does not delegate candidate selection
- no compatible published release reports availability rather than a false version conflict

## Validation
- `go test ./boot/deps/hub -count=1`
- `go test ./boot/deps/... -count=1`
- `go test ./boot/... -count=1`

No merge or release is included.