### PR TITLE
feat(excel): add bytes method for workbook

### DIFF
--- a/runtime/lua/modules/excel/module.go
+++ b/runtime/lua/modules/excel/module.go
@@ -111,6 +111,7 @@ var workbookMethods = map[string]lua.LGoFunc{
 	"rows":           workbookRows,
 	"set_cell_value": workbookSetCellValue,
 	"write_to":       workbookWriteTo,
+	"bytes":          workbookBytes,
 	"close":          workbookClose,
 }
 
@@ -334,6 +335,26 @@ func workbookWriteTo(l *lua.LState) int {
 
 	l.Push(lua.LNil)
 	return 1
+}
+
+func workbookBytes(l *lua.LState) int {
+	wb := checkWorkbook(l, 1)
+	if wb == nil {
+		return invalidError(l, "workbook expected")
+	}
+
+	if wb.closed {
+		return internalErrorMsg(l, "workbook is closed")
+	}
+
+	buf, err := wb.file.WriteToBuffer()
+	if err != nil {
+		return internalError(l, err, "write workbook")
+	}
+
+	l.Push(lua.LString(buf.String()))
+	l.Push(lua.LNil)
+	return 2
 }
 
 func workbookClose(l *lua.LState) int {

--- a/runtime/lua/modules/excel/module_test.go
+++ b/runtime/lua/modules/excel/module_test.go
@@ -951,6 +951,62 @@ func TestWorkbook_WriteTo(t *testing.T) {
 	})
 }
 
+func TestWorkbook_Bytes(t *testing.T) {
+	t.Run("returns xlsx bytes", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+
+			wb:new_sheet("TestSheet")
+			wb:set_cell_value("TestSheet", "A1", "Test Data")
+
+			local data, err = wb:bytes()
+			assert(err == nil, "bytes should succeed")
+			assert(type(data) == "string", "data should be a string")
+			assert(#data > 0, "data should not be empty")
+			assert(data:sub(1, 2) == "PK", "data should be a zip archive")
+
+			-- workbook remains usable after bytes()
+			local rows, rows_err = wb:get_rows("TestSheet")
+			assert(rows_err == nil, "workbook should remain usable")
+			assert(rows[1][1] == "Test Data", "cell value should be intact")
+
+			result = data
+			wb:close()
+		`)
+		require.NoError(t, err)
+
+		data := l.GetGlobal("result")
+		require.Equal(t, lua.LTString, data.Type())
+
+		f, err := excelize.OpenReader(bytes.NewReader([]byte(string(data.(lua.LString)))))
+		require.NoError(t, err)
+
+		val, err := f.GetCellValue("TestSheet", "A1")
+		assert.NoError(t, err)
+		assert.Equal(t, "Test Data", val)
+		_ = f.Close()
+	})
+
+	t.Run("closed workbook error", func(t *testing.T) {
+		l := setupTestVM(t)
+		defer l.Close()
+
+		err := l.DoString(`
+			local wb = excel.new()
+			wb:close()
+
+			local data, err = wb:bytes()
+			assert(data == nil, "data should be nil")
+			assert(err ~= nil, "should get error")
+			assert(err:kind() == errors.INTERNAL, "error kind should be INTERNAL")
+		`)
+		assert.NoError(t, err)
+	})
+}
+
 func TestIntegrationWorkflow(t *testing.T) {
 	l := setupTestVM(t)
 	defer l.Close()

--- a/runtime/lua/modules/excel/spec.md
+++ b/runtime/lua/modules/excel/spec.md
@@ -61,6 +61,7 @@ Returned by `excel.new()` and `excel.open()`. Represents an Excel .xlsx workbook
 | rows | (sheet: string) → Rows, error | Streaming cursor | Reads rows incrementally, constant memory |
 | set_cell_value | (sheet: string, cell: string, value: any) → error | - | Sets single cell value |
 | write_to | (writer: File) → error | - | Writes workbook to writer |
+| bytes | () → string, error | xlsx bytes | Serializes workbook to a binary string |
 | close | () → error | - | Closes workbook, releases resources |
 
 #### workbook:new_sheet(name: string) → integer, error
@@ -213,6 +214,28 @@ Writes workbook to a writer object.
 - Writer must be opened for writing before calling
 - Does not close the writer
 - Call `writer:close()` separately after writing
+
+#### workbook:bytes() → string, error
+
+Serializes the workbook to .xlsx and returns it as a binary string. Use this
+instead of `write_to` when the destination is not a filesystem writer (e.g.,
+uploading to object storage or sending over HTTP).
+
+**Returns:**
+- Success: `string, nil` - complete .xlsx file contents
+- Error: `nil, error` - structured error
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| invalid workbook | errors.INVALID | no |
+| workbook closed | errors.INTERNAL | no |
+| write failed | errors.INTERNAL | no |
+
+**Notes:**
+- The whole file is materialized in memory; prefer `write_to` for very large workbooks
+- Does not close the workbook; it remains usable afterwards
 
 #### workbook:close() → error
 

--- a/runtime/lua/modules/excel/types.go
+++ b/runtime/lua/modules/excel/types.go
@@ -21,6 +21,7 @@ var workbookType = typ.NewInterface("excel.Workbook", []typ.Method{
 	{Name: "rows", Type: typ.Func().Param("self", typ.Self).Param("sheet", typ.String).Returns(rowsType, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "set_cell_value", Type: typ.Func().Param("self", typ.Self).Param("sheet", typ.String).Param("cell", typ.String).Param("value", typ.Any).Returns(typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "write_to", Type: typ.Func().Param("self", typ.Self).Param("dest", typ.Any).Returns(typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "bytes", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(typ.LuaError)).Build()},
 })
 

--- a/tests/app/src/test/excel/_index.yaml
+++ b/tests/app/src/test/excel/_index.yaml
@@ -69,6 +69,19 @@ entries:
     imports:
       assert_primitives: app.lib:assert
 
+  - name: bytes
+    kind: function.lua
+    meta:
+      type: test
+      suite: excel
+      description: excel workbook bytes serialization
+    source: file://bytes.lua
+    method: main
+    modules:
+      - excel
+    imports:
+      assert_primitives: app.lib:assert
+
   - name: errors
     kind: function.lua
     meta:

--- a/tests/app/src/test/excel/bytes.lua
+++ b/tests/app/src/test/excel/bytes.lua
@@ -1,0 +1,35 @@
+-- Test: excel workbook bytes serialization
+local assert = require("assert_primitives")
+
+local function main()
+	local excel = require("excel")
+
+	local wb = excel.new()
+	wb:new_sheet("Data")
+	wb:set_cell_value("Data", "A1", "Name")
+	wb:set_cell_value("Data", "B1", "Score")
+	wb:set_cell_value("Data", "A2", "Alice")
+	wb:set_cell_value("Data", "B2", 42)
+
+	-- Serialize to a binary string
+	local data, err = wb:bytes()
+	assert.is_nil(err, "bytes should succeed")
+	assert.is_string(data, "data should be a string")
+	assert.eq(data:sub(1, 2), "PK", "data should be a zip archive (xlsx)")
+	assert.ok(#data > 0, "data should not be empty")
+
+	-- Workbook remains usable after bytes()
+	local rows, rows_err = wb:get_rows("Data")
+	assert.is_nil(rows_err, "workbook should remain usable after bytes")
+	assert.eq(rows[2][1], "Alice", "cell value should be intact")
+
+	-- bytes() on a closed workbook errors
+	wb:close()
+	local data2, err2 = wb:bytes()
+	assert.is_nil(data2, "data should be nil on closed workbook")
+	assert.not_nil(err2, "closed workbook should error")
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/excel/bytes.lua
+++ b/tests/app/src/test/excel/bytes.lua
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: MPL-2.0
+
 -- Test: excel workbook bytes serialization
 local assert = require("assert_primitives")
 

--- a/tests/app/src/test/excel/bytes.lua
+++ b/tests/app/src/test/excel/bytes.lua
@@ -30,6 +30,8 @@ local function main()
 	local data2, err2 = wb:bytes()
 	assert.is_nil(data2, "data should be nil on closed workbook")
 	assert.not_nil(err2, "closed workbook should error")
+	assert.eq(err2:kind(), errors.INTERNAL, "error kind should be INTERNAL")
+	assert.eq(err2:retryable(), false, "error should not be retryable")
 
 	return true
 end


### PR DESCRIPTION
# Reason for This PR

Added the **bytes** method to **workbook**, allowing data retrieval without writing it to a file. Useful for cases where files need to be stored in S3 instead of the local filesystem
