### PR TITLE
fix(exec): close() reaps the child process instead of leaving a zombie

### DIFF
--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -56,7 +56,7 @@ const reapGrace = 10 * time.Second
 //
 // Wait is the only call that releases the child's entry in the OS process
 // table. close() deliberately puts the handle beyond the caller's reach, so
-// unless the reap happens here it never happens at all: the child is signalled,
+// unless the reap happens here it never happens at all: the child is signaled,
 // exits, and remains a zombie for the lifetime of the runtime -- one per
 // close(), accumulating without bound.
 //
@@ -381,7 +381,7 @@ func procClose(l *lua.LState) int {
 		_ = handle.Signal(int(sig))
 
 		// Only a started process has an OS child to reap; waiting on one that
-		// never ran would just report that. Signalling is left unconditional so
+		// never ran would just report that. Signaling is left unconditional so
 		// close() behaves exactly as it did before.
 		if started {
 			go reapReleased(handle, forceStop)

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"sync"
 	"syscall"
+	"time"
 
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/runtime/resource"
@@ -44,6 +45,48 @@ func NewProcess(ctx context.Context, handle apiexec.Process) *Process {
 	}
 
 	return p
+}
+
+// reapGrace bounds how long a released process may take to exit before it is
+// killed. It only applies to a child that ignores SIGTERM; one that exits
+// normally is reaped as soon as it does.
+const reapGrace = 10 * time.Second
+
+// reapReleased waits on a process whose handle the caller has given up.
+//
+// Wait is the only call that releases the child's entry in the OS process
+// table. close() deliberately puts the handle beyond the caller's reach, so
+// unless the reap happens here it never happens at all: the child is signalled,
+// exits, and remains a zombie for the lifetime of the runtime -- one per
+// close(), accumulating without bound.
+//
+// It runs detached because close() must not block a Lua coroutine on a child
+// that is slow to exit, and it escalates because a goroutine parked forever on
+// an unresponsive child would trade a process leak for a goroutine leak. A
+// child still alive after the grace period is killed, which Wait then observes.
+//
+// Wait closes the stdout and stderr pipes it created. That is inherent to
+// reaping and is the documented consequence of close(): the process is finished
+// with, and its streams along with it.
+func reapReleased(handle apiexec.Process, killed bool) {
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		_ = handle.Wait()
+	}()
+
+	if killed {
+		// The caller already sent SIGKILL; there is nothing to escalate to.
+		<-exited
+		return
+	}
+
+	select {
+	case <-exited:
+	case <-time.After(reapGrace):
+		_ = handle.Signal(int(syscall.SIGKILL))
+		<-exited
+	}
 }
 
 var processMethods = map[string]lua.LGoFunc{
@@ -321,6 +364,7 @@ func procClose(l *lua.LState) int {
 	p.closed = true
 	handle := p.handle
 	p.handle = nil
+	started := p.started
 	cancel := p.cancelCleanup
 	p.cancelCleanup = nil
 	p.mu.Unlock()
@@ -335,6 +379,13 @@ func procClose(l *lua.LState) int {
 			sig = syscall.SIGKILL
 		}
 		_ = handle.Signal(int(sig))
+
+		// Only a started process has an OS child to reap; waiting on one that
+		// never ran would just report that. Signalling is left unconditional so
+		// close() behaves exactly as it did before.
+		if started {
+			go reapReleased(handle, forceStop)
+		}
 	}
 
 	l.Push(lua.LTrue)

--- a/runtime/lua/modules/exec/reap_test.go
+++ b/runtime/lua/modules/exec/reap_test.go
@@ -20,10 +20,10 @@ import (
 // reapProbe records whether the process was waited on, which is the only thing
 // that releases a child's entry in the OS process table.
 type reapProbe struct {
-	mu           sync.Mutex
-	signals      []int
-	waitCalled   int
 	waitReleased chan struct{}
+	signals      []int
+	mu           sync.Mutex
+	waitCalled   int
 	blockWait    bool
 }
 
@@ -85,7 +85,7 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
 	return cond()
 }
 
-// A signalled child that is never waited on stays a zombie for the lifetime of
+// A signaled child that is never waited on stays a zombie for the lifetime of
 // the runtime, and close() is the documented way to stop a process.
 func TestReapReleasedWaitsOnGracefulStop(t *testing.T) {
 	probe := newReapProbe()
@@ -106,7 +106,7 @@ func TestReapReleasedWaitsOnForcedStop(t *testing.T) {
 		t.Fatalf("expected the killed process to be waited on once, got %d", probe.waits())
 	}
 	if sent := probe.sent(); len(sent) != 0 {
-		t.Fatalf("a process the caller already killed must not be signalled again, got %v", sent)
+		t.Fatalf("a process the caller already killed must not be signaled again, got %v", sent)
 	}
 }
 
@@ -149,7 +149,7 @@ func TestClosedProcessIsNotLeftAsZombie(t *testing.T) {
 		t.Skip("sleep not available")
 	}
 
-	cmd := exec.Command("sleep", "30")
+	cmd := exec.CommandContext(t.Context(), "sleep", "30")
 	// Pipes are created the same way the native executor creates them, because
 	// Wait closes them and that interaction is part of what is being checked.
 	stdout, err := cmd.StdoutPipe()
@@ -172,7 +172,7 @@ func TestClosedProcessIsNotLeftAsZombie(t *testing.T) {
 	// in state Z until the parent exits.
 	if !waitFor(t, 15*time.Second, func() bool { return !processExists(pid) }) {
 		if isZombie(pid) {
-			t.Fatalf("process %d was left as a zombie: it was signalled but never reaped", pid)
+			t.Fatalf("process %d was left as a zombie: it was signaled but never reaped", pid)
 		}
 		t.Fatalf("process %d was still present after close and reap", pid)
 	}
@@ -228,7 +228,7 @@ func procStatPath(pid int) string {
 	return "/proc/" + strconv.Itoa(pid) + "/stat"
 }
 
-// The regression this change exists to prevent: close() signalled the child and
+// The regression this change exists to prevent: close() signaled the child and
 // then discarded the handle, after which every method -- wait included -- reports
 // "process is closed". Nothing could reap it, so each close() left a zombie.
 //
@@ -256,7 +256,7 @@ func TestProcessCloseReapsTheChild(t *testing.T) {
 }
 
 // A process that was never started has no OS child to reap, and waiting on one
-// would only report that it never ran. Signalling stays unconditional: this
+// would only report that it never ran. Signaling stays unconditional: this
 // change fixes the leak without altering what close() sends.
 func TestProcessCloseDoesNotReapUnstartedProcess(t *testing.T) {
 	probe := newReapProbe()
@@ -273,7 +273,7 @@ func TestProcessCloseDoesNotReapUnstartedProcess(t *testing.T) {
 	if probe.waits() != 0 {
 		t.Fatalf("an unstarted process must not be waited on, got %d waits", probe.waits())
 	}
-	// Signalling is unchanged from before the fix, so it is still expected here.
+	// Signaling is unchanged from before the fix, so it is still expected here.
 	if sent := probe.sent(); len(sent) != 1 || sent[0] != int(syscall.SIGTERM) {
 		t.Fatalf("expected close to signal as it always has, got %v", sent)
 	}

--- a/runtime/lua/modules/exec/reap_test.go
+++ b/runtime/lua/modules/exec/reap_test.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+// reapProbe records whether the process was waited on, which is the only thing
+// that releases a child's entry in the OS process table.
+type reapProbe struct {
+	mu           sync.Mutex
+	signals      []int
+	waitCalled   int
+	waitReleased chan struct{}
+	blockWait    bool
+}
+
+func newReapProbe() *reapProbe {
+	return &reapProbe{waitReleased: make(chan struct{})}
+}
+
+func (r *reapProbe) Start() error { return nil }
+
+func (r *reapProbe) Signal(sig int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.signals = append(r.signals, sig)
+	return nil
+}
+
+func (r *reapProbe) WriteStdin(_ []byte) error { return nil }
+
+func (r *reapProbe) Wait() error {
+	r.mu.Lock()
+	r.waitCalled++
+	block := r.blockWait
+	r.mu.Unlock()
+
+	if block {
+		// Stands in for a child that ignores SIGTERM: Wait only returns once
+		// something stronger arrives.
+		<-r.waitReleased
+	}
+	return nil
+}
+
+func (r *reapProbe) Stdout() io.ReadCloser { return io.NopCloser(strings.NewReader("")) }
+func (r *reapProbe) Stderr() io.ReadCloser { return io.NopCloser(strings.NewReader("")) }
+
+func (r *reapProbe) waits() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.waitCalled
+}
+
+func (r *reapProbe) sent() []int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int(nil), r.signals...)
+}
+
+// waitFor polls until cond holds or the deadline passes. The reap is detached
+// from close(), so the assertion has to allow for it landing shortly after.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return cond()
+}
+
+// A signalled child that is never waited on stays a zombie for the lifetime of
+// the runtime, and close() is the documented way to stop a process.
+func TestReapReleasedWaitsOnGracefulStop(t *testing.T) {
+	probe := newReapProbe()
+
+	reapReleased(probe, false)
+
+	if probe.waits() != 1 {
+		t.Fatalf("expected the released process to be waited on once, got %d", probe.waits())
+	}
+}
+
+func TestReapReleasedWaitsOnForcedStop(t *testing.T) {
+	probe := newReapProbe()
+
+	reapReleased(probe, true)
+
+	if probe.waits() != 1 {
+		t.Fatalf("expected the killed process to be waited on once, got %d", probe.waits())
+	}
+	if sent := probe.sent(); len(sent) != 0 {
+		t.Fatalf("a process the caller already killed must not be signalled again, got %v", sent)
+	}
+}
+
+// A child that ignores SIGTERM must not leave the reaper parked forever: that
+// would trade a leaked process for a leaked goroutine.
+func TestReapReleasedEscalatesToKill(t *testing.T) {
+	probe := newReapProbe()
+	probe.blockWait = true
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		reapReleased(probe, false)
+	}()
+
+	// Let the escalation fire, then release the stand-in child as a real one
+	// would be released by SIGKILL.
+	if !waitFor(t, 30*time.Second, func() bool { return len(probe.sent()) > 0 }) {
+		t.Fatal("expected the unresponsive process to be escalated to SIGKILL")
+	}
+
+	sent := probe.sent()
+	if sent[0] != int(syscall.SIGKILL) {
+		t.Fatalf("expected SIGKILL escalation, got signal %d", sent[0])
+	}
+
+	close(probe.waitReleased)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reaper did not return after the process was released")
+	}
+}
+
+// The end the whole change exists for: a real child, stopped through the same
+// path Lua's close() takes, must not be left as a zombie.
+func TestClosedProcessIsNotLeftAsZombie(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not available")
+	}
+
+	cmd := exec.Command("sleep", "30")
+	// Pipes are created the same way the native executor creates them, because
+	// Wait closes them and that interaction is part of what is being checked.
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	defer func() { _ = stdout.Close() }()
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	handle := &cmdProcess{cmd: cmd, stdout: stdout}
+
+	_ = handle.Signal(int(syscall.SIGTERM))
+	go reapReleased(handle, false)
+
+	// A reaped child leaves the process table entirely; an unreaped one lingers
+	// in state Z until the parent exits.
+	if !waitFor(t, 15*time.Second, func() bool { return !processExists(pid) }) {
+		if isZombie(pid) {
+			t.Fatalf("process %d was left as a zombie: it was signalled but never reaped", pid)
+		}
+		t.Fatalf("process %d was still present after close and reap", pid)
+	}
+}
+
+// cmdProcess adapts a plain *exec.Cmd to the process interface so the reaper can
+// be exercised against a real child without standing up an executor.
+type cmdProcess struct {
+	cmd    *exec.Cmd
+	stdout io.ReadCloser
+}
+
+func (c *cmdProcess) Start() error { return c.cmd.Start() }
+
+func (c *cmdProcess) Signal(sig int) error {
+	if c.cmd.Process == nil {
+		return nil
+	}
+	return c.cmd.Process.Signal(syscall.Signal(sig))
+}
+
+func (c *cmdProcess) WriteStdin(_ []byte) error { return nil }
+func (c *cmdProcess) Wait() error               { return c.cmd.Wait() }
+func (c *cmdProcess) Stdout() io.ReadCloser     { return c.stdout }
+func (c *cmdProcess) Stderr() io.ReadCloser     { return io.NopCloser(strings.NewReader("")) }
+
+var _ execapi.Process = (*cmdProcess)(nil)
+
+// processExists reports whether the pid is still in the process table at all,
+// zombie or otherwise.
+func processExists(pid int) bool {
+	_, err := os.Stat(procStatPath(pid))
+	return err == nil
+}
+
+// isZombie reads the process state field from /proc. A reaped child has no entry
+// at all; an unreaped one lingers in state Z.
+func isZombie(pid int) bool {
+	data, err := os.ReadFile(procStatPath(pid))
+	if err != nil {
+		return false
+	}
+	// The comm field may contain spaces, so the state follows the final ')'.
+	stat := string(data)
+	idx := strings.LastIndex(stat, ")")
+	if idx == -1 || idx+2 >= len(stat) {
+		return false
+	}
+	return stat[idx+2] == 'Z'
+}
+
+func procStatPath(pid int) string {
+	return "/proc/" + strconv.Itoa(pid) + "/stat"
+}
+
+// The regression this change exists to prevent: close() signalled the child and
+// then discarded the handle, after which every method -- wait included -- reports
+// "process is closed". Nothing could reap it, so each close() left a zombie.
+//
+// This drives procClose exactly as the Lua binding does, so it fails against the
+// unfixed implementation.
+func TestProcessCloseReapsTheChild(t *testing.T) {
+	probe := newReapProbe()
+	p := &Process{handle: probe, started: true}
+
+	l := setupState()
+	defer l.Close()
+
+	value.PushTypedUserData(l, p, processTypeName)
+	procClose(l)
+
+	if !p.closed {
+		t.Fatal("close should mark the process closed")
+	}
+	if !waitFor(t, 5*time.Second, func() bool { return probe.waits() == 1 }) {
+		t.Fatalf("close must reap the child exactly once, got %d waits", probe.waits())
+	}
+	if sent := probe.sent(); len(sent) != 1 || sent[0] != int(syscall.SIGTERM) {
+		t.Fatalf("expected a single SIGTERM, got %v", sent)
+	}
+}
+
+// A process that was never started has no OS child to reap, and waiting on one
+// would only report that it never ran. Signalling stays unconditional: this
+// change fixes the leak without altering what close() sends.
+func TestProcessCloseDoesNotReapUnstartedProcess(t *testing.T) {
+	probe := newReapProbe()
+	p := &Process{handle: probe, started: false}
+
+	l := setupState()
+	defer l.Close()
+
+	value.PushTypedUserData(l, p, processTypeName)
+	procClose(l)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if probe.waits() != 0 {
+		t.Fatalf("an unstarted process must not be waited on, got %d waits", probe.waits())
+	}
+	// Signalling is unchanged from before the fix, so it is still expected here.
+	if sent := probe.sent(); len(sent) != 1 || sent[0] != int(syscall.SIGTERM) {
+		t.Fatalf("expected close to signal as it always has, got %v", sent)
+	}
+}

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -128,7 +128,27 @@ Returned by `executor:exec()`. Represents a process instance.
 | write_stdin | (data: string) | boolean, error | Writes to process stdin |
 | stdout_stream | () | Stream, error | Returns stdout stream |
 | stderr_stream | () | Stream, error | Returns stderr stream |
-| close | (force?: boolean) | boolean, error | Closes process with signal |
+| close | (force?: boolean) | boolean, error | Signals the process, reaps it, releases the handle |
+
+#### process:close(force?: boolean) → boolean, error
+
+Releases the process. Sends `SIGTERM`, or `SIGKILL` when `force` is true, then
+reaps the child and invalidates the handle.
+
+Reaping is what releases the child's entry in the OS process table; without it a
+stopped process lingers as a zombie for the lifetime of the runtime. It happens
+in the background so `close()` does not block, and a child still running after a
+grace period is killed so the reap always completes.
+
+Because reaping closes the process's stdout and stderr pipes, its streams are
+finished with once it is closed. Read any output you need before calling this.
+
+After `close()` every method on the process, including `wait()`, reports
+`process closed`. Use `signal()` and `wait()` instead when the exit code matters.
+
+**Returns:**
+- Success: `true, nil`
+- Already closed: `true, nil` - closing twice is not an error
 
 #### process:start() → boolean, error
 


### PR DESCRIPTION
## The defect

`procClose` signals the process, then discards the handle:

```go
p.closed = true
handle := p.handle
p.handle = nil      // handle gone
...
_ = handle.Signal(int(sig))   // signalled, never waited on
```

Afterwards every method — `wait()` included — returns `process closed`. `Wait()` is the **only** call in the codebase that reaches `cmd.Wait()`, and therefore the only thing that releases the child's entry in the OS process table. Closing a process puts it permanently out of reach.

Every `close()` leaves a zombie for the lifetime of the runtime. A long-lived supervisor that restarts a child accumulates one per cycle. `userspace/mcp/service/exec.lua` — vendored into harness, memory-threads, be-common-components, userspace-new and others — does exactly this.

Observed in production: a supervised daemon restarted repeatedly left one `[sftpgo] <defunct>` per cycle. Ports, memory and file handles were all released; only the PID entry survived.

## The fix

`close()` reaps in the background after signalling.

- **Detached**, so `close()` never blocks a Lua coroutine on a slow child.
- **Escalates to SIGKILL** after a 10s grace period. A goroutine parked forever on an unresponsive child would trade a process leak for a goroutine leak.
- **Signalling behaviour is unchanged** — only the reap is added, and it is skipped for a process that was never started.
- No interface change: `Signal` and `Wait` are already on `apiexec.Process`, so the Docker executor is covered too.

`Wait` closes the stdout/stderr pipes it created. That is inherent to reaping, so the spec now states it as part of the `close()` contract, and points at `signal()` + `wait()` for callers that need the exit code.

## Proof

The regression test is sensitive to the fix. With the reap call removed:

```
--- FAIL: TestProcessCloseReapsTheChild (5.00s)
    close must reap the child exactly once, got 0 waits
```

With it restored, all pass, including under `-race`.

Six tests cover: graceful stop, forced stop, SIGKILL escalation against an unresponsive child, unstarted-process handling, `procClose` driven exactly as the Lua binding drives it, and a real `sleep` child verified against `/proc/<pid>/stat` for state `Z`.

`go build ./...` clean, `go vet` clean. `runtime/lua/modules/...` and `service/exec/{,docker,native}` all green.