### PR TITLE
feat(coverage): write LCOV after 'wippy test' when WIPPY_COVERAGE is set

### DIFF
--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -39,6 +39,7 @@ import (
 	terminalservice "github.com/wippyai/runtime/service/terminal"
 	securitysys "github.com/wippyai/runtime/system/security"
 	supervisorpkg "github.com/wippyai/runtime/system/supervisor"
+	lua "github.com/wippyai/go-lua"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -312,12 +313,42 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 	waitForShutdownSignal(sigChan, logger, nil)
 
 	exitCode := shutdown.Perform(ctx, loader, logger, silentLogs)
+	if lua.CoverageEnabled() {
+		dumpCoverage()
+	}
 	if exitCode != 0 {
 		_ = logger.Sync()
 		os.Exit(exitCode)
 	}
 
 	return nil
+}
+
+// dumpCoverage writes an LCOV tracefile when WIPPY_COVERAGE is set. It runs both
+// on a clean exit (return nil) and before os.Exit on a failing run, so coverage
+// is captured even when tests fail. Configured via env:
+//
+//	WIPPY_COVERAGE_FILE    output path (default: coverage.info)
+//	WIPPY_COVERAGE_FILTER  substring the source name must contain (default: all)
+func dumpCoverage() {
+	prefix := os.Getenv("WIPPY_COVERAGE_FILTER")
+	filter := func(src string) bool {
+		return prefix == "" || strings.Contains(src, prefix)
+	}
+	path := os.Getenv("WIPPY_COVERAGE_FILE")
+	if path == "" {
+		path = "coverage.info"
+	}
+	if err := lua.WriteCoverageLCOV(path, filter); err != nil {
+		fmt.Fprintf(os.Stderr, "coverage: write failed: %v\n", err)
+		return
+	}
+	lf, lh := lua.CoverageSummary(filter)
+	pct := 0.0
+	if lf > 0 {
+		pct = float64(lh) / float64(lf) * 100
+	}
+	fmt.Fprintf(os.Stderr, "coverage: %d/%d lines (%.1f%%) filter=%q -> %s\n", lh, lf, pct, prefix, path)
 }
 
 // loadRuntimeConfig resolves the effective runtime configuration for run-like


### PR DESCRIPTION
> **Depends on** [wippyai/go-lua#35](https://github.com/wippyai/go-lua/pull/35)
> (the line-coverage collector, which itself stacks on go-lua#34). This PR calls
> that collector's `WriteCoverageLCOV`/`CoverageSummary`, so it needs a go-lua
> version that includes #35 to build. Please land the go-lua PRs first.

## What

Writes an **LCOV** coverage tracefile after `wippy test` when `WIPPY_COVERAGE` is
set, so the native test suite can be run under line coverage.

## How

After the test entrypoint finishes in `runWithUseCase` (right after
`shutdown.Perform`), it calls the go-lua coverage collector:

```go
if lua.CoverageEnabled() {
    dumpCoverage()
}
```

`dumpCoverage` writes the LCOV file and prints an aggregate summary. It runs on
both the clean-exit path and before `os.Exit(exitCode)` on a failing run, so
coverage is captured even when tests fail (failing tests still execute code).

Configured via env:

- `WIPPY_COVERAGE` — enable (read by go-lua at init).
- `WIPPY_COVERAGE_FILE` — output path (default `coverage.info`).
- `WIPPY_COVERAGE_FILTER` — substring the chunk/source name must contain
  (default: all sources).

## Usage

```
WIPPY_COVERAGE=1 WIPPY_COVERAGE_FILE=coverage.info WIPPY_COVERAGE_FILTER=@app \
  wippy test --host <cli_host>
# → writes coverage.info (LCOV) and prints: coverage: <hit>/<found> lines (<pct>%)
```

The resulting `coverage.info` is consumed as-is by `genhtml`, Codecov, and editor
coverage plugins.

## Performance

No-op when `WIPPY_COVERAGE` is unset: `lua.CoverageEnabled()` short-circuits, so
normal runs are unaffected.

## Scope of changes

One file — `cmd/wippy/cmd/run.go`: the `lua` import, the `dumpCoverage` helper,
and the guarded call after `shutdown.Perform`.
