### PR TITLE
fix(test): avoid Windows stderr pipe hang

### DIFF
--- a/service/exec/native/native_test.go
+++ b/service/exec/native/native_test.go
@@ -456,8 +456,9 @@ func TestExecutor_Stderr(t *testing.T) {
 	// Use a cross-platform way to generate stderr output
 	var command string
 	if runtime.GOOS == "windows" {
-		// On Windows, use PowerShell for reliable stderr redirection
-		command = "powershell -Command \"[Console]::Error.WriteLine('error message')\""
+		// cmd closes its inherited stderr handle when it exits. PowerShell can
+		// retain that handle, preventing StderrPipe from reaching EOF before Wait.
+		command = "cmd /c \"echo error message 1>&2\""
 	} else {
 		// On Unix systems - use sh instead of bash for better compatibility
 		command = "sh -c 'echo error message >&2'"


### PR DESCRIPTION
## Summary

Use `cmd /c` instead of PowerShell to emit stderr in the Windows executor test. PowerShell can retain the inherited stderr handle and prevent `StderrPipe` from reaching EOF before `Wait`; `cmd` closes it when the child exits.

## Validation

- 100 race-enabled repetitions of `TestExecutor_Stderr`
- Windows/amd64 test-binary cross-compilation
- repository CI on the rebased head
