### PR TITLE
feat(eval): support explicit execution step limits

### DIFF
--- a/.wippy.yaml
+++ b/.wippy.yaml
@@ -68,6 +68,8 @@ functions:
 lua:
   proto_cache_size: 60000     # Lua proto cache size
   main_cache_size: 10000      # Lua main cache size
+  eval:
+    max_steps: 10000          # Default eval scheduler-step budget; 0 is unlimited
   type_system:
     enabled: true             # Enable type checking during compilation
     strict: true              # Strict mode treats all issues as compile errors

--- a/boot/components/runtime/lua/eval.go
+++ b/boot/components/runtime/lua/eval.go
@@ -20,6 +20,17 @@ const defaultEvalCacheSize = 256
 
 const EvalHostName boot.Name = "runtime.lua.eval"
 
+func evalMaxSteps(luaCfg boot.Config) (uint64, error) {
+	if luaCfg == nil {
+		return evalhost.DefaultMaxSteps, nil
+	}
+	configured := luaCfg.GetInt("eval.max_steps", int(evalhost.DefaultMaxSteps))
+	if configured < 0 {
+		return 0, fmt.Errorf("lua.eval.max_steps cannot be negative")
+	}
+	return uint64(configured), nil
+}
+
 // Eval creates the eval host boot component.
 func Eval() boot.Component {
 	return boot.New(boot.P{
@@ -42,10 +53,16 @@ func Eval() boot.Component {
 			// evaluated source).
 			evalCacheSize := defaultEvalCacheSize
 			var evalCacheTTL time.Duration
+			maxSteps := evalhost.DefaultMaxSteps
 			if cfg := boot.GetConfig(ctx); cfg != nil {
 				if luaCfg := cfg.Sub("lua"); luaCfg != nil {
 					evalCacheSize = luaCfg.GetInt("eval.cache_size", evalCacheSize)
 					evalCacheTTL = luaCfg.GetDuration("eval.cache_ttl", evalCacheTTL)
+					resolvedMaxSteps, err := evalMaxSteps(luaCfg)
+					if err != nil {
+						return ctx, err
+					}
+					maxSteps = resolvedMaxSteps
 				}
 			}
 
@@ -58,6 +75,7 @@ func Eval() boot.Component {
 					CacheSize: evalCacheSize,
 					CacheTTL:  evalCacheTTL,
 				}),
+				evalhost.WithDefaultMaxSteps(maxSteps),
 			)
 
 			// Set up import loader to load library sources from code manager

--- a/boot/components/runtime/lua/eval_test.go
+++ b/boot/components/runtime/lua/eval_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package lua
+
+import (
+	"testing"
+
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/runtime/lua/evalhost"
+)
+
+func TestEvalMaxSteps(t *testing.T) {
+	tests := []struct {
+		value   any
+		name    string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "omitted", want: evalhost.DefaultMaxSteps},
+		{name: "explicit unlimited", value: 0, want: 0},
+		{name: "positive", value: 25000, want: 25000},
+		{name: "negative", value: -1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := map[string]any{}
+			if tt.value != nil {
+				values["eval.max_steps"] = tt.value
+			}
+			cfg := boot.NewConfig(boot.WithSection("lua", values)).Sub("lua")
+			got, err := evalMaxSteps(cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("evalMaxSteps returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("evalMaxSteps = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/lua/evalhost/command.go
+++ b/runtime/lua/evalhost/command.go
@@ -46,6 +46,8 @@ type RunCmd struct {
 	AllowClasses  []string               // Additional classes to allow (e.g., "process")
 	CustomModules map[string]any         // Custom Lua tables to inject as modules
 	AllowYields   []dispatcher.CommandID // Allowed yield command IDs (empty = no yields)
+	MaxSteps      uint64                 // Scheduler step limit; zero is unlimited when explicitly set.
+	MaxStepsSet   bool                   // Distinguishes an explicit zero from an omitted limit.
 }
 
 func (c RunCmd) CmdID() dispatcher.CommandID {

--- a/runtime/lua/evalhost/host.go
+++ b/runtime/lua/evalhost/host.go
@@ -28,7 +28,9 @@ import (
 // Note: The Compiler caches module definitions but has no persistent resources.
 // All process lifecycle is managed by frame context cleanup.
 
-const maxEvalSteps = 10000
+// DefaultMaxSteps preserves the historical eval scheduler-step budget when a
+// run does not explicitly select a limit.
+const DefaultMaxSteps uint64 = 10000
 
 // ImportLoader loads a library's Lua source code by registry ID.
 // Returns the source code string or an error if not found.
@@ -100,6 +102,7 @@ type Host struct {
 	compiler     *Compiler
 	importLoader ImportLoader
 	programCache *lru.Cache[string, *Program]
+	defaultSteps uint64
 }
 
 // HostConfig configures optional Host behavior.
@@ -130,11 +133,22 @@ func WithProgramCache(cfg HostConfig) HostOption {
 	}
 }
 
+// WithDefaultMaxSteps sets the scheduler-step budget inherited by runs that do
+// not explicitly provide limits.max_steps. Zero makes the inherited default
+// unlimited; an explicit per-run zero remains distinguishable through
+// RunCmd.MaxStepsSet.
+func WithDefaultMaxSteps(maxSteps uint64) HostOption {
+	return func(h *Host) {
+		h.defaultSteps = maxSteps
+	}
+}
+
 // NewHost creates a new eval host with a module provider.
 func NewHost(log *zap.Logger, provider ModuleProvider, opts ...HostOption) *Host {
 	h := &Host{
-		log:      log,
-		compiler: NewCompiler(provider),
+		log:          log,
+		compiler:     NewCompiler(provider),
+		defaultSteps: DefaultMaxSteps,
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -265,10 +279,15 @@ func (h *Host) Run(ctx context.Context, cmd RunCmd) (any, error) {
 	// Step until done
 	var output process.StepOutput
 	var events []process.Event
-	stepCount := 0
+	maxSteps := h.defaultSteps
+	if cmd.MaxStepsSet {
+		maxSteps = cmd.MaxSteps
+	}
+
+	var stepCount uint64
 	for {
 		stepCount++
-		if stepCount > maxEvalSteps {
+		if maxSteps > 0 && stepCount > maxSteps {
 			return nil, ErrMaxStepsExceeded
 		}
 

--- a/runtime/lua/evalhost/max_steps_test.go
+++ b/runtime/lua/evalhost/max_steps_test.go
@@ -1,0 +1,67 @@
+package evalhost
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// A pure-Lua busy loop consumes one scheduler step because it does not yield.
+// These cases pin the explicit-limit and omitted-limit semantics at the host
+// boundary; yield-heavy enforcement is covered by the runner integration test.
+func TestHost_Run_MaxSteps(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider())
+
+	longLoop := `
+		return {
+			run = function()
+				local n = 0
+				for i = 1, 1000000 do
+					n = n + 1
+				end
+				return n
+			end
+		}
+	`
+
+	t.Run("omitted limit uses the host default", func(t *testing.T) {
+		result, err := host.Run(context.Background(), RunCmd{
+			Source: longLoop,
+			Method: "run",
+		})
+		if err != nil {
+			t.Fatalf("expected completion without a step limit, got %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected a result")
+		}
+	})
+
+	t.Run("explicit limit admits work within the budget", func(t *testing.T) {
+		result, err := host.Run(context.Background(), RunCmd{
+			Source:      longLoop,
+			Method:      "run",
+			MaxSteps:    1,
+			MaxStepsSet: true,
+		})
+		if err != nil {
+			t.Fatalf("expected completion within the explicit budget, got %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected a result")
+		}
+	})
+}
+
+func TestHost_DefaultMaxSteps(t *testing.T) {
+	host := NewHost(zap.NewNop(), safeModulesProvider())
+	if host.defaultSteps != DefaultMaxSteps {
+		t.Fatalf("default steps = %d, want %d", host.defaultSteps, DefaultMaxSteps)
+	}
+
+	unlimited := NewHost(zap.NewNop(), safeModulesProvider(), WithDefaultMaxSteps(0))
+	if unlimited.defaultSteps != 0 {
+		t.Fatalf("configured default steps = %d, want unlimited", unlimited.defaultSteps)
+	}
+}

--- a/runtime/lua/modules/eval/runner/integration_test.go
+++ b/runtime/lua/modules/eval/runner/integration_test.go
@@ -120,7 +120,7 @@ func (ts *testScheduler) Context() context.Context {
 	return ctx
 }
 
-func newTestScheduler() *testScheduler {
+func newTestScheduler(evalOptions ...evalhost.HostOption) *testScheduler {
 	ts := &testScheduler{
 		pending: make(map[string]chan *runtime.Result),
 	}
@@ -143,7 +143,7 @@ func newTestScheduler() *testScheduler {
 
 	// Register eval handlers with http_client module
 	modules := []*luaapi.ModuleDef{json.Module, timemod.Module, httpclient.Module, Module}
-	host := evalhost.NewHost(zap.NewNop(), func() []*luaapi.ModuleDef { return modules })
+	host := evalhost.NewHost(zap.NewNop(), func() []*luaapi.ModuleDef { return modules }, evalOptions...)
 	evalSvc := evalhost.NewDispatcher(host)
 	evalSvc.RegisterAll(func(id dispatcher.CommandID, h dispatcher.Handler) {
 		reg.Register(id, h)

--- a/runtime/lua/modules/eval/runner/max_steps_integration_test.go
+++ b/runtime/lua/modules/eval/runner/max_steps_integration_test.go
@@ -1,0 +1,123 @@
+package runner
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	"github.com/wippyai/runtime/runtime/lua/evalhost"
+)
+
+// The eval host counts scheduler steps, and a step is consumed per resume — so
+// step pressure comes from yields (module calls that leave the VM), not from
+// Lua-side loops. These tests drive real yields through the http client and pin
+// both directions of the max_steps option: a limit below the yield count is
+// refused, and a sufficient one completes. This is the end-to-end
+// proof that the option parses in runner.run, travels the RunYield -> RunCmd
+// path, and is enforced by the host loop.
+func TestRunner_MaxSteps_Enforced(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer server.Close()
+
+	sched := newTestScheduler(evalhost.WithDefaultMaxSteps(5))
+	sched.Start()
+	defer sched.Stop()
+
+	build := func(maxSteps string) string {
+		return `
+			local runner = require("eval_runner")
+
+			local result, err = runner.run({
+				source = [[
+					local http = require("http_client")
+					local function run(url)
+						for i = 1, 20 do
+							local _, herr = http.get(url)
+							if herr then return nil, herr end
+						end
+						return "done"
+					end
+					return { run = run }
+				]],
+				method = "run",
+				args = { "` + server.URL + `" },
+				modules = { "http_client" },
+				allow_classes = { "network", "io" },
+				` + maxSteps + `
+			})
+
+			if err then
+				return "ERR: " .. tostring(err)
+			end
+			return result
+		`
+	}
+
+	run := func(t *testing.T, script string) string {
+		ctx := sched.Context()
+		proc := newLuaProcess(t, script)
+		result, err := sched.Execute(ctx, uniqueTestPID(), proc, "", nil)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		if result.Error != nil {
+			t.Fatalf("process error: %v", result.Error)
+		}
+		require.NotNil(t, result.Value)
+		luaData := result.Value.Data()
+		goData := value.ToGoAny(luaData.(lua.LValue))
+		s, _ := goData.(string)
+		return s
+	}
+
+	t.Run("limit below the yield count is refused", func(t *testing.T) {
+		out := run(t, build("limits = { max_steps = 5 },"))
+		require.Contains(t, out, "maximum step limit",
+			"twenty yields against a five-step limit must exceed it, got %q", out)
+	})
+
+	t.Run("limit above the yield count completes", func(t *testing.T) {
+		out := run(t, build("limits = { max_steps = 1000 },"))
+		require.Contains(t, out, "done", "got %q", out)
+	})
+
+	t.Run("omitted limit inherits the host default", func(t *testing.T) {
+		out := run(t, build(""))
+		require.Contains(t, out, "maximum step limit",
+			"an omitted limit must inherit the five-step host default, got %q", out)
+	})
+
+	t.Run("zero limit is unlimited", func(t *testing.T) {
+		out := run(t, build("limits = { max_steps = 0 },"))
+		require.Contains(t, out, "done", "got %q", out)
+	})
+
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "negative", value: "-1"},
+		{name: "fractional", value: "1.5"},
+		{name: "string", value: `"10"`},
+	} {
+		t.Run("invalid "+tc.name+" limit is rejected", func(t *testing.T) {
+			out := run(t, build("limits = { max_steps = "+tc.value+" },"))
+			require.Contains(t, out, "limits.max_steps must be a non-negative integer", "got %q", out)
+		})
+	}
+
+	t.Run("non-table limits are rejected", func(t *testing.T) {
+		out := run(t, build("limits = 5,"))
+		require.Contains(t, out, "limits must be a table", "got %q", out)
+	})
+
+	t.Run("unknown limits are rejected", func(t *testing.T) {
+		out := run(t, build("limits = { surprise = 5 },"))
+		require.Contains(t, out, "limits contains unknown or non-string field", "got %q", out)
+	})
+}

--- a/runtime/lua/modules/eval/runner/module.go
+++ b/runtime/lua/modules/eval/runner/module.go
@@ -360,6 +360,14 @@ func runFunc(l *lua.LState) int {
 		})
 	}
 
+	maxSteps, maxStepsSet, limitsErr := parseMaxSteps(config)
+	if limitsErr != "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, limitsErr).
+			WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
 	yield := AcquireRunYield()
 	yield.Source = source
 	yield.Method = method
@@ -370,7 +378,43 @@ func runFunc(l *lua.LState) int {
 	yield.Context = contextVals
 	yield.AllowClasses = allowClasses
 	yield.CustomModules = customModules
+	yield.MaxSteps = maxSteps
+	yield.MaxStepsSet = maxStepsSet
 
 	l.Push(yield)
 	return -1
+}
+
+func parseMaxSteps(config *lua.LTable) (uint64, bool, string) {
+	rawLimits := config.RawGetString("limits")
+	if rawLimits == lua.LNil {
+		return 0, false, ""
+	}
+
+	limits, ok := rawLimits.(*lua.LTable)
+	if !ok {
+		return 0, false, "limits must be a table"
+	}
+
+	var maxSteps uint64
+	var maxStepsSet bool
+	var parseErr string
+	limits.ForEach(func(key, value lua.LValue) {
+		if parseErr != "" {
+			return
+		}
+		name, ok := key.(lua.LString)
+		if !ok || name != "max_steps" {
+			parseErr = "limits contains unknown or non-string field"
+			return
+		}
+		n, ok := value.(lua.LInteger)
+		if !ok || n < 0 {
+			parseErr = "limits.max_steps must be a non-negative integer"
+			return
+		}
+		maxSteps = uint64(n)
+		maxStepsSet = true
+	})
+	return maxSteps, maxStepsSet, parseErr
 }

--- a/runtime/lua/modules/eval/runner/module_test.go
+++ b/runtime/lua/modules/eval/runner/module_test.go
@@ -72,6 +72,8 @@ func TestRunYield_Pool(t *testing.T) {
 	}
 	y.Modules = []string{"json"}
 	y.Context = map[string]any{"key": "value"}
+	y.MaxSteps = 42
+	y.MaxStepsSet = true
 
 	ReleaseRunYield(y)
 
@@ -81,6 +83,8 @@ func TestRunYield_Pool(t *testing.T) {
 	assert.Nil(t, y2.Args)
 	assert.Nil(t, y2.Modules)
 	assert.Nil(t, y2.Context)
+	assert.Zero(t, y2.MaxSteps)
+	assert.False(t, y2.MaxStepsSet)
 	ReleaseRunYield(y2)
 }
 
@@ -96,6 +100,8 @@ func TestRunYield_ToCommand(t *testing.T) {
 	}
 	y.Modules = []string{"json", "time"}
 	y.Context = map[string]any{"user": "test"}
+	y.MaxSteps = 0
+	y.MaxStepsSet = true
 
 	cmd := y.ToCommand()
 	runCmd, ok := cmd.(evalhost.RunCmd)
@@ -105,6 +111,8 @@ func TestRunYield_ToCommand(t *testing.T) {
 	assert.Len(t, runCmd.Args, 2)
 	assert.Equal(t, []string{"json", "time"}, runCmd.Modules)
 	assert.Equal(t, map[string]any{"user": "test"}, runCmd.Context)
+	assert.Zero(t, runCmd.MaxSteps)
+	assert.True(t, runCmd.MaxStepsSet)
 }
 
 func TestRunYield_CmdID(t *testing.T) {

--- a/runtime/lua/modules/eval/runner/spec.md
+++ b/runtime/lua/modules/eval/runner/spec.md
@@ -82,6 +82,13 @@ Compiles and executes Lua code in one operation.
 | modules | string[] | no | nil | Module names allowed in code |
 | args | any[] | no | nil | Arguments passed to method |
 | context | {[string]: any} | no | nil | Context values available to code |
+| limits | table | no | nil | Execution limits for the evaluation |
+
+**limits fields:**
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| max_steps | non-negative integer | no | host default | Optional scheduler step limit. An explicit `0` means unlimited. A step is consumed per resume, so pressure comes from yields (module calls), not Lua loops. |
 
 **Returns:**
 - Success: `result, nil` - return value from executed code (type depends on code)
@@ -94,6 +101,8 @@ Compiles and executes Lua code in one operation.
 | no context | errors.INTERNAL | no |
 | permission denied | errors.PERMISSION_DENIED | no |
 | source is required | errors.INVALID | no |
+| limits is not a table or contains an unsupported field | errors.INVALID | no |
+| limits.max_steps is not a non-negative integer | errors.INVALID | no |
 | compilation failed | errors.INTERNAL | no |
 | execution failed | errors.INTERNAL | no |
 

--- a/runtime/lua/modules/eval/runner/yields.go
+++ b/runtime/lua/modules/eval/runner/yields.go
@@ -94,6 +94,8 @@ type RunYield struct {
 	AllowClasses  []string
 	CustomModules map[string]any
 	AllowYields   []dispatcher.CommandID
+	MaxSteps      uint64
+	MaxStepsSet   bool
 }
 
 var runYieldPool = sync.Pool{
@@ -115,6 +117,8 @@ func ReleaseRunYield(y *RunYield) {
 	y.AllowClasses = nil
 	y.CustomModules = nil
 	y.AllowYields = nil
+	y.MaxSteps = 0
+	y.MaxStepsSet = false
 	runYieldPool.Put(y)
 }
 
@@ -134,6 +138,8 @@ func (y *RunYield) ToCommand() dispatcher.Command {
 		AllowClasses:  y.AllowClasses,
 		CustomModules: y.CustomModules,
 		AllowYields:   y.AllowYields,
+		MaxSteps:      y.MaxSteps,
+		MaxStepsSet:   y.MaxStepsSet,
 	}
 }
 


### PR DESCRIPTION
## Why

Eval execution needs a configurable scheduler-step budget. The historical 10,000-step default must remain safe by default, while callers need explicit per-evaluation overrides, including an unlimited mode.

## What

- Add `runner.run({ limits = { max_steps = ... } })`.
- Configure the inherited host default with `lua.eval.max_steps` (`10000` by default; `0` is unlimited).
- Distinguish an omitted limit from explicit `max_steps = 0`: omitted inherits the host default, while explicit zero is unlimited.
- Enforce positive limits in the eval host using `uint64` accounting.
- Reject non-table limits, unknown fields, negative values, fractional values, and strings.

## Verification

- `make lint`
- `make test`

Rebased directly onto current `main`; no artifact changes.
