### PR TITLE
test(cli): compare canonical materialized paths

### DIFF
--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -69,9 +69,11 @@ func TestMaterializeHubRunPackInstallsExactLockArtifact(t *testing.T) {
 	sum := sha256.Sum256(content)
 	digest := "sha256:" + hex.EncodeToString(sum[:])
 
+	canonicalProjectDir, err := filepath.EvalSymlinks(projectDir)
+	require.NoError(t, err)
 	destination, err := materializeHubRunPack(source, "acme/app", "1.2.3", digest, uint64(len(content)))
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(projectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), destination)
+	require.Equal(t, filepath.Join(canonicalProjectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), destination)
 	installed, err := os.ReadFile(destination)
 	require.NoError(t, err)
 	require.Equal(t, content, installed)
@@ -79,6 +81,36 @@ func TestMaterializeHubRunPackInstallsExactLockArtifact(t *testing.T) {
 	second, err := materializeHubRunPack(source, "acme/app", "1.2.3", digest, uint64(len(content)))
 	require.NoError(t, err)
 	require.Equal(t, destination, second)
+}
+
+func TestMaterializeHubRunPackCanonicalizesSymlinkWorkingDirectory(t *testing.T) {
+	realProjectDir := t.TempDir()
+	projectAlias := filepath.Join(t.TempDir(), "project")
+	if err := os.Symlink(realProjectDir, projectAlias); err != nil {
+		t.Skipf("symlink fixture unavailable: %v", err)
+	}
+	previousDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(projectAlias))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(previousDir)) })
+
+	source := filepath.Join(t.TempDir(), "app.wapp")
+	require.NoError(t, writeTestPack(source, wapp.Metadata{"name": "app"}))
+	content, err := os.ReadFile(source)
+	require.NoError(t, err)
+	sum := sha256.Sum256(content)
+
+	canonicalProjectDir, err := filepath.EvalSymlinks(realProjectDir)
+	require.NoError(t, err)
+	destination, err := materializeHubRunPack(
+		source,
+		"acme/app",
+		"1.2.3",
+		"sha256:"+hex.EncodeToString(sum[:]),
+		uint64(len(content)),
+	)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(canonicalProjectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), destination)
 }
 
 func configForProfile(defaults boot.Config, profile string) (boot.Config, error) {

--- a/cmd/wippy/cmd/run_pack_metadata_test.go
+++ b/cmd/wippy/cmd/run_pack_metadata_test.go
@@ -73,7 +73,9 @@ func TestMaterializeHubRunPackInstallsExactLockArtifact(t *testing.T) {
 	require.NoError(t, err)
 	destination, err := materializeHubRunPack(source, "acme/app", "1.2.3", digest, uint64(len(content)))
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(canonicalProjectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), destination)
+	canonicalDestination, err := filepath.EvalSymlinks(destination)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(canonicalProjectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), canonicalDestination)
 	installed, err := os.ReadFile(destination)
 	require.NoError(t, err)
 	require.Equal(t, content, installed)
@@ -110,7 +112,9 @@ func TestMaterializeHubRunPackCanonicalizesSymlinkWorkingDirectory(t *testing.T)
 		uint64(len(content)),
 	)
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(canonicalProjectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), destination)
+	canonicalDestination, err := filepath.EvalSymlinks(destination)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(canonicalProjectDir, ".wippy", "vendor", "acme", "app-1.2.3.wapp"), canonicalDestination)
 }
 
 func configForProfile(defaults boot.Config, profile string) (boot.Config, error) {


### PR DESCRIPTION
## Summary
<!-- bigpowers-provenance: agent-generated -->

- make materialized pack path assertions robust to equivalent symlinked working directories
- add an explicit symlink-working-directory regression without requiring a specific `os.Getwd` representation

## Test plan
- [x] focused materialized-pack tests with race and shuffle
- [x] full `cmd/wippy/cmd` package
- [x] harness correctness category: 13,754 passed, 29 skipped, 0 failed