### PR TITLE
docs(test): close runtime expansion epic

### DIFF
--- a/specs/bugs/BUG-coreplugins-shutdown-sync.md
+++ b/specs/bugs/BUG-coreplugins-shutdown-sync.md
@@ -43,7 +43,8 @@ Verification completed locally:
 - canonical `make test`, `go test ./boot/... -race -short`, vet, and lint passed;
 - independent review approved with zero must-fix findings.
 
-Release gates still required:
+Release gates completed:
 
-- Ubuntu and Windows CI on the fix PR;
-- post-merge CI green.
+- fix PR merged: <https://github.com/wippyai/runtime/pull/532> at `e21f708c`;
+- PR lint, CodeQL, Ubuntu, and Windows checks passed: <https://github.com/wippyai/runtime/actions/runs/30412868979> and <https://github.com/wippyai/runtime/actions/runs/30412867979>;
+- post-merge lint, Ubuntu, Windows, and CodeQL passed: <https://github.com/wippyai/runtime/actions/runs/30413330164> and <https://github.com/wippyai/runtime/actions/runs/30413330244>.

--- a/specs/epics/e01-runtime-test-expansion/epic.yaml
+++ b/specs/epics/e01-runtime-test-expansion/epic.yaml
@@ -2,7 +2,7 @@ id: e01
 slug: runtime-test-expansion
 title: Runtime behavioral test expansion
 risk: P0
-status: release_ready
+status: done
 objective: Add 165 genuine executable leaves and remove 15 false-confidence leaves.
 stories:
   - id: e01s01

--- a/specs/state.yaml
+++ b/specs/state.yaml
@@ -1,12 +1,13 @@
-active_flow: build_epic
+active_flow: release_complete
 active_epic_id: e01
-active_story_id: e01s12
-phase: release_ready
+active_story_id: null
+phase: complete
 git:
-  branch: test/runtime-behavior-expansion
+  branch: main
   base: 55bc0336f205b3158d62d32ef434149a5f14275b
+  landed_head: e21f708cffbd1d22be7178a8870c47db5cb1fbdb
 handoff:
-  next_skill: release-branch
+  next_skill: survey-context
 metrics:
   story_start: '2026-07-28T18:04:34Z'
 decisions:
@@ -32,10 +33,13 @@ decisions:
   security_gate: APPROVED
 release:
   pr: https://github.com/wippyai/runtime/pull/531
-  code_head: b8be4156b77377cf6d2e8e02066dc7b7645549cd
+  merge_commit: acbb814ccb7cfc722bb0296025ffe4000e5d826c
+  stability_pr: https://github.com/wippyai/runtime/pull/532
+  stability_merge_commit: e21f708cffbd1d22be7178a8870c47db5cb1fbdb
+  code_head: e21f708cffbd1d22be7178a8870c47db5cb1fbdb
   ci_verified: true
-  ci_run: https://github.com/wippyai/runtime/actions/runs/30409751006
-  codeql_run: https://github.com/wippyai/runtime/actions/runs/30409749369
+  ci_run: https://github.com/wippyai/runtime/actions/runs/30413330164
+  codeql_run: https://github.com/wippyai/runtime/actions/runs/30413330244
   checks:
     lint: pass
     codeql: pass

--- a/specs/verifications/AUDIT-e01.md
+++ b/specs/verifications/AUDIT-e01.md
@@ -2,13 +2,13 @@
 
 ## Verdict
 
-**RELEASE READY BY HUMAN DECISION — executable and security gates pass; review cap exhausted (5/5), post-review correction accepted by the user.**
+**RELEASED — primary and stability PRs merged; final post-merge Linux, Windows, lint, and CodeQL gates pass.**
 
 ## Supply Chain and Security
 
 - ✓ No dependency, lockfile, generated-code, Makefile, or workflow changes.
 - ✓ Diff credential/private-key scan found no secrets.
-- ✓ Fresh-context security review approved `55bc0336..5bd49e4d`; the only later source change (`0fa36ce9`) disables test jitter and does not alter production.
+- ✓ Fresh-context security review approved `55bc0336..5bd49e4d`; all later source changes are test-only determinism or portability corrections and do not alter production.
 - ✓ Changed SQL remains parameterized; changed URL/path, origin, artifact, and lifecycle boundaries fail closed.
 
 ## Scope and Clarity
@@ -33,7 +33,9 @@
 - ✓ The one newly visible SQS conformance skip is pre-existing Docker coverage uncovered by fixing short-mode `TestMain`; no planned fingerprint skips.
 - ✓ Statement coverage rose from 61.4% to 62.9%; changed-statement coverage is 82.5%.
 - ✓ All 36 changed Go packages cross-compiled for Windows/amd64.
-- ✓ Native Windows CI exposed and then verified the platform-native L08 absolute-path correction in `b8be4156`; the final lint, CodeQL, Ubuntu, and Windows checks are green.
+- ✓ Native Windows CI exposed and then verified the platform-native L08 absolute-path correction in `b8be4156`.
+- ✓ Post-merge Ubuntu exposed a startup-ordering flaw in the `TestCorePlugins` precondition; PR <https://github.com/wippyai/runtime/pull/532> synchronizes on `StatusRunning`, passed 500 race repetitions and independent review, and merged at `e21f708c`.
+- ✓ Final post-merge lint, CodeQL, Ubuntu, and Windows checks are green.
 
 ## Safety, Performance, and Complexity
 
@@ -49,5 +51,7 @@
 - Generic traceability tooling is absent, so `specs/verifications/TRACE-e01.md` records WAIVED; Gate v4 remains the task-specific executable trace for all 12 stories and 165 fingerprints.
 - Performance benchmarking was not run because `/opt/workspace/wippy/CLAUDE.md` explicitly exempts projects under this workspace from performance and memory testing. Correctness, race, and coverage gates were still run.
 - Live cloud, Kubernetes, and production infrastructure were not mutated; all integration-dependent paths remained disabled or read-only. Local Docker executed only the read-only Linux/amd64 test container.
-- The exact final Linux JSON report attests code head `0fa36ce9`; the only later source commit makes L08's absolute path platform-native, without changing test identity or production.
+- The exact final Linux JSON report attests code head `0fa36ce9`; later source commits only make L08 platform-native and synchronize the boot shutdown test's running-state precondition, without changing test identity or production.
+- Primary PR <https://github.com/wippyai/runtime/pull/531> merged at `acbb814c`; stability PR <https://github.com/wippyai/runtime/pull/532> merged at `e21f708c`.
+- Final post-merge CI: <https://github.com/wippyai/runtime/actions/runs/30413330164> and <https://github.com/wippyai/runtime/actions/runs/30413330244>.
 - Gate v4 explicitly approves the two boot/core WS06 review-fix paths, +200 inventory arithmetic, one pre-existing accepted SQS Docker skip, and the valid Windows compile-only profile.

--- a/specs/verifications/e01-progress.md
+++ b/specs/verifications/e01-progress.md
@@ -76,3 +76,7 @@
 - Windows compile attestation: `/tmp/runtime-test-expansion-windows-compile-final.log`, SHA-256 `729bea0c517c31e77b79f25364f254a237c4fa8e88e8cd19b964b1598f57f5c7`
 - Fresh release security gate: `specs/security/REVIEW.md` — APPROVED, zero unresolved HIGH findings at confidence 8/10 or higher
 - Traceability gate: `specs/verifications/TRACE-e01.md` — WAIVED because generic matrix tooling is absent; Gate v4 provides explicit story/workstream/fingerprint trace
+- Primary release merged: <https://github.com/wippyai/runtime/pull/531> at `acbb814c`
+- Post-merge Ubuntu exposed a startup-ordering flake in `TestCorePlugins`; root cause and correction are recorded in `specs/bugs/BUG-coreplugins-shutdown-sync.md`
+- Stability fix merged: <https://github.com/wippyai/runtime/pull/532> at `e21f708c`
+- Final post-merge CI: lint, Ubuntu, Windows, and CodeQL PASS — <https://github.com/wippyai/runtime/actions/runs/30413330164> and <https://github.com/wippyai/runtime/actions/runs/30413330244>


### PR DESCRIPTION
# Reason for This PR

Close the runtime behavioral expansion lifecycle after the primary release, post-merge regression fix, and final green CI.

## Summary
<!-- bigpowers-provenance: agent-generated -->

- mark epic e01 and project state complete
- record primary merge https://github.com/wippyai/runtime/pull/531
- record stability merge https://github.com/wippyai/runtime/pull/532
- replace stale pending release gates with final post-merge evidence
- hand off to the next project survey

## Verification

- Primary merge: `acbb814c`
- Final landed head: `e21f708c`
- Final CI: https://github.com/wippyai/runtime/actions/runs/30413330164
- Final CodeQL: https://github.com/wippyai/runtime/actions/runs/30413330244
- Ubuntu, Windows, lint, and CodeQL: PASS
- YAML parsing and `git diff --check`: PASS
