### PR TITLE
fix(s3): prevent nil upload reader panic

### DIFF
--- a/api/cloudstorage/storage.go
+++ b/api/cloudstorage/storage.go
@@ -18,6 +18,9 @@ var ErrPreconditionFailed = errors.New("cloudstorage: precondition failed")
 // (HTTP 404 / SDK NoSuchKey / NotFound from the underlying provider).
 var ErrNotFound = errors.New("cloudstorage: not found")
 
+// ErrNilUploadContent is returned when an upload is requested without a body.
+var ErrNilUploadContent = errors.New("cloudstorage: upload content is nil")
+
 type (
 	// Owner identifies the owner of an object (when surfaced by the provider).
 	Owner struct {

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -261,6 +262,10 @@ func (s *Storage) DownloadObject(ctx context.Context, key string, w io.Writer, o
 
 // UploadObject uploads an object to the S3 bucket.
 func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reader, opts *cloudstorage.UploadOptions) error {
+	if isNilReader(content) {
+		return cloudstorage.ErrNilUploadContent
+	}
+
 	input := &s3.PutObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
@@ -329,6 +334,20 @@ func (s *Storage) UploadObject(ctx context.Context, key string, content io.Reade
 	}
 
 	return nil
+}
+
+func isNilReader(reader io.Reader) bool {
+	if reader == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(reader)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // DeleteObjects removes multiple objects from the S3 bucket.

--- a/service/aws/s3/storage_test.go
+++ b/service/aws/s3/storage_test.go
@@ -452,6 +452,24 @@ func (m *mockPutObjectClient) PutObject(_ context.Context, _ *s3.PutObjectInput,
 }
 
 func TestStorage_UploadObject(t *testing.T) {
+	t.Run("nil content", func(t *testing.T) {
+		storage := NewStorage(nil, "test-bucket", nil)
+
+		var content io.Reader
+		err := storage.UploadObject(context.Background(), "test-key", content, nil)
+
+		require.ErrorIs(t, err, cloudstorage.ErrNilUploadContent)
+	})
+
+	t.Run("typed nil content", func(t *testing.T) {
+		storage := NewStorage(nil, "test-bucket", nil)
+
+		var reader *bytes.Reader
+		err := storage.UploadObject(context.Background(), "test-key", reader, nil)
+
+		require.ErrorIs(t, err, cloudstorage.ErrNilUploadContent)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		mock := &mockPutObjectClient{}
 		content := bytes.NewReader([]byte("upload content"))


### PR DESCRIPTION
## Bug

S3 multipart uploads could receive a nil `io.Reader` and panic inside the AWS SDK, bringing down the runtime.

## Fix

Validate nil and typed-nil upload readers before invoking the SDK and return a stable cloudstorage error instead.

## Tests

- Added regression coverage for nil and typed-nil readers.
- Passed `make lint`, the full race-enabled `make test` suite, and the CLI smoke test.