### PR TITLE
test(core): synchronize shutdown deadline precondition

### DIFF
--- a/boot/components/core/core_test.go
+++ b/boot/components/core/core_test.go
@@ -16,21 +16,19 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 	supervisorapi "github.com/wippyai/runtime/api/supervisor"
 	bootpkg "github.com/wippyai/runtime/boot"
+	systemsupervisor "github.com/wippyai/runtime/system/supervisor"
 	"go.uber.org/zap"
 )
 
 type coreManagedService struct {
-	started      chan struct{}
 	stopped      chan struct{}
 	stopDeadline chan time.Time
 	updates      chan any
-	startOne     sync.Once
 	stopOne      sync.Once
 }
 
 func newCoreManagedService() *coreManagedService {
 	return &coreManagedService{
-		started:      make(chan struct{}),
 		stopped:      make(chan struct{}),
 		stopDeadline: make(chan time.Time, 1),
 		updates:      make(chan any),
@@ -38,7 +36,6 @@ func newCoreManagedService() *coreManagedService {
 }
 
 func (s *coreManagedService) Start(context.Context) (<-chan any, error) {
-	s.startOne.Do(func() { close(s.started) })
 	return s.updates, nil
 }
 
@@ -96,6 +93,14 @@ func TestCorePlugins(t *testing.T) {
 	}
 	service := newCoreManagedService()
 	bus := event.GetBus(ctx)
+	stateUpdates := make(chan event.Event, 8)
+	stateSubscriber, err := bus.SubscribeP(
+		runtimeCtx,
+		supervisorapi.System,
+		supervisorapi.ServiceUpdate,
+		stateUpdates,
+	)
+	require.NoError(t, err)
 	bus.Send(runtimeCtx, event.Event{System: registry.System, Kind: registry.TxBegin})
 	bus.Send(runtimeCtx, event.Event{
 		System: supervisorapi.System,
@@ -111,20 +116,21 @@ func TestCorePlugins(t *testing.T) {
 		},
 	})
 	bus.Send(runtimeCtx, event.Event{System: registry.System, Kind: registry.TxCommit})
-	select {
-	case <-service.started:
-	case <-time.After(time.Second):
-		t.Fatal("managed service did not start")
+	startTimeout := time.NewTimer(time.Second)
+	defer startTimeout.Stop()
+serviceRunning:
+	for {
+		select {
+		case update := <-stateUpdates:
+			state, ok := update.Data.(systemsupervisor.State)
+			if update.Path == "test:shutdown" && ok && state.Status == supervisorapi.StatusRunning {
+				break serviceRunning
+			}
+		case <-startTimeout.C:
+			t.Fatal("managed service did not reach running state")
+		}
 	}
-	barrier := make(chan event.Event, 1)
-	_, err = bus.SubscribeP(runtimeCtx, "test", "barrier", barrier)
-	require.NoError(t, err)
-	bus.Send(runtimeCtx, event.Event{System: "test", Kind: "barrier"})
-	select {
-	case <-barrier:
-	case <-time.After(time.Second):
-		t.Fatal("event barrier did not complete")
-	}
+	bus.Unsubscribe(runtimeCtx, stateSubscriber)
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancelShutdown()
 	shutdownDeadline, _ := shutdownCtx.Deadline()

--- a/specs/bugs/BUG-coreplugins-shutdown-sync.md
+++ b/specs/bugs/BUG-coreplugins-shutdown-sync.md
@@ -1,0 +1,49 @@
+# BUG: Core shutdown context test races service startup
+
+## Reproduce
+
+Post-merge Ubuntu CI failed `TestCorePlugins` at `boot/components/core/core_test.go:133`:
+
+```text
+service test:shutdown is starting
+stopping supervisor
+service test:shutdown is failed: context canceled
+Shutdown() error = <nil>, want deadline exceeded
+```
+
+Evidence: <https://github.com/wippyai/runtime/actions/runs/30410867871/job/90446397975>
+
+Environment: Ubuntu runner, Go 1.26.4, `go test ./boot/... -v -race -short`. The same PR-head CI had passed, confirming scheduling sensitivity. A local 500-run race repetition passed, so the CI log is the authoritative reproduction and the defect is classified as a synchronization flake rather than a deterministic platform failure.
+
+## Isolate
+
+The failure is confined to `TestCorePlugins`. The test waited for `coreManagedService.Start` to be entered and then used an unrelated event-bus barrier. Entering `Start` does not prove that `Controller.tryStart` has consumed its return and committed `StatusRunning`. The failed log contains the starting transition but no running transition before shutdown.
+
+Production `Supervisor.StopContext` correctly cancels an in-flight start. In that branch the controller reports `context.Canceled` before the shutdown context expires, so `StopContext` can return nil. The test's deadline oracle is valid only after the service reaches running state and shutdown invokes the blocking `Stop` method.
+
+## Hypotheses
+
+1. **Confirmed candidate:** the test starts shutdown before the controller commits running state. Falsification: wait for the lifecycle supervisor's `ServiceUpdate` payload to report running before shutdown; the deadline must then be observed consistently.
+2. **Rejected:** production loses the shutdown deadline after a running service is stopped. Existing focused supervisor tests and the successful PR CI prove propagation; the failed log never reached running.
+3. **Rejected:** the event bus drops registration or commit events. The failed log proves registration and start dispatch occurred.
+
+## Verify
+
+Root cause: the fixture's `started` channel signaled method entry, while the unrelated barrier could overtake the asynchronous controller transition. Neither synchronized on `StatusRunning`.
+
+A falsification attempt using `ServiceInfo.GetState` failed deterministically because this test creates one supervisor through `All()` and a second through the focused lifecycle loader; the application context intentionally retains the first registered service-info adapter. The lifecycle supervisor's own `ServiceUpdate` event payload is therefore the authoritative synchronization point for this focused loader.
+
+Fix plan: subscribe to supervisor `ServiceUpdate` before registration, wait until the `test:shutdown` event payload reports `StatusRunning`, unsubscribe, then execute the existing 50 ms shutdown deadline oracle. Remove the misleading method-entry signal and unrelated barrier.
+
+Verification completed locally:
+
+- focused test: 500 race-detector repetitions passed;
+- complete `boot/components/core` race suite passed;
+- 100 complete package repetitions passed;
+- canonical `make test`, `go test ./boot/... -race -short`, vet, and lint passed;
+- independent review approved with zero must-fix findings.
+
+Release gates still required:
+
+- Ubuntu and Windows CI on the fix PR;
+- post-merge CI green.


### PR DESCRIPTION
# Reason for This PR

Post-merge Ubuntu CI for https://github.com/wippyai/runtime/pull/531 exposed a scheduling flake in `TestCorePlugins`: the test could begin shutdown after `Service.Start` was entered but before the controller committed `StatusRunning`.

Failure: https://github.com/wippyai/runtime/actions/runs/30410867871/job/90446397975

## Summary
<!-- bigpowers-provenance: agent-generated -->

- subscribe to the lifecycle supervisor's state updates before registration
- wait for the exact `test:shutdown` running transition before exercising shutdown
- remove the method-entry signal and unrelated event barrier that did not order controller state
- preserve the existing deadline propagation, elapsed bound, and cancellation oracles

## Test Plan

- [x] `go test -race ./boot/components/core -run '^TestCorePlugins$' -count=500`
- [x] `go test -race ./boot/components/core`
- [x] `go test ./boot/components/core -count=100`
- [x] `go test ./boot/... -race -short`
- [x] canonical `make test`
- [x] `make lint`
- [x] independent review: approved, zero must-fix findings

## Evidence

- `specs/bugs/BUG-coreplugins-shutdown-sync.md`
- post-merge failure: https://github.com/wippyai/runtime/actions/runs/30410867871
