### PR TITLE
feat(http): support method-agnostic endpoints

### DIFF
--- a/api/service/http/config.go
+++ b/api/service/http/config.go
@@ -27,6 +27,9 @@ const (
 	// Static identifies a static file server component
 	Static registry.Kind = "http.static"
 
+	// MethodAny registers an endpoint for every HTTP method.
+	MethodAny = "*"
+
 	// ServerID is the key used to identify the server in configuration metadata
 	ServerID string = "server"
 	// RouterID is the key used to identify the router in configuration metadata
@@ -112,7 +115,7 @@ type (
 	EndpointConfig struct {
 		Meta   attrs.Bag   `json:"meta"`   // Metadata, todo: migrate to avoid use of this
 		Path   string      `json:"path"`   // URL path
-		Method string      `json:"method"` // Timeouts method
+		Method string      `json:"method"` // HTTP method, or MethodAny for every method
 		Func   registry.ID `json:"func"`   // Func function
 	}
 
@@ -310,7 +313,7 @@ func (c *EndpointConfig) Validate() error {
 	}
 
 	switch c.Method {
-	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete,
+	case MethodAny, http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete,
 		http.MethodPatch, http.MethodHead, http.MethodOptions, http.MethodTrace:
 	default:
 		return NewInvalidHTTPMethodError(c.Method)

--- a/api/service/http/config_test.go
+++ b/api/service/http/config_test.go
@@ -337,6 +337,18 @@ func TestEndpointConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid method-agnostic config",
+			config: EndpointConfig{
+				Meta: attrs.Bag{
+					RouterID: "test-router",
+				},
+				Path:   "/{path...}",
+				Method: "*",
+				Func:   registry.NewID("default", "test_handler"),
+			},
+			wantErr: false,
+		},
+		{
 			name: "empty path",
 			config: EndpointConfig{
 				Meta: attrs.Bag{

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -143,11 +143,14 @@ func (rm *RouteManager) AddRoute(routerID registry.ID, id registry.ID, method, p
 	// Validate method
 	method = strings.ToUpper(method)
 	switch method {
-	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete,
+	case httpapi.MethodAny, http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete,
 		http.MethodPatch, http.MethodHead, http.MethodOptions, http.MethodTrace:
 		// Valid method
 	default:
 		return httpapi.NewInvalidHTTPMethodError(method)
+	}
+	if method == httpapi.MethodAny {
+		method = ""
 	}
 
 	// Validate path
@@ -355,7 +358,7 @@ func (rm *RouteManager) Build() error {
 			allPatterns = append(allPatterns, patternEntry{handler, pattern})
 
 			// Auto-generate OPTIONS handler so CORS middleware can intercept preflight
-			if route.method != "OPTIONS" {
+			if route.method != "" && route.method != http.MethodOptions {
 				optionsPattern := buildPattern("OPTIONS", routerEntry.prefix, route.path)
 				if !registeredOptions[optionsPattern] {
 					optionsHandler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -462,6 +465,9 @@ func buildPattern(method, prefix, path string) string {
 
 	// Build full path
 	fullPath := prefix + path
+	if method == "" {
+		return fullPath
+	}
 
 	return method + " " + fullPath
 }

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -413,7 +413,8 @@ func extractParamNames(path string) []string {
 		if ch == '{' {
 			start = i + 1
 		} else if ch == '}' && start >= 0 {
-			names = append(names, path[start:i])
+			name := path[start:i]
+			names = append(names, strings.TrimSuffix(name, "..."))
 			start = -1
 		}
 	}

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -263,7 +263,7 @@ func (rm *RouteManager) Unmount(path string) error {
 
 // Build rebuilds the entire router from the current configuration
 func (rm *RouteManager) Build() error {
-	// Collect all patterns first to check for conflicts
+	// Collect all patterns before constructing the replacement mux.
 	type patternEntry struct {
 		handler http.Handler
 		pattern string

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -260,71 +261,6 @@ func (rm *RouteManager) Unmount(path string) error {
 	return nil
 }
 
-// patternSegments parses a pattern into method and path segments for conflict detection
-type patternSegments struct {
-	method   string
-	segments []string
-	isWild   []bool // true if segment is a wildcard like {id}
-}
-
-func parsePattern(pattern string) patternSegments {
-	parts := strings.SplitN(pattern, " ", 2)
-	method := parts[0]
-	path := "/"
-	if len(parts) > 1 {
-		path = parts[1]
-	}
-
-	segs := strings.Split(strings.Trim(path, "/"), "/")
-	isWild := make([]bool, len(segs))
-	for i, seg := range segs {
-		isWild[i] = strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}")
-	}
-
-	return patternSegments{method: method, segments: segs, isWild: isWild}
-}
-
-// patternsConflict checks if two patterns can match overlapping paths without one being more specific
-func patternsConflict(a, b patternSegments) bool {
-	if a.method != b.method {
-		return false
-	}
-	if len(a.segments) != len(b.segments) {
-		return false
-	}
-
-	// Check if patterns can match same paths
-	canOverlap := true
-	for i := range a.segments {
-		aLit := !a.isWild[i]
-		bLit := !b.isWild[i]
-		if aLit && bLit && a.segments[i] != b.segments[i] {
-			canOverlap = false
-			break
-		}
-	}
-	if !canOverlap {
-		return false
-	}
-
-	// Check if one is strictly more specific
-	aMoreSpecific := false
-	bMoreSpecific := false
-	for i := range a.segments {
-		if !a.isWild[i] && b.isWild[i] {
-			aMoreSpecific = true
-		}
-		if a.isWild[i] && !b.isWild[i] {
-			bMoreSpecific = true
-		}
-	}
-
-	// No conflict if exactly one is strictly more specific (ServeMux handles precedence)
-	// Conflict only if both have specificity in different segments (ambiguous)
-	// or neither has specificity (identical wildcard patterns)
-	return aMoreSpecific == bMoreSpecific
-}
-
 // Build rebuilds the entire router from the current configuration
 func (rm *RouteManager) Build() error {
 	// Collect all patterns first to check for conflicts
@@ -375,34 +311,30 @@ func (rm *RouteManager) Build() error {
 		}
 	}
 
-	// Check for conflicts before registering
-	var conflicts []string
-	parsed := make([]patternSegments, len(allPatterns))
-	for i, p := range allPatterns {
-		parsed[i] = parsePattern(p.pattern)
-	}
-
-	for i := 0; i < len(parsed); i++ {
-		for j := i + 1; j < len(parsed); j++ {
-			if patternsConflict(parsed[i], parsed[j]) {
-				conflicts = append(conflicts, allPatterns[i].pattern+" conflicts with "+allPatterns[j].pattern)
-			}
-		}
-	}
-
-	if len(conflicts) > 0 {
-		return NewRouteConflictsError(conflicts)
-	}
-
-	// Register all patterns
+	// Let ServeMux apply its complete method, path, wildcard, and subtree
+	// precedence rules. Convert registration panics into configuration errors so
+	// an invalid route set cannot crash the process during a rebuild.
 	mux := http.NewServeMux()
 	for _, p := range allPatterns {
-		mux.Handle(p.pattern, p.handler)
+		if err := registerPattern(mux, p.pattern, p.handler); err != nil {
+			return err
+		}
 	}
 
 	var h http.Handler = mux
 	rm.router.Store(&h)
 
+	return nil
+}
+
+func registerPattern(mux *http.ServeMux, pattern string, handler http.Handler) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = NewRouteConflictsError([]string{fmt.Sprint(recovered)})
+		}
+	}()
+
+	mux.Handle(pattern, handler)
 	return nil
 }
 

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -418,6 +418,14 @@ func (w *benchmarkResponseWriter) Write(body []byte) (int, error) {
 func (w *benchmarkResponseWriter) WriteHeader(int) {}
 
 func BenchmarkRouteManagerServeHTTPConcreteCatchAll(b *testing.B) {
+	benchmarkRouteManagerServeHTTPCatchAll(b, http.MethodGet, false)
+}
+
+func BenchmarkRouteManagerServeHTTPMethodAgnosticCatchAll(b *testing.B) {
+	benchmarkRouteManagerServeHTTPCatchAll(b, config.MethodAny, true)
+}
+
+func benchmarkRouteManagerServeHTTPCatchAll(b *testing.B, method string, withStaticMount bool) {
 	rm, err := NewRouteManager()
 	require.NoError(b, err)
 
@@ -426,13 +434,16 @@ func BenchmarkRouteManagerServeHTTPConcreteCatchAll(b *testing.B) {
 	require.NoError(b, rm.AddRoute(
 		routerID,
 		registry.NewID("benchmark", "endpoint"),
-		http.MethodGet,
+		method,
 		"/{path...}",
 		registry.NewID("benchmark", "handler"),
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
 	))
+	if withStaticMount {
+		require.NoError(b, rm.Mount("/app", http.NotFoundHandler()))
+	}
 	require.NoError(b, rm.Build())
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/deep/link", nil)

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -168,6 +168,53 @@ func TestRouteManager_ServeHTTP(t *testing.T) {
 	server.Close()
 }
 
+func TestRouteManager_MethodAgnosticCatchAllCoexistsWithStaticMount(t *testing.T) {
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
+
+	routerID := registry.NewID("test", "router")
+	require.NoError(t, rm.AddRouter(routerID, "", nil, nil))
+	require.NoError(t, rm.AddRoute(
+		routerID,
+		registry.NewID("test", "fallback"),
+		config.MethodAny,
+		"/{path...}",
+		registry.NewID("test", "fallback_handler"),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("dynamic:" + r.Method))
+		}),
+	))
+	require.NoError(t, rm.Mount("/app", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("static"))
+	})))
+	require.NoError(t, rm.Build())
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		expected string
+	}{
+		{name: "GET deep link", method: http.MethodGet, path: "/home", expected: "dynamic:GET"},
+		{name: "POST deep link", method: http.MethodPost, path: "/home", expected: "dynamic:POST"},
+		{name: "OPTIONS deep link", method: http.MethodOptions, path: "/home", expected: "dynamic:OPTIONS"},
+		{name: "extension method deep link", method: "PROPFIND", path: "/home", expected: "dynamic:PROPFIND"},
+		{name: "GET static asset", method: http.MethodGet, path: "/app/main.js", expected: "static"},
+		{name: "POST static asset", method: http.MethodPost, path: "/app/main.js", expected: "static"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), tt.method, tt.path, nil)
+			rm.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tt.expected, rec.Body.String())
+		})
+	}
+}
+
 func TestRouteManager_MultipleRouters(t *testing.T) {
 	rm, err := NewRouteManager()
 	require.NoError(t, err)

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -489,6 +489,10 @@ func BenchmarkRouteManagerServeHTTPConcreteCatchAll(b *testing.B) {
 }
 
 func BenchmarkRouteManagerServeHTTPMethodAgnosticCatchAll(b *testing.B) {
+	benchmarkRouteManagerServeHTTPCatchAll(b, config.MethodAny, false)
+}
+
+func BenchmarkRouteManagerServeHTTPMethodAgnosticCatchAllWithStaticMount(b *testing.B) {
 	benchmarkRouteManagerServeHTTPCatchAll(b, config.MethodAny, true)
 }
 

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -5,6 +5,7 @@ package http
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -213,6 +214,40 @@ func TestRouteManager_MethodAgnosticCatchAllCoexistsWithStaticMount(t *testing.T
 			assert.Equal(t, tt.expected, rec.Body.String())
 		})
 	}
+}
+
+func TestRouteManager_BuildReturnsMethodAgnosticConflicts(t *testing.T) {
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
+
+	routerID := registry.NewID("test", "router")
+	require.NoError(t, rm.AddRouter(routerID, "", nil, nil))
+	require.NoError(t, rm.AddRoute(
+		routerID,
+		registry.NewID("test", "index"),
+		config.MethodAny,
+		"/index.html",
+		registry.NewID("test", "index_handler"),
+		http.NotFoundHandler(),
+	))
+	require.NoError(t, rm.AddRoute(
+		routerID,
+		registry.NewID("test", "get_fallback"),
+		http.MethodGet,
+		"/{path...}",
+		registry.NewID("test", "fallback_handler"),
+		http.NotFoundHandler(),
+	))
+
+	var buildErr error
+	require.NotPanics(t, func() {
+		buildErr = rm.Build()
+	})
+	require.Error(t, buildErr)
+
+	var apiErr apierror.Error
+	require.ErrorAs(t, buildErr, &apiErr)
+	assert.Equal(t, apierror.Conflict, apiErr.Kind())
 }
 
 func TestRouteManager_MultipleRouters(t *testing.T) {
@@ -453,6 +488,32 @@ func benchmarkRouteManagerServeHTTPCatchAll(b *testing.B, method string, withSta
 	b.ResetTimer()
 	for b.Loop() {
 		rm.ServeHTTP(&w, req)
+	}
+}
+
+func BenchmarkRouteManagerBuild(b *testing.B) {
+	rm, err := NewRouteManager()
+	require.NoError(b, err)
+
+	routerID := registry.NewID("benchmark", "router")
+	require.NoError(b, rm.AddRouter(routerID, "", nil, nil))
+	for i := range 100 {
+		require.NoError(b, rm.AddRoute(
+			routerID,
+			registry.NewID("benchmark", fmt.Sprintf("endpoint_%d", i)),
+			http.MethodGet,
+			fmt.Sprintf("/routes/%d/{id}", i),
+			registry.NewID("benchmark", "handler"),
+			http.NotFoundHandler(),
+		))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := rm.Build(); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -216,6 +216,38 @@ func TestRouteManager_MethodAgnosticCatchAllCoexistsWithStaticMount(t *testing.T
 	}
 }
 
+func TestRouteManager_RestWildcardRouteInfoUsesDeclaredName(t *testing.T) {
+	rm, err := NewRouteManager()
+	require.NoError(t, err)
+
+	routerID := registry.NewID("test", "router")
+	require.NoError(t, rm.AddRouter(routerID, "", nil, nil))
+
+	var capturedPath string
+	require.NoError(t, rm.AddRoute(
+		routerID,
+		registry.NewID("test", "fallback"),
+		config.MethodAny,
+		"/{path...}",
+		registry.NewID("test", "fallback_handler"),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			routeInfo, ok := config.GetRouteInfo(r.Context())
+			require.True(t, ok)
+			capturedPath = routeInfo.Params["path"]
+			w.WriteHeader(http.StatusOK)
+		}),
+	))
+	require.NoError(t, rm.Build())
+
+	ctx, _ := contextapi.OpenFrameContext(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/projects/42/settings", nil)
+	rm.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "projects/42/settings", capturedPath)
+}
+
 func TestRouteManager_BuildReturnsMethodAgnosticConflicts(t *testing.T) {
 	rm, err := NewRouteManager()
 	require.NoError(t, err)

--- a/service/http/router_test.go
+++ b/service/http/router_test.go
@@ -356,6 +356,48 @@ func TestRouteManager_RouteUpdates(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+type benchmarkResponseWriter struct {
+	header http.Header
+}
+
+func (w *benchmarkResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *benchmarkResponseWriter) Write(body []byte) (int, error) {
+	return len(body), nil
+}
+
+func (w *benchmarkResponseWriter) WriteHeader(int) {}
+
+func BenchmarkRouteManagerServeHTTPConcreteCatchAll(b *testing.B) {
+	rm, err := NewRouteManager()
+	require.NoError(b, err)
+
+	routerID := registry.NewID("benchmark", "router")
+	require.NoError(b, rm.AddRouter(routerID, "", nil, nil))
+	require.NoError(b, rm.AddRoute(
+		routerID,
+		registry.NewID("benchmark", "endpoint"),
+		http.MethodGet,
+		"/{path...}",
+		registry.NewID("benchmark", "handler"),
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	))
+	require.NoError(b, rm.Build())
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/deep/link", nil)
+	w := benchmarkResponseWriter{header: make(http.Header)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		rm.ServeHTTP(&w, req)
+	}
+}
+
 func testGet(t *testing.T, url string) (*http.Response, error) {
 	t.Helper()
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)


### PR DESCRIPTION
## Summary
<!-- bigpowers-provenance: agent-generated -->

- support explicit quoted `method: "*"` on `http.endpoint`
- register method-agnostic endpoints as methodless `net/http.ServeMux` patterns so dynamic SPA fallbacks coexist with static submounts
- skip synthetic `OPTIONS` registration for all-method endpoints
- convert `ServeMux` registration panics into structured route-conflict errors
- expose `{path...}` rest wildcard values through route parameters

Jira: https://jira.spiralscout.com/browse/EE2-2329

## Verification

- [x] `TMPDIR=/private/tmp/wippy-tests make test`
- [x] `TMPDIR=/private/tmp/wippy-tests make lint`
- [x] `go test ./api/service/http ./service/http -race -count=1`
- [x] independent adversarial review completed with no remaining findings

## Performance

- method-agnostic and concrete catch-all routing both remain at 80 B/op and 5 allocs/op
- 100-route rebuild median improved from 457.6 µs/op to 178.2 µs/op
- rebuild allocations improved from 3,589 to 2,988 allocs/op
