### PR TITLE
feat(runtime): expose effective deployment sources

### DIFF
--- a/api/modules/source_roots.go
+++ b/api/modules/source_roots.go
@@ -5,12 +5,21 @@ package modules
 
 import (
 	"context"
+	"errors"
+	"sort"
 	"sync"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
+	regapi "github.com/wippyai/runtime/api/registry"
 )
 
 var sourceRootsKey = &ctxapi.Key{Name: "modules.source_roots"}
+
+var ErrSourceLoaderUnavailable = errors.New("effective deployment source loader unavailable")
+
+// SourceLoader rebuilds the normalized deployment baseline from its established
+// application, packed dependency, and local replacement sources.
+type SourceLoader func(context.Context) ([]regapi.Entry, error)
 
 // SourceRoots maps module names in org/module form to their local load roots.
 type SourceRoots map[string]string
@@ -18,8 +27,9 @@ type SourceRoots map[string]string
 // SourceRootRegistry stores module roots behind a mutex so runtime loaders can
 // add roots after AppContext is sealed without mutating the AppContext itself.
 type SourceRootRegistry struct {
-	roots SourceRoots
-	mu    sync.RWMutex
+	roots  SourceRoots
+	loader SourceLoader
+	mu     sync.RWMutex
 }
 
 // NewSourceRootRegistry creates an empty source root registry.
@@ -102,6 +112,48 @@ func (r *SourceRootRegistry) Get(module string) (string, bool) {
 	return root, ok && root != ""
 }
 
+// Modules returns the names of modules with local directory sources.
+// The paths remain private to Runtime; callers receive capability identifiers.
+func (r *SourceRootRegistry) Modules() []string {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	modules := make([]string, 0, len(r.roots))
+	for module, root := range r.roots {
+		if module != "" && root != "" {
+			modules = append(modules, module)
+		}
+	}
+	sort.Strings(modules)
+	return modules
+}
+
+func (r *SourceRootRegistry) SetLoader(loader SourceLoader) {
+	if r == nil || loader == nil {
+		return
+	}
+	r.mu.Lock()
+	r.loader = loader
+	r.mu.Unlock()
+}
+
+func (r *SourceRootRegistry) Load(ctx context.Context) ([]regapi.Entry, error) {
+	if r == nil {
+		return nil, ErrSourceLoaderUnavailable
+	}
+	r.mu.RLock()
+	loader := r.loader
+	r.mu.RUnlock()
+	if loader == nil {
+		return nil, ErrSourceLoaderUnavailable
+	}
+	return loader(ctx)
+}
+
 // WithSourceRootRegistry stores an empty registry in AppContext during boot.
 func WithSourceRootRegistry(ctx context.Context) context.Context {
 	ac := ctxapi.AppFromContext(ctx)
@@ -165,4 +217,50 @@ func SourceRoot(ctx context.Context, module string) (string, bool) {
 	}
 
 	return reg.Get(module)
+}
+
+// SourceModules returns stable capability identifiers for modules whose
+// effective source is locally available as a directory.
+func SourceModules(ctx context.Context) []string {
+	ac := ctxapi.AppFromContext(ctx)
+	if ac == nil {
+		return nil
+	}
+
+	reg, ok := ac.Get(sourceRootsKey).(*SourceRootRegistry)
+	if !ok || reg == nil {
+		return nil
+	}
+	return reg.Modules()
+}
+
+// WithSourceLoader registers the deployment's authoritative source reloader.
+func WithSourceLoader(ctx context.Context, loader SourceLoader) context.Context {
+	ac := ctxapi.AppFromContext(ctx)
+	if ac == nil || loader == nil {
+		return ctx
+	}
+	reg, _ := ac.Get(sourceRootsKey).(*SourceRootRegistry)
+	if reg == nil {
+		if ac.IsSealed() {
+			return ctx
+		}
+		reg = NewSourceRootRegistry()
+		ac.With(sourceRootsKey, reg)
+	}
+	reg.SetLoader(loader)
+	return ctx
+}
+
+// LoadSources rebuilds the same normalized baseline used by a restart.
+func LoadSources(ctx context.Context) ([]regapi.Entry, error) {
+	ac := ctxapi.AppFromContext(ctx)
+	if ac == nil {
+		return nil, ErrSourceLoaderUnavailable
+	}
+	reg, ok := ac.Get(sourceRootsKey).(*SourceRootRegistry)
+	if !ok || reg == nil {
+		return nil, ErrSourceLoaderUnavailable
+	}
+	return reg.Load(ctx)
 }

--- a/api/modules/source_roots.go
+++ b/api/modules/source_roots.go
@@ -15,6 +15,8 @@ import (
 
 var sourceRootsKey = &ctxapi.Key{Name: "modules.source_roots"}
 
+// ErrSourceLoaderUnavailable indicates that boot did not register the
+// deployment's normalized source reloader.
 var ErrSourceLoaderUnavailable = errors.New("effective deployment source loader unavailable")
 
 // SourceLoader rebuilds the normalized deployment baseline from its established
@@ -132,6 +134,7 @@ func (r *SourceRootRegistry) Modules() []string {
 	return modules
 }
 
+// SetLoader atomically registers the deployment's normalized source reloader.
 func (r *SourceRootRegistry) SetLoader(loader SourceLoader) {
 	if r == nil || loader == nil {
 		return
@@ -141,6 +144,8 @@ func (r *SourceRootRegistry) SetLoader(loader SourceLoader) {
 	r.mu.Unlock()
 }
 
+// Load rebuilds the normalized deployment baseline through the registered
+// source reloader.
 func (r *SourceRootRegistry) Load(ctx context.Context) ([]regapi.Entry, error) {
 	if r == nil {
 		return nil, ErrSourceLoaderUnavailable

--- a/api/modules/source_roots_test.go
+++ b/api/modules/source_roots_test.go
@@ -4,9 +4,11 @@ package modules
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
+	regapi "github.com/wippyai/runtime/api/registry"
 )
 
 func TestSourceRoots(t *testing.T) {
@@ -40,6 +42,35 @@ func TestSourceRoots(t *testing.T) {
 	root, ok = SourceRoot(ctx, "acme/plugin")
 	if !ok || root != "/repo/plugin" {
 		t.Fatalf("new SourceRoot = %q, %v; want /repo/plugin, true", root, ok)
+	}
+}
+
+func TestSourceModulesAreStableAndPathFree(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	ctx = WithSourceRoots(ctx, SourceRoots{
+		"acme/zeta":  "/private/zeta",
+		"acme/alpha": "/private/alpha",
+		"":           "/ignored",
+	})
+
+	got := SourceModules(ctx)
+	if !slices.Equal(got, []string{"acme/alpha", "acme/zeta"}) {
+		t.Fatalf("SourceModules = %v", got)
+	}
+}
+
+func TestSourceLoaderUsesRegisteredDeploymentCapability(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	WithSourceLoader(ctx, func(context.Context) ([]regapi.Entry, error) {
+		return []regapi.Entry{{ID: regapi.NewID("example", "entry"), Kind: "registry.entry"}}, nil
+	})
+
+	entries, err := LoadSources(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].ID.String() != "example:entry" {
+		t.Fatalf("LoadSources = %v", entries)
 	}
 }
 

--- a/boot/build/stages/module_config.go
+++ b/boot/build/stages/module_config.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package stages
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/registry"
+	depconfig "github.com/wippyai/runtime/boot/deps/config"
+)
+
+// FilterModuleEntries applies a module manifest's entry and metadata excludes.
+// Source-file excludes belong on depconfig.NewSourceFS before entries are loaded.
+func FilterModuleEntries(
+	ctx context.Context,
+	cfg *depconfig.ModuleConfig,
+	entries []registry.Entry,
+) ([]registry.Entry, error) {
+	if cfg == nil {
+		return entries, nil
+	}
+	entryExcludes := cfg.EntryExcludes()
+	if len(entryExcludes) == 0 && len(cfg.ExcludeMeta) == 0 {
+		return entries, nil
+	}
+
+	filtered := append([]registry.Entry(nil), entries...)
+	stage := DisableWithOptions(DisableOptions{
+		Entries:     entryExcludes,
+		MetaFilters: cfg.ExcludeMeta,
+	})
+	if err := stage.Execute(ctx, &filtered); err != nil {
+		return nil, err
+	}
+	return filtered, nil
+}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1940,16 +1940,8 @@ func (h *DependencyHandler) applyModuleConfigFilters(ctx context.Context, module
 	if err != nil {
 		return entries, nil
 	}
-	entryExcludes := cfg.EntryExcludes()
-	if len(entryExcludes) == 0 && len(cfg.ExcludeMeta) == 0 {
-		return entries, nil
-	}
-	filtered := append([]regapi.Entry(nil), entries...)
-	stage := stages.DisableWithOptions(stages.DisableOptions{
-		Entries:     entryExcludes,
-		MetaFilters: cfg.ExcludeMeta,
-	})
-	if err := stage.Execute(ctx, &filtered); err != nil {
+	filtered, err := stages.FilterModuleEntries(ctx, cfg, entries)
+	if err != nil {
 		return nil, NewDependencyLoadError(modulePath, err)
 	}
 	return filtered, nil

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -59,14 +59,13 @@ func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 	}
 
 	modulePaths := lockObj.GetModuleLoadPaths()
-	registerModuleSourceRoots(ctx, modulePaths)
 	flatPaths := make([]string, len(modulePaths))
 	for i, mp := range modulePaths {
 		flatPaths[i] = mp.Path
 	}
 	logger.Debug("load paths from lock file", zap.Strings("paths", flatPaths))
 
-	entries, err := loadEntriesWithModuleMeta(ctx, modulePaths, logger)
+	entries, err := LoadEntriesFromModuleLoadPaths(ctx, modulePaths, logger)
 	if err != nil {
 		return NewLoadEntriesFromPathsError(err)
 	}
@@ -299,6 +298,10 @@ func LoadEntriesFromModuleLoadPaths(
 	logger *zap.Logger,
 ) ([]regapi.Entry, error) {
 	registerModuleSourceRoots(ctx, modulePaths)
+	paths := append([]lock.ModuleLoadPath(nil), modulePaths...)
+	moduleapi.WithSourceLoader(ctx, func(loadCtx context.Context) ([]regapi.Entry, error) {
+		return loadEntriesWithModuleMeta(loadCtx, paths, logger)
+	})
 	return loadEntriesWithModuleMeta(ctx, modulePaths, logger)
 }
 
@@ -410,17 +413,8 @@ func applyModuleConfigFilters(
 		}
 		return entries, nil
 	}
-	entryExcludes := cfg.EntryExcludes()
-	if len(entryExcludes) == 0 && len(cfg.ExcludeMeta) == 0 {
-		return entries, nil
-	}
-
-	filtered := append([]regapi.Entry(nil), entries...)
-	stage := stages.DisableWithOptions(stages.DisableOptions{
-		Entries:     entryExcludes,
-		MetaFilters: cfg.ExcludeMeta,
-	})
-	if err := stage.Execute(ctx, &filtered); err != nil {
+	filtered, err := stages.FilterModuleEntries(ctx, cfg, entries)
+	if err != nil {
 		return nil, err
 	}
 

--- a/runtime/lua/modules/registry/loader.go
+++ b/runtime/lua/modules/registry/loader.go
@@ -5,11 +5,14 @@ package registry
 import (
 	lua "github.com/wippyai/go-lua"
 	fsapi "github.com/wippyai/runtime/api/fs"
+	moduleapi "github.com/wippyai/runtime/api/modules"
 	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	"github.com/wippyai/runtime/boot/loader"
 	"github.com/wippyai/runtime/boot/loader/interpolate"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	"github.com/wippyai/runtime/runtime/security"
 	"go.uber.org/zap"
 )
 
@@ -61,11 +64,35 @@ func NewLoaderModule(opts LoaderOptions) *luaapi.ModuleDef {
 		Description: "Registry loader for filesystem-bound loading",
 		Class:       []string{luaapi.ClassStorage, luaapi.ClassIO},
 		Build: func() (*lua.LTable, []luaapi.YieldType) {
-			mod := lua.CreateTable(0, 1)
+			mod := lua.CreateTable(0, 2)
 			mod.RawSetString("new", makeCreateLoader(opts.Log))
+			mod.RawSetString("load_sources", makeLoadSources())
 			mod.Immutable = true
 			return mod, nil
 		},
+		Types: LoaderTypes,
+	}
+}
+
+// makeLoadSources rebuilds the normalized deployment baseline. Runtime retains
+// source and path authority; Lua receives only decoded entries.
+func makeLoadSources() lua.LGoFunc {
+	return func(l *lua.LState) int {
+		ctx := l.Context()
+		if !security.IsAllowed(ctx, "system.read", "module_sources", nil) {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "permission denied: system.read on module_sources").
+				WithKind(lua.PermissionDenied).WithRetryable(false))
+			return 2
+		}
+
+		entries, loadErr := moduleapi.LoadSources(ctx)
+		if loadErr != nil {
+			l.Push(lua.LNil)
+			l.Push(lua.WrapErrorWithLua(l, loadErr, "load deployment sources").WithKind(lua.Internal).WithRetryable(false))
+			return 2
+		}
+		return pushLoaderEntries(l, entries)
 	}
 }
 
@@ -161,23 +188,7 @@ func loaderLoadDirectory(l *lua.LState) int {
 		return 2
 	}
 
-	entriesTable := l.CreateTable(len(entries), 0)
-	for i, entry := range entries {
-		entryTable, convErr := entryToLuaTable(l, entry)
-		if convErr != nil {
-			err := lua.WrapErrorWithLua(l, convErr, "convert entry").
-				WithKind(lua.Internal).
-				WithRetryable(false)
-			l.Push(lua.LNil)
-			l.Push(err)
-			return 2
-		}
-		entriesTable.RawSetInt(i+1, entryTable)
-	}
-
-	l.Push(entriesTable)
-	l.Push(lua.LNil)
-	return 2
+	return pushLoaderEntries(l, entries)
 }
 
 // loaderLoadFile loads entries from a single file
@@ -207,6 +218,10 @@ func loaderLoadFile(l *lua.LState) int {
 		return 2
 	}
 
+	return pushLoaderEntries(l, entries)
+}
+
+func pushLoaderEntries(l *lua.LState, entries []regapi.Entry) int {
 	entriesTable := l.CreateTable(len(entries), 0)
 	for i, entry := range entries {
 		entryTable, convErr := entryToLuaTable(l, entry)

--- a/runtime/lua/modules/registry/loader_test.go
+++ b/runtime/lua/modules/registry/loader_test.go
@@ -3,10 +3,13 @@
 package registry
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	lua "github.com/wippyai/go-lua"
+	moduleapi "github.com/wippyai/runtime/api/modules"
+	regapi "github.com/wippyai/runtime/api/registry"
 	"go.uber.org/zap"
 )
 
@@ -50,6 +53,64 @@ func TestLoaderModuleInfo(t *testing.T) {
 
 	if len(module.Class) == 0 {
 		t.Error("expected at least one class")
+	}
+}
+
+func TestLoadSourcesUsesRegisteredCapability(t *testing.T) {
+	ctx := setupContextWithTranscoder()
+	moduleapi.WithSourceLoader(ctx, func(context.Context) ([]regapi.Entry, error) {
+		return []regapi.Entry{{ID: regapi.NewID("example.source", "probe"), Kind: "registry.entry"}}, nil
+	})
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+
+	module := NewLoaderModule(DefaultLoaderOptions())
+	table, _ := module.Build()
+	l.SetGlobal("loader", table)
+	if err := l.DoString(`
+		local entries, err = loader.load_sources()
+		assert(err == nil, tostring(err))
+		assert(#entries == 1)
+		assert(entries[1].id == "example.source:probe")
+	`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadSourcesRejectsMissingCapability(t *testing.T) {
+	ctx := setupContextWithTranscoder()
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+
+	module := NewLoaderModule(DefaultLoaderOptions())
+	table, _ := module.Build()
+	l.SetGlobal("loader", table)
+	if err := l.DoString(`
+		local entries, err = loader.load_sources()
+		assert(entries == nil)
+		assert(err ~= nil)
+	`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadSourcesRequiresPermission(t *testing.T) {
+	ctx := setupStrictContextWithTranscoder()
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+
+	module := NewLoaderModule(DefaultLoaderOptions())
+	table, _ := module.Build()
+	l.SetGlobal("loader", table)
+	if err := l.DoString(`
+		local entries, err = loader.load_sources()
+		assert(entries == nil)
+		assert(err ~= nil)
+	`); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/runtime/lua/modules/registry/loader_types.go
+++ b/runtime/lua/modules/registry/loader_types.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	typio "github.com/wippyai/go-lua/types/io"
+	"github.com/wippyai/go-lua/types/typ"
+)
+
+var loaderEntryType = typ.NewRecord().
+	Field("id", typ.String).
+	Field("kind", typ.String).
+	Field("meta", typ.NewMap(typ.String, typ.Unknown)).
+	Field("data", typ.Unknown).
+	Build()
+
+var loaderInstanceType = typ.NewInterface("registry.Loader", []typ.Method{
+	{Name: "load_directory", Type: typ.Func().
+		Param("self", typ.Self).
+		Param("directory", typ.String).
+		Returns(typ.NewArray(loaderEntryType), typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "load_file", Type: typ.Func().
+		Param("self", typ.Self).
+		Param("path", typ.String).
+		Returns(typ.NewArray(loaderEntryType), typ.NewOptional(typ.LuaError)).Build()},
+})
+
+// LoaderTypes returns the type manifest for the source loader module.
+func LoaderTypes() *typio.Manifest {
+	m := typio.NewManifest(loaderModuleName)
+	m.DefineType("Entry", loaderEntryType)
+	m.DefineType("Loader", loaderInstanceType)
+	m.SetExport(typ.NewInterface(loaderModuleName, []typ.Method{
+		{Name: "new", Type: typ.Func().Param("filesystem", typ.String).
+			Returns(loaderInstanceType, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "load_sources", Type: typ.Func().
+			Returns(typ.NewArray(loaderEntryType), typ.NewOptional(typ.LuaError)).Build()},
+	}))
+	return m
+}

--- a/runtime/lua/modules/registry/module_test.go
+++ b/runtime/lua/modules/registry/module_test.go
@@ -655,6 +655,17 @@ func setupContextWithTranscoder() context.Context {
 	return ctx
 }
 
+func setupStrictContextWithTranscoder() context.Context {
+	appCtx := ctxapi.NewAppContext()
+	ctx := ctxapi.WithAppContext(context.Background(), appCtx)
+
+	dtt := transcoder.GlobalTranscoder()
+	json.Register(dtt)
+	luapayload.Register(dtt)
+	ctx = payload.WithTranscoder(ctx, dtt)
+	return security.SetStrictMode(ctx, true)
+}
+
 func TestRegistryGetWithEntryData(t *testing.T) {
 	// Create context with transcoder
 	ctx := setupContextWithTranscoder()

--- a/runtime/lua/modules/system/module.go
+++ b/runtime/lua/modules/system/module.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	lua "github.com/wippyai/go-lua"
+	moduleapi "github.com/wippyai/runtime/api/modules"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	"github.com/wippyai/runtime/api/supervisor"
 	"github.com/wippyai/runtime/runtime/security"
@@ -22,7 +23,7 @@ var (
 )
 
 func initModuleTable() {
-	mod := lua.CreateTable(0, 12)
+	mod := lua.CreateTable(0, 13)
 
 	mod.RawSetString("memory", createMemoryTable())
 	mod.RawSetString("gc", createGCTable())
@@ -36,6 +37,7 @@ func initModuleTable() {
 	mod.RawSetString("hosts", createHostsTable())
 	mod.RawSetString("exit", lua.LGoFunc(exit))
 	mod.RawSetString("modules", lua.LGoFunc(modules))
+	mod.RawSetString("source_modules", lua.LGoFunc(sourceModules))
 
 	mod.Immutable = true
 	moduleTable = mod
@@ -463,6 +465,24 @@ func modules(l *lua.LState) int {
 		result.RawSetInt(i+1, modTable)
 	}
 
+	l.Push(result)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func sourceModules(l *lua.LState) int {
+	if !security.IsAllowed(l.Context(), "system.read", "module_sources", nil) {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "permission denied: system.read on module_sources").
+			WithKind(lua.PermissionDenied).WithRetryable(false))
+		return 2
+	}
+
+	modules := moduleapi.SourceModules(l.Context())
+	result := l.CreateTable(len(modules), 0)
+	for i, module := range modules {
+		result.RawSetInt(i+1, lua.LString(module))
+	}
 	l.Push(result)
 	l.Push(lua.LNil)
 	return 2

--- a/runtime/lua/modules/system/module_test.go
+++ b/runtime/lua/modules/system/module_test.go
@@ -8,6 +8,7 @@ import (
 
 	lua "github.com/wippyai/go-lua"
 	ctxapi "github.com/wippyai/runtime/api/context"
+	moduleapi "github.com/wippyai/runtime/api/modules"
 	"github.com/wippyai/runtime/api/security"
 )
 
@@ -44,6 +45,50 @@ func TestLoad(t *testing.T) {
 	// Check functions exist
 	checkFunction(t, l, "system", "exit")
 	checkFunction(t, l, "system", "modules")
+	checkFunction(t, l, "system", "source_modules")
+}
+
+func TestSourceModulesExposeNamesWithoutPaths(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ctx := security.SetStrictMode(ctxapi.NewRootContext(), false)
+	moduleapi.WithSourceRoots(ctx, moduleapi.SourceRoots{
+		"acme/zeta":  "/private/zeta",
+		"acme/alpha": "/private/alpha",
+	})
+	l.SetContext(ctx)
+
+	tbl, _ := Module.Build()
+	l.SetGlobal("system", tbl)
+	if err := l.DoString(`
+		local sources, err = system.source_modules()
+		assert(err == nil)
+		assert(#sources == 2)
+		assert(sources[1] == "acme/alpha")
+		assert(sources[2] == "acme/zeta")
+		assert(not string.find(sources[1], "/private", 1, true))
+	`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSourceModulesRequiresPermission(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	ctx := security.SetStrictMode(ctxapi.NewRootContext(), true)
+	l.SetContext(ctx)
+
+	tbl, _ := Module.Build()
+	l.SetGlobal("system", tbl)
+	if err := l.DoString(`
+		local sources, err = system.source_modules()
+		assert(sources == nil)
+		assert(err ~= nil)
+	`); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestLoadReuse(t *testing.T) {

--- a/runtime/lua/modules/system/spec.md
+++ b/runtime/lua/modules/system/spec.md
@@ -53,6 +53,18 @@ Returns list of all loaded Lua modules with metadata.
 
 **Permissions:** Requires `system.read` on `modules`.
 
+### source_modules() → string[], error
+
+Returns stable module identifiers for dependencies whose effective source is
+available locally as a directory. Paths are not exposed. Packed dependencies
+are absent.
+
+Use `loader.load_sources()` to rebuild the normalized deployment baseline.
+These identifiers describe which module owners are locally authoritative; they
+do not expose filesystem paths.
+
+**Permissions:** Requires `system.read` on `module_sources`.
+
 ## system.memory
 
 Memory statistics and control.

--- a/runtime/lua/modules/system/types.go
+++ b/runtime/lua/modules/system/types.go
@@ -152,6 +152,7 @@ var lockType = typ.NewInterface("system.lock", []typ.Method{
 var systemMethodsType = typ.NewInterface("system", []typ.Method{
 	{Name: "exit", Type: typ.Func().OptParam("code", typ.Number).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "modules", Type: typ.Func().Returns(typ.NewArray(moduleInfoType), typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "source_modules", Type: typ.Func().Returns(typ.NewArray(typ.String), typ.NewOptional(typ.LuaError)).Build()},
 })
 
 // ModuleTypes returns the type manifest for the system module.


### PR DESCRIPTION
## Summary

Expose a narrow Runtime capability for governance tooling to reload the established deployment source graph without parsing `wippy.lock`, workspace YAML, or private source paths.

- `system.source_modules()` returns only locally authoritative module identities
- `loader.load_sources()` reloads the full deployment through the same filtering, ownership, override, disable, and linking pipeline used at boot
- source paths remain Runtime-private and access requires `system.read` on `module_sources`
- the normal `wippy run` lock-loading path registers the same reloader instead of maintaining a second load path
- module manifest filtering is shared between boot loading and Hub reconciliation

This should merge after #544 so local replacements are authoritative under both boot and live reconciliation.

## Verification

- `go test ./...`
- `make lint`
- combined local binary with #544
- isolated Kickside deployment: baseline sync `0/0/0`; live replacement edit updated only its 22 owned entries; restart preserved the update; next sync `0/0/0`; 386 packed/unmounted entries remained untouched