### PR TITLE
feat(deps): add explicit build dependencies

### DIFF
--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -63,6 +63,8 @@ const (
 	// NamespaceDependency represents a module dependency entry
 	NamespaceDependency Kind = "ns.dependency"
 
+	NamespaceBuildDependency Kind = "ns.build_dependency"
+
 	// NamespaceDefinition represents module metadata (readme, license, authors, etc.)
 	NamespaceDefinition Kind = "ns.definition"
 )

--- a/boot/deps/config/config.go
+++ b/boot/deps/config/config.go
@@ -19,16 +19,17 @@ const (
 )
 
 type ModuleConfig struct {
-	ExcludeMeta  map[string][]string `yaml:"exclude_meta,omitempty"`
-	Metadata     map[string]any      `yaml:"metadata,omitempty"`
-	Publish      PublishConfig       `yaml:"publish,omitempty"`
-	Repository   string              `yaml:"repository,omitempty"`
-	Description  string              `yaml:"description,omitempty"`
-	License      string              `yaml:"license,omitempty"`
-	Version      string              `yaml:"version"`
-	Homepage     string              `yaml:"homepage,omitempty"`
-	ModuleName   string              `yaml:"module"`
-	Organization string              `yaml:"organization"`
+	ExcludeMeta   map[string][]string `yaml:"exclude_meta,omitempty"`
+	Metadata      map[string]any      `yaml:"metadata,omitempty"`
+	Publish       PublishConfig       `yaml:"publish,omitempty"`
+	Repository    string              `yaml:"repository,omitempty"`
+	Description   string              `yaml:"description,omitempty"`
+	License       string              `yaml:"license,omitempty"`
+	Version       string              `yaml:"version"`
+	Homepage      string              `yaml:"homepage,omitempty"`
+	ModuleName    string              `yaml:"module"`
+	Organization  string              `yaml:"organization"`
+	RequiresWippy string              `yaml:"requires_wippy,omitempty"`
 	// Type is the module's kind on the hub: library, application, agent or
 	// plugin. Declaring it here makes the manifest the source of truth — hub
 	// requires it to create a module, and reclassifies the module when it
@@ -128,10 +129,36 @@ func (c *ModuleConfig) Validate() error {
 	if err := ValidateModuleType(c.Type); err != nil {
 		return err
 	}
+	if err := c.ValidateRuntimeVersion("dev"); err != nil {
+		return err
+	}
 	if err := c.validatePublishOwnership(); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func (c *ModuleConfig) ValidateRuntimeVersion(current string) error {
+	required := strings.TrimSpace(c.RequiresWippy)
+	if required == "" {
+		return nil
+	}
+	constraint, err := semver.NewConstraint(required)
+	if err != nil {
+		return fmt.Errorf("requires_wippy must be a valid semver constraint: %w", err)
+	}
+	current = strings.TrimSpace(current)
+	if current == "dev" {
+		return nil
+	}
+	currentVersion, err := semver.NewVersion(current)
+	if err != nil {
+		return fmt.Errorf("wippy version %q is not valid semver: %w", current, err)
+	}
+	if !constraint.Check(currentVersion) {
+		return fmt.Errorf("wippy %s does not satisfy requires_wippy %s", current, required)
+	}
 	return nil
 }
 
@@ -165,6 +192,9 @@ func (c *ModuleConfig) ValidateForLabel() error {
 	}
 
 	if err := ValidateModuleType(c.Type); err != nil {
+		return err
+	}
+	if err := c.ValidateRuntimeVersion("dev"); err != nil {
 		return err
 	}
 	if err := c.validatePublishOwnership(); err != nil {

--- a/boot/deps/config/requires_wippy_test.go
+++ b/boot/deps/config/requires_wippy_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleConfigRequiresWippy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), DefaultConfigFile)
+	require.NoError(t, os.WriteFile(path, []byte(`organization: acme
+module: consumer
+version: 1.0.0
+requires_wippy: ">=1.2.0"
+`), 0o644))
+	cfg, err := LoadFrom(path)
+	require.NoError(t, err)
+	require.Equal(t, ">=1.2.0", cfg.RequiresWippy)
+	require.NoError(t, cfg.ValidateRuntimeVersion("1.2.0"))
+	require.NoError(t, cfg.ValidateRuntimeVersion("dev"))
+	require.EqualError(t, cfg.ValidateRuntimeVersion("1.1.9"), "wippy 1.1.9 does not satisfy requires_wippy >=1.2.0")
+}

--- a/boot/deps/hub/download.go
+++ b/boot/deps/hub/download.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -39,7 +38,7 @@ func ExpectedArtifactDigest(pinned, served string) (string, error) {
 	if pinned == "" {
 		return served, nil
 	}
-	if served != "" && !strings.EqualFold(pinned, served) {
+	if served != "" && !artifactDigestsEqual(pinned, served) {
 		return "", fmt.Errorf("artifact digest mismatch: lock pins %s, download reports %s", pinned, served)
 	}
 	return pinned, nil

--- a/boot/deps/hub/download.go
+++ b/boot/deps/hub/download.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -32,6 +33,29 @@ type DownloadInfo struct {
 	Version   string
 	Size      uint64
 	Protected bool
+}
+
+func ExpectedArtifactDigest(pinned, served string) (string, error) {
+	if pinned == "" {
+		return served, nil
+	}
+	if served != "" && !strings.EqualFold(pinned, served) {
+		return "", fmt.Errorf("artifact digest mismatch: lock pins %s, download reports %s", pinned, served)
+	}
+	return pinned, nil
+}
+
+func VerifyCachedArtifact(path, digest string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if err := VerifyDownloadedArtifact(path, digest, 0); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 type DownloadParams struct {

--- a/boot/deps/hub/download_test.go
+++ b/boot/deps/hub/download_test.go
@@ -19,6 +19,12 @@ func TestExpectedArtifactDigestPreservesPinnedDigest(t *testing.T) {
 	require.Equal(t, "sha256:abc", digest)
 }
 
+func TestExpectedArtifactDigestAcceptsLegacyBareDigest(t *testing.T) {
+	digest, err := ExpectedArtifactDigest("abc", "sha256:ABC")
+	require.NoError(t, err)
+	require.Equal(t, "abc", digest)
+}
+
 func TestExpectedArtifactDigestRejectsServerDrift(t *testing.T) {
 	_, err := ExpectedArtifactDigest("sha256:abc", "sha256:def")
 	require.EqualError(t, err, "artifact digest mismatch: lock pins sha256:abc, download reports sha256:def")

--- a/boot/deps/hub/download_test.go
+++ b/boot/deps/hub/download_test.go
@@ -13,6 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExpectedArtifactDigestPreservesPinnedDigest(t *testing.T) {
+	digest, err := ExpectedArtifactDigest("sha256:abc", "sha256:ABC")
+	require.NoError(t, err)
+	require.Equal(t, "sha256:abc", digest)
+}
+
+func TestExpectedArtifactDigestRejectsServerDrift(t *testing.T) {
+	_, err := ExpectedArtifactDigest("sha256:abc", "sha256:def")
+	require.EqualError(t, err, "artifact digest mismatch: lock pins sha256:abc, download reports sha256:def")
+}
+
 func TestDownloadToFileRetriesTransientStatus(t *testing.T) {
 	var attempts int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -14,23 +14,25 @@ import (
 )
 
 type ResolvedModule struct {
-	Org       string
-	Name      string
-	Version   string
-	VersionID string
-	Source    string
-	Digest    string
-	URL       string
-	SizeBytes uint64
-	Protected bool
-	BuildOnly bool
+	Org             string
+	Name            string
+	Version         string
+	VersionID       string
+	Source          string
+	Digest          string
+	URL             string
+	SizeBytes       uint64
+	Protected       bool
+	BuildOnly       bool
+	BuildDependency bool
 }
 
 type DependencySpec struct {
-	Org        string
-	Name       string
-	Constraint string
-	BuildOnly  bool
+	Org             string
+	Name            string
+	Constraint      string
+	BuildOnly       bool
+	BuildDependency bool
 }
 
 type ResolutionError struct {

--- a/boot/deps/hub/manifest.go
+++ b/boot/deps/hub/manifest.go
@@ -23,12 +23,14 @@ type ResolvedModule struct {
 	URL       string
 	SizeBytes uint64
 	Protected bool
+	BuildOnly bool
 }
 
 type DependencySpec struct {
 	Org        string
 	Name       string
 	Constraint string
+	BuildOnly  bool
 }
 
 type ResolutionError struct {

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -58,6 +58,9 @@ func Resolve(ctx context.Context, provider ManifestProvider, roots []DependencyS
 		if !root.BuildOnly {
 			r.runtimeRoots[source] = struct{}{}
 		}
+		if root.BuildOnly || root.BuildDependency {
+			r.buildRoots[source] = struct{}{}
+		}
 	}
 
 	if err := r.run(ctx); err != nil {
@@ -97,6 +100,7 @@ type resolver struct {
 	queue        []string
 	queued       map[string]bool
 	runtimeRoots map[string]struct{}
+	buildRoots   map[string]struct{}
 
 	errors     []ResolutionError
 	maxDepth   int
@@ -119,6 +123,7 @@ func newResolver(provider ManifestProvider, maxDepth, maxModules int, lockedVers
 		pending:        make(map[string]ResolutionError),
 		queued:         make(map[string]bool),
 		runtimeRoots:   make(map[string]struct{}),
+		buildRoots:     make(map[string]struct{}),
 	}
 }
 
@@ -541,7 +546,8 @@ func (r *resolver) conflictMessage(key string) string {
 // collectModules returns the resolved modules in a deterministic, walk-order
 // independent order.
 func (r *resolver) collectModules() []ResolvedModule {
-	runtimeModules := r.runtimeModules()
+	runtimeModules := r.reachableModules(r.runtimeRoots)
+	buildModules := r.reachableModules(r.buildRoots)
 	keys := make([]string, 0, len(r.modules))
 	for key := range r.modules {
 		keys = append(keys, key)
@@ -552,16 +558,18 @@ func (r *resolver) collectModules() []ResolvedModule {
 	for _, key := range keys {
 		module := r.modules[key]
 		_, runtime := runtimeModules[key]
+		_, buildDependency := buildModules[key]
 		module.BuildOnly = !runtime
+		module.BuildDependency = buildDependency
 		out = append(out, module)
 	}
 	return out
 }
 
-func (r *resolver) runtimeModules() map[string]struct{} {
-	runtime := make(map[string]struct{}, len(r.modules))
+func (r *resolver) reachableModules(roots map[string]struct{}) map[string]struct{} {
+	reachable := make(map[string]struct{}, len(r.modules))
 	queue := make([]string, 0, len(r.modules))
-	for source := range r.runtimeRoots {
+	for source := range roots {
 		queue = append(queue, r.edges[source]...)
 	}
 	for len(queue) > 0 {
@@ -571,13 +579,13 @@ func (r *resolver) runtimeModules() map[string]struct{} {
 		if !selected {
 			continue
 		}
-		if _, seen := runtime[key]; seen {
+		if _, seen := reachable[key]; seen {
 			continue
 		}
-		runtime[key] = struct{}{}
+		reachable[key] = struct{}{}
 		queue = append(queue, r.edges[moduleSource(key, version)]...)
 	}
-	return runtime
+	return reachable
 }
 
 // collectErrors returns resolution errors deterministically: any global failure
@@ -647,7 +655,7 @@ func (r *resolver) fetchManifest(ctx context.Context, org, name, version string)
 	}
 
 	expected := r.lockedDigests[org+"/"+name+"@"+version]
-	if expected == "" || manifest.Digest == expected {
+	if expected == "" || artifactDigestsEqual(manifest.Digest, expected) {
 		return manifest, nil
 	}
 
@@ -656,7 +664,7 @@ func (r *resolver) fetchManifest(ctx context.Context, org, name, version string)
 		if ferr != nil {
 			return nil, ferr
 		}
-		if fresh != nil && fresh.Digest == expected {
+		if fresh != nil && artifactDigestsEqual(fresh.Digest, expected) {
 			return fresh, nil
 		}
 		if fresh != nil {

--- a/boot/deps/hub/resolve.go
+++ b/boot/deps/hub/resolve.go
@@ -53,7 +53,11 @@ func Resolve(ctx context.Context, provider ManifestProvider, roots []DependencyS
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		r.addConstraint(root.Org+"/"+root.Name, rootSource(i), root.Constraint)
+		source := rootSource(i)
+		r.addConstraint(root.Org+"/"+root.Name, source, root.Constraint)
+		if !root.BuildOnly {
+			r.runtimeRoots[source] = struct{}{}
+		}
 	}
 
 	if err := r.run(ctx); err != nil {
@@ -90,8 +94,9 @@ type resolver struct {
 	signature map[string]string
 	pending   map[string]ResolutionError
 
-	queue  []string
-	queued map[string]bool
+	queue        []string
+	queued       map[string]bool
+	runtimeRoots map[string]struct{}
 
 	errors     []ResolutionError
 	maxDepth   int
@@ -113,6 +118,7 @@ func newResolver(provider ManifestProvider, maxDepth, maxModules int, lockedVers
 		signature:      make(map[string]string),
 		pending:        make(map[string]ResolutionError),
 		queued:         make(map[string]bool),
+		runtimeRoots:   make(map[string]struct{}),
 	}
 }
 
@@ -535,6 +541,7 @@ func (r *resolver) conflictMessage(key string) string {
 // collectModules returns the resolved modules in a deterministic, walk-order
 // independent order.
 func (r *resolver) collectModules() []ResolvedModule {
+	runtimeModules := r.runtimeModules()
 	keys := make([]string, 0, len(r.modules))
 	for key := range r.modules {
 		keys = append(keys, key)
@@ -543,9 +550,34 @@ func (r *resolver) collectModules() []ResolvedModule {
 
 	out := make([]ResolvedModule, 0, len(keys))
 	for _, key := range keys {
-		out = append(out, r.modules[key])
+		module := r.modules[key]
+		_, runtime := runtimeModules[key]
+		module.BuildOnly = !runtime
+		out = append(out, module)
 	}
 	return out
+}
+
+func (r *resolver) runtimeModules() map[string]struct{} {
+	runtime := make(map[string]struct{}, len(r.modules))
+	queue := make([]string, 0, len(r.modules))
+	for source := range r.runtimeRoots {
+		queue = append(queue, r.edges[source]...)
+	}
+	for len(queue) > 0 {
+		key := queue[0]
+		queue = queue[1:]
+		version, selected := r.resolved[key]
+		if !selected {
+			continue
+		}
+		if _, seen := runtime[key]; seen {
+			continue
+		}
+		runtime[key] = struct{}{}
+		queue = append(queue, r.edges[moduleSource(key, version)]...)
+	}
+	return runtime
 }
 
 // collectErrors returns resolution errors deterministically: any global failure

--- a/boot/deps/hub/resolve_build_dependency_test.go
+++ b/boot/deps/hub/resolve_build_dependency_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResolveRuntimeWinsAcrossDifferentRootConstraints(t *testing.T) {
+	provider := newFakeProvider()
+	provider.addModule("acme", "shared", "1.0.0")
+	provider.addModule("acme", "shared", "1.1.0")
+
+	result, err := Resolve(context.Background(), provider, []DependencySpec{
+		{Org: "acme", Name: "shared", Constraint: ">=1.0.0"},
+		{Org: "acme", Name: "shared", Constraint: "1.1.0", BuildOnly: true},
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Modules, 1)
+	require.Equal(t, "1.1.0", result.Modules[0].Version)
+	require.False(t, result.Modules[0].BuildOnly)
+}
+
 func TestResolveClassifiesBuildOnlyReachability(t *testing.T) {
 	provider := newFakeProvider()
 	provider.addModule("acme", "runtime", "1.0.0", ManifestDep{Org: "acme", Name: "shared", Version: "1.0.0"})

--- a/boot/deps/hub/resolve_build_dependency_test.go
+++ b/boot/deps/hub/resolve_build_dependency_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveClassifiesBuildOnlyReachability(t *testing.T) {
+	provider := newFakeProvider()
+	provider.addModule("acme", "runtime", "1.0.0", ManifestDep{Org: "acme", Name: "shared", Version: "1.0.0"})
+	provider.addModule("acme", "frontend", "1.0.0",
+		ManifestDep{Org: "acme", Name: "shared", Version: "1.0.0"},
+		ManifestDep{Org: "acme", Name: "frontend-only", Version: "1.0.0"},
+	)
+	provider.addModule("acme", "shared", "1.0.0")
+	provider.addModule("acme", "frontend-only", "1.0.0")
+
+	result, err := Resolve(context.Background(), provider, []DependencySpec{
+		{Org: "acme", Name: "runtime", Constraint: "1.0.0"},
+		{Org: "acme", Name: "frontend", Constraint: "1.0.0", BuildOnly: true},
+	}, nil)
+	require.NoError(t, err)
+
+	roles := make(map[string]bool, len(result.Modules))
+	for _, module := range result.Modules {
+		roles[module.Org+"/"+module.Name] = module.BuildOnly
+	}
+	require.Equal(t, map[string]bool{
+		"acme/frontend":      true,
+		"acme/frontend-only": true,
+		"acme/runtime":       false,
+		"acme/shared":        false,
+	}, roles)
+}

--- a/boot/deps/hub/resolve_build_dependency_test.go
+++ b/boot/deps/hub/resolve_build_dependency_test.go
@@ -22,6 +22,7 @@ func TestResolveRuntimeWinsAcrossDifferentRootConstraints(t *testing.T) {
 	require.Len(t, result.Modules, 1)
 	require.Equal(t, "1.1.0", result.Modules[0].Version)
 	require.False(t, result.Modules[0].BuildOnly)
+	require.True(t, result.Modules[0].BuildDependency)
 }
 
 func TestResolveClassifiesBuildOnlyReachability(t *testing.T) {
@@ -41,8 +42,11 @@ func TestResolveClassifiesBuildOnlyReachability(t *testing.T) {
 	require.NoError(t, err)
 
 	roles := make(map[string]bool, len(result.Modules))
+	buildDependencies := make(map[string]bool, len(result.Modules))
 	for _, module := range result.Modules {
-		roles[module.Org+"/"+module.Name] = module.BuildOnly
+		name := module.Org + "/" + module.Name
+		roles[name] = module.BuildOnly
+		buildDependencies[name] = module.BuildDependency
 	}
 	require.Equal(t, map[string]bool{
 		"acme/frontend":      true,
@@ -50,4 +54,10 @@ func TestResolveClassifiesBuildOnlyReachability(t *testing.T) {
 		"acme/runtime":       false,
 		"acme/shared":        false,
 	}, roles)
+	require.Equal(t, map[string]bool{
+		"acme/frontend":      true,
+		"acme/frontend-only": true,
+		"acme/runtime":       false,
+		"acme/shared":        true,
+	}, buildDependencies)
 }

--- a/boot/deps/lock/build_dependency_test.go
+++ b/boot/deps/lock/build_dependency_test.go
@@ -5,6 +5,8 @@ package lock
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +15,7 @@ import (
 func TestDiffReportsBuildRoleChanges(t *testing.T) {
 	oldLock, err := New(filepath.Join(t.TempDir(), "old.lock"))
 	require.NoError(t, err)
-	oldLock.SetModule(Module{Name: "acme/shared", Version: "1.0.0", Hash: "sha256:shared", BuildOnly: true})
+	oldLock.SetModule(Module{Name: "acme/shared", Version: "1.0.0", Hash: "sha256:shared", BuildOnly: true, BuildDependency: true})
 	newLock, err := New(filepath.Join(t.TempDir(), "new.lock"))
 	require.NoError(t, err)
 	newLock.SetModule(Module{Name: "acme/shared", Version: "1.0.0", Hash: "sha256:shared"})
@@ -21,12 +23,13 @@ func TestDiffReportsBuildRoleChanges(t *testing.T) {
 	changes := Diff(oldLock, newLock)
 	require.Equal(t, []ModuleChange{
 		{
-			Name:         "acme/shared",
-			OldVersion:   "1.0.0",
-			NewVersion:   "1.0.0",
-			OldHash:      "sha256:shared",
-			NewHash:      "sha256:shared",
-			OldBuildOnly: true,
+			Name:               "acme/shared",
+			OldVersion:         "1.0.0",
+			NewVersion:         "1.0.0",
+			OldHash:            "sha256:shared",
+			NewHash:            "sha256:shared",
+			OldBuildOnly:       true,
+			OldBuildDependency: true,
 		},
 	}, changes.Updated)
 }
@@ -36,6 +39,22 @@ func TestValidateRejectsRemoteBuildOnlyModuleWithoutDigest(t *testing.T) {
 	require.NoError(t, err)
 	lockObj.SetModule(Module{Name: "acme/frontend", Version: "1.0.0", BuildOnly: true})
 	require.EqualError(t, Validate(lockObj), "build-only module acme/frontend requires an artifact digest")
+}
+
+func TestValidateRejectsMalformedBuildDigests(t *testing.T) {
+	for _, digest := range []string{
+		" ",
+		"md5:" + strings.Repeat("a", 32),
+		"sha256:abc",
+		"sha256:" + strings.Repeat("z", 64),
+	} {
+		t.Run(digest, func(t *testing.T) {
+			lockObj, err := New(filepath.Join(t.TempDir(), DefaultFilename))
+			require.NoError(t, err)
+			lockObj.SetModule(Module{Name: "acme/frontend", Version: "1.0.0", Hash: digest, BuildOnly: true})
+			require.EqualError(t, Validate(lockObj), "build module acme/frontend has invalid artifact digest "+strconv.Quote(digest))
+		})
+	}
 }
 
 func TestValidateAllowsBuildOnlyReplacementWithoutDigest(t *testing.T) {

--- a/boot/deps/lock/build_dependency_test.go
+++ b/boot/deps/lock/build_dependency_test.go
@@ -3,6 +3,7 @@
 package lock
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +29,23 @@ func TestDiffReportsBuildRoleChanges(t *testing.T) {
 			OldBuildOnly: true,
 		},
 	}, changes.Updated)
+}
+
+func TestValidateRejectsRemoteBuildOnlyModuleWithoutDigest(t *testing.T) {
+	lockObj, err := New(filepath.Join(t.TempDir(), DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(Module{Name: "acme/frontend", Version: "1.0.0", BuildOnly: true})
+	require.EqualError(t, Validate(lockObj), "build-only module acme/frontend requires an artifact digest")
+}
+
+func TestValidateAllowsBuildOnlyReplacementWithoutDigest(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "local", "frontend"), 0o755))
+	lockObj, err := New(filepath.Join(root, DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(Module{Name: "acme/frontend", Version: "1.0.0", BuildOnly: true})
+	lockObj.SetReplacement(Replacement{From: "acme/frontend", To: "local/frontend"})
+	require.NoError(t, Validate(lockObj))
 }
 
 func TestValidateRejectsBuildOnlyDeploymentRoot(t *testing.T) {

--- a/boot/deps/lock/build_dependency_test.go
+++ b/boot/deps/lock/build_dependency_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateRejectsBuildOnlyDeploymentRoot(t *testing.T) {
+	lockObj, err := New(filepath.Join(t.TempDir(), DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(Module{Name: "acme/app", Version: "1.0.0", Root: true, BuildOnly: true})
+	require.EqualError(t, Validate(lockObj), "deployment root acme/app cannot be build-only")
+}
+
 func TestLockSeparatesRuntimeAndArtifactModulePaths(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), DefaultFilename)
 	lockObj, err := New(lockPath)

--- a/boot/deps/lock/build_dependency_test.go
+++ b/boot/deps/lock/build_dependency_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package lock
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockSeparatesRuntimeAndArtifactModulePaths(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), DefaultFilename)
+	lockObj, err := New(lockPath)
+	require.NoError(t, err)
+	lockObj.SetDirectories(Directories{Modules: ".wippy", Src: "app"})
+	lockObj.SetModule(Module{Name: "acme/runtime", Version: "1.0.0"})
+	lockObj.SetModule(Module{Name: "acme/frontend", Version: "1.0.0", BuildOnly: true})
+	require.NoError(t, lockObj.Write())
+
+	reloaded, err := New(lockPath)
+	require.NoError(t, err)
+
+	runtimePaths := reloaded.GetModuleLoadPaths()
+	require.Len(t, runtimePaths, 2)
+	require.Equal(t, "acme/runtime", runtimePaths[1].Module)
+
+	artifactPaths := reloaded.GetArtifactModuleLoadPaths()
+	require.Len(t, artifactPaths, 3)
+	require.Equal(t, "acme/frontend", artifactPaths[1].Module)
+	require.Equal(t, "acme/runtime", artifactPaths[2].Module)
+
+	frontend, ok := reloaded.GetModule("acme/frontend")
+	require.True(t, ok)
+	require.True(t, frontend.BuildOnly)
+}

--- a/boot/deps/lock/build_dependency_test.go
+++ b/boot/deps/lock/build_dependency_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDiffReportsBuildRoleChanges(t *testing.T) {
+	oldLock, err := New(filepath.Join(t.TempDir(), "old.lock"))
+	require.NoError(t, err)
+	oldLock.SetModule(Module{Name: "acme/shared", Version: "1.0.0", Hash: "sha256:shared", BuildOnly: true})
+	newLock, err := New(filepath.Join(t.TempDir(), "new.lock"))
+	require.NoError(t, err)
+	newLock.SetModule(Module{Name: "acme/shared", Version: "1.0.0", Hash: "sha256:shared"})
+
+	changes := Diff(oldLock, newLock)
+	require.Equal(t, []ModuleChange{
+		{
+			Name:         "acme/shared",
+			OldVersion:   "1.0.0",
+			NewVersion:   "1.0.0",
+			OldHash:      "sha256:shared",
+			NewHash:      "sha256:shared",
+			OldBuildOnly: true,
+		},
+	}, changes.Updated)
+}
+
 func TestValidateRejectsBuildOnlyDeploymentRoot(t *testing.T) {
 	lockObj, err := New(filepath.Join(t.TempDir(), DefaultFilename))
 	require.NoError(t, err)

--- a/boot/deps/lock/diff.go
+++ b/boot/deps/lock/diff.go
@@ -25,15 +25,18 @@ func Diff(old, newLock *Lock) *Changes {
 		oldMod, existed := oldModules[name]
 		if !existed {
 			changes.Installed = append(changes.Installed, newMod)
-		} else if oldMod.Version != newMod.Version || oldMod.Hash != newMod.Hash || oldMod.BuildOnly != newMod.BuildOnly {
+		} else if oldMod.Version != newMod.Version || oldMod.Hash != newMod.Hash ||
+			oldMod.BuildOnly != newMod.BuildOnly || oldMod.BuildDependency != newMod.BuildDependency {
 			changes.Updated = append(changes.Updated, ModuleChange{
-				Name:         name,
-				OldVersion:   oldMod.Version,
-				NewVersion:   newMod.Version,
-				OldHash:      oldMod.Hash,
-				NewHash:      newMod.Hash,
-				OldBuildOnly: oldMod.BuildOnly,
-				NewBuildOnly: newMod.BuildOnly,
+				Name:               name,
+				OldVersion:         oldMod.Version,
+				NewVersion:         newMod.Version,
+				OldHash:            oldMod.Hash,
+				NewHash:            newMod.Hash,
+				OldBuildOnly:       oldMod.BuildOnly,
+				NewBuildOnly:       newMod.BuildOnly,
+				OldBuildDependency: oldMod.BuildDependency,
+				NewBuildDependency: newMod.BuildDependency,
 			})
 		}
 	}

--- a/boot/deps/lock/diff.go
+++ b/boot/deps/lock/diff.go
@@ -25,13 +25,15 @@ func Diff(old, newLock *Lock) *Changes {
 		oldMod, existed := oldModules[name]
 		if !existed {
 			changes.Installed = append(changes.Installed, newMod)
-		} else if oldMod.Version != newMod.Version || oldMod.Hash != newMod.Hash {
+		} else if oldMod.Version != newMod.Version || oldMod.Hash != newMod.Hash || oldMod.BuildOnly != newMod.BuildOnly {
 			changes.Updated = append(changes.Updated, ModuleChange{
-				Name:       name,
-				OldVersion: oldMod.Version,
-				NewVersion: newMod.Version,
-				OldHash:    oldMod.Hash,
-				NewHash:    newMod.Hash,
+				Name:         name,
+				OldVersion:   oldMod.Version,
+				NewVersion:   newMod.Version,
+				OldHash:      oldMod.Hash,
+				NewHash:      newMod.Hash,
+				OldBuildOnly: oldMod.BuildOnly,
+				NewBuildOnly: newMod.BuildOnly,
 			})
 		}
 	}

--- a/boot/deps/lock/errors.go
+++ b/boot/deps/lock/errors.go
@@ -30,6 +30,10 @@ func NewMultipleRootModulesError() apierror.Error {
 	return apierror.New(apierror.Invalid, "lock file selects more than one deployment root").WithRetryable(apierror.False)
 }
 
+func NewBuildOnlyRootError(moduleName string) apierror.Error {
+	return apierror.New(apierror.Invalid, fmt.Sprintf("deployment root %s cannot be build-only", moduleName)).WithRetryable(apierror.False)
+}
+
 func NewInvalidReplacementsError(cause error) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid replacements").WithCause(cause)
 }

--- a/boot/deps/lock/errors.go
+++ b/boot/deps/lock/errors.go
@@ -34,6 +34,10 @@ func NewBuildOnlyRootError(moduleName string) apierror.Error {
 	return apierror.New(apierror.Invalid, fmt.Sprintf("deployment root %s cannot be build-only", moduleName)).WithRetryable(apierror.False)
 }
 
+func NewBuildOnlyDigestError(moduleName string) apierror.Error {
+	return apierror.New(apierror.Invalid, fmt.Sprintf("build-only module %s requires an artifact digest", moduleName)).WithRetryable(apierror.False)
+}
+
 func NewInvalidReplacementsError(cause error) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid replacements").WithCause(cause)
 }

--- a/boot/deps/lock/errors.go
+++ b/boot/deps/lock/errors.go
@@ -38,6 +38,10 @@ func NewBuildOnlyDigestError(moduleName string) apierror.Error {
 	return apierror.New(apierror.Invalid, fmt.Sprintf("build-only module %s requires an artifact digest", moduleName)).WithRetryable(apierror.False)
 }
 
+func NewInvalidBuildDigestError(moduleName, digest string) apierror.Error {
+	return apierror.New(apierror.Invalid, fmt.Sprintf("build module %s has invalid artifact digest %q", moduleName, digest)).WithRetryable(apierror.False)
+}
+
 func NewInvalidReplacementsError(cause error) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid replacements").WithCause(cause)
 }

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -429,8 +429,9 @@ func (l *Lock) getModuleLoadPaths(runtimeOnly bool) []ModuleLoadPath {
 
 	if l.data.Directories.Src != "" {
 		paths = append(paths, ModuleLoadPath{
-			Path: ResolveLockPath(lockDir, l.data.Directories.Src),
-			Root: true,
+			Path:       ResolveLockPath(lockDir, l.data.Directories.Src),
+			SourceRoot: lockDir,
+			Root:       true,
 		})
 	}
 

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -434,10 +434,16 @@ func (l *Lock) getModuleLoadPaths(runtimeOnly bool) []ModuleLoadPath {
 		})
 	}
 
+	modules := make(map[string]Module, len(l.data.Modules))
+	for _, module := range l.data.Modules {
+		modules[module.Name] = module
+	}
+
 	replaced := make(map[string]struct{}, len(replacements))
 	for _, repl := range replacements {
 		replaced[repl.From] = struct{}{}
-		if runtimeOnly && l.isBuildOnlyModule(repl.From) {
+		module := modules[repl.From]
+		if runtimeOnly && module.BuildOnly {
 			continue
 		}
 		if repl.To != "" {
@@ -447,7 +453,7 @@ func (l *Lock) getModuleLoadPaths(runtimeOnly bool) []ModuleLoadPath {
 				Path:       path,
 				Module:     repl.From,
 				SourceRoot: root,
-				Root:       l.IsRootModule(repl.From),
+				Root:       module.Root,
 			})
 		}
 	}
@@ -479,11 +485,6 @@ func (l *Lock) getModuleLoadPaths(runtimeOnly bool) []ModuleLoadPath {
 	}
 
 	return paths
-}
-
-func (l *Lock) isBuildOnlyModule(name string) bool {
-	module, ok := l.GetModule(name)
-	return ok && module.BuildOnly
 }
 
 func moduleEntryLoadPath(root string) string {

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -415,6 +415,14 @@ type ModuleLoadPath struct {
 // App source has empty Module/Version.
 // Replacement paths carry Module from replacement "from" and empty Version.
 func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
+	return l.getModuleLoadPaths(true)
+}
+
+func (l *Lock) GetArtifactModuleLoadPaths() []ModuleLoadPath {
+	return l.getModuleLoadPaths(false)
+}
+
+func (l *Lock) getModuleLoadPaths(runtimeOnly bool) []ModuleLoadPath {
 	lockDir := filepath.Dir(l.path)
 	replacements := l.effectiveReplacements()
 	paths := make([]ModuleLoadPath, 0, 1+len(replacements)+len(l.data.Modules))
@@ -429,6 +437,9 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 	replaced := make(map[string]struct{}, len(replacements))
 	for _, repl := range replacements {
 		replaced[repl.From] = struct{}{}
+		if runtimeOnly && l.isBuildOnlyModule(repl.From) {
+			continue
+		}
 		if repl.To != "" {
 			root := ResolveLockPath(lockDir, repl.To)
 			path := moduleEntryLoadPath(root)
@@ -448,6 +459,9 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 		if _, hasReplacement := replaced[mod.Name]; hasReplacement {
 			continue
 		}
+		if runtimeOnly && mod.BuildOnly {
+			continue
+		}
 
 		name, err := graph.ParseName(mod.Name)
 		if err != nil {
@@ -465,6 +479,11 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 	}
 
 	return paths
+}
+
+func (l *Lock) isBuildOnlyModule(name string) bool {
+	module, ok := l.GetModule(name)
+	return ok && module.BuildOnly
 }
 
 func moduleEntryLoadPath(root string) string {

--- a/boot/deps/lock/types.go
+++ b/boot/deps/lock/types.go
@@ -46,9 +46,11 @@ type Changes struct {
 
 // ModuleChange represents a module that changed between lock files.
 type ModuleChange struct {
-	Name       string // Module name
-	OldVersion string // Previous version
-	NewVersion string // New version
-	OldHash    string // Previous hash
-	NewHash    string // New hash
+	Name         string // Module name
+	OldVersion   string // Previous version
+	NewVersion   string // New version
+	OldHash      string // Previous hash
+	NewHash      string // New hash
+	OldBuildOnly bool
+	NewBuildOnly bool
 }

--- a/boot/deps/lock/types.go
+++ b/boot/deps/lock/types.go
@@ -28,6 +28,7 @@ type Module struct {
 	Hash      string `yaml:"hash,omitempty"`       // Manifest digest (e.g. sha256:...), populated on install
 	LocalHash string `yaml:"local_hash,omitempty"` // Computed hash from loaded entries for verification
 	Root      bool   `yaml:"root,omitempty"`       // Selected deployment root, not a transitive module
+	BuildOnly bool   `yaml:"build_only,omitempty"`
 }
 
 // Replacement represents a local module override for development.

--- a/boot/deps/lock/types.go
+++ b/boot/deps/lock/types.go
@@ -23,12 +23,13 @@ type Directories struct {
 
 // Module represents a locked dependency.
 type Module struct {
-	Name      string `yaml:"name"`                 // Module identifier in org/module format
-	Version   string `yaml:"version"`              // Semantic version (e.g., v0.0.11)
-	Hash      string `yaml:"hash,omitempty"`       // Manifest digest (e.g. sha256:...), populated on install
-	LocalHash string `yaml:"local_hash,omitempty"` // Computed hash from loaded entries for verification
-	Root      bool   `yaml:"root,omitempty"`       // Selected deployment root, not a transitive module
-	BuildOnly bool   `yaml:"build_only,omitempty"`
+	Name            string `yaml:"name"`                 // Module identifier in org/module format
+	Version         string `yaml:"version"`              // Semantic version (e.g., v0.0.11)
+	Hash            string `yaml:"hash,omitempty"`       // Manifest digest (e.g. sha256:...), populated on install
+	LocalHash       string `yaml:"local_hash,omitempty"` // Computed hash from loaded entries for verification
+	Root            bool   `yaml:"root,omitempty"`       // Selected deployment root, not a transitive module
+	BuildOnly       bool   `yaml:"build_only,omitempty"`
+	BuildDependency bool   `yaml:"build_dependency,omitempty"`
 }
 
 // Replacement represents a local module override for development.
@@ -46,11 +47,13 @@ type Changes struct {
 
 // ModuleChange represents a module that changed between lock files.
 type ModuleChange struct {
-	Name         string // Module name
-	OldVersion   string // Previous version
-	NewVersion   string // New version
-	OldHash      string // Previous hash
-	NewHash      string // New hash
-	OldBuildOnly bool
-	NewBuildOnly bool
+	Name               string // Module name
+	OldVersion         string // Previous version
+	NewVersion         string // New version
+	OldHash            string // Previous hash
+	NewHash            string // New hash
+	OldBuildOnly       bool
+	NewBuildOnly       bool
+	OldBuildDependency bool
+	NewBuildDependency bool
 }

--- a/boot/deps/lock/validate.go
+++ b/boot/deps/lock/validate.go
@@ -21,6 +21,9 @@ func Validate(l *Lock) error {
 			return NewModuleEmptyVersionError(mod.Name)
 		}
 		if mod.Root {
+			if mod.BuildOnly {
+				return NewBuildOnlyRootError(mod.Name)
+			}
 			rootCount++
 		}
 	}

--- a/boot/deps/lock/validate.go
+++ b/boot/deps/lock/validate.go
@@ -3,6 +3,7 @@
 package lock
 
 import (
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,8 +32,13 @@ func Validate(l *Lock) error {
 			}
 			rootCount++
 		}
-		if _, replaced := replacements[mod.Name]; mod.BuildOnly && mod.Hash == "" && !replaced {
+		_, replaced := replacements[mod.Name]
+		buildDependency := mod.BuildDependency || mod.BuildOnly
+		if buildDependency && mod.Hash == "" && !replaced {
 			return NewBuildOnlyDigestError(mod.Name)
+		}
+		if buildDependency && mod.Hash != "" && !replaced && !validBuildDigest(mod.Hash) {
+			return NewInvalidBuildDigestError(mod.Name, mod.Hash)
 		}
 	}
 	if rootCount > 1 {
@@ -52,6 +58,18 @@ func Validate(l *Lock) error {
 	}
 
 	return nil
+}
+
+func validBuildDigest(digest string) bool {
+	if digest != strings.TrimSpace(digest) {
+		return false
+	}
+	parts := strings.SplitN(digest, ":", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "sha256") || len(parts[1]) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(parts[1])
+	return err == nil
 }
 
 // ValidateReplacements checks that all replacement paths exist.

--- a/boot/deps/lock/validate.go
+++ b/boot/deps/lock/validate.go
@@ -11,6 +11,11 @@ import (
 // Validate validates the entire lock file structure.
 // Returns an error if any validation fails.
 func Validate(l *Lock) error {
+	replacements := make(map[string]struct{})
+	for _, replacement := range l.GetReplacements() {
+		replacements[replacement.From] = struct{}{}
+	}
+
 	rootCount := 0
 	for _, mod := range l.data.Modules {
 		if err := ValidateModuleName(mod.Name); err != nil {
@@ -25,6 +30,9 @@ func Validate(l *Lock) error {
 				return NewBuildOnlyRootError(mod.Name)
 			}
 			rootCount++
+		}
+		if _, replaced := replacements[mod.Name]; mod.BuildOnly && mod.Hash == "" && !replaced {
+			return NewBuildOnlyDigestError(mod.Name)
 		}
 	}
 	if rootCount > 1 {

--- a/cmd/internal/entries/build_dependency_test.go
+++ b/cmd/internal/entries/build_dependency_test.go
@@ -3,13 +3,37 @@
 package entries
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
+	"github.com/wippyai/runtime/boot/deps/hub"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
 )
+
+func TestVerifyCachedArtifactRejectsCorruption(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "module.wapp")
+	content := []byte("module")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	digest := sha256.Sum256(content)
+	pinned := fmt.Sprintf("sha256:%x", digest)
+
+	valid, err := hub.VerifyCachedArtifact(path, pinned)
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	require.NoError(t, os.WriteFile(path, []byte("corrupted"), 0o644))
+	valid, err = hub.VerifyCachedArtifact(path, pinned)
+	require.False(t, valid)
+	require.ErrorContains(t, err, "digest mismatch")
+}
 
 func TestPrepareRuntimeEntriesRejectsMissingRequiresWippy(t *testing.T) {
 	entries := []regapi.Entry{{
@@ -20,6 +44,44 @@ func TestPrepareRuntimeEntriesRejectsMissingRequiresWippy(t *testing.T) {
 
 	_, err := prepareRuntimeEntries(entries, &depconfig.ModuleConfig{}, "1.2.0")
 	require.EqualError(t, err, "ns.build_dependency requires requires_wippy in wippy.yaml")
+}
+
+func TestLoadEntriesWithModuleMetaValidatesOwningManifest(t *testing.T) {
+	ctx := setupTestContext(t)
+	root := t.TempDir()
+	appRoot := filepath.Join(root, "app")
+	replacementRoot := filepath.Join(root, "replacement")
+	require.NoError(t, os.MkdirAll(filepath.Join(appRoot, "src"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(replacementRoot, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(appRoot, "wippy.yaml"), []byte("requires_wippy: '>=0.0.0'\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(appRoot, "src", "_index.yaml"), []byte(`version: "1.0"
+namespace: app
+entries:
+  - name: runtime
+    kind: function.lua
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementRoot, "wippy.yaml"), []byte("organization: local\nmodule: frontend\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementRoot, "src", "_index.yaml"), []byte(`version: "1.0"
+namespace: local.frontend
+entries:
+  - name: package
+    kind: ns.build_dependency
+    component: acme/package
+    version: 2.0.0
+`), 0o644))
+	paths := []lock.ModuleLoadPath{
+		{Path: filepath.Join(appRoot, "src"), SourceRoot: appRoot, Root: true},
+		{Path: filepath.Join(replacementRoot, "src"), SourceRoot: replacementRoot, Module: "local/frontend"},
+	}
+
+	_, err := loadEntriesWithModuleMeta(ctx, paths, zap.NewNop())
+	require.EqualError(t, err, "ns.build_dependency requires requires_wippy in wippy.yaml")
+
+	require.NoError(t, os.WriteFile(filepath.Join(replacementRoot, "wippy.yaml"), []byte("organization: local\nmodule: frontend\nrequires_wippy: '>=0.0.0'\n"), 0o644))
+	loaded, err := loadEntriesWithModuleMeta(ctx, paths, zap.NewNop())
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	require.Equal(t, regapi.Kind("function.lua"), loaded[0].Kind)
 }
 
 func TestPrepareRuntimeEntriesStripsCompatibleBuildDependencies(t *testing.T) {

--- a/cmd/internal/entries/build_dependency_test.go
+++ b/cmd/internal/entries/build_dependency_test.go
@@ -15,8 +15,27 @@ import (
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
+
+func TestExtractInstalledBuildModulePreservesVerifiedArtifact(t *testing.T) {
+	root := t.TempDir()
+	wappPath := createTestWappFile(t, root, "frontend", []wapp.Entry{{
+		ID: wapp.NewID("frontend", "package"), Kind: "ns.definition",
+	}})
+	content, err := os.ReadFile(wappPath)
+	require.NoError(t, err)
+	digest := sha256.Sum256(content)
+	dirPath := filepath.Join(root, "frontend")
+
+	require.NoError(t, extractInstalledModule(wappPath, dirPath, true))
+	require.FileExists(t, wappPath)
+	require.DirExists(t, dirPath)
+	valid, err := hub.VerifyCachedArtifact(wappPath, fmt.Sprintf("sha256:%x", digest))
+	require.NoError(t, err)
+	require.True(t, valid)
+}
 
 func TestVerifyCachedArtifactRejectsCorruption(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "module.wapp")
@@ -82,6 +101,33 @@ entries:
 	require.NoError(t, err)
 	require.Len(t, loaded, 1)
 	require.Equal(t, regapi.Kind("function.lua"), loaded[0].Kind)
+}
+
+func TestValidateBuildOnlyReplacementSourcesUsesArtifactPaths(t *testing.T) {
+	ctx := setupTestContext(t)
+	root := t.TempDir()
+	replacementRoot := filepath.Join(root, "replacement")
+	require.NoError(t, os.MkdirAll(filepath.Join(replacementRoot, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementRoot, "wippy.yaml"), []byte("organization: local\nmodule: frontend\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementRoot, "src", "_index.yaml"), []byte(`version: "1.0"
+namespace: local.frontend
+entries:
+  - name: package
+    kind: ns.build_dependency
+    component: acme/package
+    version: 2.0.0
+`), 0o644))
+	lockObj, err := lock.New(filepath.Join(root, lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{Name: "local/frontend", Version: "1.0.0", BuildOnly: true})
+	lockObj.SetReplacement(lock.Replacement{From: "local/frontend", To: "replacement"})
+	require.NoError(t, lock.Validate(lockObj))
+
+	err = validateBuildOnlyReplacementSources(ctx, lockObj, zap.NewNop())
+	require.EqualError(t, err, "ns.build_dependency requires requires_wippy in wippy.yaml")
+
+	require.NoError(t, os.WriteFile(filepath.Join(replacementRoot, "wippy.yaml"), []byte("organization: local\nmodule: frontend\nrequires_wippy: '>=0.0.0'\n"), 0o644))
+	require.NoError(t, validateBuildOnlyReplacementSources(ctx, lockObj, zap.NewNop()))
 }
 
 func TestPrepareRuntimeEntriesStripsCompatibleBuildDependencies(t *testing.T) {

--- a/cmd/internal/entries/build_dependency_test.go
+++ b/cmd/internal/entries/build_dependency_test.go
@@ -35,6 +35,12 @@ func TestExtractInstalledBuildModulePreservesVerifiedArtifact(t *testing.T) {
 	valid, err := hub.VerifyCachedArtifact(wappPath, fmt.Sprintf("sha256:%x", digest))
 	require.NoError(t, err)
 	require.True(t, valid)
+
+	tamperedPath := filepath.Join(dirPath, "tampered.txt")
+	require.NoError(t, os.WriteFile(tamperedPath, []byte("tampered"), 0o644))
+	require.NoError(t, extractInstalledModule(wappPath, dirPath, true))
+	require.NoFileExists(t, tamperedPath)
+	require.FileExists(t, wappPath)
 }
 
 func TestVerifyCachedArtifactRejectsCorruption(t *testing.T) {

--- a/cmd/internal/entries/build_dependency_test.go
+++ b/cmd/internal/entries/build_dependency_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package entries
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
+)
+
+func TestPrepareRuntimeEntriesRejectsMissingRequiresWippy(t *testing.T) {
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.dependencies", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "acme/frontend", "version": "1.0.0"}),
+	}}
+
+	_, err := prepareRuntimeEntries(entries, &depconfig.ModuleConfig{}, "1.2.0")
+	require.EqualError(t, err, "ns.build_dependency requires requires_wippy in wippy.yaml")
+}
+
+func TestPrepareRuntimeEntriesStripsCompatibleBuildDependencies(t *testing.T) {
+	runtimeEntry := regapi.Entry{ID: regapi.NewID("app", "runtime"), Kind: "function.lua"}
+	entries := []regapi.Entry{
+		runtimeEntry,
+		{
+			ID:   regapi.NewID("app.dependencies", "frontend"),
+			Kind: regapi.NamespaceBuildDependency,
+			Data: payload.New(map[string]any{"component": "acme/frontend", "version": "1.0.0"}),
+		},
+	}
+
+	prepared, err := prepareRuntimeEntries(entries, &depconfig.ModuleConfig{RequiresWippy: ">=1.2.0"}, "1.2.0")
+	require.NoError(t, err)
+	require.Equal(t, []regapi.Entry{runtimeEntry}, prepared)
+}

--- a/cmd/internal/entries/extract.go
+++ b/cmd/internal/entries/extract.go
@@ -10,3 +10,7 @@ import "github.com/wippyai/runtime/boot/deps/wappextract"
 func ExtractWappToDir(wappPath, targetDir string) error {
 	return wappextract.ExtractWappToDir(wappPath, targetDir)
 }
+
+func ExtractWappToDirKeepSource(wappPath, targetDir string) error {
+	return wappextract.ExtractWappToDirKeepSource(wappPath, targetDir)
+}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -16,6 +16,7 @@ import (
 	moduleapi "github.com/wippyai/runtime/api/modules"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/version"
 	bootpkg "github.com/wippyai/runtime/boot"
 	"github.com/wippyai/runtime/boot/build"
 	"github.com/wippyai/runtime/boot/build/stages"
@@ -71,6 +72,22 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 		return NewLoadEntriesFromPathsError(err)
 	}
 
+	var moduleCfg *depconfig.ModuleConfig
+	for _, entry := range entries {
+		if entry.Kind != regapi.NamespaceBuildDependency {
+			continue
+		}
+		moduleCfg, err = depconfig.Load(filepath.Dir(lockObj.Path()))
+		if err != nil {
+			return NewLoadEntriesFromPathsError(err)
+		}
+		break
+	}
+	entries, err = prepareRuntimeEntries(entries, moduleCfg, version.Short())
+	if err != nil {
+		return NewLoadEntriesFromPathsError(err)
+	}
+
 	logger.Info("loaded entries", zap.Int("count", len(entries)))
 
 	// Register .wapp files with embed registry for fs.embed support
@@ -84,6 +101,32 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 
 	logger.Info("entries loaded to registry successfully")
 	return nil
+}
+
+func prepareRuntimeEntries(entries []regapi.Entry, cfg *depconfig.ModuleConfig, currentVersion string) ([]regapi.Entry, error) {
+	buildCount := 0
+	for _, entry := range entries {
+		if entry.Kind == regapi.NamespaceBuildDependency {
+			buildCount++
+		}
+	}
+	if buildCount == 0 {
+		return entries, nil
+	}
+	if cfg == nil || strings.TrimSpace(cfg.RequiresWippy) == "" {
+		return nil, fmt.Errorf("ns.build_dependency requires requires_wippy in wippy.yaml")
+	}
+	if err := cfg.ValidateRuntimeVersion(currentVersion); err != nil {
+		return nil, err
+	}
+
+	runtimeEntries := make([]regapi.Entry, 0, len(entries)-buildCount)
+	for _, entry := range entries {
+		if entry.Kind != regapi.NamespaceBuildDependency {
+			runtimeEntries = append(runtimeEntries, entry)
+		}
+	}
+	return runtimeEntries, nil
 }
 
 // EnsureModulesInstalled checks if modules from the lock file are installed,

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -54,6 +54,9 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 	if err := lock.Validate(lockObj); err != nil {
 		return NewInvalidLockFileError(fmt.Errorf("lock file %s: %w", lockObj.Path(), err))
 	}
+	if err := validateBuildOnlyReplacementSources(ctx, lockObj, logger); err != nil {
+		return NewLoadEntriesFromPathsError(err)
+	}
 
 	if err := ensureModulesInstalledFromLock(ctx, lockObj, logger); err != nil {
 		return NewEnsureModulesInstalledError(err)
@@ -178,7 +181,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			if shouldUnpack {
 				if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 					logger.Info("unpacking .wapp to directory", zap.String("module", mod.Name))
-					if err := ExtractWappToDir(wappPath, dirPath); err != nil {
+					if err := extractInstalledModule(wappPath, dirPath, mod.BuildOnly); err != nil {
 						return NewExtractModuleError(mod.Name, err)
 					}
 				} else if err != nil {
@@ -195,7 +198,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewExtractModuleError(mod.Name, err)
 			}
-		} else if mod.Hash == "" {
+		} else if !mod.BuildOnly || mod.Hash == "" {
 			resolved := lock.ResolveModuleDir(vendorPath, name, mod.Version)
 			if _, err := os.Stat(resolved.Path); err == nil {
 				continue
@@ -272,7 +275,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
-			if err := ExtractWappToDir(fullWappPath, dirPath); err != nil {
+			if err := extractInstalledModule(fullWappPath, dirPath, mod.BuildOnly); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
 		}
@@ -281,6 +284,13 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 
 	logger.Info("modules installed successfully")
 	return nil
+}
+
+func extractInstalledModule(wappPath, dirPath string, buildOnly bool) error {
+	if buildOnly {
+		return ExtractWappToDirKeepSource(wappPath, dirPath)
+	}
+	return ExtractWappToDir(wappPath, dirPath)
 }
 
 // createHubClient creates a hub client using stored credentials.
@@ -400,27 +410,9 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 	var entries []regapi.Entry
 
 	for _, mp := range modulePaths {
-		loaded, err := loadEntriesFromModulePath(ctx, mp, ldr, dtt, logger)
+		loaded, err := loadPreparedEntriesFromModulePath(ctx, mp, ldr, dtt, logger)
 		if err != nil {
 			return nil, err
-		}
-
-		if shouldApplyModuleConfigFilters(mp) {
-			loaded, err = applyModuleConfigFilters(ctx, mp, loaded, logger)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if countBuildDependencies(loaded) > 0 {
-			moduleCfg, err := depconfig.Load(mp.SourceRoot)
-			if err != nil {
-				return nil, err
-			}
-			loaded, err = prepareRuntimeEntries(loaded, moduleCfg, version.Short())
-			if err != nil {
-				return nil, err
-			}
 		}
 
 		for i := range loaded {
@@ -440,6 +432,56 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 	}
 
 	return entries, nil
+}
+
+func validateBuildOnlyReplacementSources(ctx context.Context, lockObj *lock.Lock, logger *zap.Logger) error {
+	dtt := payload.GetTranscoder(ctx)
+	if dtt == nil {
+		return ErrTranscoderNotFound
+	}
+	ldr := boot.GetLoader(ctx)
+	if ldr == nil {
+		return ErrLoaderNotFound
+	}
+
+	modules := make(map[string]lock.Module)
+	for _, module := range lockObj.GetModules() {
+		modules[module.Name] = module
+	}
+	for _, modulePath := range lockObj.GetArtifactModuleLoadPaths() {
+		module, exists := modules[modulePath.Module]
+		if !exists || !module.BuildOnly {
+			continue
+		}
+		if _, replaced := lockObj.GetReplacement(modulePath.Module); !replaced {
+			continue
+		}
+		if _, err := loadPreparedEntriesFromModulePath(ctx, modulePath, ldr, dtt, logger); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadPreparedEntriesFromModulePath(ctx context.Context, modulePath lock.ModuleLoadPath, ldr boot.Loader, dtt payload.Transcoder, logger *zap.Logger) ([]regapi.Entry, error) {
+	loaded, err := loadEntriesFromModulePath(ctx, modulePath, ldr, dtt, logger)
+	if err != nil {
+		return nil, err
+	}
+	if shouldApplyModuleConfigFilters(modulePath) {
+		loaded, err = applyModuleConfigFilters(ctx, modulePath, loaded, logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if countBuildDependencies(loaded) == 0 {
+		return loaded, nil
+	}
+	moduleCfg, err := depconfig.Load(modulePath.SourceRoot)
+	if err != nil {
+		return nil, err
+	}
+	return prepareRuntimeEntries(loaded, moduleCfg, version.Short())
 }
 
 func shouldApplyModuleConfigFilters(mp lock.ModuleLoadPath) bool {

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -176,12 +176,18 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 
 		dirPath := filepath.Join(vendorPath, lock.ModulePath(name))
 		wappPath := filepath.Join(vendorPath, lock.WappPath(name, mod.Version))
+		buildDependency := mod.BuildDependency || mod.BuildOnly
 		cachedArtifact, verifyErr := hub.VerifyCachedArtifact(wappPath, mod.Hash)
 		if cachedArtifact {
-			if shouldUnpack {
+			if shouldUnpack && buildDependency {
+				logger.Info("refreshing build dependency directory", zap.String("module", mod.Name))
+				if err := extractInstalledModule(wappPath, dirPath, true); err != nil {
+					return NewExtractModuleError(mod.Name, err)
+				}
+			} else if shouldUnpack {
 				if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 					logger.Info("unpacking .wapp to directory", zap.String("module", mod.Name))
-					if err := extractInstalledModule(wappPath, dirPath, mod.BuildOnly); err != nil {
+					if err := extractInstalledModule(wappPath, dirPath, false); err != nil {
 						return NewExtractModuleError(mod.Name, err)
 					}
 				} else if err != nil {
@@ -198,7 +204,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewExtractModuleError(mod.Name, err)
 			}
-		} else if !mod.BuildOnly || mod.Hash == "" {
+		} else if !buildDependency || mod.Hash == "" {
 			resolved := lock.ResolveModuleDir(vendorPath, name, mod.Version)
 			if _, err := os.Stat(resolved.Path); err == nil {
 				continue
@@ -254,7 +260,8 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 		if err != nil {
 			return NewDownloadModuleError(moduleRef, err)
 		}
-		if mod.BuildOnly && expectedDigest == "" {
+		buildDependency := mod.BuildDependency || mod.BuildOnly
+		if buildDependency && expectedDigest == "" {
 			return NewDownloadModuleError(moduleRef, fmt.Errorf("build dependency has no artifact digest"))
 		}
 
@@ -275,7 +282,7 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
-			if err := extractInstalledModule(fullWappPath, dirPath, mod.BuildOnly); err != nil {
+			if err := extractInstalledModule(fullWappPath, dirPath, buildDependency); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
 		}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -72,22 +72,6 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 		return NewLoadEntriesFromPathsError(err)
 	}
 
-	var moduleCfg *depconfig.ModuleConfig
-	for _, entry := range entries {
-		if entry.Kind != regapi.NamespaceBuildDependency {
-			continue
-		}
-		moduleCfg, err = depconfig.Load(filepath.Dir(lockObj.Path()))
-		if err != nil {
-			return NewLoadEntriesFromPathsError(err)
-		}
-		break
-	}
-	entries, err = prepareRuntimeEntries(entries, moduleCfg, version.Short())
-	if err != nil {
-		return NewLoadEntriesFromPathsError(err)
-	}
-
 	logger.Info("loaded entries", zap.Int("count", len(entries)))
 
 	// Register .wapp files with embed registry for fs.embed support
@@ -104,12 +88,7 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 }
 
 func prepareRuntimeEntries(entries []regapi.Entry, cfg *depconfig.ModuleConfig, currentVersion string) ([]regapi.Entry, error) {
-	buildCount := 0
-	for _, entry := range entries {
-		if entry.Kind == regapi.NamespaceBuildDependency {
-			buildCount++
-		}
-	}
+	buildCount := countBuildDependencies(entries)
 	if buildCount == 0 {
 		return entries, nil
 	}
@@ -127,6 +106,16 @@ func prepareRuntimeEntries(entries []regapi.Entry, cfg *depconfig.ModuleConfig, 
 		}
 	}
 	return runtimeEntries, nil
+}
+
+func countBuildDependencies(entries []regapi.Entry) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Kind == regapi.NamespaceBuildDependency {
+			count++
+		}
+	}
+	return count
 }
 
 // EnsureModulesInstalled checks if modules from the lock file are installed,
@@ -182,22 +171,35 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 			continue
 		}
 
-		resolved := lock.ResolveModuleDir(vendorPath, name, mod.Version)
-		if resolved.IsWapp {
+		dirPath := filepath.Join(vendorPath, lock.ModulePath(name))
+		wappPath := filepath.Join(vendorPath, lock.WappPath(name, mod.Version))
+		cachedArtifact, verifyErr := hub.VerifyCachedArtifact(wappPath, mod.Hash)
+		if cachedArtifact {
 			if shouldUnpack {
-				// Migrate legacy .wapp to extracted directory when unpack is enabled
-				dirPath := filepath.Join(vendorPath, lock.ModulePath(name))
-				logger.Info("unpacking .wapp to directory", zap.String("module", mod.Name))
-				if err := ExtractWappToDir(resolved.Path, dirPath); err != nil {
+				if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+					logger.Info("unpacking .wapp to directory", zap.String("module", mod.Name))
+					if err := ExtractWappToDir(wappPath, dirPath); err != nil {
+						return NewExtractModuleError(mod.Name, err)
+					}
+				} else if err != nil {
 					return NewExtractModuleError(mod.Name, err)
 				}
 			}
-			// When unpack=false, keep .wapp as-is (already installed)
 			continue
 		}
-
-		if _, err := os.Stat(resolved.Path); err == nil {
-			continue
+		if verifyErr != nil {
+			logger.Warn("cached module failed integrity check", zap.String("module", mod.Name), zap.Error(verifyErr))
+			if err := os.Remove(wappPath); err != nil && !os.IsNotExist(err) {
+				return NewExtractModuleError(mod.Name, err)
+			}
+			if err := os.RemoveAll(dirPath); err != nil {
+				return NewExtractModuleError(mod.Name, err)
+			}
+		} else if mod.Hash == "" {
+			resolved := lock.ResolveModuleDir(vendorPath, name, mod.Version)
+			if _, err := os.Stat(resolved.Path); err == nil {
+				continue
+			}
 		}
 
 		missingModules = append(missingModules, mod)
@@ -245,13 +247,23 @@ func ensureModulesInstalledFromLock(ctx context.Context, lockObj *lock.Lock, log
 		if downloadInfo.URL == "" {
 			return NewNoContentDownloadedError(moduleRef)
 		}
+		expectedDigest, err := hub.ExpectedArtifactDigest(mod.Hash, downloadInfo.Digest)
+		if err != nil {
+			return NewDownloadModuleError(moduleRef, err)
+		}
+		if mod.BuildOnly && expectedDigest == "" {
+			return NewDownloadModuleError(moduleRef, fmt.Errorf("build dependency has no artifact digest"))
+		}
 
-		// Download .wapp file
 		wappPath := lock.WappPath(name, mod.Version)
 		fullWappPath := filepath.Join(vendorPath, wappPath)
 
 		if err := hubClient.DownloadToFile(ctx, downloadInfo.URL, fullWappPath); err != nil {
 			return NewDownloadModuleError(moduleRef, err)
+		}
+		if err := hub.VerifyDownloadedArtifact(fullWappPath, expectedDigest, downloadInfo.Size); err != nil {
+			_ = os.Remove(fullWappPath)
+			return NewDownloadModuleError(moduleRef, fmt.Errorf("artifact integrity check failed: %w", err))
 		}
 
 		if shouldUnpack {
@@ -395,6 +407,17 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 
 		if shouldApplyModuleConfigFilters(mp) {
 			loaded, err = applyModuleConfigFilters(ctx, mp, loaded, logger)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if countBuildDependencies(loaded) > 0 {
+			moduleCfg, err := depconfig.Load(mp.SourceRoot)
+			if err != nil {
+				return nil, err
+			}
+			loaded, err = prepareRuntimeEntries(loaded, moduleCfg, version.Short())
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -184,7 +184,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				if shouldUnpack {
 					if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 						logger.Info("unpacking .wapp to directory", zap.String("module", module.Name))
-						if err := entries.ExtractWappToDir(wappPath, dirPath); err != nil {
+						if err := extractInstalledModule(wappPath, dirPath, module.BuildOnly); err != nil {
 							return NewExtractModuleError(module.Name, err)
 						}
 					} else if err != nil {
@@ -202,7 +202,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				if err := os.RemoveAll(dirPath); err != nil {
 					return NewStoreModuleError(moduleRef, err)
 				}
-			} else if module.Hash == "" {
+			} else if !module.BuildOnly || module.Hash == "" {
 				resolved := lock.ResolveModuleDir(vendorDir, modName, module.Version)
 				if _, err := os.Stat(resolved.Path); err == nil {
 					logger.Info("module already installed, skipping download",
@@ -259,7 +259,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewStoreModuleError(moduleRef, err)
 			}
-			if err := entries.ExtractWappToDir(wappPath, dirPath); err != nil {
+			if err := extractInstalledModule(wappPath, dirPath, module.BuildOnly); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
 		}
@@ -296,6 +296,13 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func extractInstalledModule(wappPath, dirPath string, buildOnly bool) error {
+	if buildOnly {
+		return entries.ExtractWappToDirKeepSource(wappPath, dirPath)
+	}
+	return entries.ExtractWappToDir(wappPath, dirPath)
 }
 
 type installSelection struct {

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -177,14 +177,20 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 		dirPath := filepath.Join(vendorDir, lock.ModulePath(modName))
 		wappPath := filepath.Join(vendorDir, lock.WappPath(modName, module.Version))
+		buildDependency := module.BuildDependency || module.BuildOnly
 
 		if !refresh {
 			cachedArtifact, verifyErr := hub.VerifyCachedArtifact(wappPath, module.Hash)
 			if cachedArtifact {
-				if shouldUnpack {
+				if shouldUnpack && buildDependency {
+					logger.Info("refreshing build dependency directory", zap.String("module", module.Name))
+					if err := extractInstalledModule(wappPath, dirPath, true); err != nil {
+						return NewExtractModuleError(module.Name, err)
+					}
+				} else if shouldUnpack {
 					if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 						logger.Info("unpacking .wapp to directory", zap.String("module", module.Name))
-						if err := extractInstalledModule(wappPath, dirPath, module.BuildOnly); err != nil {
+						if err := extractInstalledModule(wappPath, dirPath, false); err != nil {
 							return NewExtractModuleError(module.Name, err)
 						}
 					} else if err != nil {
@@ -202,7 +208,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				if err := os.RemoveAll(dirPath); err != nil {
 					return NewStoreModuleError(moduleRef, err)
 				}
-			} else if !module.BuildOnly || module.Hash == "" {
+			} else if !buildDependency || module.Hash == "" {
 				resolved := lock.ResolveModuleDir(vendorDir, modName, module.Version)
 				if _, err := os.Stat(resolved.Path); err == nil {
 					logger.Info("module already installed, skipping download",
@@ -236,7 +242,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return NewDownloadModuleError(moduleRef, err)
 		}
-		if module.BuildOnly && expectedDigest == "" {
+		if buildDependency && expectedDigest == "" {
 			return NewDownloadModuleError(moduleRef, fmt.Errorf("build dependency has no artifact digest"))
 		}
 
@@ -259,7 +265,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err := os.RemoveAll(dirPath); err != nil {
 				return NewStoreModuleError(moduleRef, err)
 			}
-			if err := extractInstalledModule(wappPath, dirPath, module.BuildOnly); err != nil {
+			if err := extractInstalledModule(wappPath, dirPath, buildDependency); err != nil {
 				return NewExtractModuleError(moduleRef, err)
 			}
 		}

--- a/cmd/wippy/cmd/install.go
+++ b/cmd/wippy/cmd/install.go
@@ -176,27 +176,41 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 
 		dirPath := filepath.Join(vendorDir, lock.ModulePath(modName))
+		wappPath := filepath.Join(vendorDir, lock.WappPath(modName, module.Version))
 
 		if !refresh {
-			resolved := lock.ResolveModuleDir(vendorDir, modName, module.Version)
-			if resolved.IsWapp {
+			cachedArtifact, verifyErr := hub.VerifyCachedArtifact(wappPath, module.Hash)
+			if cachedArtifact {
 				if shouldUnpack {
-					// Unpack .wapp to directory when unpack is enabled
-					logger.Info("unpacking .wapp to directory", zap.String("module", module.Name))
-					if err := entries.ExtractWappToDir(resolved.Path, dirPath); err != nil {
-						return NewExtractModuleError(module.Name, err)
+					if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+						logger.Info("unpacking .wapp to directory", zap.String("module", module.Name))
+						if err := entries.ExtractWappToDir(wappPath, dirPath); err != nil {
+							return NewExtractModuleError(module.Name, err)
+						}
+					} else if err != nil {
+						return NewStoreModuleError(moduleRef, err)
 					}
 				}
-				// When unpack=false, keep .wapp as-is (already installed)
 				cached++
 				continue
 			}
-			if _, err := os.Stat(resolved.Path); err == nil {
-				logger.Info("module already installed, skipping download",
-					zap.String("module", module.Name),
-					zap.String("version", module.Version))
-				cached++
-				continue
+			if verifyErr != nil {
+				logger.Warn("cached module failed integrity check", zap.String("module", module.Name), zap.Error(verifyErr))
+				if err := os.Remove(wappPath); err != nil && !os.IsNotExist(err) {
+					return NewStoreModuleError(moduleRef, err)
+				}
+				if err := os.RemoveAll(dirPath); err != nil {
+					return NewStoreModuleError(moduleRef, err)
+				}
+			} else if module.Hash == "" {
+				resolved := lock.ResolveModuleDir(vendorDir, modName, module.Version)
+				if _, err := os.Stat(resolved.Path); err == nil {
+					logger.Info("module already installed, skipping download",
+						zap.String("module", module.Name),
+						zap.String("version", module.Version))
+					cached++
+					continue
+				}
 			}
 		}
 
@@ -218,15 +232,26 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			return NewNoContentDownloadedError(moduleRef)
 		}
 
+		expectedDigest, err := hub.ExpectedArtifactDigest(module.Hash, downloadInfo.Digest)
+		if err != nil {
+			return NewDownloadModuleError(moduleRef, err)
+		}
+		if module.BuildOnly && expectedDigest == "" {
+			return NewDownloadModuleError(moduleRef, fmt.Errorf("build dependency has no artifact digest"))
+		}
+
 		// Download .wapp file. Prefer the hub-mediated download path
 		// (one HTTPS hop to the hub, hub-side retry into S3) — same
 		// motivation as publish: a direct-to-S3 GET from a client on a
 		// flaky network fails without retry. Fall back to the legacy
 		// presigned-URL flow only if the new endpoint is missing on
 		// this hub deployment.
-		wappPath := filepath.Join(vendorDir, lock.WappPath(modName, module.Version))
 		if err := downloadWappViaHubOrLegacy(app.Ctx, hubClient, downloadInfo, wappPath); err != nil {
 			return NewDownloadModuleError(moduleRef, err)
+		}
+		if err := hub.VerifyDownloadedArtifact(wappPath, expectedDigest, downloadInfo.Size); err != nil {
+			_ = os.Remove(wappPath)
+			return NewDownloadModuleError(moduleRef, fmt.Errorf("artifact integrity check failed: %w", err))
 		}
 
 		if shouldUnpack {
@@ -240,9 +265,8 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 		// When unpack=false, keep .wapp file as-is
 
-		// Update hash from download info if available
-		if downloadInfo.Digest != "" && module.Hash != downloadInfo.Digest {
-			module.Hash = downloadInfo.Digest
+		if module.Hash == "" && expectedDigest != "" {
+			module.Hash = expectedDigest
 			lockObj.SetModule(module)
 		}
 

--- a/cmd/wippy/cmd/install_test.go
+++ b/cmd/wippy/cmd/install_test.go
@@ -3,13 +3,40 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	"go.uber.org/zap"
 )
+
+func TestVerifyCachedArtifactChecksPinnedDigest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "module.wapp")
+	content := []byte("module")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	digest := sha256.Sum256(content)
+
+	valid, err := hub.VerifyCachedArtifact(path, fmt.Sprintf("sha256:%x", digest))
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	require.NoError(t, os.WriteFile(path, []byte("corrupted"), 0o644))
+	valid, err = hub.VerifyCachedArtifact(path, fmt.Sprintf("sha256:%x", digest))
+	require.False(t, valid)
+	require.ErrorContains(t, err, "digest mismatch")
+}
+
+func TestVerifyCachedArtifactTreatsMissingFileAsCacheMiss(t *testing.T) {
+	valid, err := hub.VerifyCachedArtifact(filepath.Join(t.TempDir(), "missing.wapp"), "sha256:missing")
+	require.NoError(t, err)
+	require.False(t, valid)
+}
 
 func TestShouldBypassInstallCache(t *testing.T) {
 	t.Run("returns false when no flags exist", func(t *testing.T) {

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -158,6 +158,9 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return NewInitAppError(err)
 	}
+	if err := loadPublishRuntimeConfig(cmd, app); err != nil {
+		return err
+	}
 
 	outputFile := filepath.Join(os.TempDir(), cfg.OutputFileName())
 	defer os.Remove(outputFile)
@@ -249,6 +252,15 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 
 	fmt.Println()
 
+	return nil
+}
+
+func loadPublishRuntimeConfig(cmd *cobra.Command, app *appinit.Context) error {
+	cfg, err := loadRuntimeConfig(cmd, app.Logger.Named("publish"))
+	if err != nil {
+		return err
+	}
+	boot.WithConfig(app.Ctx, cfg)
 	return nil
 }
 

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -470,7 +470,7 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		if entry.Kind != regapi.NamespaceBuildDependency {
 			continue
 		}
-		lockObj, lockErr := lock.New(filepath.Join(srcDir, lock.DefaultFilename))
+		lockObj, lockErr := lock.New(filepath.Join(srcDir, lock.DefaultFilename), lock.WithWorkspaceConfig(boot.GetConfig(ctx)))
 		if lockErr != nil {
 			return nil, NewPublishConfigError(lockErr)
 		}

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -20,12 +20,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/boot"
+	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/version"
 	"github.com/wippyai/runtime/boot/build"
 	"github.com/wippyai/runtime/boot/build/stages"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
 	"github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/hub"
+	"github.com/wippyai/runtime/boot/deps/lock"
 	appinit "github.com/wippyai/runtime/cmd/internal/app"
 	"github.com/wippyai/runtime/cmd/internal/entries"
 	"github.com/wippyai/wapp"
@@ -460,6 +462,22 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		return nil, NewPublishMultipleDefinitionsError(definitionCount)
 	}
 
+	provenance := frontendProvenance{}
+	for _, entry := range srcEntries {
+		if entry.Kind != regapi.NamespaceBuildDependency {
+			continue
+		}
+		lockObj, lockErr := lock.New(filepath.Join(srcDir, lock.DefaultFilename))
+		if lockErr != nil {
+			return nil, NewPublishConfigError(lockErr)
+		}
+		srcEntries, provenance, lockErr = stripBuildDependencies(ctx, app.Transcoder, srcEntries, lockObj)
+		if lockErr != nil {
+			return nil, NewPublishConfigError(lockErr)
+		}
+		break
+	}
+
 	disableOpts := stages.DisableOptions{
 		Entries:     cfg.EntryExcludes(),
 		MetaFilters: cfg.ExcludeMeta,
@@ -490,6 +508,9 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		"wippy_commit":  version.Commit,
 		"packed_at":     time.Now().UTC().Format(time.RFC3339),
 		"entry_count":   len(srcEntries),
+	}
+	if len(provenance.Imports) > 0 {
+		metadata["fe_provenance"] = provenance
 	}
 
 	if cfg.Description != "" {

--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -462,6 +462,9 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		return nil, NewPublishMultipleDefinitionsError(definitionCount)
 	}
 
+	if err := cfg.ValidateRuntimeVersion(version.Short()); err != nil {
+		return nil, NewPublishConfigError(err)
+	}
 	provenance := frontendProvenance{}
 	for _, entry := range srcEntries {
 		if entry.Kind != regapi.NamespaceBuildDependency {
@@ -476,6 +479,9 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 			return nil, NewPublishConfigError(lockErr)
 		}
 		break
+	}
+	if len(provenance.Imports) > 0 && strings.TrimSpace(cfg.RequiresWippy) == "" {
+		return nil, NewPublishConfigError(fmt.Errorf("ns.build_dependency requires requires_wippy in wippy.yaml"))
 	}
 
 	disableOpts := stages.DisableOptions{
@@ -508,6 +514,9 @@ func packModule(ctx context.Context, app *appinit.Context, cfg *config.ModuleCon
 		"wippy_commit":  version.Commit,
 		"packed_at":     time.Now().UTC().Format(time.RFC3339),
 		"entry_count":   len(srcEntries),
+	}
+	if cfg.RequiresWippy != "" {
+		metadata["requires_wippy"] = cfg.RequiresWippy
 	}
 	if len(provenance.Imports) > 0 {
 		metadata["fe_provenance"] = provenance

--- a/cmd/wippy/cmd/publish_build_dependency.go
+++ b/cmd/wippy/cmd/publish_build_dependency.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/semver"
 	"github.com/wippyai/runtime/boot/deps/lock"
 )
 
@@ -42,6 +43,7 @@ func stripBuildDependencies(
 		}
 		var definition struct {
 			Component  string `json:"component"`
+			Version    string `json:"version"`
 			Parameters []any  `json:"parameters"`
 		}
 		if err := transcoder.Unmarshal(entry.Data, &definition); err != nil {
@@ -56,6 +58,14 @@ func stripBuildDependencies(
 		module, ok := lockObj.GetModule(definition.Component)
 		if !ok || module.Version == "" || module.Hash == "" {
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s is not pinned with a digest", definition.Component)
+		}
+		constraint, err := semver.ParseConstraint(definition.Version)
+		if err != nil {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s has invalid version %s: %w", entry.ID.String(), definition.Version, err)
+		}
+		lockedVersion, err := semver.ParseVersion(module.Version)
+		if err != nil || !constraint.Match(lockedVersion) {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s requires %s@%s but lock selects %s", entry.ID.String(), definition.Component, definition.Version, module.Version)
 		}
 		provenance.Imports = append(provenance.Imports, frontendImportProvenance{
 			Entry:   entry.ID.String(),

--- a/cmd/wippy/cmd/publish_build_dependency.go
+++ b/cmd/wippy/cmd/publish_build_dependency.go
@@ -59,12 +59,12 @@ func stripBuildDependencies(
 		if !ok || module.Version == "" || module.Hash == "" {
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s is not pinned with a digest", definition.Component)
 		}
-		constraint, err := semver.ParseConstraint(definition.Version)
+		declaredVersion, err := semver.ParseVersion(definition.Version)
 		if err != nil {
-			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s has invalid version %s: %w", entry.ID.String(), definition.Version, err)
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s must use an exact semver version: %s", entry.ID.String(), definition.Version)
 		}
 		lockedVersion, err := semver.ParseVersion(module.Version)
-		if err != nil || !constraint.Match(lockedVersion) {
+		if err != nil || !declaredVersion.Equal(lockedVersion) {
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s requires %s@%s but lock selects %s", entry.ID.String(), definition.Component, definition.Version, module.Version)
 		}
 		provenance.Imports = append(provenance.Imports, frontendImportProvenance{

--- a/cmd/wippy/cmd/publish_build_dependency.go
+++ b/cmd/wippy/cmd/publish_build_dependency.go
@@ -46,6 +46,7 @@ func stripBuildDependencies(
 		replacements[replacement.From] = struct{}{}
 	}
 	vendorDir := lock.ResolveLockPath(filepath.Dir(lockObj.Path()), lockObj.GetVendorPath())
+	verifiedArtifacts := make(map[string]struct{})
 
 	provenance := frontendProvenance{ManifestVersion: 1}
 	filtered := make([]regapi.Entry, 0, len(entries))
@@ -91,8 +92,12 @@ func stripBuildDependencies(
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s has invalid component: %w", entry.ID.String(), err)
 		}
 		artifactPath := filepath.Join(vendorDir, lock.WappPath(moduleName, module.Version))
-		if err := hub.VerifyDownloadedArtifact(artifactPath, module.Hash, 0); err != nil {
-			return nil, frontendProvenance{}, fmt.Errorf("verify build dependency %s@%s: %w", definition.Component, module.Version, err)
+		verificationKey := artifactPath + "@" + module.Hash
+		if _, verified := verifiedArtifacts[verificationKey]; !verified {
+			if err := hub.VerifyDownloadedArtifact(artifactPath, module.Hash, 0); err != nil {
+				return nil, frontendProvenance{}, fmt.Errorf("verify build dependency %s@%s: %w", definition.Component, module.Version, err)
+			}
+			verifiedArtifacts[verificationKey] = struct{}{}
 		}
 		provenance.Imports = append(provenance.Imports, frontendImportProvenance{
 			Entry:   entry.ID.String(),

--- a/cmd/wippy/cmd/publish_build_dependency.go
+++ b/cmd/wippy/cmd/publish_build_dependency.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+type frontendProvenance struct {
+	Imports         []frontendImportProvenance `json:"imports"`
+	ManifestVersion int                        `json:"manifest_version"`
+}
+
+type frontendImportProvenance struct {
+	Entry   string `json:"entry"`
+	Module  string `json:"module"`
+	Version string `json:"version"`
+	Digest  string `json:"digest"`
+}
+
+func stripBuildDependencies(
+	ctx context.Context,
+	transcoder payload.Transcoder,
+	entries []regapi.Entry,
+	lockObj *lock.Lock,
+) ([]regapi.Entry, frontendProvenance, error) {
+	provenance := frontendProvenance{ManifestVersion: 1}
+	filtered := make([]regapi.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Kind != regapi.NamespaceBuildDependency {
+			filtered = append(filtered, entry)
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, frontendProvenance{}, err
+		}
+		var definition struct {
+			Component  string `json:"component"`
+			Parameters []any  `json:"parameters"`
+		}
+		if err := transcoder.Unmarshal(entry.Data, &definition); err != nil {
+			return nil, frontendProvenance{}, fmt.Errorf("decode build dependency %s: %w", entry.ID.String(), err)
+		}
+		if definition.Component == "" {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s requires component", entry.ID.String())
+		}
+		if len(definition.Parameters) > 0 {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s cannot declare parameters", entry.ID.String())
+		}
+		module, ok := lockObj.GetModule(definition.Component)
+		if !ok || module.Version == "" || module.Hash == "" {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s is not pinned with a digest", definition.Component)
+		}
+		provenance.Imports = append(provenance.Imports, frontendImportProvenance{
+			Entry:   entry.ID.String(),
+			Module:  definition.Component,
+			Version: module.Version,
+			Digest:  module.Hash,
+		})
+	}
+	sort.Slice(provenance.Imports, func(i, j int) bool {
+		left, right := provenance.Imports[i], provenance.Imports[j]
+		if left.Module != right.Module {
+			return left.Module < right.Module
+		}
+		return left.Entry < right.Entry
+	})
+	return filtered, provenance, nil
+}

--- a/cmd/wippy/cmd/publish_build_dependency.go
+++ b/cmd/wippy/cmd/publish_build_dependency.go
@@ -5,11 +5,14 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/semver"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
 )
 
@@ -31,6 +34,19 @@ func stripBuildDependencies(
 	entries []regapi.Entry,
 	lockObj *lock.Lock,
 ) ([]regapi.Entry, frontendProvenance, error) {
+	if err := lock.Validate(lockObj); err != nil {
+		return nil, frontendProvenance{}, fmt.Errorf("validate build dependency lock: %w", err)
+	}
+	modules := make(map[string]lock.Module)
+	for _, module := range lockObj.GetModules() {
+		modules[module.Name] = module
+	}
+	replacements := make(map[string]struct{})
+	for _, replacement := range lockObj.GetReplacements() {
+		replacements[replacement.From] = struct{}{}
+	}
+	vendorDir := lock.ResolveLockPath(filepath.Dir(lockObj.Path()), lockObj.GetVendorPath())
+
 	provenance := frontendProvenance{ManifestVersion: 1}
 	filtered := make([]regapi.Entry, 0, len(entries))
 	for _, entry := range entries {
@@ -55,7 +71,10 @@ func stripBuildDependencies(
 		if len(definition.Parameters) > 0 {
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s cannot declare parameters", entry.ID.String())
 		}
-		module, ok := lockObj.GetModule(definition.Component)
+		if _, replaced := replacements[definition.Component]; replaced {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s uses a local replacement", definition.Component)
+		}
+		module, ok := modules[definition.Component]
 		if !ok || module.Version == "" || module.Hash == "" {
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s is not pinned with a digest", definition.Component)
 		}
@@ -66,6 +85,14 @@ func stripBuildDependencies(
 		lockedVersion, err := semver.ParseVersion(module.Version)
 		if err != nil || !declaredVersion.Equal(lockedVersion) {
 			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s requires %s@%s but lock selects %s", entry.ID.String(), definition.Component, definition.Version, module.Version)
+		}
+		moduleName, err := graph.ParseName(definition.Component)
+		if err != nil {
+			return nil, frontendProvenance{}, fmt.Errorf("build dependency %s has invalid component: %w", entry.ID.String(), err)
+		}
+		artifactPath := filepath.Join(vendorDir, lock.WappPath(moduleName, module.Version))
+		if err := hub.VerifyDownloadedArtifact(artifactPath, module.Hash, 0); err != nil {
+			return nil, frontendProvenance{}, fmt.Errorf("verify build dependency %s@%s: %w", definition.Component, module.Version, err)
 		}
 		provenance.Imports = append(provenance.Imports, frontendImportProvenance{
 			Entry:   entry.ID.String(),

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+func TestStripBuildDependenciesRecordsLockedProvenance(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{
+		Name:      "acme/frontend",
+		Version:   "2.0.0",
+		Hash:      "sha256:frontend",
+		BuildOnly: true,
+	})
+	entries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("app.deps", "runtime"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "acme/runtime", "version": "1.0.0"}),
+		},
+		{
+			ID:   regapi.NewID("app.deps", "frontend"),
+			Kind: regapi.NamespaceBuildDependency,
+			Data: payload.New(map[string]any{"component": "acme/frontend", "version": "2.0.0"}),
+		},
+	}
+
+	filtered, provenance, err := stripBuildDependencies(ctx, payload.GetTranscoder(ctx), entries, lockObj)
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, regapi.NamespaceDependency, filtered[0].Kind)
+	require.Equal(t, frontendProvenance{
+		ManifestVersion: 1,
+		Imports: []frontendImportProvenance{
+			{
+				Entry:   "app.deps:frontend",
+				Module:  "acme/frontend",
+				Version: "2.0.0",
+				Digest:  "sha256:frontend",
+			},
+		},
+	}, provenance)
+}

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -65,6 +65,26 @@ entries:
 	require.JSONEq(t, `{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":"sha256:frontend"}]}`, string(encoded))
 }
 
+func TestStripBuildDependenciesRejectsStaleLockVersion(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{
+		Name:      "acme/frontend",
+		Version:   "1.0.0",
+		Hash:      "sha256:frontend",
+		BuildOnly: true,
+	})
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "acme/frontend", "version": "2.0.0"}),
+	}}
+
+	_, _, err = stripBuildDependencies(ctx, payload.GetTranscoder(ctx), entries, lockObj)
+	require.EqualError(t, err, "build dependency app.deps:frontend requires acme/frontend@2.0.0 but lock selects 1.0.0")
+}
+
 func TestStripBuildDependenciesRecordsLockedProvenance(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	bootapi "github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
@@ -21,6 +22,8 @@ import (
 	appinit "github.com/wippyai/runtime/cmd/internal/app"
 	"github.com/wippyai/wapp"
 )
+
+const validBuildDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 func TestPackModuleStripsBuildDependencies(t *testing.T) {
 	root := t.TempDir()
@@ -69,6 +72,38 @@ entries:
 	require.JSONEq(t, fmt.Sprintf(`{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":%q}]}`, digest), string(encoded))
 }
 
+func TestPackModuleRejectsWorkspaceBuildReplacement(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "local", "frontend"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src", "_index.yaml"), []byte(`version: "1.0"
+namespace: app
+entries:
+  - name: module
+    kind: ns.definition
+  - name: frontend
+    kind: ns.build_dependency
+    component: acme/frontend
+    version: "2.0.0"
+`), 0o644))
+	lockObj, err := lock.New(filepath.Join(root, lock.DefaultFilename))
+	require.NoError(t, err)
+	digest := writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("remote package"))
+	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: digest, BuildOnly: true, BuildDependency: true})
+	require.NoError(t, lockObj.Write())
+	app, err := appinit.Init(context.Background(), false, false, false, true, time.Now())
+	require.NoError(t, err)
+	bootapi.WithConfig(app.Ctx, bootapi.NewConfig(
+		bootapi.WithSection("boot", map[string]any{"config_dir": root}),
+		bootapi.WithSection("workspace", map[string]any{"replacements.acme/frontend": "local/frontend"}),
+	))
+
+	_, err = packModule(app.Ctx, app, &depconfig.ModuleConfig{
+		Organization: "acme", ModuleName: "consumer", Version: "1.0.0", RequiresWippy: ">=1.2.0",
+	}, root, filepath.Join(root, "consumer.wapp"), nil)
+	require.ErrorContains(t, err, "build dependency acme/frontend uses a local replacement")
+}
+
 func TestStripBuildDependenciesRejectsStaleLockVersion(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
@@ -76,7 +111,7 @@ func TestStripBuildDependenciesRejectsStaleLockVersion(t *testing.T) {
 	lockObj.SetModule(lock.Module{
 		Name:      "acme/frontend",
 		Version:   "1.0.0",
-		Hash:      "sha256:frontend",
+		Hash:      validBuildDigest,
 		BuildOnly: true,
 	})
 	entries := []regapi.Entry{{
@@ -94,7 +129,7 @@ func TestStripBuildDependenciesRejectsVersionRanges(t *testing.T) {
 	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
 	require.NoError(t, err)
 	lockObj.SetModule(lock.Module{
-		Name: "acme/frontend", Version: "2.0.0", Hash: "sha256:frontend", BuildOnly: true,
+		Name: "acme/frontend", Version: "2.0.0", Hash: validBuildDigest, BuildOnly: true,
 	})
 	entries := []regapi.Entry{{
 		ID:   regapi.NewID("app.deps", "frontend"),

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
-	bootapi "github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
@@ -72,7 +72,7 @@ entries:
 	require.JSONEq(t, fmt.Sprintf(`{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":%q}]}`, digest), string(encoded))
 }
 
-func TestPackModuleRejectsWorkspaceBuildReplacement(t *testing.T) {
+func TestLoadPublishRuntimeConfigRejectsWorkspaceBuildReplacement(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "src"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "local", "frontend"), 0o755))
@@ -91,12 +91,16 @@ entries:
 	digest := writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("remote package"))
 	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: digest, BuildOnly: true, BuildDependency: true})
 	require.NoError(t, lockObj.Write())
+	runtimeConfigPath := filepath.Join(root, ".wippy.yaml")
+	require.NoError(t, os.WriteFile(runtimeConfigPath, []byte(`version: "1.0"
+workspace:
+  replacements:
+    acme/frontend: local/frontend
+`), 0o644))
+	setTestConfigFiles(t, runtimeConfigPath)
 	app, err := appinit.Init(context.Background(), false, false, false, true, time.Now())
 	require.NoError(t, err)
-	bootapi.WithConfig(app.Ctx, bootapi.NewConfig(
-		bootapi.WithSection("boot", map[string]any{"config_dir": root}),
-		bootapi.WithSection("workspace", map[string]any{"replacements.acme/frontend": "local/frontend"}),
-	))
+	require.NoError(t, loadPublishRuntimeConfig(&cobra.Command{}, app))
 
 	_, err = packModule(app.Ctx, app, &depconfig.ModuleConfig{
 		Organization: "acme", ModuleName: "consumer", Version: "1.0.0", RequiresWippy: ">=1.2.0",

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -4,7 +4,9 @@ package cmd
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
+	"github.com/wippyai/runtime/boot/deps/graph"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	appinit "github.com/wippyai/runtime/cmd/internal/app"
 	"github.com/wippyai/wapp"
@@ -34,7 +37,8 @@ entries:
 `), 0o644))
 	lockObj, err := lock.New(filepath.Join(root, lock.DefaultFilename))
 	require.NoError(t, err)
-	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: "sha256:frontend", BuildOnly: true})
+	digest := writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("frontend package"))
+	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: digest, BuildOnly: true})
 	require.NoError(t, lockObj.Write())
 	app, err := appinit.Init(context.Background(), false, false, false, true, time.Now())
 	require.NoError(t, err)
@@ -62,7 +66,7 @@ entries:
 	require.Equal(t, ">=1.2.0", metadata["requires_wippy"])
 	encoded, err := json.Marshal(metadata["fe_provenance"])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":"sha256:frontend"}]}`, string(encoded))
+	require.JSONEq(t, fmt.Sprintf(`{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":%q}]}`, digest), string(encoded))
 }
 
 func TestStripBuildDependenciesRejectsStaleLockVersion(t *testing.T) {
@@ -106,10 +110,11 @@ func TestStripBuildDependenciesRecordsLockedProvenance(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
 	require.NoError(t, err)
+	digest := writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("frontend package"))
 	lockObj.SetModule(lock.Module{
 		Name:      "acme/frontend",
 		Version:   "2.0.0",
-		Hash:      "sha256:frontend",
+		Hash:      digest,
 		BuildOnly: true,
 	})
 	entries := []regapi.Entry{
@@ -136,8 +141,56 @@ func TestStripBuildDependenciesRecordsLockedProvenance(t *testing.T) {
 				Entry:   "app.deps:frontend",
 				Module:  "acme/frontend",
 				Version: "2.0.0",
-				Digest:  "sha256:frontend",
+				Digest:  digest,
 			},
 		},
 	}, provenance)
+}
+
+func TestStripBuildDependenciesRejectsReplacement(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	root := t.TempDir()
+	lockObj, err := lock.New(filepath.Join(root, lock.DefaultFilename))
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "local", "frontend"), 0o755))
+	digest := writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("frontend package"))
+	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: digest, BuildOnly: true})
+	lockObj.SetReplacement(lock.Replacement{From: "acme/frontend", To: "local/frontend"})
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "acme/frontend", "version": "2.0.0"}),
+	}}
+
+	_, _, err = stripBuildDependencies(ctx, payload.GetTranscoder(ctx), entries, lockObj)
+	require.EqualError(t, err, "build dependency acme/frontend uses a local replacement")
+}
+
+func TestStripBuildDependenciesRejectsCorruptedArtifact(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
+	require.NoError(t, err)
+	digest := writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("expected"))
+	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: digest, BuildOnly: true})
+	writeBuildArtifact(t, lockObj, "acme/frontend", "2.0.0", []byte("corrupted"))
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "acme/frontend", "version": "2.0.0"}),
+	}}
+
+	_, _, err = stripBuildDependencies(ctx, payload.GetTranscoder(ctx), entries, lockObj)
+	require.ErrorContains(t, err, "verify build dependency acme/frontend@2.0.0")
+	require.ErrorContains(t, err, "digest mismatch")
+}
+
+func writeBuildArtifact(t *testing.T, lockObj *lock.Lock, moduleName, moduleVersion string, content []byte) string {
+	t.Helper()
+	name, err := graph.ParseName(moduleName)
+	require.NoError(t, err)
+	path := filepath.Join(filepath.Dir(lockObj.Path()), lockObj.GetVendorPath(), lock.WappPath(name, moduleVersion))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	digest := sha256.Sum256(content)
+	return fmt.Sprintf("sha256:%x", digest)
 }

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -40,9 +40,10 @@ entries:
 	require.NoError(t, err)
 	output := filepath.Join(root, "consumer.wapp")
 	_, err = packModule(app.Ctx, app, &depconfig.ModuleConfig{
-		Organization: "acme",
-		ModuleName:   "consumer",
-		Version:      "1.0.0",
+		Organization:  "acme",
+		ModuleName:    "consumer",
+		Version:       "1.0.0",
+		RequiresWippy: ">=1.2.0",
 	}, root, output, nil)
 	require.NoError(t, err)
 
@@ -58,6 +59,7 @@ entries:
 	}
 	metadata, err := reader.GetMetadata()
 	require.NoError(t, err)
+	require.Equal(t, ">=1.2.0", metadata["requires_wippy"])
 	encoded, err := json.Marshal(metadata["fe_provenance"])
 	require.NoError(t, err)
 	require.JSONEq(t, `{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":"sha256:frontend"}]}`, string(encoded))

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -3,14 +3,65 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/lock"
+	appinit "github.com/wippyai/runtime/cmd/internal/app"
+	"github.com/wippyai/wapp"
 )
+
+func TestPackModuleStripsBuildDependencies(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src", "_index.yaml"), []byte(`version: "1.0"
+namespace: app
+entries:
+  - name: module
+    kind: ns.definition
+  - name: frontend
+    kind: ns.build_dependency
+    component: acme/frontend
+    version: "2.0.0"
+`), 0o644))
+	lockObj, err := lock.New(filepath.Join(root, lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{Name: "acme/frontend", Version: "2.0.0", Hash: "sha256:frontend", BuildOnly: true})
+	require.NoError(t, lockObj.Write())
+	app, err := appinit.Init(context.Background(), false, false, false, true, time.Now())
+	require.NoError(t, err)
+	output := filepath.Join(root, "consumer.wapp")
+	_, err = packModule(app.Ctx, app, &depconfig.ModuleConfig{
+		Organization: "acme",
+		ModuleName:   "consumer",
+		Version:      "1.0.0",
+	}, root, output, nil)
+	require.NoError(t, err)
+
+	file, err := os.Open(output)
+	require.NoError(t, err)
+	defer file.Close()
+	reader, err := wapp.NewReader(file)
+	require.NoError(t, err)
+	packedEntries, err := reader.GetEntries()
+	require.NoError(t, err)
+	for _, entry := range packedEntries {
+		require.NotEqual(t, regapi.NamespaceBuildDependency, entry.Kind)
+	}
+	metadata, err := reader.GetMetadata()
+	require.NoError(t, err)
+	encoded, err := json.Marshal(metadata["fe_provenance"])
+	require.NoError(t, err)
+	require.JSONEq(t, `{"manifest_version":1,"imports":[{"entry":"app:frontend","module":"acme/frontend","version":"2.0.0","digest":"sha256:frontend"}]}`, string(encoded))
+}
 
 func TestStripBuildDependenciesRecordsLockedProvenance(t *testing.T) {
 	ctx := setupLoaderContext(t)

--- a/cmd/wippy/cmd/publish_build_dependency_test.go
+++ b/cmd/wippy/cmd/publish_build_dependency_test.go
@@ -85,6 +85,23 @@ func TestStripBuildDependenciesRejectsStaleLockVersion(t *testing.T) {
 	require.EqualError(t, err, "build dependency app.deps:frontend requires acme/frontend@2.0.0 but lock selects 1.0.0")
 }
 
+func TestStripBuildDependenciesRejectsVersionRanges(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{
+		Name: "acme/frontend", Version: "2.0.0", Hash: "sha256:frontend", BuildOnly: true,
+	})
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "acme/frontend", "version": ">=2.0.0"}),
+	}}
+
+	_, _, err = stripBuildDependencies(ctx, payload.GetTranscoder(ctx), entries, lockObj)
+	require.EqualError(t, err, "build dependency app.deps:frontend must use an exact semver version: >=2.0.0")
+}
+
 func TestStripBuildDependenciesRecordsLockedProvenance(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -264,8 +264,8 @@ func validateBuildDependencyRuntime(cfg *depconfig.ModuleConfig, entries []regap
 }
 
 type dependencyDeclaration struct {
-	dependencyRequest
 	owner string
+	dependencyRequest
 }
 
 type resolvedDependencyGraph struct {
@@ -306,7 +306,7 @@ func resolveDependencyGraph(entries []regapi.Entry, dtt payload.Transcoder, repl
 		queue = queue[1:]
 		for _, dependency := range byOwner[current.module] {
 			edgeBuild := dependency.BuildDependency
-			dependency.BuildOnly = !(current.runtime && !edgeBuild)
+			dependency.BuildOnly = !current.runtime || edgeBuild
 			dependency.BuildDependency = current.build || edgeBuild
 			component := dependency.Org + "/" + dependency.Module
 			if replacedModules[component] {

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -148,7 +148,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Extract root dependencies from entries
-	rootDeps := extractRootDependencies(entries, app.Transcoder)
+	rootDeps, err := extractRootDependencies(entries, app.Transcoder)
+	if err != nil {
+		return NewLoadEntriesFromSourceError(err)
+	}
 	logger.Info("found root dependencies", zap.Int("count", len(rootDeps)))
 
 	// Local replacements participate in the active graph but are never resolved
@@ -163,7 +166,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		hubDeps := make([]hub.DependencySpec, 0, len(rootDeps))
 		for _, dep := range rootDeps {
 			depName := dep.Org + "/" + dep.Module
-			if replacedModules[depName] {
+			if replacedModules[depName] && !dep.BuildOnly {
 				logger.Info("skipping replaced module from hub resolution", zap.String("module", depName))
 				continue
 			}
@@ -171,6 +174,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 				Org:        dep.Org,
 				Name:       dep.Module,
 				Constraint: dep.Constraint,
+				BuildOnly:  dep.BuildOnly,
 			})
 		}
 
@@ -236,26 +240,32 @@ type dependencyRequest struct {
 	Org        string
 	Module     string
 	Constraint string
+	BuildOnly  bool
 }
 
-func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder) []dependencyRequest {
+func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder) ([]dependencyRequest, error) {
 	deps := make([]dependencyRequest, 0, len(entries))
-	seen := make(map[string]bool)
+	seen := make(map[string]int)
 
 	for _, entry := range entries {
-		if entry.Kind != "ns.dependency" {
+		if entry.Kind != regapi.NamespaceDependency && entry.Kind != regapi.NamespaceBuildDependency {
 			continue
 		}
 
 		var depData struct {
-			Component string `json:"component"`
-			Version   string `json:"version"`
+			Component  string `json:"component"`
+			Version    string `json:"version"`
+			Parameters []any  `json:"parameters"`
 		}
 
 		if err := dtt.Unmarshal(entry.Data, &depData); err != nil {
-			continue
+			return nil, fmt.Errorf("decode dependency %s: %w", entry.ID.String(), err)
 		}
 
+		buildOnly := entry.Kind == regapi.NamespaceBuildDependency
+		if buildOnly && len(depData.Parameters) > 0 {
+			return nil, fmt.Errorf("build dependency %s cannot declare parameters", entry.ID.String())
+		}
 		if depData.Component == "" {
 			continue
 		}
@@ -266,19 +276,21 @@ func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder) []d
 		}
 
 		key := depData.Component + "@" + depData.Version
-		if seen[key] {
+		if index, ok := seen[key]; ok {
+			deps[index].BuildOnly = deps[index].BuildOnly && buildOnly
 			continue
 		}
-		seen[key] = true
+		seen[key] = len(deps)
 
 		deps = append(deps, dependencyRequest{
 			Org:        parts[0],
 			Module:     parts[1],
 			Constraint: depData.Version,
+			BuildOnly:  buildOnly,
 		})
 	}
 
-	return deps
+	return deps, nil
 }
 
 func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, modulesDir, srcDir string) (*lock.Lock, error) {
@@ -345,11 +357,14 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 	}
 
 	// Extract source constraints
-	rootDeps := extractRootDependencies(entries, app.Transcoder)
-	sourceConstraints := make(map[string]string)
+	rootDeps, err := extractRootDependencies(entries, app.Transcoder)
+	if err != nil {
+		return NewLoadEntriesFromSourceError(err)
+	}
+	sourceConstraints := make(map[string]dependencyRequest)
 	for _, dep := range rootDeps {
 		key := fmt.Sprintf("%s/%s", dep.Org, dep.Module)
-		sourceConstraints[key] = dep.Constraint
+		sourceConstraints[key] = dep
 	}
 
 	// Build frozen constraints from lock file (all modules except targets and replaced)
@@ -375,12 +390,13 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 			Org:        parts[0],
 			Name:       parts[1],
 			Constraint: "=" + mod.Version,
+			BuildOnly:  mod.BuildOnly,
 		})
 	}
 
 	// Add target modules with source constraints
 	for _, moduleName := range effectiveTargets {
-		constraint, ok := sourceConstraints[moduleName]
+		dependency, ok := sourceConstraints[moduleName]
 		if !ok {
 			logger.Warn("module not found in source dependencies", zap.String("module", moduleName))
 			continue
@@ -394,7 +410,8 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 		hubDeps = append(hubDeps, hub.DependencySpec{
 			Org:        parts[0],
 			Name:       parts[1],
-			Constraint: constraint,
+			Constraint: dependency.Constraint,
+			BuildOnly:  dependency.BuildOnly,
 		})
 	}
 

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -15,6 +15,7 @@ import (
 	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/semver"
 	"github.com/wippyai/runtime/api/version"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
@@ -150,10 +151,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	replacedModules := effectiveReplacementModules(oldLockObj)
-	rootDeps, err := extractRootDependencies(entries, app.Transcoder, replacedModules)
+	dependencyGraph, err := resolveDependencyGraph(entries, app.Transcoder, replacedModules)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
+	rootDeps := dependencyGraph.dependencies
 	if containsBuildDependency(entries) {
 		moduleCfg, loadErr := depconfig.Load(projectDir)
 		if loadErr != nil {
@@ -208,6 +210,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if oldLockObj != nil {
 		preserveReplacements(newLockObj, oldLockObj.GetTrackedReplacements())
 	}
+	preserveBuildOnlyReplacementModules(newLockObj, oldLockObj, dependencyGraph.replacements)
 	if err := lock.Validate(newLockObj); err != nil {
 		return NewInvalidLockFileError(fmt.Errorf("generated lock file %s: %w", newLockObj.Path(), err))
 	}
@@ -272,10 +275,20 @@ type dependencyDeclaration struct {
 	owner string
 }
 
+type resolvedDependencyGraph struct {
+	dependencies []dependencyRequest
+	replacements []dependencyRequest
+}
+
 func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder, replacedModules map[string]bool) ([]dependencyRequest, error) {
+	graph, err := resolveDependencyGraph(entries, dtt, replacedModules)
+	return graph.dependencies, err
+}
+
+func resolveDependencyGraph(entries []regapi.Entry, dtt payload.Transcoder, replacedModules map[string]bool) (resolvedDependencyGraph, error) {
 	declarations, err := decodeDependencyDeclarations(entries, dtt)
 	if err != nil {
-		return nil, err
+		return resolvedDependencyGraph{}, err
 	}
 
 	byOwner := make(map[string][]dependencyRequest)
@@ -289,6 +302,8 @@ func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder, rep
 	}
 	queue := []reachability{{}}
 	replacementRoles := make(map[string]bool)
+	replacementIndexes := make(map[string]int)
+	replacements := make([]dependencyRequest, 0, len(replacedModules))
 	dependencies := make([]dependencyRequest, 0, len(declarations))
 	seen := make(map[string]int)
 
@@ -300,9 +315,15 @@ func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder, rep
 			component := dependency.Org + "/" + dependency.Module
 			if replacedModules[component] {
 				previous, visited := replacementRoles[component]
-				if !visited || previous && !dependency.BuildOnly {
+				if !visited {
 					replacementRoles[component] = dependency.BuildOnly
+					replacementIndexes[component] = len(replacements)
+					replacements = append(replacements, dependency)
 					queue = append(queue, reachability{module: component, buildOnly: dependency.BuildOnly})
+				} else if previous && !dependency.BuildOnly {
+					replacementRoles[component] = false
+					replacements[replacementIndexes[component]].BuildOnly = false
+					queue = append(queue, reachability{module: component})
 				}
 				continue
 			}
@@ -317,7 +338,7 @@ func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder, rep
 		}
 	}
 
-	return dependencies, nil
+	return resolvedDependencyGraph{dependencies: dependencies, replacements: replacements}, nil
 }
 
 func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder) ([]dependencyDeclaration, error) {
@@ -339,6 +360,11 @@ func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder
 		buildOnly := entry.Kind == regapi.NamespaceBuildDependency
 		if buildOnly && len(data.Parameters) > 0 {
 			return nil, fmt.Errorf("build dependency %s cannot declare parameters", entry.ID.String())
+		}
+		if buildOnly {
+			if _, err := semver.ParseVersion(data.Version); err != nil {
+				return nil, fmt.Errorf("build dependency %s must use an exact semver version: %s", entry.ID.String(), data.Version)
+			}
 		}
 		parts := strings.SplitN(data.Component, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -429,10 +455,11 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 		return NewLoadEntriesFromSourceError(err)
 	}
 
-	rootDeps, err := extractRootDependencies(entries, app.Transcoder, replacedModules)
+	dependencyGraph, err := resolveDependencyGraph(entries, app.Transcoder, replacedModules)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
+	rootDeps := dependencyGraph.dependencies
 	if containsBuildDependency(entries) {
 		moduleCfg, loadErr := depconfig.Load(filepath.Dir(lockObj.Path()))
 		if loadErr != nil {
@@ -484,6 +511,7 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 
 	// Preserve all replacements from current lock file
 	preserveReplacements(newLockObj, lockObj.GetTrackedReplacements())
+	preserveBuildOnlyReplacementModules(newLockObj, oldLockObj, dependencyGraph.replacements)
 	if err := lock.Validate(newLockObj); err != nil {
 		return NewInvalidLockFileError(fmt.Errorf("generated lock file %s: %w", newLockObj.Path(), err))
 	}
@@ -690,6 +718,23 @@ func preserveReplacements(lockObj *lock.Lock, replacements []lock.Replacement) {
 
 	for _, repl := range replacements {
 		lockObj.SetReplacement(repl)
+	}
+}
+
+func preserveBuildOnlyReplacementModules(lockObj, oldLockObj *lock.Lock, replacements []dependencyRequest) {
+	for _, replacement := range replacements {
+		if !replacement.BuildOnly {
+			continue
+		}
+		name := replacement.Org + "/" + replacement.Module
+		module := lock.Module{Name: name, Version: replacement.Constraint, BuildOnly: true}
+		if oldLockObj != nil {
+			if oldModule, ok := oldLockObj.GetModule(name); ok {
+				module.Version = oldModule.Version
+				module.Root = oldModule.Root
+			}
+		}
+		lockObj.SetModule(module)
 	}
 }
 

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -738,6 +738,18 @@ func preserveReplacements(lockObj *lock.Lock, replacements []lock.Replacement) {
 }
 
 func preserveBuildReplacementModules(lockObj, oldLockObj *lock.Lock, replacements []dependencyRequest) {
+	oldModules := make(map[string]lock.Module)
+	if oldLockObj != nil {
+		for _, module := range oldLockObj.GetModules() {
+			oldModules[module.Name] = module
+		}
+	}
+	modules := lockObj.GetModules()
+	indexes := make(map[string]int, len(modules)+len(replacements))
+	for index, module := range modules {
+		indexes[module.Name] = index
+	}
+
 	for _, replacement := range replacements {
 		if !replacement.BuildDependency {
 			continue
@@ -747,14 +759,18 @@ func preserveBuildReplacementModules(lockObj, oldLockObj *lock.Lock, replacement
 			Name: name, Version: replacement.Constraint,
 			BuildOnly: replacement.BuildOnly, BuildDependency: true,
 		}
-		if oldLockObj != nil {
-			if oldModule, ok := oldLockObj.GetModule(name); ok {
-				module.Version = oldModule.Version
-				module.Root = oldModule.Root
-			}
+		if oldModule, ok := oldModules[name]; ok {
+			module.Version = oldModule.Version
+			module.Root = oldModule.Root
 		}
-		lockObj.SetModule(module)
+		if index, exists := indexes[name]; exists {
+			modules[index] = module
+			continue
+		}
+		indexes[name] = len(modules)
+		modules = append(modules, module)
 	}
+	lockObj.ReplaceModules(modules)
 }
 
 func pruneStaleVendorArtifacts(lockObj *lock.Lock, changes *lock.Changes, logger *zap.Logger) {

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/boot"
 	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
@@ -148,25 +149,21 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return NewLoadEntriesFromSourceError(err)
 	}
 
-	// Extract root dependencies from entries
-	rootDeps, err := extractRootDependencies(entries, app.Transcoder)
+	replacedModules := effectiveReplacementModules(oldLockObj)
+	rootDeps, err := extractRootDependencies(entries, app.Transcoder, replacedModules)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
-	if containsBuildDependency(rootDeps) {
+	if containsBuildDependency(entries) {
 		moduleCfg, loadErr := depconfig.Load(projectDir)
 		if loadErr != nil {
 			return NewLoadEntriesFromSourceError(loadErr)
 		}
-		if validateErr := validateBuildDependencyRuntime(moduleCfg, rootDeps, version.Short()); validateErr != nil {
+		if validateErr := validateBuildDependencyRuntime(moduleCfg, entries, version.Short()); validateErr != nil {
 			return NewLoadEntriesFromSourceError(validateErr)
 		}
 	}
 	logger.Info("found root dependencies", zap.Int("count", len(rootDeps)))
-
-	// Local replacements participate in the active graph but are never resolved
-	// from the Hub.
-	replacedModules := effectiveReplacementModules(oldLockObj)
 
 	resolvedModules := make([]hub.ResolvedModule, 0)
 	if len(rootDeps) == 0 {
@@ -175,11 +172,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		// Convert to hub dependency specs, skipping replaced modules
 		hubDeps := make([]hub.DependencySpec, 0, len(rootDeps))
 		for _, dep := range rootDeps {
-			depName := dep.Org + "/" + dep.Module
-			if replacedModules[depName] && !dep.BuildOnly {
-				logger.Info("skipping replaced module from hub resolution", zap.String("module", depName))
-				continue
-			}
 			hubDeps = append(hubDeps, hub.DependencySpec{
 				Org:        dep.Org,
 				Name:       dep.Module,
@@ -215,6 +207,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	// Preserve all replacements from old lock file
 	if oldLockObj != nil {
 		preserveReplacements(newLockObj, oldLockObj.GetTrackedReplacements())
+	}
+	if err := lock.Validate(newLockObj); err != nil {
+		return NewInvalidLockFileError(fmt.Errorf("generated lock file %s: %w", newLockObj.Path(), err))
 	}
 
 	// Save lock file
@@ -253,17 +248,17 @@ type dependencyRequest struct {
 	BuildOnly  bool
 }
 
-func containsBuildDependency(dependencies []dependencyRequest) bool {
-	for _, dependency := range dependencies {
-		if dependency.BuildOnly {
+func containsBuildDependency(entries []regapi.Entry) bool {
+	for _, entry := range entries {
+		if entry.Kind == regapi.NamespaceBuildDependency {
 			return true
 		}
 	}
 	return false
 }
 
-func validateBuildDependencyRuntime(cfg *depconfig.ModuleConfig, dependencies []dependencyRequest, current string) error {
-	if !containsBuildDependency(dependencies) {
+func validateBuildDependencyRuntime(cfg *depconfig.ModuleConfig, entries []regapi.Entry, current string) error {
+	if !containsBuildDependency(entries) {
 		return nil
 	}
 	if cfg == nil || strings.TrimSpace(cfg.RequiresWippy) == "" {
@@ -272,54 +267,102 @@ func validateBuildDependencyRuntime(cfg *depconfig.ModuleConfig, dependencies []
 	return cfg.ValidateRuntimeVersion(current)
 }
 
-func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder) ([]dependencyRequest, error) {
-	deps := make([]dependencyRequest, 0, len(entries))
+type dependencyDeclaration struct {
+	dependencyRequest
+	owner string
+}
+
+func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder, replacedModules map[string]bool) ([]dependencyRequest, error) {
+	declarations, err := decodeDependencyDeclarations(entries, dtt)
+	if err != nil {
+		return nil, err
+	}
+
+	byOwner := make(map[string][]dependencyRequest)
+	for _, declaration := range declarations {
+		byOwner[declaration.owner] = append(byOwner[declaration.owner], declaration.dependencyRequest)
+	}
+
+	type reachability struct {
+		module    string
+		buildOnly bool
+	}
+	queue := []reachability{{}}
+	replacementRoles := make(map[string]bool)
+	dependencies := make([]dependencyRequest, 0, len(declarations))
 	seen := make(map[string]int)
 
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, dependency := range byOwner[current.module] {
+			dependency.BuildOnly = current.buildOnly || dependency.BuildOnly
+			component := dependency.Org + "/" + dependency.Module
+			if replacedModules[component] {
+				previous, visited := replacementRoles[component]
+				if !visited || previous && !dependency.BuildOnly {
+					replacementRoles[component] = dependency.BuildOnly
+					queue = append(queue, reachability{module: component, buildOnly: dependency.BuildOnly})
+				}
+				continue
+			}
+
+			key := component + "@" + dependency.Constraint
+			if index, ok := seen[key]; ok {
+				dependencies[index].BuildOnly = dependencies[index].BuildOnly && dependency.BuildOnly
+				continue
+			}
+			seen[key] = len(dependencies)
+			dependencies = append(dependencies, dependency)
+		}
+	}
+
+	return dependencies, nil
+}
+
+func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder) ([]dependencyDeclaration, error) {
+	declarations := make([]dependencyDeclaration, 0, len(entries))
 	for _, entry := range entries {
 		if entry.Kind != regapi.NamespaceDependency && entry.Kind != regapi.NamespaceBuildDependency {
 			continue
 		}
 
-		var depData struct {
+		var data struct {
 			Component  string `json:"component"`
 			Version    string `json:"version"`
 			Parameters []any  `json:"parameters"`
 		}
-
-		if err := dtt.Unmarshal(entry.Data, &depData); err != nil {
+		if err := dtt.Unmarshal(entry.Data, &data); err != nil {
 			return nil, fmt.Errorf("decode dependency %s: %w", entry.ID.String(), err)
 		}
 
 		buildOnly := entry.Kind == regapi.NamespaceBuildDependency
-		if buildOnly && len(depData.Parameters) > 0 {
+		if buildOnly && len(data.Parameters) > 0 {
 			return nil, fmt.Errorf("build dependency %s cannot declare parameters", entry.ID.String())
 		}
-		if depData.Component == "" {
+		parts := strings.SplitN(data.Component, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			if buildOnly {
+				return nil, fmt.Errorf("build dependency %s has invalid component %s", entry.ID.String(), data.Component)
+			}
 			continue
 		}
 
-		parts := strings.SplitN(depData.Component, "/", 2)
-		if len(parts) != 2 {
-			continue
+		owner := ""
+		if entry.Meta != nil {
+			owner = entry.Meta.GetString("module", "")
 		}
-
-		key := depData.Component + "@" + depData.Version
-		if index, ok := seen[key]; ok {
-			deps[index].BuildOnly = deps[index].BuildOnly && buildOnly
-			continue
-		}
-		seen[key] = len(deps)
-
-		deps = append(deps, dependencyRequest{
-			Org:        parts[0],
-			Module:     parts[1],
-			Constraint: depData.Version,
-			BuildOnly:  buildOnly,
+		declarations = append(declarations, dependencyDeclaration{
+			dependencyRequest: dependencyRequest{
+				Org:        parts[0],
+				Module:     parts[1],
+				Constraint: data.Version,
+				BuildOnly:  buildOnly,
+			},
+			owner: owner,
 		})
 	}
-
-	return deps, nil
+	return declarations, nil
 }
 
 func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, modulesDir, srcDir string) (*lock.Lock, error) {
@@ -386,76 +429,41 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 		return NewLoadEntriesFromSourceError(err)
 	}
 
-	// Extract source constraints
-	rootDeps, err := extractRootDependencies(entries, app.Transcoder)
+	rootDeps, err := extractRootDependencies(entries, app.Transcoder, replacedModules)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
-	if containsBuildDependency(rootDeps) {
+	if containsBuildDependency(entries) {
 		moduleCfg, loadErr := depconfig.Load(filepath.Dir(lockObj.Path()))
 		if loadErr != nil {
 			return NewLoadEntriesFromSourceError(loadErr)
 		}
-		if validateErr := validateBuildDependencyRuntime(moduleCfg, rootDeps, version.Short()); validateErr != nil {
+		if validateErr := validateBuildDependencyRuntime(moduleCfg, entries, version.Short()); validateErr != nil {
 			return NewLoadEntriesFromSourceError(validateErr)
 		}
 	}
-	sourceConstraints := make(map[string]dependencyRequest)
-	for _, dep := range rootDeps {
-		key := fmt.Sprintf("%s/%s", dep.Org, dep.Module)
-		sourceConstraints[key] = dep
-	}
 
-	// Build frozen constraints from lock file (all modules except targets and replaced)
-	targetSet := make(map[string]bool)
+	targetSet := make(map[string]bool, len(effectiveTargets))
 	for _, name := range effectiveTargets {
+		parts := strings.SplitN(name, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return NewParseModuleNameError(name, fmt.Errorf("invalid format, expected org/module"))
+		}
 		targetSet[name] = true
 	}
 
-	modules := lockObj.GetModules()
-	hubDeps := make([]hub.DependencySpec, 0, len(modules)+len(targetModules))
-
-	for _, mod := range modules {
-		parts := strings.SplitN(mod.Name, "/", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		if targetSet[mod.Name] || replacedModules[mod.Name] {
-			continue
-		}
-
+	hubDeps := make([]hub.DependencySpec, 0, len(rootDeps))
+	for _, dependency := range rootDeps {
 		hubDeps = append(hubDeps, hub.DependencySpec{
-			Org:        parts[0],
-			Name:       parts[1],
-			Constraint: "=" + mod.Version,
-			BuildOnly:  mod.BuildOnly,
-		})
-	}
-
-	// Add target modules with source constraints
-	for _, moduleName := range effectiveTargets {
-		dependency, ok := sourceConstraints[moduleName]
-		if !ok {
-			logger.Warn("module not found in source dependencies", zap.String("module", moduleName))
-			continue
-		}
-
-		parts := strings.SplitN(moduleName, "/", 2)
-		if len(parts) != 2 {
-			return NewParseModuleNameError(moduleName, fmt.Errorf("invalid format, expected org/module"))
-		}
-
-		hubDeps = append(hubDeps, hub.DependencySpec{
-			Org:        parts[0],
-			Name:       parts[1],
+			Org:        dependency.Org,
+			Name:       dependency.Module,
 			Constraint: dependency.Constraint,
 			BuildOnly:  dependency.BuildOnly,
 		})
 	}
 
 	logger.Info("resolving with frozen dependencies")
-	result, err := hub.Resolve(app.Ctx, hubClient, hubDeps, nil)
+	result, err := hub.Resolve(app.Ctx, hubClient, hubDeps, targetedResolveOptions(lockObj, targetSet, replacedModules))
 	if err != nil {
 		return NewBuildDependencyGraphError(err)
 	}
@@ -476,6 +484,9 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 
 	// Preserve all replacements from current lock file
 	preserveReplacements(newLockObj, lockObj.GetTrackedReplacements())
+	if err := lock.Validate(newLockObj); err != nil {
+		return NewInvalidLockFileError(fmt.Errorf("generated lock file %s: %w", newLockObj.Path(), err))
+	}
 
 	// Detect changes
 	changes := lock.Diff(oldLockObj, newLockObj)
@@ -553,9 +564,10 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 		moduleRoot = filepath.Dir(lockObj.Path())
 	}
 	paths := []struct {
-		label string
-		path  string
-		root  string
+		label  string
+		path   string
+		root   string
+		module string
 	}{
 		{label: "source", path: srcDir, root: moduleRoot},
 	}
@@ -571,13 +583,15 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 				replacementRoot = mp.Path
 			}
 			paths = append(paths, struct {
-				label string
-				path  string
-				root  string
+				label  string
+				path   string
+				root   string
+				module string
 			}{
-				label: "replacement " + mp.Module,
-				path:  mp.Path,
-				root:  replacementRoot,
+				label:  "replacement " + mp.Module,
+				path:   mp.Path,
+				root:   replacementRoot,
+				module: mp.Module,
 			})
 		}
 	}
@@ -604,6 +618,16 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 		if err != nil {
 			return nil, fmt.Errorf("%s path %s: %w", scanPath.label, absPath, err)
 		}
+		if scanPath.module != "" {
+			for i := range loaded {
+				meta := attrs.NewBag()
+				if loaded[i].Meta != nil {
+					meta = attrs.NewBagFrom(loaded[i].Meta)
+				}
+				meta.Set("module", scanPath.module)
+				loaded[i].Meta = meta
+			}
+		}
 		entries = append(entries, loaded...)
 	}
 
@@ -619,6 +643,21 @@ func effectiveReplacementModules(lockObj *lock.Lock) map[string]bool {
 		modules[replacement.From] = true
 	}
 	return modules
+}
+
+func targetedResolveOptions(lockObj *lock.Lock, targets, replacements map[string]bool) *hub.ResolveOptions {
+	versions := make(map[string]string)
+	digests := make(map[string]string)
+	for _, module := range lockObj.GetModules() {
+		if targets[module.Name] || replacements[module.Name] {
+			continue
+		}
+		versions[module.Name] = module.Version
+		if module.Hash != "" {
+			digests[module.Name] = module.Hash
+		}
+	}
+	return &hub.ResolveOptions{LockedVersions: versions, LockedDigests: digests}
 }
 
 func logChanges(logger *zap.Logger, changes *lock.Changes) {
@@ -669,6 +708,9 @@ func pruneStaleVendorArtifacts(lockObj *lock.Lock, changes *lock.Changes, logger
 		pruneModuleArtifacts(vendorDir, removed.Name, removed.Version, true, logger)
 	}
 	for _, updated := range changes.Updated {
+		if updated.OldVersion == updated.NewVersion && updated.OldHash == updated.NewHash {
+			continue
+		}
 		pruneModuleArtifacts(vendorDir, updated.Name, updated.OldVersion, true, logger)
 	}
 }

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -307,9 +307,10 @@ func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, mo
 	lockedModules := make([]lock.Module, 0, len(modules))
 	for _, m := range modules {
 		lockedModules = append(lockedModules, lock.Module{
-			Name:    fmt.Sprintf("%s/%s", m.Org, m.Name),
-			Version: m.Version,
-			Hash:    m.Digest,
+			Name:      fmt.Sprintf("%s/%s", m.Org, m.Name),
+			Version:   m.Version,
+			Hash:      m.Digest,
+			BuildOnly: m.BuildOnly,
 		})
 	}
 	lockObj.ReplaceModules(lockedModules)

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -524,7 +524,7 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 
 	if lockObj != nil {
 		replacements := effectiveReplacementModules(lockObj)
-		for _, mp := range lockObj.GetModuleLoadPaths() {
+		for _, mp := range lockObj.GetArtifactModuleLoadPaths() {
 			if mp.Module == "" || !replacements[mp.Module] {
 				continue
 			}

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -156,15 +156,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return NewLoadEntriesFromSourceError(err)
 	}
 	rootDeps := dependencyGraph.dependencies
-	if containsBuildDependency(entries) {
-		moduleCfg, loadErr := depconfig.Load(projectDir)
-		if loadErr != nil {
-			return NewLoadEntriesFromSourceError(loadErr)
-		}
-		if validateErr := validateBuildDependencyRuntime(moduleCfg, entries, version.Short()); validateErr != nil {
-			return NewLoadEntriesFromSourceError(validateErr)
-		}
-	}
 	logger.Info("found root dependencies", zap.Int("count", len(rootDeps)))
 
 	resolvedModules := make([]hub.ResolvedModule, 0)
@@ -348,16 +339,26 @@ func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder
 			continue
 		}
 
+		buildOnly := entry.Kind == regapi.NamespaceBuildDependency
 		var data struct {
 			Component  string `json:"component"`
 			Version    string `json:"version"`
 			Parameters []any  `json:"parameters"`
 		}
 		if err := dtt.Unmarshal(entry.Data, &data); err != nil {
-			return nil, fmt.Errorf("decode dependency %s: %w", entry.ID.String(), err)
+			if buildOnly {
+				return nil, fmt.Errorf("decode dependency %s: %w", entry.ID.String(), err)
+			}
+			continue
 		}
 
-		buildOnly := entry.Kind == regapi.NamespaceBuildDependency
+		parts := strings.SplitN(data.Component, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			if buildOnly {
+				return nil, fmt.Errorf("build dependency %s has invalid component %s", entry.ID.String(), data.Component)
+			}
+			continue
+		}
 		if buildOnly && len(data.Parameters) > 0 {
 			return nil, fmt.Errorf("build dependency %s cannot declare parameters", entry.ID.String())
 		}
@@ -365,13 +366,6 @@ func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder
 			if _, err := semver.ParseVersion(data.Version); err != nil {
 				return nil, fmt.Errorf("build dependency %s must use an exact semver version: %s", entry.ID.String(), data.Version)
 			}
-		}
-		parts := strings.SplitN(data.Component, "/", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			if buildOnly {
-				return nil, fmt.Errorf("build dependency %s has invalid component %s", entry.ID.String(), data.Component)
-			}
-			continue
 		}
 
 		owner := ""
@@ -460,16 +454,6 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 		return NewLoadEntriesFromSourceError(err)
 	}
 	rootDeps := dependencyGraph.dependencies
-	if containsBuildDependency(entries) {
-		moduleCfg, loadErr := depconfig.Load(filepath.Dir(lockObj.Path()))
-		if loadErr != nil {
-			return NewLoadEntriesFromSourceError(loadErr)
-		}
-		if validateErr := validateBuildDependencyRuntime(moduleCfg, entries, version.Short()); validateErr != nil {
-			return NewLoadEntriesFromSourceError(validateErr)
-		}
-	}
-
 	targetSet := make(map[string]bool, len(effectiveTargets))
 	for _, name := range effectiveTargets {
 		parts := strings.SplitN(name, "/", 2)
@@ -640,11 +624,19 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 			zap.String("kind", scanPath.label),
 			zap.String("path", absPath))
 
-		cfg, _ := depconfig.Load(scanPath.root)
+		cfg, configErr := depconfig.Load(scanPath.root)
 		sourceFS := depconfig.NewSourceFS(os.DirFS(absPath), cfg, scanPath.root, absPath)
 		loaded, err := ldr.LoadFS(ctx, sourceFS)
 		if err != nil {
 			return nil, fmt.Errorf("%s path %s: %w", scanPath.label, absPath, err)
+		}
+		if containsBuildDependency(loaded) {
+			if configErr != nil {
+				return nil, fmt.Errorf("%s config: %w", scanPath.label, configErr)
+			}
+			if err := validateBuildDependencyRuntime(cfg, loaded, version.Short()); err != nil {
+				return nil, fmt.Errorf("%s: %w", scanPath.label, err)
+			}
 		}
 		if scanPath.module != "" {
 			for i := range loaded {
@@ -682,7 +674,7 @@ func targetedResolveOptions(lockObj *lock.Lock, targets, replacements map[string
 		}
 		versions[module.Name] = module.Version
 		if module.Hash != "" {
-			digests[module.Name] = module.Hash
+			digests[module.Name+"@"+module.Version] = module.Hash
 		}
 	}
 	return &hub.ResolveOptions{LockedVersions: versions, LockedDigests: digests}

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -14,6 +14,7 @@ import (
 	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/version"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/graph"
@@ -152,6 +153,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
+	if containsBuildDependency(rootDeps) {
+		moduleCfg, loadErr := depconfig.Load(projectDir)
+		if loadErr != nil {
+			return NewLoadEntriesFromSourceError(loadErr)
+		}
+		if validateErr := validateBuildDependencyRuntime(moduleCfg, rootDeps, version.Short()); validateErr != nil {
+			return NewLoadEntriesFromSourceError(validateErr)
+		}
+	}
 	logger.Info("found root dependencies", zap.Int("count", len(rootDeps)))
 
 	// Local replacements participate in the active graph but are never resolved
@@ -241,6 +251,25 @@ type dependencyRequest struct {
 	Module     string
 	Constraint string
 	BuildOnly  bool
+}
+
+func containsBuildDependency(dependencies []dependencyRequest) bool {
+	for _, dependency := range dependencies {
+		if dependency.BuildOnly {
+			return true
+		}
+	}
+	return false
+}
+
+func validateBuildDependencyRuntime(cfg *depconfig.ModuleConfig, dependencies []dependencyRequest, current string) error {
+	if !containsBuildDependency(dependencies) {
+		return nil
+	}
+	if cfg == nil || strings.TrimSpace(cfg.RequiresWippy) == "" {
+		return fmt.Errorf("ns.build_dependency requires requires_wippy in wippy.yaml")
+	}
+	return cfg.ValidateRuntimeVersion(current)
 }
 
 func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder) ([]dependencyRequest, error) {
@@ -361,6 +390,15 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 	rootDeps, err := extractRootDependencies(entries, app.Transcoder)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
+	}
+	if containsBuildDependency(rootDeps) {
+		moduleCfg, loadErr := depconfig.Load(filepath.Dir(lockObj.Path()))
+		if loadErr != nil {
+			return NewLoadEntriesFromSourceError(loadErr)
+		}
+		if validateErr := validateBuildDependencyRuntime(moduleCfg, rootDeps, version.Short()); validateErr != nil {
+			return NewLoadEntriesFromSourceError(validateErr)
+		}
 	}
 	sourceConstraints := make(map[string]dependencyRequest)
 	for _, dep := range rootDeps {

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -166,10 +166,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		hubDeps := make([]hub.DependencySpec, 0, len(rootDeps))
 		for _, dep := range rootDeps {
 			hubDeps = append(hubDeps, hub.DependencySpec{
-				Org:        dep.Org,
-				Name:       dep.Module,
-				Constraint: dep.Constraint,
-				BuildOnly:  dep.BuildOnly,
+				Org:             dep.Org,
+				Name:            dep.Module,
+				Constraint:      dep.Constraint,
+				BuildOnly:       dep.BuildOnly,
+				BuildDependency: dep.BuildDependency,
 			})
 		}
 
@@ -201,7 +202,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if oldLockObj != nil {
 		preserveReplacements(newLockObj, oldLockObj.GetTrackedReplacements())
 	}
-	preserveBuildOnlyReplacementModules(newLockObj, oldLockObj, dependencyGraph.replacements)
+	preserveBuildReplacementModules(newLockObj, oldLockObj, dependencyGraph.replacements)
 	if err := lock.Validate(newLockObj); err != nil {
 		return NewInvalidLockFileError(fmt.Errorf("generated lock file %s: %w", newLockObj.Path(), err))
 	}
@@ -236,10 +237,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 }
 
 type dependencyRequest struct {
-	Org        string
-	Module     string
-	Constraint string
-	BuildOnly  bool
+	Org             string
+	Module          string
+	Constraint      string
+	BuildOnly       bool
+	BuildDependency bool
 }
 
 func containsBuildDependency(entries []regapi.Entry) bool {
@@ -288,11 +290,12 @@ func resolveDependencyGraph(entries []regapi.Entry, dtt payload.Transcoder, repl
 	}
 
 	type reachability struct {
-		module    string
-		buildOnly bool
+		module  string
+		runtime bool
+		build   bool
 	}
-	queue := []reachability{{}}
-	replacementRoles := make(map[string]bool)
+	queue := []reachability{{runtime: true}}
+	replacementRoles := make(map[string]reachability)
 	replacementIndexes := make(map[string]int)
 	replacements := make([]dependencyRequest, 0, len(replacedModules))
 	dependencies := make([]dependencyRequest, 0, len(declarations))
@@ -302,19 +305,28 @@ func resolveDependencyGraph(entries []regapi.Entry, dtt payload.Transcoder, repl
 		current := queue[0]
 		queue = queue[1:]
 		for _, dependency := range byOwner[current.module] {
-			dependency.BuildOnly = current.buildOnly || dependency.BuildOnly
+			edgeBuild := dependency.BuildDependency
+			dependency.BuildOnly = !(current.runtime && !edgeBuild)
+			dependency.BuildDependency = current.build || edgeBuild
 			component := dependency.Org + "/" + dependency.Module
 			if replacedModules[component] {
 				previous, visited := replacementRoles[component]
+				combined := reachability{
+					module:  component,
+					runtime: previous.runtime || !dependency.BuildOnly,
+					build:   previous.build || dependency.BuildDependency,
+				}
 				if !visited {
-					replacementRoles[component] = dependency.BuildOnly
 					replacementIndexes[component] = len(replacements)
 					replacements = append(replacements, dependency)
-					queue = append(queue, reachability{module: component, buildOnly: dependency.BuildOnly})
-				} else if previous && !dependency.BuildOnly {
-					replacementRoles[component] = false
-					replacements[replacementIndexes[component]].BuildOnly = false
-					queue = append(queue, reachability{module: component})
+				} else {
+					index := replacementIndexes[component]
+					replacements[index].BuildOnly = !combined.runtime
+					replacements[index].BuildDependency = combined.build
+				}
+				if !visited || combined.runtime != previous.runtime || combined.build != previous.build {
+					replacementRoles[component] = combined
+					queue = append(queue, combined)
 				}
 				continue
 			}
@@ -322,6 +334,7 @@ func resolveDependencyGraph(entries []regapi.Entry, dtt payload.Transcoder, repl
 			key := component + "@" + dependency.Constraint
 			if index, ok := seen[key]; ok {
 				dependencies[index].BuildOnly = dependencies[index].BuildOnly && dependency.BuildOnly
+				dependencies[index].BuildDependency = dependencies[index].BuildDependency || dependency.BuildDependency
 				continue
 			}
 			seen[key] = len(dependencies)
@@ -374,10 +387,11 @@ func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder
 		}
 		declarations = append(declarations, dependencyDeclaration{
 			dependencyRequest: dependencyRequest{
-				Org:        parts[0],
-				Module:     parts[1],
-				Constraint: data.Version,
-				BuildOnly:  buildOnly,
+				Org:             parts[0],
+				Module:          parts[1],
+				Constraint:      data.Version,
+				BuildOnly:       buildOnly,
+				BuildDependency: buildOnly,
 			},
 			owner: owner,
 		})
@@ -399,10 +413,11 @@ func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, mo
 	lockedModules := make([]lock.Module, 0, len(modules))
 	for _, m := range modules {
 		lockedModules = append(lockedModules, lock.Module{
-			Name:      fmt.Sprintf("%s/%s", m.Org, m.Name),
-			Version:   m.Version,
-			Hash:      m.Digest,
-			BuildOnly: m.BuildOnly,
+			Name:            fmt.Sprintf("%s/%s", m.Org, m.Name),
+			Version:         m.Version,
+			Hash:            m.Digest,
+			BuildOnly:       m.BuildOnly,
+			BuildDependency: m.BuildDependency,
 		})
 	}
 	lockObj.ReplaceModules(lockedModules)
@@ -466,10 +481,11 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 	hubDeps := make([]hub.DependencySpec, 0, len(rootDeps))
 	for _, dependency := range rootDeps {
 		hubDeps = append(hubDeps, hub.DependencySpec{
-			Org:        dependency.Org,
-			Name:       dependency.Module,
-			Constraint: dependency.Constraint,
-			BuildOnly:  dependency.BuildOnly,
+			Org:             dependency.Org,
+			Name:            dependency.Module,
+			Constraint:      dependency.Constraint,
+			BuildOnly:       dependency.BuildOnly,
+			BuildDependency: dependency.BuildDependency,
 		})
 	}
 
@@ -495,7 +511,7 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 
 	// Preserve all replacements from current lock file
 	preserveReplacements(newLockObj, lockObj.GetTrackedReplacements())
-	preserveBuildOnlyReplacementModules(newLockObj, oldLockObj, dependencyGraph.replacements)
+	preserveBuildReplacementModules(newLockObj, oldLockObj, dependencyGraph.replacements)
 	if err := lock.Validate(newLockObj); err != nil {
 		return NewInvalidLockFileError(fmt.Errorf("generated lock file %s: %w", newLockObj.Path(), err))
 	}
@@ -700,7 +716,8 @@ func logChanges(logger *zap.Logger, changes *lock.Changes) {
 		for _, mod := range changes.Updated {
 			logger.Info("~ updating", zap.String("module", mod.Name),
 				zap.String("old", mod.OldVersion), zap.String("new", mod.NewVersion),
-				zap.Bool("old_build_only", mod.OldBuildOnly), zap.Bool("new_build_only", mod.NewBuildOnly))
+				zap.Bool("old_build_only", mod.OldBuildOnly), zap.Bool("new_build_only", mod.NewBuildOnly),
+				zap.Bool("old_build_dependency", mod.OldBuildDependency), zap.Bool("new_build_dependency", mod.NewBuildDependency))
 		}
 		for _, mod := range changes.Removed {
 			logger.Info("- removing", zap.String("module", mod.Name), zap.String("version", mod.Version))
@@ -720,13 +737,16 @@ func preserveReplacements(lockObj *lock.Lock, replacements []lock.Replacement) {
 	}
 }
 
-func preserveBuildOnlyReplacementModules(lockObj, oldLockObj *lock.Lock, replacements []dependencyRequest) {
+func preserveBuildReplacementModules(lockObj, oldLockObj *lock.Lock, replacements []dependencyRequest) {
 	for _, replacement := range replacements {
-		if !replacement.BuildOnly {
+		if !replacement.BuildDependency {
 			continue
 		}
 		name := replacement.Org + "/" + replacement.Module
-		module := lock.Module{Name: name, Version: replacement.Constraint, BuildOnly: true}
+		module := lock.Module{
+			Name: name, Version: replacement.Constraint,
+			BuildOnly: replacement.BuildOnly, BuildDependency: true,
+		}
 		if oldLockObj != nil {
 			if oldModule, ok := oldLockObj.GetModule(name); ok {
 				module.Version = oldModule.Version

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -192,7 +192,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Convert resolved modules to lock file
-	newLockObj, err := convertResolvedToLock(lockFilePath, resolvedModules, modulesDir, srcDir)
+	newLockObj, err := convertResolvedToLock(lockFilePath, resolvedModules, modulesDir, srcDir, effectiveReplacementOption(oldLockObj))
 	if err != nil {
 		return NewLoadLockFileError(err)
 	}
@@ -385,8 +385,8 @@ func decodeDependencyDeclarations(entries []regapi.Entry, dtt payload.Transcoder
 	return declarations, nil
 }
 
-func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, modulesDir, srcDir string) (*lock.Lock, error) {
-	lockObj, err := lock.New(lockFilePath)
+func convertResolvedToLock(lockFilePath string, modules []hub.ResolvedModule, modulesDir, srcDir string, options ...lock.Option) (*lock.Lock, error) {
+	lockObj, err := lock.New(lockFilePath, options...)
 	if err != nil {
 		return nil, fmt.Errorf("lock file %s: %w", lockFilePath, err)
 	}
@@ -488,7 +488,7 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 	}
 
 	// Build new lock file
-	newLockObj, err := convertResolvedToLock(lockFilePath, result.Modules, modulesDir, srcDir)
+	newLockObj, err := convertResolvedToLock(lockFilePath, result.Modules, modulesDir, srcDir, effectiveReplacementOption(oldLockObj))
 	if err != nil {
 		return NewLoadLockFileError(err)
 	}
@@ -652,6 +652,13 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 	}
 
 	return entries, nil
+}
+
+func effectiveReplacementOption(lockObj *lock.Lock) lock.Option {
+	if lockObj == nil {
+		return lock.WithWorkspaceReplacements(nil)
+	}
+	return lock.WithWorkspaceReplacements(lockObj.GetReplacements())
 }
 
 func effectiveReplacementModules(lockObj *lock.Lock) map[string]bool {

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -633,7 +633,8 @@ func logChanges(logger *zap.Logger, changes *lock.Changes) {
 		}
 		for _, mod := range changes.Updated {
 			logger.Info("~ updating", zap.String("module", mod.Name),
-				zap.String("old", mod.OldVersion), zap.String("new", mod.NewVersion))
+				zap.String("old", mod.OldVersion), zap.String("new", mod.NewVersion),
+				zap.Bool("old_build_only", mod.OldBuildOnly), zap.Bool("new_build_only", mod.NewBuildOnly))
 		}
 		for _, mod := range changes.Removed {
 			logger.Info("- removing", zap.String("module", mod.Name), zap.String("version", mod.Version))

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
@@ -52,10 +53,81 @@ func TestExtractRootDependenciesPreservesBuildRole(t *testing.T) {
 		},
 	}
 
-	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx))
+	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), nil)
 	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{
 		{Org: "acme", Module: "runtime", Constraint: "1.0.0"},
 		{Org: "acme", Module: "frontend", Constraint: "2.0.0", BuildOnly: true},
 	}, dependencies)
+}
+
+func TestExtractRootDependenciesPropagatesBuildRoleThroughReplacement(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("app.deps", "frontend"),
+			Kind: regapi.NamespaceBuildDependency,
+			Data: payload.New(map[string]any{"component": "local/frontend", "version": "1.0.0"}),
+		},
+		{
+			ID:   regapi.NewID("local.frontend", "runtime"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "acme/runtime", "version": "2.0.0"}),
+			Meta: attrs.NewBagFrom(map[string]any{"module": "local/frontend"}),
+		},
+	}
+
+	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
+	require.NoError(t, err)
+	require.Equal(t, []dependencyRequest{{
+		Org: "acme", Module: "runtime", Constraint: "2.0.0", BuildOnly: true,
+	}}, dependencies)
+}
+
+func TestExtractRootDependenciesRuntimeWinsThroughReplacement(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("app.deps", "frontend-runtime"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "local/frontend", "version": "1.0.0"}),
+		},
+		{
+			ID:   regapi.NewID("app.deps", "frontend-build"),
+			Kind: regapi.NamespaceBuildDependency,
+			Data: payload.New(map[string]any{"component": "local/frontend", "version": "2.0.0"}),
+		},
+		{
+			ID:   regapi.NewID("local.frontend", "runtime"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "acme/runtime", "version": "3.0.0"}),
+			Meta: attrs.NewBagFrom(map[string]any{"module": "local/frontend"}),
+		},
+	}
+
+	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
+	require.NoError(t, err)
+	require.Equal(t, []dependencyRequest{{
+		Org: "acme", Module: "runtime", Constraint: "3.0.0",
+	}}, dependencies)
+}
+
+func TestExtractRootDependenciesRejectsMalformedBuildComponent(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "frontend", "version": "1.0.0"}),
+	}}
+
+	_, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), nil)
+	require.EqualError(t, err, "build dependency app.deps:frontend has invalid component frontend")
+}
+
+func TestContainsBuildDependencyChecksDeclarationsBeforeRuntimeWins(t *testing.T) {
+	entries := []regapi.Entry{
+		{Kind: regapi.NamespaceDependency},
+		{Kind: regapi.NamespaceBuildDependency},
+	}
+	require.True(t, containsBuildDependency(entries))
 }

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+)
+
+func TestExtractRootDependenciesPreservesBuildRole(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{
+		{
+			ID:   regapi.NewID("app.deps", "runtime"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "acme/runtime", "version": "1.0.0"}),
+		},
+		{
+			ID:   regapi.NewID("app.deps", "frontend"),
+			Kind: regapi.NamespaceBuildDependency,
+			Data: payload.New(map[string]any{"component": "acme/frontend", "version": "2.0.0"}),
+		},
+	}
+
+	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx))
+	require.NoError(t, err)
+	require.Equal(t, []dependencyRequest{
+		{Org: "acme", Module: "runtime", Constraint: "1.0.0"},
+		{Org: "acme", Module: "frontend", Constraint: "2.0.0", BuildOnly: true},
+	}, dependencies)
+}

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -33,13 +33,15 @@ func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.
 
 func TestConvertResolvedToLockPreservesBuildOnlyRole(t *testing.T) {
 	lockObj, err := convertResolvedToLock(filepath.Join(t.TempDir(), "wippy.lock"), []hub.ResolvedModule{
-		{Org: "acme", Name: "frontend", Version: "2.0.0", BuildOnly: true},
+		{Org: "acme", Name: "frontend", Version: "2.0.0", Digest: "sha256:frontend", BuildOnly: true},
 	}, ".wippy", ".")
 	require.NoError(t, err)
 
 	module, ok := lockObj.GetModule("acme/frontend")
 	require.True(t, ok)
 	require.True(t, module.BuildOnly)
+	require.Equal(t, "sha256:frontend", module.Hash)
+	require.NoError(t, lock.Validate(lockObj))
 }
 
 func TestExtractRootDependenciesPreservesBuildRole(t *testing.T) {

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -18,6 +18,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const testBuildArtifactDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.T) {
 	entries := []regapi.Entry{{Kind: regapi.NamespaceBuildDependency}}
 	require.EqualError(t,
@@ -33,14 +35,15 @@ func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.
 
 func TestConvertResolvedToLockPreservesBuildOnlyRole(t *testing.T) {
 	lockObj, err := convertResolvedToLock(filepath.Join(t.TempDir(), "wippy.lock"), []hub.ResolvedModule{
-		{Org: "acme", Name: "frontend", Version: "2.0.0", Digest: "sha256:frontend", BuildOnly: true},
+		{Org: "acme", Name: "frontend", Version: "2.0.0", Digest: testBuildArtifactDigest, BuildOnly: true, BuildDependency: true},
 	}, ".wippy", ".")
 	require.NoError(t, err)
 
 	module, ok := lockObj.GetModule("acme/frontend")
 	require.True(t, ok)
 	require.True(t, module.BuildOnly)
-	require.Equal(t, "sha256:frontend", module.Hash)
+	require.Equal(t, testBuildArtifactDigest, module.Hash)
+	require.True(t, module.BuildDependency)
 	require.NoError(t, lock.Validate(lockObj))
 }
 
@@ -63,7 +66,7 @@ func TestExtractRootDependenciesPreservesBuildRole(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{
 		{Org: "acme", Module: "runtime", Constraint: "1.0.0"},
-		{Org: "acme", Module: "frontend", Constraint: "2.0.0", BuildOnly: true},
+		{Org: "acme", Module: "frontend", Constraint: "2.0.0", BuildOnly: true, BuildDependency: true},
 	}, dependencies)
 }
 
@@ -86,10 +89,10 @@ func TestExtractRootDependenciesPropagatesBuildRoleThroughReplacement(t *testing
 	graph, err := resolveDependencyGraph(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
 	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{{
-		Org: "acme", Module: "runtime", Constraint: "2.0.0", BuildOnly: true,
+		Org: "acme", Module: "runtime", Constraint: "2.0.0", BuildOnly: true, BuildDependency: true,
 	}}, graph.dependencies)
 	require.Equal(t, []dependencyRequest{{
-		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true,
+		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true, BuildDependency: true,
 	}}, graph.replacements)
 }
 
@@ -116,10 +119,10 @@ func TestExtractRootDependenciesPropagatesBuildRoleThroughNestedReplacements(t *
 		"local/frontend": true, "local/theme": true,
 	})
 	require.NoError(t, err)
-	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "tokens", Constraint: "3.0.0", BuildOnly: true}}, graph.dependencies)
+	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "tokens", Constraint: "3.0.0", BuildOnly: true, BuildDependency: true}}, graph.dependencies)
 	require.Equal(t, []dependencyRequest{
-		{Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true},
-		{Org: "local", Module: "theme", Constraint: "2.0.0", BuildOnly: true},
+		{Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true, BuildDependency: true},
+		{Org: "local", Module: "theme", Constraint: "2.0.0", BuildOnly: true, BuildDependency: true},
 	}, graph.replacements)
 }
 
@@ -147,10 +150,10 @@ func TestExtractRootDependenciesRuntimeWinsThroughReplacement(t *testing.T) {
 	graph, err := resolveDependencyGraph(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
 	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{{
-		Org: "acme", Module: "runtime", Constraint: "3.0.0",
+		Org: "acme", Module: "runtime", Constraint: "3.0.0", BuildDependency: true,
 	}}, graph.dependencies)
 	require.Equal(t, []dependencyRequest{{
-		Org: "local", Module: "frontend", Constraint: "1.0.0",
+		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildDependency: true,
 	}}, graph.replacements)
 }
 
@@ -163,8 +166,8 @@ func TestGeneratedLockValidatesWorkspaceBuildOnlyReplacement(t *testing.T) {
 	require.NoError(t, err)
 	newLock, err := convertResolvedToLock(oldLock.Path(), nil, ".wippy", ".", effectiveReplacementOption(oldLock))
 	require.NoError(t, err)
-	preserveBuildOnlyReplacementModules(newLock, oldLock, []dependencyRequest{{
-		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true,
+	preserveBuildReplacementModules(newLock, oldLock, []dependencyRequest{{
+		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true, BuildDependency: true,
 	}})
 
 	require.NoError(t, lock.Validate(newLock))
@@ -177,8 +180,8 @@ func TestPreserveBuildOnlyReplacementModulesRetainsRoleAndRejectsRootTransition(
 	newLock, err := lock.New(filepath.Join(t.TempDir(), "new.lock"))
 	require.NoError(t, err)
 
-	preserveBuildOnlyReplacementModules(newLock, oldLock, []dependencyRequest{{
-		Org: "local", Module: "frontend", Constraint: "2.0.0", BuildOnly: true,
+	preserveBuildReplacementModules(newLock, oldLock, []dependencyRequest{{
+		Org: "local", Module: "frontend", Constraint: "2.0.0", BuildOnly: true, BuildDependency: true,
 	}})
 
 	module, ok := newLock.GetModule("local/frontend")

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -154,6 +154,22 @@ func TestExtractRootDependenciesRuntimeWinsThroughReplacement(t *testing.T) {
 	}}, graph.replacements)
 }
 
+func TestGeneratedLockValidatesWorkspaceBuildOnlyReplacement(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "local", "frontend"), 0o755))
+	oldLock, err := lock.New(filepath.Join(root, lock.DefaultFilename), lock.WithWorkspaceReplacements([]lock.Replacement{{
+		From: "local/frontend", To: "local/frontend",
+	}}))
+	require.NoError(t, err)
+	newLock, err := convertResolvedToLock(oldLock.Path(), nil, ".wippy", ".", effectiveReplacementOption(oldLock))
+	require.NoError(t, err)
+	preserveBuildOnlyReplacementModules(newLock, oldLock, []dependencyRequest{{
+		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true,
+	}})
+
+	require.NoError(t, lock.Validate(newLock))
+}
+
 func TestPreserveBuildOnlyReplacementModulesRetainsRoleAndRejectsRootTransition(t *testing.T) {
 	oldLock, err := lock.New(filepath.Join(t.TempDir(), "old.lock"))
 	require.NoError(t, err)

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -3,12 +3,25 @@
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/hub"
 )
+
+func TestConvertResolvedToLockPreservesBuildOnlyRole(t *testing.T) {
+	lockObj, err := convertResolvedToLock(filepath.Join(t.TempDir(), "wippy.lock"), []hub.ResolvedModule{
+		{Org: "acme", Name: "frontend", Version: "2.0.0", BuildOnly: true},
+	}, ".wippy", ".")
+	require.NoError(t, err)
+
+	module, ok := lockObj.GetModule("acme/frontend")
+	require.True(t, ok)
+	require.True(t, module.BuildOnly)
+}
 
 func TestExtractRootDependenciesPreservesBuildRole(t *testing.T) {
 	ctx := setupLoaderContext(t)

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -9,8 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/hub"
 )
+
+func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.T) {
+	dependencies := []dependencyRequest{{Org: "acme", Module: "frontend", BuildOnly: true}}
+	require.EqualError(t,
+		validateBuildDependencyRuntime(&depconfig.ModuleConfig{}, dependencies, "1.2.0"),
+		"ns.build_dependency requires requires_wippy in wippy.yaml",
+	)
+	require.NoError(t, validateBuildDependencyRuntime(&depconfig.ModuleConfig{RequiresWippy: ">=1.2.0"}, dependencies, "1.2.0"))
+	require.EqualError(t,
+		validateBuildDependencyRuntime(&depconfig.ModuleConfig{RequiresWippy: ">=1.3.0"}, dependencies, "1.2.0"),
+		"wippy 1.2.0 does not satisfy requires_wippy >=1.3.0",
+	)
+}
 
 func TestConvertResolvedToLockPreservesBuildOnlyRole(t *testing.T) {
 	lockObj, err := convertResolvedToLock(filepath.Join(t.TempDir(), "wippy.lock"), []hub.ResolvedModule{

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.T) {
-	dependencies := []dependencyRequest{{Org: "acme", Module: "frontend", BuildOnly: true}}
+	entries := []regapi.Entry{{Kind: regapi.NamespaceBuildDependency}}
 	require.EqualError(t,
-		validateBuildDependencyRuntime(&depconfig.ModuleConfig{}, dependencies, "1.2.0"),
+		validateBuildDependencyRuntime(&depconfig.ModuleConfig{}, entries, "1.2.0"),
 		"ns.build_dependency requires requires_wippy in wippy.yaml",
 	)
-	require.NoError(t, validateBuildDependencyRuntime(&depconfig.ModuleConfig{RequiresWippy: ">=1.2.0"}, dependencies, "1.2.0"))
+	require.NoError(t, validateBuildDependencyRuntime(&depconfig.ModuleConfig{RequiresWippy: ">=1.2.0"}, entries, "1.2.0"))
 	require.EqualError(t,
-		validateBuildDependencyRuntime(&depconfig.ModuleConfig{RequiresWippy: ">=1.3.0"}, dependencies, "1.2.0"),
+		validateBuildDependencyRuntime(&depconfig.ModuleConfig{RequiresWippy: ">=1.3.0"}, entries, "1.2.0"),
 		"wippy 1.2.0 does not satisfy requires_wippy >=1.3.0",
 	)
 }

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -3,16 +3,19 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/attrs"
+	bootapi "github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
 )
 
 func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.T) {
@@ -88,6 +91,36 @@ func TestExtractRootDependenciesPropagatesBuildRoleThroughReplacement(t *testing
 	}}, graph.replacements)
 }
 
+func TestExtractRootDependenciesPropagatesBuildRoleThroughNestedReplacements(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{
+		{
+			ID: regapi.NewID("app.deps", "frontend"), Kind: regapi.NamespaceBuildDependency,
+			Data: payload.New(map[string]any{"component": "local/frontend", "version": "1.0.0"}),
+		},
+		{
+			ID: regapi.NewID("local.frontend", "theme"), Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "local/theme", "version": "2.0.0"}),
+			Meta: attrs.NewBagFrom(map[string]any{"module": "local/frontend"}),
+		},
+		{
+			ID: regapi.NewID("local.theme", "tokens"), Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": "acme/tokens", "version": "3.0.0"}),
+			Meta: attrs.NewBagFrom(map[string]any{"module": "local/theme"}),
+		},
+	}
+
+	graph, err := resolveDependencyGraph(entries, payload.GetTranscoder(ctx), map[string]bool{
+		"local/frontend": true, "local/theme": true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "tokens", Constraint: "3.0.0", BuildOnly: true}}, graph.dependencies)
+	require.Equal(t, []dependencyRequest{
+		{Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true},
+		{Org: "local", Module: "theme", Constraint: "2.0.0", BuildOnly: true},
+	}, graph.replacements)
+}
+
 func TestExtractRootDependenciesRuntimeWinsThroughReplacement(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	entries := []regapi.Entry{
@@ -147,7 +180,7 @@ func TestTargetedResolveOptionsPinsOnlyNonTargets(t *testing.T) {
 
 	options := targetedResolveOptions(lockObj, map[string]bool{"acme/target": true}, map[string]bool{"local/replaced": true})
 	require.Equal(t, map[string]string{"acme/frozen": "1.0.0"}, options.LockedVersions)
-	require.Equal(t, map[string]string{"acme/frozen": "sha256:frozen"}, options.LockedDigests)
+	require.Equal(t, map[string]string{"acme/frozen@1.0.0": "sha256:frozen"}, options.LockedDigests)
 }
 
 func TestExtractRootDependenciesRejectsMalformedBuildComponent(t *testing.T) {
@@ -162,6 +195,19 @@ func TestExtractRootDependenciesRejectsMalformedBuildComponent(t *testing.T) {
 	require.EqualError(t, err, "build dependency app.deps:frontend has invalid component frontend")
 }
 
+func TestExtractRootDependenciesPreservesMalformedRuntimeDependencyBehavior(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "legacy"),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.New("malformed"),
+	}}
+
+	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), nil)
+	require.NoError(t, err)
+	require.Empty(t, dependencies)
+}
+
 func TestExtractRootDependenciesRejectsBuildVersionRanges(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	entries := []regapi.Entry{{
@@ -172,6 +218,47 @@ func TestExtractRootDependenciesRejectsBuildVersionRanges(t *testing.T) {
 
 	_, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), nil)
 	require.EqualError(t, err, "build dependency app.deps:frontend must use an exact semver version: >=1.0.0")
+}
+
+func TestLoadDependencyScanEntriesValidatesReplacementRequiresWippy(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	loader := bootapi.GetLoader(ctx)
+	require.NotNil(t, loader)
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "app")
+	replacementDir := filepath.Join(tmpDir, "local", "frontend")
+	require.NoError(t, os.MkdirAll(appDir, 0o755))
+	require.NoError(t, os.MkdirAll(replacementDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "wippy.yaml"), []byte("requires_wippy: '>=0.0.0'\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(`version: "1.0"
+namespace: app.dependencies
+entries:
+  - name: frontend
+    kind: ns.dependency
+    component: local/frontend
+    version: 1.0.0
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementDir, "_index.yaml"), []byte(`version: "1.0"
+namespace: local.frontend
+entries:
+  - name: package
+    kind: ns.build_dependency
+    component: acme/package
+    version: 2.0.0
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementDir, "wippy.yaml"), []byte("organization: local\nmodule: frontend\n"), 0o644))
+
+	lockObj, err := lock.New(filepath.Join(tmpDir, lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetReplacement(lock.Replacement{From: "local/frontend", To: "local/frontend"})
+	lockObj.SetModule(lock.Module{Name: "local/frontend", Version: "1.0.0"})
+
+	_, err = loadDependencyScanEntries(ctx, loader, appDir, lockObj, zap.NewNop())
+	require.EqualError(t, err, "replacement local/frontend: ns.build_dependency requires requires_wippy in wippy.yaml")
+
+	require.NoError(t, os.WriteFile(filepath.Join(replacementDir, "wippy.yaml"), []byte("organization: local\nmodule: frontend\nrequires_wippy: '>=0.0.0'\n"), 0o644))
+	_, err = loadDependencyScanEntries(ctx, loader, appDir, lockObj, zap.NewNop())
+	require.NoError(t, err)
 }
 
 func TestContainsBuildDependencyChecksDeclarationsBeforeRuntimeWins(t *testing.T) {

--- a/cmd/wippy/cmd/update_build_dependency_test.go
+++ b/cmd/wippy/cmd/update_build_dependency_test.go
@@ -12,6 +12,7 @@ import (
 	regapi "github.com/wippyai/runtime/api/registry"
 	depconfig "github.com/wippyai/runtime/boot/deps/config"
 	"github.com/wippyai/runtime/boot/deps/hub"
+	"github.com/wippyai/runtime/boot/deps/lock"
 )
 
 func TestValidateBuildDependencyRuntimeRequiresCompatibleDeclaration(t *testing.T) {
@@ -77,11 +78,14 @@ func TestExtractRootDependenciesPropagatesBuildRoleThroughReplacement(t *testing
 		},
 	}
 
-	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
+	graph, err := resolveDependencyGraph(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
 	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{{
 		Org: "acme", Module: "runtime", Constraint: "2.0.0", BuildOnly: true,
-	}}, dependencies)
+	}}, graph.dependencies)
+	require.Equal(t, []dependencyRequest{{
+		Org: "local", Module: "frontend", Constraint: "1.0.0", BuildOnly: true,
+	}}, graph.replacements)
 }
 
 func TestExtractRootDependenciesRuntimeWinsThroughReplacement(t *testing.T) {
@@ -105,11 +109,45 @@ func TestExtractRootDependenciesRuntimeWinsThroughReplacement(t *testing.T) {
 		},
 	}
 
-	dependencies, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
+	graph, err := resolveDependencyGraph(entries, payload.GetTranscoder(ctx), map[string]bool{"local/frontend": true})
 	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{{
 		Org: "acme", Module: "runtime", Constraint: "3.0.0",
-	}}, dependencies)
+	}}, graph.dependencies)
+	require.Equal(t, []dependencyRequest{{
+		Org: "local", Module: "frontend", Constraint: "1.0.0",
+	}}, graph.replacements)
+}
+
+func TestPreserveBuildOnlyReplacementModulesRetainsRoleAndRejectsRootTransition(t *testing.T) {
+	oldLock, err := lock.New(filepath.Join(t.TempDir(), "old.lock"))
+	require.NoError(t, err)
+	oldLock.SetModule(lock.Module{Name: "local/frontend", Version: "1.0.0", Root: true})
+	newLock, err := lock.New(filepath.Join(t.TempDir(), "new.lock"))
+	require.NoError(t, err)
+
+	preserveBuildOnlyReplacementModules(newLock, oldLock, []dependencyRequest{{
+		Org: "local", Module: "frontend", Constraint: "2.0.0", BuildOnly: true,
+	}})
+
+	module, ok := newLock.GetModule("local/frontend")
+	require.True(t, ok)
+	require.Equal(t, "1.0.0", module.Version)
+	require.True(t, module.BuildOnly)
+	require.True(t, module.Root)
+	require.EqualError(t, lock.Validate(newLock), "deployment root local/frontend cannot be build-only")
+}
+
+func TestTargetedResolveOptionsPinsOnlyNonTargets(t *testing.T) {
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename))
+	require.NoError(t, err)
+	lockObj.SetModule(lock.Module{Name: "acme/target", Version: "2.0.0", Hash: "sha256:target", BuildOnly: true})
+	lockObj.SetModule(lock.Module{Name: "acme/frozen", Version: "1.0.0", Hash: "sha256:frozen"})
+	lockObj.SetModule(lock.Module{Name: "local/replaced", Version: "3.0.0", Hash: "sha256:replaced"})
+
+	options := targetedResolveOptions(lockObj, map[string]bool{"acme/target": true}, map[string]bool{"local/replaced": true})
+	require.Equal(t, map[string]string{"acme/frozen": "1.0.0"}, options.LockedVersions)
+	require.Equal(t, map[string]string{"acme/frozen": "sha256:frozen"}, options.LockedDigests)
 }
 
 func TestExtractRootDependenciesRejectsMalformedBuildComponent(t *testing.T) {
@@ -122,6 +160,18 @@ func TestExtractRootDependenciesRejectsMalformedBuildComponent(t *testing.T) {
 
 	_, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), nil)
 	require.EqualError(t, err, "build dependency app.deps:frontend has invalid component frontend")
+}
+
+func TestExtractRootDependenciesRejectsBuildVersionRanges(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	entries := []regapi.Entry{{
+		ID:   regapi.NewID("app.deps", "frontend"),
+		Kind: regapi.NamespaceBuildDependency,
+		Data: payload.New(map[string]any{"component": "acme/frontend", "version": ">=1.0.0"}),
+	}}
+
+	_, err := extractRootDependencies(entries, payload.GetTranscoder(ctx), nil)
+	require.EqualError(t, err, "build dependency app.deps:frontend must use an exact semver version: >=1.0.0")
 }
 
 func TestContainsBuildDependencyChecksDeclarationsBeforeRuntimeWins(t *testing.T) {

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -176,7 +176,7 @@ entries:
 	require.NoError(t, err)
 	dependencies, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx), effectiveReplacementModules(lockObj))
 	require.NoError(t, err)
-	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "runtime", Constraint: "v1.0.0", BuildOnly: true}}, dependencies)
+	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "runtime", Constraint: "v1.0.0", BuildOnly: true, BuildDependency: true}}, dependencies)
 }
 
 func TestPruneStaleVendorArtifactsKeepsRoleOnlyUpdates(t *testing.T) {

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -146,6 +146,7 @@ func TestLoadDependencyScanEntriesIncludesWorkspaceReplacement(t *testing.T) {
 	replacementDir := filepath.Join(tmpDir, "local", "component")
 	require.NoError(t, os.MkdirAll(appDir, 0o755))
 	require.NoError(t, os.MkdirAll(replacementDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "wippy.yaml"), []byte("requires_wippy: '>=0.0.0'\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(`version: "1.0"
 namespace: app.dependencies
 entries:

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -146,6 +146,14 @@ func TestLoadDependencyScanEntriesIncludesWorkspaceReplacement(t *testing.T) {
 	replacementDir := filepath.Join(tmpDir, "local", "component")
 	require.NoError(t, os.MkdirAll(appDir, 0o755))
 	require.NoError(t, os.MkdirAll(replacementDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(`version: "1.0"
+namespace: app.dependencies
+entries:
+  - name: component
+    kind: ns.build_dependency
+    component: local/component
+    version: v1.0.0
+`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(replacementDir, "_index.yaml"), []byte(`version: "1.0"
 namespace: local.component
 entries:
@@ -253,6 +261,10 @@ entries:
     kind: ns.dependency
     component: wippy/facade
     version: ">=v0.5.39"
+  - name: local_ui
+    kind: ns.dependency
+    component: acme/ui
+    version: "v1.0.0"
 `
 	if err := os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(appYAML), 0o644); err != nil {
 		t.Fatalf("write app index: %v", err)

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -164,7 +164,8 @@ entries:
 
 	loaded, err := loadDependencyScanEntries(ctx, ldr, appDir, lockObj, zap.NewNop())
 	require.NoError(t, err)
-	dependencies := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
+	dependencies, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
+	require.NoError(t, err)
 	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "runtime", Constraint: "v1.0.0"}}, dependencies)
 }
 
@@ -303,7 +304,10 @@ entries:
 		t.Fatalf("loadDependencyScanEntries failed: %v", err)
 	}
 
-	deps := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
+	deps, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
+	if err != nil {
+		t.Fatalf("extractRootDependencies failed: %v", err)
+	}
 	got := map[string]string{}
 	for _, dep := range deps {
 		got[dep.Org+"/"+dep.Module] = dep.Constraint

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -165,9 +165,23 @@ entries:
 
 	loaded, err := loadDependencyScanEntries(ctx, ldr, appDir, lockObj, zap.NewNop())
 	require.NoError(t, err)
-	dependencies, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
+	dependencies, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx), effectiveReplacementModules(lockObj))
 	require.NoError(t, err)
-	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "runtime", Constraint: "v1.0.0"}}, dependencies)
+	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "runtime", Constraint: "v1.0.0", BuildOnly: true}}, dependencies)
+}
+
+func TestPruneStaleVendorArtifactsKeepsRoleOnlyUpdates(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockObj, err := lock.New(filepath.Join(tmpDir, lock.DefaultFilename))
+	require.NoError(t, err)
+	artifact := filepath.Join(tmpDir, ".wippy", "vendor", "acme", "shared-1.0.0.wapp")
+	mustWriteFile(t, artifact)
+
+	pruneStaleVendorArtifacts(lockObj, &lock.Changes{Updated: []lock.ModuleChange{{
+		Name: "acme/shared", OldVersion: "1.0.0", NewVersion: "1.0.0", OldHash: "sha256:same", NewHash: "sha256:same", OldBuildOnly: true,
+	}}}, zap.NewNop())
+
+	require.FileExists(t, artifact)
 }
 
 func TestPruneStaleVendorArtifacts_RemovesStaleArtifacts(t *testing.T) {
@@ -305,7 +319,7 @@ entries:
 		t.Fatalf("loadDependencyScanEntries failed: %v", err)
 	}
 
-	deps, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
+	deps, err := extractRootDependencies(loaded, payload.GetTranscoder(ctx), effectiveReplacementModules(lockObj))
 	if err != nil {
 		t.Fatalf("extractRootDependencies failed: %v", err)
 	}

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -161,6 +161,7 @@ entries:
 	}}))
 	require.NoError(t, err)
 	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "app"})
+	lockObj.SetModule(lock.Module{Name: "local/component", Version: "v1.0.0", BuildOnly: true})
 
 	loaded, err := loadDependencyScanEntries(ctx, ldr, appDir, lockObj, zap.NewNop())
 	require.NoError(t, err)


### PR DESCRIPTION
## Architectural decision for review

This PR introduces `ns.build_dependency` as an explicit source/build-time edge instead of extending `ns.dependency` with `bind: false`.

The explicit kind is intentional and is the main decision requested from the reviewer:

- Released CLIs permissively ignore unknown dependency fields. A legacy CLI could therefore interpret `ns.dependency` plus `bind: false` as a normal runtime dependency and bind backend entries accidentally.
- Released CLIs do not recognize `ns.build_dependency`, so they cannot silently reinterpret the edge as runtime-bound.
- A module using the new kind must declare a compatible `requires_wippy`, making the feature requirement explicit and fail-closed in supported CLIs.

## Semantics

- Build dependencies use exact semantic versions.
- Resolution, authentication, download, digest verification, installation, and lock persistence are identical to remote runtime dependencies.
- The resolver classifies the selected graph in memory in O(V+E), without a second manifest walk or N+1 I/O.
- The lock records two additive facts:
  - `build_only`: no runtime path reaches the module.
  - `build_dependency`: at least one build path reaches the module.
- Runtime reachability wins. A module reached by both runtime and build paths remains runtime-loadable while retaining its verified WAPP as a reproducible build input.
- Build-only modules and local replacements never contribute backend entries, requirements, parameters, embedded runtime resources, or registrations.
- Each source manifest that owns a build edge must independently satisfy `requires_wippy`.
- Remote build inputs require canonical SHA-256 digests before a generated lock can be written.
- Cached/downloaded artifacts are verified against the pinned digest; server digest drift is rejected.
- With unpacking enabled, build inputs retain the verified WAPP and atomically recreate the extracted directory, preventing a modified directory from diverging from published provenance.

## Publishing contract

Published consumers are closed artifacts:

- `ns.build_dependency` entries are removed before normalization and packaging.
- Exact module/version/SHA-256 tuples are emitted as sorted inert `fe_provenance` metadata.
- Missing, stale, malformed, corrupted, tracked-replaced, or workspace-replaced build inputs fail publication.
- WAPP v1 remains unchanged.

## Compatibility

- Existing `ns.dependency` behavior is preserved.
- Legacy lockfiles without the additive role fields remain runtime-bound.
- Legacy bare runtime digests remain compatible with equivalent `sha256:` values.
- No WAPP format or protocol change is introduced.

## Scope boundary

This PR is the runtime dependency/update/install/publish foundation. `fe-install`, `fe-check`, frontend ABI validation, and Hub server-authoritative redistribution are intentionally handled by follow-up implementation rather than hidden inside the dependency primitive.

## Verification

- `make test`
- `go test ./boot/deps/config ./boot/deps/lock ./boot/deps/hub ./cmd/internal/entries ./cmd/wippy/cmd -count=1`
- `git diff --check 0fe48f50..HEAD`
- LSP and pi-lens diagnostics: clean

The implementation went through five independent dual-review rounds. The final round identified workspace replacement loading in the actual publish command; that finding was fixed and the complete harness was rerun. The review iteration cap is now exhausted, so this PR intentionally leaves the final architectural approval to the human reviewer.
