### PR TITLE
Fix command security and propagate exec exit status

### DIFF
--- a/api/registry/id.go
+++ b/api/registry/id.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"unique"
@@ -102,7 +103,9 @@ func (t *ID) UnmarshalJSON(data []byte) error {
 			NS   Namespace `json:"ns"`
 			Name Name      `json:"name"`
 		}
-		if err := json.Unmarshal(data, &obj); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&obj); err != nil {
 			return err
 		}
 		if obj.NS == "" && strings.Contains(obj.Name, ":") {

--- a/api/registry/id_test.go
+++ b/api/registry/id_test.go
@@ -107,6 +107,12 @@ func TestID_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestID_UnmarshalJSON_RejectsUnknownObjectFields(t *testing.T) {
+	var id ID
+	err := json.Unmarshal([]byte(`{"ns":"app","name":"runner","secret":"nope"}`), &id)
+	assert.ErrorContains(t, err, "unknown field")
+}
+
 // TestID_UnmarshalJSON_RealWorld tests the UnmarshalJSON method with more realistic examples
 func TestID_UnmarshalJSON_RealWorld(t *testing.T) {
 	tests := []struct {

--- a/api/supervisor/shutdown.go
+++ b/api/supervisor/shutdown.go
@@ -30,12 +30,6 @@ func GetExitCode() int {
 	return int(exitCode.Load())
 }
 
-// ShutdownTriggered reports whether TriggerShutdown has already initiated
-// graceful shutdown for the current runtime instance.
-func ShutdownTriggered() bool {
-	return shutdownSent.Load()
-}
-
 // SetSignalChannel stores the signal channel in the application context.
 // Must be called during boot before AppContext is sealed.
 func SetSignalChannel(ctx context.Context, ch chan<- os.Signal) {

--- a/api/supervisor/shutdown.go
+++ b/api/supervisor/shutdown.go
@@ -30,6 +30,12 @@ func GetExitCode() int {
 	return int(exitCode.Load())
 }
 
+// ShutdownTriggered reports whether TriggerShutdown has already initiated
+// graceful shutdown for the current runtime instance.
+func ShutdownTriggered() bool {
+	return shutdownSent.Load()
+}
+
 // SetSignalChannel stores the signal channel in the application context.
 // Must be called during boot before AppContext is sealed.
 func SetSignalChannel(ctx context.Context, ch chan<- os.Signal) {

--- a/cmd/wippy/cmd/command_security_test.go
+++ b/cmd/wippy/cmd/command_security_test.go
@@ -115,6 +115,26 @@ func TestExtractCommandMeta_Security(t *testing.T) {
 		assert.Contains(t, err.Error(), "decode command metadata")
 	})
 
+	t.Run("policy object rejects unknown ID fields", func(t *testing.T) {
+		meta, err := extractCommandMeta(map[string]any{
+			"command": map[string]any{
+				"name": "test",
+				"security": map[string]any{
+					"actor": map[string]any{"id": "a"},
+					"policies": []any{map[string]any{
+						"ns":     "app",
+						"name":   "runner",
+						"secret": "must-reject",
+					}},
+				},
+			},
+		})
+		assert.Nil(t, meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field")
+		assert.Contains(t, err.Error(), "secret")
+	})
+
 	t.Run("unknown security fields fail decoding", func(t *testing.T) {
 		meta, err := extractCommandMeta(map[string]any{
 			"command": map[string]any{

--- a/cmd/wippy/cmd/command_security_test.go
+++ b/cmd/wippy/cmd/command_security_test.go
@@ -29,6 +29,7 @@ func (r *commandEntryRegistry) GetEntry(registry.ID) (registry.Entry, error) {
 type commandSecurityRegistry struct {
 	secapi.Registry
 	policies map[registry.ID]secapi.Policy
+	groups   map[registry.ID]secapi.Scope
 }
 
 func (r *commandSecurityRegistry) GetPolicy(id registry.ID) (secapi.Policy, error) {
@@ -37,6 +38,14 @@ func (r *commandSecurityRegistry) GetPolicy(id registry.ID) (secapi.Policy, erro
 		return nil, secapi.ErrPolicyNotFound
 	}
 	return policy, nil
+}
+
+func (r *commandSecurityRegistry) GetPolicyGroup(id registry.ID) (secapi.Scope, error) {
+	scope, ok := r.groups[id]
+	if !ok {
+		return nil, secapi.ErrGroupNotFound
+	}
+	return scope, nil
 }
 
 type commandPolicy struct{ id registry.ID }
@@ -79,16 +88,16 @@ func TestExtractCommandMeta_Security(t *testing.T) {
 		assert.Equal(t, []registry.ID{registry.NewID("app.security", "admin")}, meta.Security.PolicyGroups)
 	})
 
-	t.Run("empty security block remains declared", func(t *testing.T) {
+	t.Run("empty security block is rejected", func(t *testing.T) {
 		meta, err := extractCommandMeta(map[string]any{
 			"command": map[string]any{
 				"name":     "test",
 				"security": map[string]any{"actor": map[string]any{}},
 			},
 		})
-		require.NoError(t, err)
-		require.NotNil(t, meta)
-		assert.NotNil(t, meta.Security)
+		assert.Nil(t, meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "security configuration is empty")
 	})
 
 	t.Run("malformed policy entries fail decoding", func(t *testing.T) {
@@ -104,6 +113,32 @@ func TestExtractCommandMeta_Security(t *testing.T) {
 		assert.Nil(t, meta)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode command metadata")
+	})
+
+	t.Run("unknown security fields fail decoding", func(t *testing.T) {
+		meta, err := extractCommandMeta(map[string]any{
+			"command": map[string]any{
+				"name": "test",
+				"security": map[string]any{
+					"actor":    map[string]any{"id": "a"},
+					"polciies": []any{"app:runner"},
+				},
+			},
+		})
+		assert.Nil(t, meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field")
+	})
+
+	t.Run("security requires a command name", func(t *testing.T) {
+		meta, err := extractCommandMeta(map[string]any{
+			"command": map[string]any{
+				"security": map[string]any{"actor": map[string]any{"id": "a"}},
+			},
+		})
+		assert.Nil(t, meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "security requires a command name")
 	})
 
 	t.Run("unknown command metadata remains compatible", func(t *testing.T) {
@@ -189,9 +224,46 @@ func TestResolveCommandSecurity_FailsClosed(t *testing.T) {
 		rootCtx = secapi.WithRegistry(rootCtx, &commandSecurityRegistry{policies: map[registry.ID]secapi.Policy{}})
 
 		pairs, err := resolveCommandSecurity(rootCtx, registry.NewID("app", "runner"))
-		require.Len(t, pairs, 1)
+		assert.Nil(t, pairs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), policyID.String())
+	})
+
+	t.Run("missing group returns no partial pairs", func(t *testing.T) {
+		groupID := registry.NewID("app", "missing-group")
+		rootCtx := registry.WithRegistry(ctxapi.NewRootContext(), &commandEntryRegistry{entry: registry.Entry{
+			Meta: map[string]any{"command": map[string]any{
+				"name":     "runner",
+				"security": map[string]any{"groups": []any{groupID.String()}},
+			}},
+		}})
+		rootCtx = secapi.WithRegistry(rootCtx, &commandSecurityRegistry{groups: map[registry.ID]secapi.Scope{}})
+
+		pairs, err := resolveCommandSecurity(rootCtx, registry.NewID("app", "runner"))
+		assert.Nil(t, pairs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), groupID.String())
+	})
+
+	t.Run("mixed valid and missing policy references are atomic", func(t *testing.T) {
+		validID := registry.NewID("app", "valid")
+		missingID := registry.NewID("app", "missing")
+		rootCtx := registry.WithRegistry(ctxapi.NewRootContext(), &commandEntryRegistry{entry: registry.Entry{
+			Meta: map[string]any{"command": map[string]any{
+				"name": "runner",
+				"security": map[string]any{
+					"policies": []any{validID.String(), missingID.String()},
+				},
+			}},
+		}})
+		rootCtx = secapi.WithRegistry(rootCtx, &commandSecurityRegistry{
+			policies: map[registry.ID]secapi.Policy{validID: commandPolicy{id: validID}},
+		})
+
+		pairs, err := resolveCommandSecurity(rootCtx, registry.NewID("app", "runner"))
+		assert.Nil(t, pairs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), missingID.String())
 	})
 
 	t.Run("entry lookup failure", func(t *testing.T) {

--- a/cmd/wippy/cmd/exec.go
+++ b/cmd/wippy/cmd/exec.go
@@ -21,27 +21,35 @@ import (
 // outer run loop can still perform the normal graceful shutdown after the
 // child has been canceled.
 func newExecSignalContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	execCtx, cancel := context.WithCancel(ctx)
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-
+	execCtx, cancel := newExecSignalContextWithChannel(ctx, sigChan)
 	go func() {
-		defer signal.Stop(sigChan)
-		select {
-		case <-sigChan:
-			// The supervisor's internal shutdown channel is separate from this
-			// OS signal channel, so every signal received here is external and
-			// must cancel the in-flight child.
-			cancel()
-		case <-ctx.Done():
-		case <-execCtx.Done():
-		}
+		<-execCtx.Done()
+		signal.Stop(sigChan)
 	}()
 
 	return execCtx, func() {
 		cancel()
 		signal.Stop(sigChan)
 	}
+}
+
+// newExecSignalContextWithChannel is the signal-independent part of
+// newExecSignalContext. Keeping the channel injectable makes cancellation
+// behavior testable on platforms where sending an OS signal is unsupported.
+func newExecSignalContextWithChannel(ctx context.Context, sigChan <-chan os.Signal) (context.Context, context.CancelFunc) {
+	execCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-sigChan:
+			cancel()
+		case <-ctx.Done():
+		case <-execCtx.Done():
+		}
+	}()
+
+	return execCtx, cancel
 }
 
 // execWasInterrupted reports a user interrupt without mistaking cancellation

--- a/cmd/wippy/cmd/exec.go
+++ b/cmd/wippy/cmd/exec.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/runtime"
+)
+
+type execCompletion struct {
+	data any
+	err  error
+}
+
+type execResultReceiver struct {
+	once sync.Once
+	done chan execCompletion
+}
+
+func (r *execResultReceiver) CompleteYield(_ uint64, data any, err error) {
+	r.once.Do(func() {
+		r.done <- execCompletion{data: data, err: err}
+	})
+}
+
+// waitForExecResult dispatches process.exec and does not return until the
+// launched process has produced an ExecResult or the caller is canceled. The
+// command is intentionally not pooled here: a cancellation may race with a
+// handler's final callback, and retaining this small command until the
+// callback is harmless while avoiding use-after-release hazards.
+func waitForExecResult(ctx context.Context, command *process.ExecCmd) (*runtime.Result, error) {
+	d := dispatcher.GetDispatcher(ctx)
+	if d == nil {
+		return nil, fmt.Errorf("process dispatcher not available")
+	}
+	handler := d.Dispatch(command)
+	if handler == nil {
+		return nil, fmt.Errorf("process exec handler not available")
+	}
+
+	receiver := &execResultReceiver{done: make(chan execCompletion, 1)}
+	if err := handler.Handle(ctx, command, 1, receiver); err != nil {
+		return nil, err
+	}
+
+	select {
+	case completion := <-receiver.done:
+		if completion.err != nil {
+			return nil, completion.err
+		}
+		result, ok := completion.data.(process.ExecResult)
+		if !ok {
+			return nil, fmt.Errorf("process exec returned %T, want process.ExecResult", completion.data)
+		}
+		return result.Result, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/cmd/wippy/cmd/exec.go
+++ b/cmd/wippy/cmd/exec.go
@@ -14,7 +14,6 @@ import (
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/runtime"
-	supervisorapi "github.com/wippyai/runtime/api/supervisor"
 )
 
 // newExecSignalContext gives an in-flight CLI exec its own interrupt-aware
@@ -29,14 +28,10 @@ func newExecSignalContext(ctx context.Context) (context.Context, context.CancelF
 	go func() {
 		defer signal.Stop(sigChan)
 		select {
-		case sig := <-sigChan:
-			// TriggerShutdown uses SIGTERM on the supervisor channel after a
-			// process has already completed. It must not cancel the exec
-			// watcher before the topology result can be delivered. An external
-			// SIGTERM remains a genuine cancellation request.
-			if sig == syscall.SIGTERM && supervisorapi.ShutdownTriggered() {
-				return
-			}
+		case <-sigChan:
+			// The supervisor's internal shutdown channel is separate from this
+			// OS signal channel, so every signal received here is external and
+			// must cancel the in-flight child.
 			cancel()
 		case <-ctx.Done():
 		case <-execCtx.Done():

--- a/cmd/wippy/cmd/exec.go
+++ b/cmd/wippy/cmd/exec.go
@@ -56,8 +56,8 @@ type execCompletion struct {
 }
 
 type execResultReceiver struct {
-	once sync.Once
 	done chan execCompletion
+	once sync.Once
 }
 
 func (r *execResultReceiver) CompleteYield(_ uint64, data any, err error) {

--- a/cmd/wippy/cmd/exec.go
+++ b/cmd/wippy/cmd/exec.go
@@ -4,13 +4,56 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/runtime"
+	supervisorapi "github.com/wippyai/runtime/api/supervisor"
 )
+
+// newExecSignalContext gives an in-flight CLI exec its own interrupt-aware
+// context. The regular supervisor signal channel remains untouched so the
+// outer run loop can still perform the normal graceful shutdown after the
+// child has been canceled.
+func newExecSignalContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	execCtx, cancel := context.WithCancel(ctx)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		defer signal.Stop(sigChan)
+		select {
+		case sig := <-sigChan:
+			// TriggerShutdown uses SIGTERM on the supervisor channel after a
+			// process has already completed. It must not cancel the exec
+			// watcher before the topology result can be delivered. An external
+			// SIGTERM remains a genuine cancellation request.
+			if sig == syscall.SIGTERM && supervisorapi.ShutdownTriggered() {
+				return
+			}
+			cancel()
+		case <-ctx.Done():
+		case <-execCtx.Done():
+		}
+	}()
+
+	return execCtx, func() {
+		cancel()
+		signal.Stop(sigChan)
+	}
+}
+
+// execWasInterrupted reports a user interrupt without mistaking cancellation
+// inherited from the parent runtime context for Ctrl-C.
+func execWasInterrupted(execCtx, parentCtx context.Context, err error) bool {
+	return errors.Is(err, context.Canceled) && parentCtx.Err() == nil && execCtx.Err() != nil
+}
 
 type execCompletion struct {
 	data any

--- a/cmd/wippy/cmd/exec_signal_unix_test.go
+++ b/cmd/wippy/cmd/exec_signal_unix_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+// TestExecSignalSubprocessHelper is the child half of the bounded interrupt
+// test below. Keeping it in a Unix-only test exercises real OS signal delivery
+// while the handler represents an active process.exec child.
+func TestExecSignalSubprocessHelper(t *testing.T) {
+	if os.Getenv("WIPPY_EXEC_SIGNAL_HELPER") != "1" {
+		return
+	}
+
+	started := make(chan struct{})
+	handler := dispatcher.HandlerFunc(func(ctx context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+		close(started)
+		go func() {
+			<-ctx.Done()
+			receiver.CompleteYield(tag, process.ExecResult{}, ctx.Err())
+		}()
+		return nil
+	})
+	ctx := newExecTestContext(t, handler)
+
+	// Keep the signal-aware context as the parent of the dispatch context while
+	// retaining the test registry in the application context.
+	execCtx, stopExec := newExecSignalContext(ctx)
+	defer stopExec()
+	fmt.Fprintln(os.Stdout, "ready")
+	_, err := waitForExecResult(execCtx, &process.ExecCmd{
+		Source: registry.NewID("app", "active"),
+		HostID: "terminal",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	select {
+	case <-started:
+	default:
+		t.Fatal("exec handler did not start before signal")
+	}
+}
+
+func TestExecSignalSubprocessCancelsActiveExec(t *testing.T) {
+	child := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestExecSignalSubprocessHelper")
+	child.Env = append(os.Environ(), "WIPPY_EXEC_SIGNAL_HELPER=1")
+	stdout, err := child.StdoutPipe()
+	require.NoError(t, err)
+	child.Stderr = os.Stderr
+	require.NoError(t, child.Start())
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- child.Wait() }()
+
+	ready := make(chan struct{})
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if scanner.Text() == "ready" {
+				close(ready)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		_ = child.Process.Kill()
+		<-waitDone
+		t.Fatal("exec signal helper did not become ready")
+	}
+
+	require.NoError(t, child.Process.Signal(os.Interrupt))
+	select {
+	case err := <-waitDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		_ = child.Process.Kill()
+		<-waitDone
+		t.Fatal("active exec child did not cancel after SIGINT")
+	}
+}

--- a/cmd/wippy/cmd/exec_test.go
+++ b/cmd/wippy/cmd/exec_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/runtime"
+	terminalservice "github.com/wippyai/runtime/service/terminal"
+)
+
+type execTestRegistry struct {
+	handler dispatcher.Handler
+}
+
+func (r *execTestRegistry) Get(id dispatcher.CommandID) dispatcher.Handler {
+	if id == process.Exec {
+		return r.handler
+	}
+	return nil
+}
+
+func (r *execTestRegistry) Has(id dispatcher.CommandID) bool {
+	return id == process.Exec && r.handler != nil
+}
+
+func (r *execTestRegistry) Register(id dispatcher.CommandID, handler dispatcher.Handler) {
+	if id == process.Exec {
+		r.handler = handler
+	}
+}
+
+func (r *execTestRegistry) Dispatch(cmd dispatcher.Command) dispatcher.Handler {
+	return r.Get(cmd.CmdID())
+}
+
+func newExecTestContext(t *testing.T, handler dispatcher.Handler) context.Context {
+	t.Helper()
+	app := ctxapi.NewAppContext()
+	ctx := ctxapi.WithAppContext(context.Background(), app)
+	require.NoError(t, dispatcher.WithRegistry(ctx, &execTestRegistry{handler: handler}))
+	return ctx
+}
+
+func TestWaitForExecResult_WaitsForCompletion(t *testing.T) {
+	started := make(chan struct{})
+	handler := dispatcher.HandlerFunc(func(_ context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+		close(started)
+		time.AfterFunc(25*time.Millisecond, func() {
+			receiver.CompleteYield(tag, process.ExecResult{
+				Result: &runtime.Result{Value: payload.New(int64(0))},
+			}, nil)
+		})
+		return nil
+	})
+
+	ctx := newExecTestContext(t, handler)
+	command := &process.ExecCmd{Source: registry.NewID("app", "runner"), HostID: "terminal"}
+	startedAt := time.Now()
+	result, err := waitForExecResult(ctx, command)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.GreaterOrEqual(t, time.Since(startedAt), 20*time.Millisecond)
+	assert.Equal(t, 0, terminalservice.ExitCode(result))
+	select {
+	case <-started:
+	default:
+		t.Fatal("exec handler was not called")
+	}
+}
+
+func TestWaitForExecResult_PreservesRunnerFailureResult(t *testing.T) {
+	handler := dispatcher.HandlerFunc(func(_ context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+		receiver.CompleteYield(tag, process.ExecResult{
+			Result: &runtime.Result{Value: payload.New(int64(1))},
+		}, nil)
+		return nil
+	})
+
+	result, err := waitForExecResult(
+		newExecTestContext(t, handler),
+		&process.ExecCmd{Source: registry.NewID("app", "runner"), HostID: "terminal"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, terminalservice.ExitCode(result))
+}
+
+func TestWaitForExecResult_PreservesRuntimeError(t *testing.T) {
+	handler := dispatcher.HandlerFunc(func(_ context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+		receiver.CompleteYield(tag, process.ExecResult{
+			Result: &runtime.Result{Error: errors.New("runner failed")},
+		}, nil)
+		return nil
+	})
+
+	result, err := waitForExecResult(
+		newExecTestContext(t, handler),
+		&process.ExecCmd{Source: registry.NewID("app", "runner"), HostID: "terminal"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, terminalservice.ExitCode(result))
+}
+
+func TestWaitForExecResult_PropagatesHandlerError(t *testing.T) {
+	handler := dispatcher.HandlerFunc(func(context.Context, dispatcher.Command, uint64, dispatcher.ResultReceiver) error {
+		return errors.New("dispatch failed")
+	})
+
+	result, err := waitForExecResult(
+		newExecTestContext(t, handler),
+		&process.ExecCmd{Source: registry.NewID("app", "runner"), HostID: "terminal"},
+	)
+	assert.Nil(t, result)
+	assert.EqualError(t, err, "dispatch failed")
+}
+
+func TestWaitForExecResult_ContextCancellationIsBounded(t *testing.T) {
+	handler := dispatcher.HandlerFunc(func(context.Context, dispatcher.Command, uint64, dispatcher.ResultReceiver) error {
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(newExecTestContext(t, handler))
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := waitForExecResult(ctx, &process.ExecCmd{
+		Source: registry.NewID("app", "runner"),
+		HostID: "terminal",
+	})
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/cmd/wippy/cmd/exec_test.go
+++ b/cmd/wippy/cmd/exec_test.go
@@ -152,8 +152,8 @@ func TestWaitForExecResult_ContextCancellationIsBounded(t *testing.T) {
 
 func TestExecSignalContext_CancelsOnExternalInterrupt(t *testing.T) {
 	tests := []struct {
-		name string
 		sig  os.Signal
+		name string
 	}{
 		{name: "interrupt", sig: os.Interrupt},
 		{name: "terminate", sig: syscall.SIGTERM},
@@ -241,7 +241,7 @@ func TestExecSignalSubprocessHelper(t *testing.T) {
 }
 
 func TestExecSignalSubprocessCancelsActiveExec(t *testing.T) {
-	child := exec.Command(os.Args[0], "-test.run=TestExecSignalSubprocessHelper")
+	child := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestExecSignalSubprocessHelper")
 	child.Env = append(os.Environ(), "WIPPY_EXEC_SIGNAL_HELPER=1")
 	stdout, err := child.StdoutPipe()
 	require.NoError(t, err)

--- a/cmd/wippy/cmd/exec_test.go
+++ b/cmd/wippy/cmd/exec_test.go
@@ -179,7 +179,7 @@ func TestExecSignalContext_CancelsOnExternalInterrupt(t *testing.T) {
 	}
 }
 
-func TestExecSignalContext_IgnoresSupervisorSIGTERM(t *testing.T) {
+func TestExecSignalContext_DoesNotReactToSupervisorChannel(t *testing.T) {
 	resetExecShutdownState(t)
 	t.Cleanup(func() { resetExecShutdownState(t) })
 	ctx, stop := newExecSignalContext(context.Background())
@@ -190,13 +190,9 @@ func TestExecSignalContext_IgnoresSupervisorSIGTERM(t *testing.T) {
 	supervisorapi.SetSignalChannel(supervisorCtx, make(chan os.Signal, 1))
 	supervisorapi.TriggerShutdown(supervisorCtx, 0)
 
-	current, err := os.FindProcess(os.Getpid())
-	require.NoError(t, err)
-	require.NoError(t, current.Signal(syscall.SIGTERM))
-
 	select {
 	case <-ctx.Done():
-		t.Fatal("internal supervisor SIGTERM canceled exec context")
+		t.Fatal("internal supervisor channel signal canceled exec context")
 	case <-time.After(100 * time.Millisecond):
 	}
 }

--- a/cmd/wippy/cmd/exec_test.go
+++ b/cmd/wippy/cmd/exec_test.go
@@ -3,13 +3,9 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"errors"
-	"fmt"
 	"os"
-	"os/exec"
-	"syscall"
 	"testing"
 	"time"
 
@@ -150,39 +146,23 @@ func TestWaitForExecResult_ContextCancellationIsBounded(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
-func TestExecSignalContext_CancelsOnExternalInterrupt(t *testing.T) {
-	tests := []struct {
-		sig  os.Signal
-		name string
-	}{
-		{name: "interrupt", sig: os.Interrupt},
-		{name: "terminate", sig: syscall.SIGTERM},
-	}
+func TestExecSignalContext_CancelsOnExternalSignal(t *testing.T) {
+	sigChan := make(chan os.Signal, 1)
+	ctx, stop := newExecSignalContextWithChannel(context.Background(), sigChan)
+	defer stop()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetExecShutdownState(t)
-			ctx, stop := newExecSignalContext(context.Background())
-			defer stop()
-
-			current, err := os.FindProcess(os.Getpid())
-			require.NoError(t, err)
-			require.NoError(t, current.Signal(tt.sig))
-
-			select {
-			case <-ctx.Done():
-				assert.ErrorIs(t, ctx.Err(), context.Canceled)
-			case <-time.After(2 * time.Second):
-				t.Fatalf("%s did not cancel exec context", tt.sig)
-			}
-		})
+	sigChan <- os.Interrupt
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("external signal did not cancel exec context")
 	}
 }
 
 func TestExecSignalContext_DoesNotReactToSupervisorChannel(t *testing.T) {
-	resetExecShutdownState(t)
-	t.Cleanup(func() { resetExecShutdownState(t) })
-	ctx, stop := newExecSignalContext(context.Background())
+	sigChan := make(chan os.Signal, 1)
+	ctx, stop := newExecSignalContextWithChannel(context.Background(), sigChan)
 	defer stop()
 
 	app := ctxapi.NewAppContext()
@@ -194,89 +174,5 @@ func TestExecSignalContext_DoesNotReactToSupervisorChannel(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("internal supervisor channel signal canceled exec context")
 	case <-time.After(100 * time.Millisecond):
-	}
-}
-
-func resetExecShutdownState(t *testing.T) {
-	t.Helper()
-	app := ctxapi.NewAppContext()
-	ctx := ctxapi.WithAppContext(context.Background(), app)
-	supervisorapi.SetSignalChannel(ctx, make(chan os.Signal, 1))
-}
-
-// TestExecSignalSubprocessHelper is the child half of the bounded interrupt
-// test below. Keeping it in the test binary exercises real OS signal delivery
-// while the handler represents an active process.exec child.
-func TestExecSignalSubprocessHelper(t *testing.T) {
-	if os.Getenv("WIPPY_EXEC_SIGNAL_HELPER") != "1" {
-		return
-	}
-
-	started := make(chan struct{})
-	handler := dispatcher.HandlerFunc(func(ctx context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
-		close(started)
-		go func() {
-			<-ctx.Done()
-			receiver.CompleteYield(tag, process.ExecResult{}, ctx.Err())
-		}()
-		return nil
-	})
-	ctx := newExecTestContext(t, handler)
-
-	// Keep the signal-aware context as the parent of the dispatch context while
-	// retaining the test registry in the application context.
-	execCtx, stopExec := newExecSignalContext(ctx)
-	defer stopExec()
-	fmt.Fprintln(os.Stdout, "ready")
-	_, err := waitForExecResult(execCtx, &process.ExecCmd{
-		Source: registry.NewID("app", "active"),
-		HostID: "terminal",
-	})
-	require.ErrorIs(t, err, context.Canceled)
-	select {
-	case <-started:
-	default:
-		t.Fatal("exec handler did not start before signal")
-	}
-}
-
-func TestExecSignalSubprocessCancelsActiveExec(t *testing.T) {
-	child := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestExecSignalSubprocessHelper")
-	child.Env = append(os.Environ(), "WIPPY_EXEC_SIGNAL_HELPER=1")
-	stdout, err := child.StdoutPipe()
-	require.NoError(t, err)
-	child.Stderr = os.Stderr
-	require.NoError(t, child.Start())
-
-	waitDone := make(chan error, 1)
-	go func() { waitDone <- child.Wait() }()
-
-	ready := make(chan struct{})
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			if scanner.Text() == "ready" {
-				close(ready)
-				return
-			}
-		}
-	}()
-
-	select {
-	case <-ready:
-	case <-time.After(2 * time.Second):
-		_ = child.Process.Kill()
-		<-waitDone
-		t.Fatal("exec signal helper did not become ready")
-	}
-
-	require.NoError(t, child.Process.Signal(os.Interrupt))
-	select {
-	case err := <-waitDone:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		_ = child.Process.Kill()
-		<-waitDone
-		t.Fatal("active exec child did not cancel after SIGINT")
 	}
 }

--- a/cmd/wippy/cmd/exec_test.go
+++ b/cmd/wippy/cmd/exec_test.go
@@ -3,8 +3,13 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 
@@ -16,6 +21,7 @@ import (
 	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/runtime"
+	supervisorapi "github.com/wippyai/runtime/api/supervisor"
 	terminalservice "github.com/wippyai/runtime/service/terminal"
 )
 
@@ -142,4 +148,139 @@ func TestWaitForExecResult_ContextCancellationIsBounded(t *testing.T) {
 	})
 	assert.Nil(t, result)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestExecSignalContext_CancelsOnExternalInterrupt(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  os.Signal
+	}{
+		{name: "interrupt", sig: os.Interrupt},
+		{name: "terminate", sig: syscall.SIGTERM},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetExecShutdownState(t)
+			ctx, stop := newExecSignalContext(context.Background())
+			defer stop()
+
+			current, err := os.FindProcess(os.Getpid())
+			require.NoError(t, err)
+			require.NoError(t, current.Signal(tt.sig))
+
+			select {
+			case <-ctx.Done():
+				assert.ErrorIs(t, ctx.Err(), context.Canceled)
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s did not cancel exec context", tt.sig)
+			}
+		})
+	}
+}
+
+func TestExecSignalContext_IgnoresSupervisorSIGTERM(t *testing.T) {
+	resetExecShutdownState(t)
+	t.Cleanup(func() { resetExecShutdownState(t) })
+	ctx, stop := newExecSignalContext(context.Background())
+	defer stop()
+
+	app := ctxapi.NewAppContext()
+	supervisorCtx := ctxapi.WithAppContext(context.Background(), app)
+	supervisorapi.SetSignalChannel(supervisorCtx, make(chan os.Signal, 1))
+	supervisorapi.TriggerShutdown(supervisorCtx, 0)
+
+	current, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, current.Signal(syscall.SIGTERM))
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("internal supervisor SIGTERM canceled exec context")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func resetExecShutdownState(t *testing.T) {
+	t.Helper()
+	app := ctxapi.NewAppContext()
+	ctx := ctxapi.WithAppContext(context.Background(), app)
+	supervisorapi.SetSignalChannel(ctx, make(chan os.Signal, 1))
+}
+
+// TestExecSignalSubprocessHelper is the child half of the bounded interrupt
+// test below. Keeping it in the test binary exercises real OS signal delivery
+// while the handler represents an active process.exec child.
+func TestExecSignalSubprocessHelper(t *testing.T) {
+	if os.Getenv("WIPPY_EXEC_SIGNAL_HELPER") != "1" {
+		return
+	}
+
+	started := make(chan struct{})
+	handler := dispatcher.HandlerFunc(func(ctx context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+		close(started)
+		go func() {
+			<-ctx.Done()
+			receiver.CompleteYield(tag, process.ExecResult{}, ctx.Err())
+		}()
+		return nil
+	})
+	ctx := newExecTestContext(t, handler)
+
+	// Keep the signal-aware context as the parent of the dispatch context while
+	// retaining the test registry in the application context.
+	execCtx, stopExec := newExecSignalContext(ctx)
+	defer stopExec()
+	fmt.Fprintln(os.Stdout, "ready")
+	_, err := waitForExecResult(execCtx, &process.ExecCmd{
+		Source: registry.NewID("app", "active"),
+		HostID: "terminal",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	select {
+	case <-started:
+	default:
+		t.Fatal("exec handler did not start before signal")
+	}
+}
+
+func TestExecSignalSubprocessCancelsActiveExec(t *testing.T) {
+	child := exec.Command(os.Args[0], "-test.run=TestExecSignalSubprocessHelper")
+	child.Env = append(os.Environ(), "WIPPY_EXEC_SIGNAL_HELPER=1")
+	stdout, err := child.StdoutPipe()
+	require.NoError(t, err)
+	child.Stderr = os.Stderr
+	require.NoError(t, child.Start())
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- child.Wait() }()
+
+	ready := make(chan struct{})
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if scanner.Text() == "ready" {
+				close(ready)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		_ = child.Process.Kill()
+		<-waitDone
+		t.Fatal("exec signal helper did not become ready")
+	}
+
+	require.NoError(t, child.Process.Signal(os.Interrupt))
+	select {
+	case err := <-waitDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		_ = child.Process.Kill()
+		<-waitDone
+		t.Fatal("active exec child did not cancel after SIGINT")
+	}
 }

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -291,9 +291,16 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 
 	// Handle exec: launch process and wait for completion
 	if execSpec != "" {
-		if err := launchExecProcess(ctx, logger, execSpec, execHost, args); err != nil {
-			logger.Error("exec launch failed", zap.Error(err))
-			return err
+		execCtx, stopExecSignals := newExecSignalContext(ctx)
+		execErr := launchExecProcess(execCtx, logger, execSpec, execHost, args)
+		interrupted := execWasInterrupted(execCtx, ctx, execErr)
+		stopExecSignals()
+		if execErr != nil && !interrupted {
+			logger.Error("exec launch failed", zap.Error(execErr))
+			return execErr
+		}
+		if interrupted {
+			logger.Info("exec interrupted", zap.String("signal", "SIGINT"))
 		}
 	}
 

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"github.com/wippyai/runtime/cmd/internal/entries"
 	"github.com/wippyai/runtime/cmd/internal/shutdown"
 	embedpkg "github.com/wippyai/runtime/service/fs/embed"
+	terminalservice "github.com/wippyai/runtime/service/terminal"
 	securitysys "github.com/wippyai/runtime/system/security"
 	supervisorpkg "github.com/wippyai/runtime/system/supervisor"
 	"go.uber.org/zap"
@@ -401,18 +403,62 @@ func extractCommandMeta(meta map[string]any) (*commandMeta, error) {
 	if err != nil {
 		return nil, fmt.Errorf("encode command metadata: %w", err)
 	}
+	var commandFields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &commandFields); err != nil {
+		return nil, fmt.Errorf("decode command metadata fields: %w", err)
+	}
 	var command commandMeta
 	if err := json.Unmarshal(encoded, &command); err != nil {
 		return nil, fmt.Errorf("decode command metadata: %w", err)
 	}
 	if command.Name == "" {
+		if _, declared := commandFields["security"]; declared {
+			return nil, fmt.Errorf("decode command metadata: security requires a command name")
+		}
 		return nil, nil
 	}
 	if command.UseCase == "" {
 		command.UseCase = defaultUseCase
 	}
 
+	if securityData, declared := commandFields["security"]; declared {
+		if bytes.Equal(bytes.TrimSpace(securityData), []byte("null")) {
+			return nil, fmt.Errorf("decode command metadata: security must be an object")
+		}
+
+		var config secapi.Config
+		decoder := json.NewDecoder(bytes.NewReader(securityData))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&config); err != nil {
+			return nil, fmt.Errorf("decode command security metadata: %w", err)
+		}
+		if err := validateCommandSecurityConfig(&config); err != nil {
+			return nil, fmt.Errorf("decode command security metadata: %w", err)
+		}
+		command.Security = &config
+	}
+
 	return &command, nil
+}
+
+func validateCommandSecurityConfig(config *secapi.Config) error {
+	if config == nil {
+		return fmt.Errorf("security configuration is nil")
+	}
+	if config.Actor.ID == "" && len(config.Actor.Meta) == 0 && len(config.PolicyGroups) == 0 && len(config.Policies) == 0 {
+		return fmt.Errorf("security configuration is empty")
+	}
+	for _, groupID := range config.PolicyGroups {
+		if groupID.NS == "" && groupID.Name == "" {
+			return fmt.Errorf("security policy group reference is empty")
+		}
+	}
+	for _, policyID := range config.Policies {
+		if policyID.NS == "" && policyID.Name == "" {
+			return fmt.Errorf("security policy reference is empty")
+		}
+	}
+	return nil
 }
 
 // runList prints all command-enabled process entries from resolved lock modules.
@@ -861,11 +907,6 @@ func launchExecProcess(ctx context.Context, logger *zap.Logger, execSpec, hostID
 		}
 	}
 
-	manager := process.GetManager(ctx)
-	if manager == nil {
-		return ErrProcessManagerNotAvailable
-	}
-
 	if err := waitForHostRunning(ctx, hostID); err != nil {
 		return err
 	}
@@ -875,30 +916,32 @@ func launchExecProcess(ctx context.Context, logger *zap.Logger, execSpec, hostID
 		input = append(input, payload.NewString(arg))
 	}
 
-	start := &process.Start{
-		HostID: hostID,
-		Source: source,
-		Input:  input,
-	}
-
 	// A command entry may declare its own security context (actor + policy
 	// scope). The CLI launcher is the trust anchor for terminal commands —
 	// the operator started this command on their own deployment — so the
 	// launcher resolves the declared context and attaches it to the start
 	// context. Without it a command under strict security mode executes with
 	// an incomplete context and every check denies.
-	start.Context = append(start.Context, securityPairs...)
-
-	pid, err := manager.Start(ctx, start)
+	result, err := waitForExecResult(ctx, &process.ExecCmd{
+		HostID:  hostID,
+		Source:  source,
+		Input:   input,
+		Context: securityPairs,
+	})
 	if err != nil {
-		return NewStartProcessError(hostID, err)
+		return fmt.Errorf("execute %s: %w", source.String(), err)
 	}
 
-	logger.Debug("exec process started",
-		zap.String("pid", pid.String()),
+	// The terminal host also performs this transition from its lifecycle hook,
+	// but the CLI owns the awaited ExecResult and must bridge it to the shell
+	// even if a host implementation does not emit its own shutdown signal.
+	exitCode := terminalservice.ExitCode(result)
+	supervisorapi.TriggerShutdown(ctx, exitCode)
+	logger.Debug("exec process completed",
 		zap.String("host", hostID),
 		zap.String("source", source.String()),
-		zap.Strings("args", args))
+		zap.Strings("args", args),
+		zap.Int("exit_code", exitCode))
 
 	return nil
 }

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -722,9 +722,16 @@ func runPackEntries(
 	}
 
 	if entryID != "" {
-		if err := launchExecProcess(appCtx, logger, entryID, "", args); err != nil {
-			logger.Error("exec launch failed", zap.Error(err))
-			return err
+		execCtx, stopExecSignals := newExecSignalContext(appCtx)
+		execErr := launchExecProcess(execCtx, logger, entryID, "", args)
+		interrupted := execWasInterrupted(execCtx, appCtx, execErr)
+		stopExecSignals()
+		if execErr != nil && !interrupted {
+			logger.Error("exec launch failed", zap.Error(execErr))
+			return execErr
+		}
+		if interrupted {
+			logger.Info("exec interrupted", zap.String("signal", "SIGINT"))
 		}
 	}
 

--- a/runtime/lua/component/function/lifecycle.go
+++ b/runtime/lua/component/function/lifecycle.go
@@ -109,7 +109,11 @@ func (m *Manager) Execute(ctx context.Context, task runtime.Task) (*runtime.Resu
 		}
 	}
 
-	ctx = securitysys.WithSecurityConfig(ctx, entry.security)
+	var securityErr error
+	ctx, securityErr = securitysys.WithSecurityConfigE(ctx, entry.security)
+	if securityErr != nil {
+		return nil, runtimelua.NewOperationError("resolve function security", securityErr)
+	}
 
 	result, err := entry.pool.Call(ctx, entry.method, task.Payloads)
 	return result, err

--- a/service/host/host.go
+++ b/service/host/host.go
@@ -6,6 +6,7 @@ package host
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -100,7 +101,15 @@ func (h *Host) Run(ctx context.Context, start *process.Start) (pid.PID, error) {
 	processID := h.preparePID(ctx, start)
 	frameCtx := h.prepareContext(ctx, processID, start)
 	if meta != nil && meta.Security != nil {
-		frameCtx = securitysys.WithSecurityConfig(frameCtx, meta.Security)
+		var securityErr error
+		frameCtx, securityErr = securitysys.WithSecurityConfigE(frameCtx, meta.Security)
+		if securityErr != nil {
+			proc.Close()
+			if fc := ctxapi.FrameFromContext(frameCtx); fc != nil {
+				ctxapi.ReleaseFrameContext(fc)
+			}
+			return pid.PID{}, fmt.Errorf("resolve process security: %w", securityErr)
+		}
 	}
 
 	method := "main"

--- a/service/terminal/host.go
+++ b/service/terminal/host.go
@@ -134,6 +134,14 @@ func completionExitCode(result *runtime.Result) (int, string) {
 	return 0, ""
 }
 
+// ExitCode returns the shell status represented by a completed process. It is
+// shared by CLI exec bridges so the awaited dispatcher result and terminal
+// lifecycle use identical exit semantics.
+func ExitCode(result *runtime.Result) int {
+	code, _ := completionExitCode(result)
+	return code
+}
+
 func numericExitCode(data any) (int, bool) {
 	if data == nil {
 		return 0, false
@@ -316,15 +324,16 @@ func (h *Host) prepareContext(ctx context.Context, processID pid.PID, start *pro
 		}
 	}
 
-	pairsLen := 3 + len(start.Context)
+	pairsLen := 4 + len(start.Context)
 	pairs := make([]ctxapi.Pair, pairsLen)
 	pairs[0] = ctxapi.Pair{Key: runtime.FrameIDKey, Value: start.Source}
 	pairs[1] = ctxapi.Pair{Key: runtime.FramePIDKey, Value: processID}
+	pairs[2] = ctxapi.Pair{Key: runtime.FrameLifecycleOptionsKey, Value: start.Options}
 	tc := terminalapi.NewTerminalContextWithArgs(os.Stdin, os.Stdout, os.Stderr, args)
 	tc.Raw = h.raw
 	tc.Input = NewInputReader(os.Stdin, h.raw, h.scheduler, processID)
-	pairs[2] = ctxapi.Pair{Key: terminalapi.Key(), Value: tc}
-	copy(pairs[3:], start.Context)
+	pairs[3] = ctxapi.Pair{Key: terminalapi.Key(), Value: tc}
+	copy(pairs[4:], start.Context)
 
 	if err := fc.SetMultiple(pairs...); err != nil {
 		h.log.Error("failed to set frame context", zap.Error(err))

--- a/service/terminal/host.go
+++ b/service/terminal/host.go
@@ -5,6 +5,7 @@ package terminal
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"reflect"
@@ -215,7 +216,15 @@ func (h *Host) Run(ctx context.Context, start *process.Start) (pid.PID, error) {
 
 	frameCtx := h.prepareContext(ctx, processID, start)
 	if meta != nil && meta.Security != nil {
-		frameCtx = securitysys.WithSecurityConfig(frameCtx, meta.Security)
+		var securityErr error
+		frameCtx, securityErr = securitysys.WithSecurityConfigE(frameCtx, meta.Security)
+		if securityErr != nil {
+			proc.Close()
+			if fc := ctxapi.FrameFromContext(frameCtx); fc != nil {
+				ctxapi.ReleaseFrameContext(fc)
+			}
+			return pid.PID{}, fmt.Errorf("resolve process security: %w", securityErr)
+		}
 	}
 
 	method := "main"

--- a/service/terminal/host_test.go
+++ b/service/terminal/host_test.go
@@ -389,9 +389,12 @@ func TestHost_PrepareContext(t *testing.T) {
 	h.ctx = context.Background()
 
 	processID := pid.PID{Node: "test", Host: "host", UniqID: "test1"}
+	opts := attrs.NewBag()
+	opts.Set(process.ProcessParentKey, pid.PID{Host: "parent", UniqID: "proc"})
 	start := &process.Start{
-		Source: registry.ID{NS: "test", Name: "process"},
-		Input:  []payload.Payload{payload.New("arg1"), payload.New("arg2")},
+		Source:  registry.ID{NS: "test", Name: "process"},
+		Input:   []payload.Payload{payload.New("arg1"), payload.New("arg2")},
+		Options: opts,
 	}
 
 	ctx := ctxapi.NewRootContext()
@@ -407,6 +410,10 @@ func TestHost_PrepareContext(t *testing.T) {
 	val, ok = fc.Get(runtime.FrameIDKey)
 	assert.True(t, ok)
 	assert.Equal(t, start.Source, val)
+
+	val, ok = fc.Get(runtime.FrameLifecycleOptionsKey)
+	assert.True(t, ok)
+	assert.Equal(t, start.Options, val)
 
 	val, ok = fc.Get(terminalapi.Key())
 	assert.True(t, ok)

--- a/system/process/dispatcher.go
+++ b/system/process/dispatcher.go
@@ -229,7 +229,20 @@ func (d *Dispatcher) handleExec(ctx context.Context, cmd dispatcher.Command, tag
 		for {
 			select {
 			case <-ctx.Done():
-				// Context canceled - cleanup and return error but don't cancel child
+				// process.exec owns the child for the lifetime of this request. A
+				// canceled CLI/request context must therefore cancel the child as
+				// well; otherwise a timed-out exec can outlive its watcher and leak
+				// work after the caller has already returned.
+				if cancelErr := d.manager.Cancel(
+					context.WithoutCancel(ctx),
+					watcherPID,
+					processPID,
+					"process.exec canceled: "+ctx.Err().Error(),
+				); cancelErr != nil {
+					d.logger.Warn("failed to cancel exec process",
+						zap.String("pid", processPID.String()),
+						zap.Error(cancelErr))
+				}
 				receiver.CompleteYield(tag, api.ExecResult{}, ctx.Err())
 				return
 

--- a/system/process/dispatcher_test.go
+++ b/system/process/dispatcher_test.go
@@ -714,6 +714,7 @@ func TestDispatcher_HandleExec_ContextCanceled(t *testing.T) {
 	topo.On("Register", mock.Anything).Return(nil)
 	topo.On("Remove", mock.Anything).Return()
 	manager.On("Start", mock.Anything, mock.Anything).Return(processPID, nil)
+	manager.On("Cancel", mock.Anything, mock.Anything, processPID, mock.Anything).Return(nil)
 
 	d := NewDispatcher(manager, router, topo, nil)
 
@@ -749,6 +750,7 @@ func TestDispatcher_HandleExec_ContextCanceled(t *testing.T) {
 
 	assert.NotNil(t, receiver.err)
 	assert.ErrorIs(t, receiver.err, context.Canceled)
+	manager.AssertCalled(t, "Cancel", mock.Anything, mock.Anything, processPID, mock.Anything)
 }
 
 func TestDispatcher_HandleExec_StartError(t *testing.T) {

--- a/system/security/context.go
+++ b/system/security/context.go
@@ -13,18 +13,36 @@ func actorConfigured(actor security.Actor) bool {
 	return actor.ID != "" || len(actor.Meta) > 0
 }
 
-// WithSecurityConfig configures the security context based on the provided configuration.
-func WithSecurityConfig(ctx context.Context, config *security.Config) context.Context {
-	pairs, _ := ResolveConfigPairs(ctx, config)
+// WithSecurityConfigE configures the security context and reports resolution
+// or frame installation failures. Callers at a trust or startup boundary
+// should use this form so a missing policy cannot silently fall back to the
+// inherited context.
+func WithSecurityConfigE(ctx context.Context, config *security.Config) (context.Context, error) {
+	pairs, err := ResolveConfigPairs(ctx, config)
+	if err != nil {
+		return ctx, err
+	}
 	if len(pairs) == 0 {
-		return ctx
+		return ctx, nil
 	}
 
 	fc := ctxapi.FrameFromContext(ctx)
 	if fc == nil {
-		return ctx
+		return ctx, ctxapi.ErrNoFrameContext
 	}
-	_ = fc.SetMultiple(pairs...)
+	if err := fc.SetMultiple(pairs...); err != nil {
+		return ctx, err
+	}
+
+	return ctx, nil
+}
+
+// WithSecurityConfig configures the security context based on the provided
+// configuration. It is retained for compatibility with callers that cannot
+// return an error; startup and execution boundaries should prefer
+// WithSecurityConfigE.
+func WithSecurityConfig(ctx context.Context, config *security.Config) context.Context {
+	ctx, _ = WithSecurityConfigE(ctx, config)
 
 	return ctx
 }

--- a/system/security/pairs.go
+++ b/system/security/pairs.go
@@ -15,10 +15,10 @@ import (
 // in ctx. The returned pairs are a complete security context that can either be
 // applied locally or transported to a new process frame.
 //
-// Resolution is best-effort: valid pairs are returned together with errors for
-// unresolved policy references. Existing callers that historically tolerated
-// missing references can apply the pairs and ignore the error; trust boundaries
-// such as process launchers must reject it.
+// Resolution is atomic: if any declared policy or policy group cannot be fully
+// resolved, no pairs are returned. Returning an actor or a partial scope beside
+// an error would let a caller accidentally cross a security boundary with an
+// incomplete configuration.
 func ResolveConfigPairs(ctx context.Context, config *security.Config) ([]ctxapi.Pair, error) {
 	if config == nil {
 		return nil, nil
@@ -42,10 +42,7 @@ func ResolveConfigPairs(ctx context.Context, config *security.Config) ([]ctxapi.
 
 	reg, ok := security.GetRegistry(ctx)
 	if !ok {
-		if hasExistingScope && existingScope != nil {
-			pairs = append(pairs, security.ScopePair(existingScope))
-		}
-		return pairs, fmt.Errorf("security registry not available")
+		return nil, fmt.Errorf("security registry not available")
 	}
 
 	policies := make([]security.Policy, 0, len(config.PolicyGroups)+len(config.Policies))
@@ -56,7 +53,22 @@ func ResolveConfigPairs(ctx context.Context, config *security.Config) ([]ctxapi.
 			resolutionErrors = append(resolutionErrors, fmt.Errorf("resolve security policy group %s: %w", groupID.String(), err))
 			continue
 		}
-		policies = append(policies, groupScope.Policies()...)
+		if groupScope == nil {
+			resolutionErrors = append(resolutionErrors, fmt.Errorf("resolve security policy group %s: empty scope", groupID.String()))
+			continue
+		}
+		groupPolicies := groupScope.Policies()
+		if len(groupPolicies) == 0 {
+			resolutionErrors = append(resolutionErrors, fmt.Errorf("resolve security policy group %s: group contains no policies", groupID.String()))
+			continue
+		}
+		for index, policy := range groupPolicies {
+			if policy == nil {
+				resolutionErrors = append(resolutionErrors, fmt.Errorf("resolve security policy group %s: policy %d is nil", groupID.String(), index))
+				continue
+			}
+			policies = append(policies, policy)
+		}
 	}
 	for _, policyID := range config.Policies {
 		policy, err := reg.GetPolicy(policyID)
@@ -64,7 +76,17 @@ func ResolveConfigPairs(ctx context.Context, config *security.Config) ([]ctxapi.
 			resolutionErrors = append(resolutionErrors, fmt.Errorf("resolve security policy %s: %w", policyID.String(), err))
 			continue
 		}
+		if policy == nil {
+			resolutionErrors = append(resolutionErrors, fmt.Errorf("resolve security policy %s: policy is nil", policyID.String()))
+			continue
+		}
 		policies = append(policies, policy)
+	}
+	if len(resolutionErrors) > 0 {
+		return nil, errors.Join(resolutionErrors...)
+	}
+	if len(policies) == 0 {
+		return nil, fmt.Errorf("security configuration resolved no policies")
 	}
 
 	scope := existingScope
@@ -79,5 +101,5 @@ func ResolveConfigPairs(ctx context.Context, config *security.Config) ([]ctxapi.
 		pairs = append(pairs, security.ScopePair(scope))
 	}
 
-	return pairs, errors.Join(resolutionErrors...)
+	return pairs, nil
 }

--- a/system/security/pairs_test.go
+++ b/system/security/pairs_test.go
@@ -42,20 +42,59 @@ func TestResolveConfigPairs(t *testing.T) {
 			Actor:    security.Actor{ID: "wippy.test:runner"},
 			Policies: []registry.ID{registry.NewID("test", "policy")},
 		})
-		require.Len(t, pairs, 1)
+		assert.Nil(t, pairs)
 		require.EqualError(t, err, "security registry not available")
 	})
 
-	t.Run("unresolvable references return partial pairs and an error", func(t *testing.T) {
+	t.Run("unresolvable references return no partial pairs", func(t *testing.T) {
 		reg := NewPolicyRegistry(eventbus.NewBus(), nil)
 		regCtx := security.WithRegistry(ctx, reg)
 		pairs, err := ResolveConfigPairs(regCtx, &security.Config{
 			Actor:    security.Actor{ID: "a"},
 			Policies: []registry.ID{registry.NewID("test", "missing")},
 		})
-		require.Len(t, pairs, 1)
+		assert.Nil(t, pairs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "test:missing")
+	})
+
+	t.Run("mixed valid and missing references are atomic", func(t *testing.T) {
+		reg := NewPolicyRegistry(eventbus.NewBus(), nil)
+		valid := newMockPolicy("valid", security.Allow)
+		validID := valid.ID()
+		reg.handleEvent(event.Event{
+			Kind: security.PolicyRegister,
+			Path: validID.String(),
+			Data: &security.PolicyEntry{Policy: valid},
+		})
+		regCtx := security.WithRegistry(ctx, reg)
+		pairs, err := ResolveConfigPairs(regCtx, &security.Config{
+			Actor: security.Actor{ID: "a"},
+			Policies: []registry.ID{
+				validID,
+				registry.NewID("test", "missing"),
+			},
+		})
+		assert.Nil(t, pairs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "test:missing")
+	})
+
+	t.Run("empty declared group is rejected", func(t *testing.T) {
+		reg := NewPolicyRegistry(eventbus.NewBus(), nil)
+		groupID := registry.NewID("test", "empty")
+		reg.groups.Store(groupID, []registry.ID{})
+		emptyRoot := ctxapi.NewRootContext()
+		regCtx, emptyFrame := ctxapi.OpenFrameContext(emptyRoot)
+		t.Cleanup(func() { ctxapi.ReleaseFrameContext(emptyFrame) })
+		regCtx = security.WithRegistry(regCtx, reg)
+		pairs, err := ResolveConfigPairs(regCtx, &security.Config{
+			Actor:        security.Actor{ID: "a"},
+			PolicyGroups: []registry.ID{groupID},
+		})
+		assert.Nil(t, pairs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no policies")
 	})
 
 	t.Run("pairs install actor and scope into a frame context", func(t *testing.T) {

--- a/system/security/registry.go
+++ b/system/security/registry.go
@@ -269,11 +269,15 @@ func (r *PolicyRegistry) GetPolicyGroup(groupID registry.ID) (security.Scope, er
 
 	for _, id := range policyIDs {
 		if policy, err := r.GetPolicy(id); err == nil {
+			if policy == nil {
+				return nil, fmt.Errorf("policy %s referenced in group %s is nil", id.String(), groupID.String())
+			}
 			policies = append(policies, policy)
 		} else {
 			r.logger.Warn("policy referenced in group not found",
 				zap.String("group", groupID.String()),
 				zap.String("policy", id.String()))
+			return nil, fmt.Errorf("policy %s referenced in group %s: %w", id.String(), groupID.String(), err)
 		}
 	}
 

--- a/system/security/registry_edge_test.go
+++ b/system/security/registry_edge_test.go
@@ -223,8 +223,9 @@ func TestPolicyRegistry_GetPolicyGroup_MissingPolicyReference(t *testing.T) {
 	reg.groups.Store(groupID, []registry.ID{policyID})
 
 	scope, err := reg.GetPolicyGroup(groupID)
-	require.NoError(t, err)
-	assert.Empty(t, scope.Policies())
+	assert.Nil(t, scope)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), policyID.String())
 }
 
 // --- register policy in multiple groups ---

--- a/system/supervisor/controller.go
+++ b/system/supervisor/controller.go
@@ -52,6 +52,7 @@ type Controller struct {
 	startCancel   context.CancelFunc
 	config        supervisor.LifecycleConfig
 	startMu       sync.Mutex
+	securityErr   error
 }
 
 // NewController creates a new service lifecycle controller with the specified configuration.
@@ -76,7 +77,11 @@ func NewController(
 	ctx, fc := ctxapi.ForkFrameContext(ctx)
 
 	if config.Security != nil {
-		ctx = securitysys.WithSecurityConfig(ctx, config.Security)
+		var securityErr error
+		ctx, securityErr = securitysys.WithSecurityConfigE(ctx, config.Security)
+		if securityErr != nil {
+			ctrl.securityErr = fmt.Errorf("resolve service security: %w", securityErr)
+		}
 	}
 
 	// Seal the frame since this is service-level and won't be modified
@@ -94,11 +99,20 @@ func NewController(
 // Start initiates the service and transitions it to the running state.
 func (c *Controller) Start() error {
 	c.state.setDesiredStatus(supervisor.StatusRunning)
+	if c.securityErr != nil {
+		c.updateState(supervisor.StatusExited, c.securityErr)
+		return c.securityErr
+	}
 	return c.runCommand(ctrlOp{kind: ctrlStart})
 }
 
 // Stop gracefully stops the service and transitions it to the stopped state.
 func (c *Controller) Stop() error {
+	if c.securityErr != nil {
+		c.state.setDesiredStatus(supervisor.StatusStopped)
+		c.cancel()
+		return nil
+	}
 	return c.StopContext(context.Background())
 }
 
@@ -106,6 +120,11 @@ func (c *Controller) Stop() error {
 func (c *Controller) StopContext(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if c.securityErr != nil {
+		c.state.setDesiredStatus(supervisor.StatusStopped)
+		c.cancel()
+		return nil
 	}
 	c.state.setDesiredStatus(supervisor.StatusStopped)
 	return c.runCommand(ctrlOp{kind: ctrlStop, ctx: ctx})

--- a/system/supervisor/controller.go
+++ b/system/supervisor/controller.go
@@ -44,15 +44,15 @@ type Controller struct {
 	service       supervisor.Service
 	root          context.Context
 	ctx           context.Context
-	state         *internalState
-	onStateChange func(supervisor.Status, any)
+	securityErr   error
 	stateChanged  chan struct{}
+	onStateChange func(supervisor.Status, any)
 	cancel        context.CancelFunc
 	ops           chan ctrlOp
 	startCancel   context.CancelFunc
+	state         *internalState
 	config        supervisor.LifecycleConfig
 	startMu       sync.Mutex
-	securityErr   error
 }
 
 // NewController creates a new service lifecycle controller with the specified configuration.


### PR DESCRIPTION
Makes command security resolution atomic and fail-closed, strictly validates command security metadata, awaits process execution results so CLI exit codes reflect Lua runner results, and propagates SIGINT/SIGTERM cancellation to active children. Includes focused security, process, terminal, signal, and CLI exit-code tests.