### PR TITLE
fix(deps): make local replacements authoritative

### DIFF
--- a/boot/deps/hub/operation_planner.go
+++ b/boot/deps/hub/operation_planner.go
@@ -3,6 +3,7 @@
 package hub
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -49,6 +50,11 @@ func (p operationPlanner) plan(current regapi.State, desired []regapi.Entry, opt
 		desiredByID[idKey(entry.ID)] = entry
 	}
 
+	recreate, err := p.kindReplacementClosure(currentByID, desiredByID, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	ops := make([]regapi.Operation, 0)
 	originalKey := opts.originalKey
 	for key, entry := range desiredByID {
@@ -59,14 +65,14 @@ func (p operationPlanner) plan(current regapi.State, desired []regapi.Entry, opt
 			if entryConflict(existing, entry) {
 				return nil, NewDependencyEntryConflictError(entry.ID.String(), entryModule(existing), entryModule(entry))
 			}
+			if _, replace := recreate[key]; replace {
+				ops = append(ops,
+					regapi.Operation{Kind: regapi.EntryDelete, Entry: existing},
+					regapi.Operation{Kind: regapi.EntryCreate, Entry: entry},
+				)
+				continue
+			}
 			if !entriesEqual(existing, entry) {
-				if existing.Kind != entry.Kind {
-					ops = append(ops,
-						regapi.Operation{Kind: regapi.EntryDelete, Entry: existing},
-						regapi.Operation{Kind: regapi.EntryCreate, Entry: entry},
-					)
-					continue
-				}
 				if preserveImmutableResidentEntry(existing, entry, opts.mutableModules) {
 					continue
 				}
@@ -98,6 +104,85 @@ func (p operationPlanner) plan(current regapi.State, desired []regapi.Entry, opt
 	}
 
 	return ops, nil
+}
+
+// kindReplacementClosure returns the entries that must be recreated when an
+// entry changes kind. Registry kinds are immutable, so the provider must be
+// deleted and created. Every still-live dependent must cross that boundary in
+// the same changeset; otherwise the delete would temporarily invalidate the
+// resident graph.
+func (p operationPlanner) kindReplacementClosure(
+	currentByID map[string]regapi.Entry,
+	desiredByID map[string]regapi.Entry,
+	opts operationPlanOptions,
+) (map[string]struct{}, error) {
+	recreate := make(map[string]struct{})
+	for key, current := range currentByID {
+		if desired, ok := desiredByID[key]; ok && current.Kind != desired.Kind {
+			recreate[key] = struct{}{}
+		}
+	}
+	if len(recreate) == 0 || p.resolver == nil {
+		return recreate, nil
+	}
+
+	universe := dependencyEntryUniverse(currentByID, desiredByID)
+
+	for changed := true; changed; {
+		changed = false
+		for key, current := range currentByID {
+			if _, already := recreate[key]; already {
+				continue
+			}
+			effective, present := desiredByID[key]
+			if !present {
+				if missingDesiredEntryWillBeDeleted(current, opts.controlledModules) {
+					continue
+				}
+				effective = current
+			}
+			if !entryDependsOnSet(effective, recreate, universe, p.resolver) {
+				continue
+			}
+			if !present || key == opts.originalKey {
+				return nil, fmt.Errorf("cannot replace registry entry kind for live dependent %s outside desired state", current.ID.String())
+			}
+			recreate[key] = struct{}{}
+			changed = true
+		}
+	}
+	return recreate, nil
+}
+
+func entryDependsOnSet(
+	entry regapi.Entry,
+	targets map[string]struct{},
+	universe dependencyEntryUniverseView,
+	resolver regapi.DependencyResolver,
+) bool {
+	dependencies := append([]string(nil), entry.Meta.GetSlice(regapi.TagDependsOn)...)
+	dependencies = append(dependencies, resolver.Extract(entry)...)
+	for _, dep := range dependencies {
+		switch depType, value := parseDependencyRef(dep); depType {
+		case "direct":
+			if _, ok := targets[idKey(resolveDependencyRef(entry.ID.NS, value))]; ok {
+				return true
+			}
+		case "group":
+			for _, id := range universe.groups[value] {
+				if _, ok := targets[idKey(id)]; ok {
+					return true
+				}
+			}
+		case "namespace":
+			for _, id := range universe.ns[value] {
+				if _, ok := targets[idKey(id)]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func hasLiveDependent(
@@ -146,17 +231,19 @@ type dependencyEntryUniverseView struct {
 	ns     map[string][]regapi.ID
 }
 
-func dependencyEntryUniverse(entries map[string]regapi.Entry) dependencyEntryUniverseView {
+func dependencyEntryUniverse(entrySets ...map[string]regapi.Entry) dependencyEntryUniverseView {
 	universe := dependencyEntryUniverseView{
 		groups: make(map[string][]regapi.ID),
 		ns:     make(map[string][]regapi.ID),
 	}
-	for _, entry := range entries {
-		for _, group := range entry.Meta.GetSlice(regapi.TagGroups) {
-			universe.groups[group] = append(universe.groups[group], entry.ID)
-		}
-		if entry.ID.NS != "" {
-			universe.ns[entry.ID.NS] = append(universe.ns[entry.ID.NS], entry.ID)
+	for _, entries := range entrySets {
+		for _, entry := range entries {
+			for _, group := range entry.Meta.GetSlice(regapi.TagGroups) {
+				universe.groups[group] = append(universe.groups[group], entry.ID)
+			}
+			if entry.ID.NS != "" {
+				universe.ns[entry.ID.NS] = append(universe.ns[entry.ID.NS], entry.ID)
+			}
 		}
 	}
 	return universe

--- a/boot/deps/hub/operation_planner_test.go
+++ b/boot/deps/hub/operation_planner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	regtop "github.com/wippyai/runtime/system/registry/topology"
+	"go.uber.org/zap"
 )
 
 func TestOperationPlanner_MutableArtifactBoundary(t *testing.T) {
@@ -183,6 +184,89 @@ func TestOperationPlanner_LiveDependentRetainsControlledEntry(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Empty(t, ops)
+}
+
+func TestOperationPlanner_KindReplacementRecreatesLiveDependentClosure(t *testing.T) {
+	provider := plannerTestEntry("test.provider", "acme/provider", "v1.0.0", "sha256:a", "provider")
+	provider.ID = regapi.NewID("test", "provider")
+	dependent := plannerTestEntry("test.dependent", "acme/dependent", "v1.0.0", "sha256:b", "dependent")
+	dependent.ID = regapi.NewID("test", "dependent")
+	dependent.Meta.Set(regapi.TagDependsOn, []string{provider.ID.Name})
+	outer := plannerTestEntry("test.outer", "acme/outer", "v1.0.0", "sha256:c", "outer")
+	outer.ID = regapi.NewID("test", "outer")
+	outer.Meta.Set(regapi.TagDependsOn, []string{dependent.ID.Name})
+	unrelated := plannerTestEntry("test.unrelated", "acme/unrelated", "v1.0.0", "sha256:d", "unrelated")
+	unrelated.ID = regapi.NewID("test", "unrelated")
+
+	desiredProvider := clonePlannerTestEntry(provider)
+	desiredProvider.Kind = "test.provider.v2"
+	current := regapi.State{provider, dependent, outer, unrelated}
+	desired := []regapi.Entry{desiredProvider, dependent, outer, unrelated}
+	resolver := regtop.NewResolver()
+	ops, err := (operationPlanner{resolver: resolver}).plan(current, desired, operationPlanOptions{
+		controlledModules: map[string]struct{}{
+			"acme/provider": {}, "acme/dependent": {}, "acme/outer": {}, "acme/unrelated": {},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops, 6)
+
+	counts := make(map[string]map[string]int)
+	for _, op := range ops {
+		key := idKey(op.Entry.ID)
+		if counts[key] == nil {
+			counts[key] = make(map[string]int)
+		}
+		counts[key][op.Kind]++
+	}
+	for _, id := range []regapi.ID{provider.ID, dependent.ID, outer.ID} {
+		assert.Equal(t, 1, counts[idKey(id)][regapi.EntryDelete])
+		assert.Equal(t, 1, counts[idKey(id)][regapi.EntryCreate])
+	}
+	assert.Nil(t, counts[idKey(unrelated.ID)])
+
+	builder := regtop.NewStateBuilder(zap.NewNop(), resolver)
+	sorted, err := builder.SortChangeSet(current, ops)
+	require.NoError(t, err)
+	state := regtop.NewStateMap(current)
+	for _, op := range sorted {
+		state, err = builder.ApplyOperation(state, op)
+		require.NoError(t, err)
+	}
+	assertPlannerStatesEqual(t, desired, regtop.StateMapToSlice(state))
+}
+
+func TestOperationPlanner_KindReplacementDoesNotRecreateRewiredDependent(t *testing.T) {
+	provider := plannerTestEntry("test.provider", "acme/provider", "v1.0.0", "sha256:a", "provider")
+	provider.ID = regapi.NewID("test", "provider")
+	dependent := plannerTestEntry("test.dependent", "acme/dependent", "v1.0.0", "sha256:b", "dependent")
+	dependent.ID = regapi.NewID("test", "dependent")
+	dependent.Meta.Set(regapi.TagDependsOn, []string{provider.ID.Name})
+
+	desiredProvider := clonePlannerTestEntry(provider)
+	desiredProvider.Kind = "test.provider.v2"
+	desiredDependent := clonePlannerTestEntry(dependent)
+	desiredDependent.Meta.Set(regapi.TagDependsOn, []string{})
+	ops, err := (operationPlanner{resolver: regtop.NewResolver()}).plan(
+		regapi.State{provider, dependent},
+		[]regapi.Entry{desiredProvider, desiredDependent},
+		operationPlanOptions{controlledModules: map[string]struct{}{"acme/provider": {}, "acme/dependent": {}}},
+	)
+	require.NoError(t, err)
+	require.Len(t, ops, 3)
+	assert.Equal(t, 1, countPlannerOperation(ops, dependent.ID, regapi.EntryUpdate))
+	assert.Equal(t, 0, countPlannerOperation(ops, dependent.ID, regapi.EntryDelete))
+	assert.Equal(t, 0, countPlannerOperation(ops, dependent.ID, regapi.EntryCreate))
+}
+
+func countPlannerOperation(ops []regapi.Operation, id regapi.ID, kind string) int {
+	count := 0
+	for _, op := range ops {
+		if op.Entry.ID == id && op.Kind == kind {
+			count++
+		}
+	}
+	return count
 }
 
 func TestOperationPlanner_PlanConvergesAndIsIdempotent(t *testing.T) {

--- a/boot/deps/hub/tree_digest.go
+++ b/boot/deps/hub/tree_digest.go
@@ -34,6 +34,13 @@ func digestReplacementTree(root string) (string, uint64, error) {
 	return digestDirectoryTreeFiltered(root, cfg.ExcludesSourcePath)
 }
 
+// ReplacementTreeIdentity returns the canonical identity used for a local
+// replacement. Baseline loading and dependency reconciliation must use the
+// same identity or the same source tree can appear as two module generations.
+func ReplacementTreeIdentity(root string) (string, uint64, error) {
+	return digestReplacementTree(root)
+}
+
 func digestDirectoryTreeFiltered(root string, excluded func(string) bool) (string, uint64, error) {
 	hash := sha256.New()
 	var total uint64

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -404,16 +404,19 @@ func WappPath(name graph.Name, version string) string {
 
 // ModuleLoadPath pairs a filesystem path with its owning module metadata.
 type ModuleLoadPath struct {
-	Path       string
-	Module     string // module name in org/module format, empty for app source
-	Version    string // module version, empty for app source
-	SourceRoot string // module root for module-relative resources; defaults to Path
-	Root       bool   // selected deployment root from the lock graph
+	Path        string
+	Module      string // module name in org/module format, empty for app source
+	Version     string // module version, empty for app source
+	SourceRoot  string // module root for module-relative resources; defaults to Path
+	Root        bool   // selected deployment root from the lock graph
+	Replacement bool   // source is an effective workspace replacement
 }
 
 // GetModuleLoadPaths returns load paths annotated with module ownership.
 // App source has empty Module/Version.
-// Replacement paths carry Module from replacement "from" and empty Version.
+// Replacement paths carry Module from replacement "from" and retain the
+// selected lock version when one exists. The replacement changes source
+// ownership, not the resolved release identity.
 func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 	lockDir := filepath.Dir(l.path)
 	replacements := l.effectiveReplacements()
@@ -426,6 +429,11 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 		})
 	}
 
+	selectedVersions := make(map[string]string, len(l.data.Modules))
+	for _, mod := range l.data.Modules {
+		selectedVersions[mod.Name] = mod.Version
+	}
+
 	replaced := make(map[string]struct{}, len(replacements))
 	for _, repl := range replacements {
 		replaced[repl.From] = struct{}{}
@@ -433,10 +441,12 @@ func (l *Lock) GetModuleLoadPaths() []ModuleLoadPath {
 			root := ResolveLockPath(lockDir, repl.To)
 			path := moduleEntryLoadPath(root)
 			paths = append(paths, ModuleLoadPath{
-				Path:       path,
-				Module:     repl.From,
-				SourceRoot: root,
-				Root:       l.IsRootModule(repl.From),
+				Path:        path,
+				Module:      repl.From,
+				Version:     selectedVersions[repl.From],
+				SourceRoot:  root,
+				Root:        l.IsRootModule(repl.From),
+				Replacement: true,
 			})
 		}
 	}

--- a/boot/deps/lock/module_load_paths_test.go
+++ b/boot/deps/lock/module_load_paths_test.go
@@ -44,8 +44,8 @@ func TestLock_GetModuleLoadPaths(t *testing.T) {
 			t.Fatalf("src path = %+v, want root app path with empty module/version", got)
 		}
 
-		if got := paths[1]; got.Path != filepath.Join(tmpDir, "local/users") || got.SourceRoot != filepath.Join(tmpDir, "local/users") || got.Module != "userspace/users" || got.Version != "" {
-			t.Fatalf("replacement path = %+v, want replacement module and empty version", got)
+		if got := paths[1]; got.Path != filepath.Join(tmpDir, "local/users") || got.SourceRoot != filepath.Join(tmpDir, "local/users") || got.Module != "userspace/users" || got.Version != "v1.2.3" || !got.Replacement {
+			t.Fatalf("replacement path = %+v, want replacement module with selected version", got)
 		}
 
 		if got := paths[2]; got.Path != filepath.Join(tmpDir, ".wippy", "vendor", "demo", "sql") || got.SourceRoot != filepath.Join(tmpDir, ".wippy", "vendor", "demo", "sql") || got.Module != "demo/sql" || got.Version != "v2.0.0" {
@@ -231,8 +231,11 @@ func TestLock_GetModuleLoadPaths(t *testing.T) {
 		if got.Module != "acme/ui" {
 			t.Fatalf("module = %q, want acme/ui", got.Module)
 		}
-		if got.Version != "" {
-			t.Fatalf("replacement version = %q, want empty", got.Version)
+		if got.Version != "v1.0.0" {
+			t.Fatalf("replacement version = %q, want selected version v1.0.0", got.Version)
+		}
+		if !got.Replacement {
+			t.Fatal("replacement path was not marked as replacement source")
 		}
 	})
 
@@ -264,6 +267,12 @@ func TestLock_GetModuleLoadPaths(t *testing.T) {
 		}
 		if got.SourceRoot != replacementDir {
 			t.Fatalf("source root = %q, want replacement root %q", got.SourceRoot, replacementDir)
+		}
+		if got.Version != "" {
+			t.Fatalf("workspace-only replacement version = %q, want empty", got.Version)
+		}
+		if !got.Replacement {
+			t.Fatal("workspace-only source was not marked as replacement")
 		}
 	})
 }

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -342,12 +342,37 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 		return nil, ErrLoaderNotFound
 	}
 
+	replacementOwners := make(map[string]struct{})
+	for _, mp := range modulePaths {
+		if mp.Replacement && mp.Module != "" {
+			replacementOwners[mp.Module] = struct{}{}
+		}
+	}
+
 	var entries []regapi.Entry
 
 	for _, mp := range modulePaths {
+		moduleDigest := ""
+		if mp.Replacement {
+			// Replacements are authoritative. If the configured source cannot be
+			// identified, fail instead of silently restoring an embedded generation.
+			root := mp.SourceRoot
+			if root == "" {
+				root = mp.Path
+			}
+			var digestErr error
+			moduleDigest, _, digestErr = hub.ReplacementTreeIdentity(root)
+			if digestErr != nil {
+				return nil, fmt.Errorf("identify replacement module %s: %w", mp.Module, digestErr)
+			}
+		}
+
 		loaded, err := loadEntriesFromModulePath(ctx, mp, ldr, dtt, logger)
 		if err != nil {
 			return nil, err
+		}
+		if !mp.Replacement && len(replacementOwners) > 0 {
+			loaded = excludeReplacementOwnedEntries(loaded, replacementOwners)
 		}
 
 		if shouldApplyModuleConfigFilters(mp) {
@@ -359,7 +384,7 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 
 		for i := range loaded {
 			if mp.Module != "" {
-				loaded[i] = markModuleMeta(loaded[i], mp.Module, mp.Version)
+				loaded[i] = markModuleIdentity(loaded[i], mp.Module, mp.Version, moduleDigest, mp.Replacement)
 			}
 			if mp.Root && loaded[i].Kind == regapi.NamespaceDependency {
 				loaded[i].DependencyRoot = true
@@ -374,6 +399,21 @@ func loadEntriesWithModuleMeta(ctx context.Context, modulePaths []lock.ModuleLoa
 	}
 
 	return entries, nil
+}
+
+func excludeReplacementOwnedEntries(entries []regapi.Entry, replacementOwners map[string]struct{}) []regapi.Entry {
+	filtered := entries[:0]
+	for _, entry := range entries {
+		owner := ""
+		if entry.Meta != nil {
+			owner = entry.Meta.GetString("module", "")
+		}
+		if _, replaced := replacementOwners[owner]; replaced {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
 func shouldApplyModuleConfigFilters(mp lock.ModuleLoadPath) bool {
@@ -507,6 +547,26 @@ func markModuleMeta(entry regapi.Entry, moduleName, moduleVersion string) regapi
 	meta.Set("module", moduleName)
 	if moduleVersion != "" {
 		meta.Set("module_version", moduleVersion)
+	}
+	entry.Meta = meta
+	return entry
+}
+
+func markModuleIdentity(entry regapi.Entry, moduleName, moduleVersion, moduleDigest string, replacement bool) regapi.Entry {
+	entry = markModuleMeta(entry, moduleName, moduleVersion)
+	if moduleDigest == "" && !replacement {
+		return entry
+	}
+	meta := attrs.NewBagFrom(entry.Meta)
+	if replacement {
+		if moduleVersion == "" {
+			delete(meta, "module_version")
+		} else {
+			meta.Set("module_version", moduleVersion)
+		}
+	}
+	if moduleDigest != "" {
+		meta.Set("module_digest", moduleDigest)
 	}
 	entry.Meta = meta
 	return entry

--- a/cmd/internal/entries/loader_test.go
+++ b/cmd/internal/entries/loader_test.go
@@ -21,6 +21,7 @@ import (
 	regapi "github.com/wippyai/runtime/api/registry"
 	bootpkg "github.com/wippyai/runtime/boot"
 	"github.com/wippyai/runtime/boot/components/core"
+	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
 	transcoder "github.com/wippyai/runtime/system/payload"
 	yamlpayload "github.com/wippyai/runtime/system/payload/yaml"
@@ -243,6 +244,93 @@ entries:
 	if got := loaded[0].Meta.GetString("module", ""); got != "acme/app" {
 		t.Fatalf("package ownership = %q, want acme/app", got)
 	}
+}
+
+func TestLoadEntriesFromReplacementCarriesCanonicalTreeIdentity(t *testing.T) {
+	ctx := setupTestContext(t)
+	moduleRoot := t.TempDir()
+	sourceDir := filepath.Join(moduleRoot, "src")
+	require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "_index.yaml"), []byte(`version: "1.0"
+namespace: replacement.test
+entries:
+  - name: value
+    kind: test.value
+    data: local
+`), 0o600))
+
+	wantDigest, _, err := hub.ReplacementTreeIdentity(moduleRoot)
+	require.NoError(t, err)
+	loaded, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{{
+		Path: sourceDir, Module: "acme/replacement", Version: "1.2.3", SourceRoot: moduleRoot, Replacement: true,
+	}}, zap.NewNop())
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, "acme/replacement", loaded[0].Meta.GetString("module", ""))
+	assert.Equal(t, "1.2.3", loaded[0].Meta.GetString("module_version", ""))
+	assert.Equal(t, wantDigest, loaded[0].Meta.GetString("module_digest", ""))
+}
+
+func TestLoadEntriesFromMissingReplacementFailsClosed(t *testing.T) {
+	ctx := setupTestContext(t)
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	_, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{{
+		Path: missing, Module: "acme/replacement", SourceRoot: missing, Replacement: true,
+	}}, zap.NewNop())
+	require.ErrorContains(t, err, "identify replacement module acme/replacement")
+}
+
+func TestLoadEntriesFromReplacementOwnsEntriesOverApplicationSnapshot(t *testing.T) {
+	ctx := setupTestContext(t)
+	appDir := t.TempDir()
+	replacementRoot := t.TempDir()
+	replacementSource := filepath.Join(replacementRoot, "src")
+	require.NoError(t, os.MkdirAll(replacementSource, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "_index.yaml"), []byte(`version: "1.0"
+namespace: ownership.test
+entries:
+  - name: value
+    kind: test.value
+    meta:
+      module: acme/replacement
+      module_version: 0.9.0
+      module_digest: sha256-tree-v1:stale
+    data: stale
+  - name: app_value
+    kind: test.value
+    data: application
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementSource, "_index.yaml"), []byte(`version: "1.0"
+namespace: ownership.test
+entries:
+  - name: value
+    kind: test.value
+    meta:
+      module: acme/replacement
+      module_version: 0.9.0
+      module_digest: sha256-tree-v1:stale
+    data: local
+`), 0o600))
+
+	wantDigest, _, err := hub.ReplacementTreeIdentity(replacementRoot)
+	require.NoError(t, err)
+	loaded, err := LoadEntriesFromModuleLoadPaths(ctx, []lock.ModuleLoadPath{
+		{Path: appDir, Root: true},
+		{Path: replacementSource, Module: "acme/replacement", SourceRoot: replacementRoot, Replacement: true},
+	}, zap.NewNop())
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	byID := make(map[regapi.ID]regapi.Entry, len(loaded))
+	for _, entry := range loaded {
+		byID[entry.ID] = entry
+	}
+	owned := byID[regapi.NewID("ownership.test", "value")]
+	assert.Equal(t, "local", owned.Data.Data())
+	assert.Equal(t, "acme/replacement", owned.Meta.GetString("module", ""))
+	assert.Equal(t, wantDigest, owned.Meta.GetString("module_digest", ""))
+	assert.Empty(t, owned.Meta.GetString("module_version", ""))
+	assert.Equal(t, "application", byID[regapi.NewID("ownership.test", "app_value")].Data.Data())
 }
 
 func TestLoadEntriesFromModuleLoadPathsMarksUnownedAppSourceDependencyRoot(t *testing.T) {


### PR DESCRIPTION
## Problem

Workspace replacements were treated as extra load paths rather than authoritative module sources. A restart could therefore load an application snapshot and its local replacement as two generations of the same module. Leaving a replacement also planned a same-ID kind replacement without rebuilding still-live dependents, producing an unsatisfiable dependency cycle.

## Semantics

- An effective workspace replacement owns entries whose `meta.module` names that module.
- A missing authoritative replacement fails closed; it never restores an embedded older generation.
- A replacement of a locked module retains the selected lock version; a workspace-only sidecar remains versionless.
- Direct baseline loading and dependency reconciliation use the same filtered replacement-tree identity.
- Immutable kind transitions recreate the transitive live dependent closure in one changeset. The topology validator remains strict.
- Packed versus unpacked storage does not affect replacement authority.

## Verification

- Added behavior tests for replacement ownership over an application snapshot, missing-source failure, canonical tree identity, locked and workspace-only version identity, transitive dependent recreation, unrelated entry preservation, and dependency rewiring.
- Proved the failure with an ownership-only control binary: local replacement to published source still failed with `same-ID replacement has an unsatisfiable dependency cycle`.
- Proved the full binary through published source → replacement → source edit → restart → published source → replacement against a preserved application state.
- App shell and main UI returned HTTP 200 after each successful transition; unchanged restarts made no Hub download calls.
- `make test`
- `make lint`

No application lockfile or concrete module selection is included.
