### PR TITLE
feat(cloudstorage): implement presigned multipart upload

### DIFF
--- a/api/cloudstorage/command.go
+++ b/api/cloudstorage/command.go
@@ -15,18 +15,26 @@ func init() {
 		ListObjects, DownloadObject, UploadObject,
 		DeleteObjects, PresignedGetURL, PresignedPutURL,
 		HeadObject,
+		CreateMultipartUpload, PresignedUploadPartURLs,
+		CompleteMultipartUpload, AbortMultipartUpload,
+		OpenReader,
 	)
 }
 
 // Command IDs for cloud storage operations.
 const (
-	ListObjects     dispatcher.CommandID = 160
-	DownloadObject  dispatcher.CommandID = 161
-	UploadObject    dispatcher.CommandID = 162
-	DeleteObjects   dispatcher.CommandID = 163
-	PresignedGetURL dispatcher.CommandID = 164
-	PresignedPutURL dispatcher.CommandID = 165
-	HeadObject      dispatcher.CommandID = 166
+	ListObjects             dispatcher.CommandID = 160
+	DownloadObject          dispatcher.CommandID = 161
+	UploadObject            dispatcher.CommandID = 162
+	DeleteObjects           dispatcher.CommandID = 163
+	PresignedGetURL         dispatcher.CommandID = 164
+	PresignedPutURL         dispatcher.CommandID = 165
+	HeadObject              dispatcher.CommandID = 166
+	CreateMultipartUpload   dispatcher.CommandID = 167
+	PresignedUploadPartURLs dispatcher.CommandID = 168
+	CompleteMultipartUpload dispatcher.CommandID = 169
+	AbortMultipartUpload    dispatcher.CommandID = 173
+	OpenReader              dispatcher.CommandID = 174
 )
 
 // ListObjectsCmd lists objects in cloud storage.

--- a/api/cloudstorage/multipart.go
+++ b/api/cloudstorage/multipart.go
@@ -32,7 +32,7 @@ type (
 
 	PresignedUploadPartOptions struct {
 		PartNumbers []int32
-		Expiration time.Duration
+		Expiration  time.Duration
 	}
 
 	PresignedPartURL struct {

--- a/api/cloudstorage/multipart.go
+++ b/api/cloudstorage/multipart.go
@@ -31,6 +31,7 @@ type (
 	}
 
 	PresignedUploadPartOptions struct {
+		Headers     map[string]string
 		PartNumbers []int32
 		Expiration  time.Duration
 	}

--- a/api/cloudstorage/multipart.go
+++ b/api/cloudstorage/multipart.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudstorage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+)
+
+var ErrMultipartUnsupported = errors.New("cloudstorage: multipart uploads not supported by this provider")
+
+const MaxPartNumber = 10000
+const MaxPresignPartBatch = 1000
+
+type (
+	CreateMultipartUploadOptions struct {
+		Metadata           map[string]string
+		Headers            map[string]string
+		ContentType        string
+		CacheControl       string
+		ContentDisposition string
+		ContentEncoding    string
+	}
+
+	CreateMultipartUploadResult struct {
+		UploadID string
+	}
+
+	PresignedUploadPartOptions struct {
+		PartNumbers []int32
+		Expiration time.Duration
+	}
+
+	PresignedPartURL struct {
+		URL        string
+		PartNumber int32
+	}
+
+	CompletedPart struct {
+		ETag       string
+		PartNumber int32
+	}
+
+	CompleteMultipartUploadResult struct {
+		ETag      string
+		VersionID string
+		Location  string
+	}
+
+	MultipartStorage interface {
+		Storage
+
+		CreateMultipartUpload(ctx context.Context, key string, opts *CreateMultipartUploadOptions) (*CreateMultipartUploadResult, error)
+
+		PresignedUploadPartURLs(ctx context.Context, key, uploadID string, opts *PresignedUploadPartOptions) ([]PresignedPartURL, error)
+
+		CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []CompletedPart) (*CompleteMultipartUploadResult, error)
+
+		AbortMultipartUpload(ctx context.Context, key, uploadID string) error
+	}
+)
+
+type CreateMultipartUploadCmd struct {
+	Storage Storage
+	Options *CreateMultipartUploadOptions
+	Key     string
+}
+
+var createMultipartUploadCmdPool = sync.Pool{New: func() any { return &CreateMultipartUploadCmd{} }}
+
+func AcquireCreateMultipartUploadCmd() *CreateMultipartUploadCmd {
+	return createMultipartUploadCmdPool.Get().(*CreateMultipartUploadCmd)
+}
+func (c *CreateMultipartUploadCmd) CmdID() dispatcher.CommandID { return CreateMultipartUpload }
+func (c *CreateMultipartUploadCmd) Release() {
+	c.Storage = nil
+	c.Key = ""
+	c.Options = nil
+	createMultipartUploadCmdPool.Put(c)
+}
+
+type CreateMultipartUploadResponse struct {
+	Result *CreateMultipartUploadResult
+	Error  error
+}
+
+type PresignedPartURLsCmd struct {
+	Storage  Storage
+	Options  *PresignedUploadPartOptions
+	Key      string
+	UploadID string
+}
+
+var presignedPartURLsCmdPool = sync.Pool{New: func() any { return &PresignedPartURLsCmd{} }}
+
+func AcquirePresignedPartURLsCmd() *PresignedPartURLsCmd {
+	return presignedPartURLsCmdPool.Get().(*PresignedPartURLsCmd)
+}
+func (c *PresignedPartURLsCmd) CmdID() dispatcher.CommandID { return PresignedUploadPartURLs }
+func (c *PresignedPartURLsCmd) Release() {
+	c.Storage = nil
+	c.Key = ""
+	c.UploadID = ""
+	c.Options = nil
+	presignedPartURLsCmdPool.Put(c)
+}
+
+type PresignedPartURLsResponse struct {
+	Error error
+	URLs  []PresignedPartURL
+}
+
+type CompleteMultipartUploadCmd struct {
+	Storage  Storage
+	Key      string
+	UploadID string
+	Parts    []CompletedPart
+}
+
+var completeMultipartUploadCmdPool = sync.Pool{New: func() any { return &CompleteMultipartUploadCmd{} }}
+
+func AcquireCompleteMultipartUploadCmd() *CompleteMultipartUploadCmd {
+	return completeMultipartUploadCmdPool.Get().(*CompleteMultipartUploadCmd)
+}
+func (c *CompleteMultipartUploadCmd) CmdID() dispatcher.CommandID { return CompleteMultipartUpload }
+func (c *CompleteMultipartUploadCmd) Release() {
+	c.Storage = nil
+	c.Key = ""
+	c.UploadID = ""
+	c.Parts = nil
+	completeMultipartUploadCmdPool.Put(c)
+}
+
+type CompleteMultipartUploadResponse struct {
+	Result *CompleteMultipartUploadResult
+	Error  error
+}
+
+type AbortMultipartUploadCmd struct {
+	Storage  Storage
+	Key      string
+	UploadID string
+}
+
+var abortMultipartUploadCmdPool = sync.Pool{New: func() any { return &AbortMultipartUploadCmd{} }}
+
+func AcquireAbortMultipartUploadCmd() *AbortMultipartUploadCmd {
+	return abortMultipartUploadCmdPool.Get().(*AbortMultipartUploadCmd)
+}
+func (c *AbortMultipartUploadCmd) CmdID() dispatcher.CommandID { return AbortMultipartUpload }
+func (c *AbortMultipartUploadCmd) Release() {
+	c.Storage = nil
+	c.Key = ""
+	c.UploadID = ""
+	abortMultipartUploadCmdPool.Put(c)
+}
+
+type AbortMultipartUploadResponse struct {
+	Error error
+}

--- a/api/cloudstorage/readerat.go
+++ b/api/cloudstorage/readerat.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudstorage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+)
+
+var ErrReaderClosed = errors.New("cloudstorage: reader closed")
+
+const (
+	DefaultReaderBlockSize   = 8 * 1024 * 1024
+	DefaultReaderCacheBlocks = 4
+	MaxReaderCacheBlocks = 64
+)
+
+type RangeReaderAtOptions struct {
+	ETag string
+	BlockSize int64
+	CacheBlocks int
+}
+
+type cachedBlock struct {
+	data []byte
+	idx  int64
+	use  uint64
+}
+
+type RangeReaderAt struct {
+	storage Storage
+	ctx     context.Context
+	key     string
+	etag    string
+	blocks  []cachedBlock
+
+	blockSize int64
+	size      int64
+	useSeq    uint64
+
+	mu     sync.Mutex
+	closed bool
+}
+
+var _ io.ReaderAt = (*RangeReaderAt)(nil)
+
+func NewRangeReaderAt(ctx context.Context, storage Storage, key string, size int64, opts *RangeReaderAtOptions) *RangeReaderAt {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	blockSize := int64(DefaultReaderBlockSize)
+	cacheBlocks := DefaultReaderCacheBlocks
+	etag := ""
+	if opts != nil {
+		if opts.BlockSize > 0 {
+			blockSize = opts.BlockSize
+		}
+		if opts.CacheBlocks > 0 {
+			cacheBlocks = opts.CacheBlocks
+		}
+		if cacheBlocks > MaxReaderCacheBlocks {
+			cacheBlocks = MaxReaderCacheBlocks
+		}
+		etag = opts.ETag
+	}
+
+	return &RangeReaderAt{
+		storage:   storage,
+		ctx:       ctx,
+		key:       key,
+		etag:      etag,
+		blockSize: blockSize,
+		size:      size,
+		blocks:    make([]cachedBlock, 0, cacheBlocks),
+	}
+}
+
+func (r *RangeReaderAt) Size() int64 { return r.size }
+
+func (r *RangeReaderAt) Key() string { return r.key }
+
+func (r *RangeReaderAt) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closed = true
+	r.blocks = nil
+	return nil
+}
+
+func (r *RangeReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, errors.New("cloudstorage: negative read offset")
+	}
+	if len(p) == 0 {
+		if off >= r.size {
+			return 0, io.EOF
+		}
+		return 0, nil
+	}
+	if off >= r.size {
+		return 0, io.EOF
+	}
+
+	n := 0
+	for n < len(p) {
+		pos := off + int64(n)
+		if pos >= r.size {
+			return n, io.EOF
+		}
+		block, err := r.block(pos / r.blockSize)
+		if err != nil {
+			return n, err
+		}
+		lo := int(pos - (pos/r.blockSize)*r.blockSize)
+		if lo >= len(block) {
+			return n, io.ErrUnexpectedEOF
+		}
+		n += copy(p[n:], block[lo:])
+	}
+	return n, nil
+}
+
+func (r *RangeReaderAt) block(idx int64) ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil, ErrReaderClosed
+	}
+
+	r.useSeq++
+	for i := range r.blocks {
+		if r.blocks[i].idx == idx {
+			r.blocks[i].use = r.useSeq
+			return r.blocks[i].data, nil
+		}
+	}
+
+	data, err := r.fetch(idx)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := cachedBlock{data: data, idx: idx, use: r.useSeq}
+	if len(r.blocks) < cap(r.blocks) {
+		r.blocks = append(r.blocks, entry)
+		return data, nil
+	}
+
+	lru := 0
+	for i := 1; i < len(r.blocks); i++ {
+		if r.blocks[i].use < r.blocks[lru].use {
+			lru = i
+		}
+	}
+	r.blocks[lru] = entry
+	return data, nil
+}
+
+func (r *RangeReaderAt) fetch(idx int64) ([]byte, error) {
+	start := idx * r.blockSize
+	end := start + r.blockSize
+	if end > r.size {
+		end = r.size
+	}
+	want := end - start
+
+	var buf bytes.Buffer
+	buf.Grow(int(want))
+
+	opts := &DownloadOptions{
+		Range: fmt.Sprintf("bytes=%d-%d", start, end-1),
+	}
+	if r.etag != "" {
+		opts.IfMatch = r.etag
+	}
+
+	if err := r.storage.DownloadObject(r.ctx, r.key, &buf, opts); err != nil {
+		return nil, err
+	}
+	if int64(buf.Len()) != want {
+		return nil, fmt.Errorf("cloudstorage: range read returned %d bytes, want %d (object changed?): %w",
+			buf.Len(), want, io.ErrUnexpectedEOF)
+	}
+	return buf.Bytes(), nil
+}
+
+type OpenReaderCmd struct {
+	Storage Storage
+	Key     string
+}
+
+var openReaderCmdPool = sync.Pool{New: func() any { return &OpenReaderCmd{} }}
+
+func AcquireOpenReaderCmd() *OpenReaderCmd           { return openReaderCmdPool.Get().(*OpenReaderCmd) }
+func (c *OpenReaderCmd) CmdID() dispatcher.CommandID { return OpenReader }
+func (c *OpenReaderCmd) Release() {
+	c.Storage = nil
+	c.Key = ""
+	openReaderCmdPool.Put(c)
+}
+
+type OpenReaderResponse struct {
+	Error error
+	ETag  string
+	Size  int64
+}

--- a/api/cloudstorage/readerat.go
+++ b/api/cloudstorage/readerat.go
@@ -18,12 +18,12 @@ var ErrReaderClosed = errors.New("cloudstorage: reader closed")
 const (
 	DefaultReaderBlockSize   = 8 * 1024 * 1024
 	DefaultReaderCacheBlocks = 4
-	MaxReaderCacheBlocks = 64
+	MaxReaderCacheBlocks     = 64
 )
 
 type RangeReaderAtOptions struct {
-	ETag string
-	BlockSize int64
+	ETag        string
+	BlockSize   int64
 	CacheBlocks int
 }
 

--- a/api/cloudstorage/readerat.go
+++ b/api/cloudstorage/readerat.go
@@ -13,12 +13,17 @@ import (
 	"github.com/wippyai/runtime/api/dispatcher"
 )
 
-var ErrReaderClosed = errors.New("cloudstorage: reader closed")
+var (
+	ErrReaderClosed   = errors.New("cloudstorage: reader closed")
+	ErrReaderUnpinned = errors.New("cloudstorage: object has no consistency token")
+)
 
 const (
 	DefaultReaderBlockSize   = 8 * 1024 * 1024
 	DefaultReaderCacheBlocks = 4
+	MaxReaderBlockSize       = 128 * 1024 * 1024
 	MaxReaderCacheBlocks     = 64
+	MaxReaderCacheBytes      = 256 * 1024 * 1024
 )
 
 type RangeReaderAtOptions struct {
@@ -36,6 +41,7 @@ type cachedBlock struct {
 type RangeReaderAt struct {
 	storage Storage
 	ctx     context.Context
+	cancel  context.CancelFunc
 	key     string
 	etag    string
 	blocks  []cachedBlock
@@ -54,6 +60,7 @@ func NewRangeReaderAt(ctx context.Context, storage Storage, key string, size int
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	ctx, cancel := context.WithCancel(ctx)
 
 	blockSize := int64(DefaultReaderBlockSize)
 	cacheBlocks := DefaultReaderCacheBlocks
@@ -61,6 +68,9 @@ func NewRangeReaderAt(ctx context.Context, storage Storage, key string, size int
 	if opts != nil {
 		if opts.BlockSize > 0 {
 			blockSize = opts.BlockSize
+		}
+		if blockSize > MaxReaderBlockSize {
+			blockSize = MaxReaderBlockSize
 		}
 		if opts.CacheBlocks > 0 {
 			cacheBlocks = opts.CacheBlocks
@@ -70,10 +80,14 @@ func NewRangeReaderAt(ctx context.Context, storage Storage, key string, size int
 		}
 		etag = opts.ETag
 	}
+	if maxBlocks := int64(MaxReaderCacheBytes) / blockSize; int64(cacheBlocks) > maxBlocks {
+		cacheBlocks = int(maxBlocks)
+	}
 
 	return &RangeReaderAt{
 		storage:   storage,
 		ctx:       ctx,
+		cancel:    cancel,
 		key:       key,
 		etag:      etag,
 		blockSize: blockSize,
@@ -87,6 +101,7 @@ func (r *RangeReaderAt) Size() int64 { return r.size }
 func (r *RangeReaderAt) Key() string { return r.key }
 
 func (r *RangeReaderAt) Close() error {
+	r.cancel()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.closed = true
@@ -133,6 +148,9 @@ func (r *RangeReaderAt) block(idx int64) ([]byte, error) {
 
 	if r.closed {
 		return nil, ErrReaderClosed
+	}
+	if err := r.ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	r.useSeq++

--- a/api/cloudstorage/readerat_test.go
+++ b/api/cloudstorage/readerat_test.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudstorage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rangeFakeStorage struct {
+	etag     string
+	data     []byte
+	mu       sync.Mutex
+	fetches  int
+	failEtag bool
+}
+
+func (f *rangeFakeStorage) fetchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fetches
+}
+
+func (f *rangeFakeStorage) DownloadObject(_ context.Context, _ string, w io.Writer, opts *DownloadOptions) error {
+	f.mu.Lock()
+	f.fetches++
+	f.mu.Unlock()
+
+	if f.failEtag && opts != nil && opts.IfMatch != "" && opts.IfMatch != f.etag {
+		return ErrPreconditionFailed
+	}
+
+	start, end := int64(0), int64(len(f.data))-1
+	if opts != nil && opts.Range != "" {
+		spec, ok := strings.CutPrefix(opts.Range, "bytes=")
+		if !ok {
+			return fmt.Errorf("bad range %q", opts.Range)
+		}
+		lo, hi, ok := strings.Cut(spec, "-")
+		if !ok {
+			return fmt.Errorf("bad range %q", opts.Range)
+		}
+		var err error
+		if start, err = strconv.ParseInt(lo, 10, 64); err != nil {
+			return err
+		}
+		if end, err = strconv.ParseInt(hi, 10, 64); err != nil {
+			return err
+		}
+	}
+	if start < 0 || start >= int64(len(f.data)) {
+		return errors.New("range start out of bounds")
+	}
+	if end >= int64(len(f.data)) {
+		end = int64(len(f.data)) - 1
+	}
+	_, err := w.Write(f.data[start : end+1])
+	return err
+}
+
+func (f *rangeFakeStorage) ListObjects(context.Context, *ListObjectsOptions) (*ListObjectsResult, error) {
+	panic("unexpected ListObjects")
+}
+func (f *rangeFakeStorage) HeadObject(context.Context, string) (*HeadObjectResult, error) {
+	panic("unexpected HeadObject")
+}
+func (f *rangeFakeStorage) UploadObject(context.Context, string, io.Reader, *UploadOptions) error {
+	panic("unexpected UploadObject")
+}
+func (f *rangeFakeStorage) DeleteObjects(context.Context, []string) error {
+	panic("unexpected DeleteObjects")
+}
+func (f *rangeFakeStorage) PresignedGetURL(context.Context, string, *PresignedGetOptions) (string, error) {
+	panic("unexpected PresignedGetURL")
+}
+func (f *rangeFakeStorage) PresignedPutURL(context.Context, string, *PresignedPutOptions) (string, error) {
+	panic("unexpected PresignedPutURL")
+}
+
+func testPattern(n int) []byte {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	return data
+}
+
+func newTestReader(t *testing.T, size int64, blockSize int64, cacheBlocks int) (*RangeReaderAt, *rangeFakeStorage) {
+	t.Helper()
+	fake := &rangeFakeStorage{data: testPattern(int(size))}
+	r := NewRangeReaderAt(context.Background(), fake, "obj.zip", size, &RangeReaderAtOptions{
+		BlockSize:   blockSize,
+		CacheBlocks: cacheBlocks,
+	})
+	return r, fake
+}
+
+func TestRangeReaderAt_FullSequentialRead(t *testing.T) {
+	const size = 1000
+	r, fake := newTestReader(t, size, 64, 2)
+
+	got := make([]byte, size)
+	n, err := r.ReadAt(got, 0)
+	require.NoError(t, err)
+	assert.Equal(t, size, n)
+	assert.Equal(t, testPattern(size), got)
+	// ceil(1000/64) = 16 block fetches, each exactly once.
+	assert.Equal(t, 16, fake.fetchCount())
+}
+
+func TestRangeReaderAt_ReadViaIoSectionReader(t *testing.T) {
+	// io.SectionReader is how archive/zip consumes an io.ReaderAt.
+	const size = 4096
+	r, _ := newTestReader(t, size, 512, 4)
+
+	sec := io.NewSectionReader(r, 100, 300)
+	got, err := io.ReadAll(sec)
+	require.NoError(t, err)
+	assert.Equal(t, testPattern(size)[100:400], got)
+}
+
+func TestRangeReaderAt_CrossBlockRead(t *testing.T) {
+	const size = 256
+	r, fake := newTestReader(t, size, 100, 4)
+
+	got := make([]byte, 150)
+	n, err := r.ReadAt(got, 75)
+	require.NoError(t, err)
+	assert.Equal(t, 150, n)
+	assert.Equal(t, testPattern(size)[75:225], got)
+	// Offsets 75..224 span blocks 0, 1, 2.
+	assert.Equal(t, 3, fake.fetchCount())
+}
+
+func TestRangeReaderAt_CacheHits(t *testing.T) {
+	const size = 300
+	r, fake := newTestReader(t, size, 100, 4)
+
+	buf := make([]byte, 50)
+	_, err := r.ReadAt(buf, 0)
+	require.NoError(t, err)
+	_, err = r.ReadAt(buf, 25)
+	require.NoError(t, err)
+	_, err = r.ReadAt(buf, 50)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fake.fetchCount(), "same block must be fetched once")
+}
+
+func TestRangeReaderAt_LRUEviction(t *testing.T) {
+	const size = 400
+	r, fake := newTestReader(t, size, 100, 2)
+
+	buf := make([]byte, 10)
+	for _, off := range []int64{0, 100, 200} { // fills blocks 0,1 then evicts 0
+		_, err := r.ReadAt(buf, off)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 3, fake.fetchCount())
+
+	_, err := r.ReadAt(buf, 0) // block 0 was evicted → refetch
+	require.NoError(t, err)
+	assert.Equal(t, 4, fake.fetchCount())
+
+	_, err = r.ReadAt(buf, 200) // block 2 still resident
+	require.NoError(t, err)
+	assert.Equal(t, 4, fake.fetchCount())
+}
+
+func TestRangeReaderAt_EOF(t *testing.T) {
+	const size = 100
+	r, _ := newTestReader(t, size, 64, 2)
+
+	// Read ending exactly at EOF: full read, no error.
+	got := make([]byte, 40)
+	n, err := r.ReadAt(got, 60)
+	require.NoError(t, err)
+	assert.Equal(t, 40, n)
+
+	// Read crossing EOF: partial read + io.EOF.
+	n, err = r.ReadAt(make([]byte, 50), 80)
+	assert.Equal(t, 20, n)
+	assert.ErrorIs(t, err, io.EOF)
+
+	// Read at EOF.
+	n, err = r.ReadAt(got, 100)
+	assert.Zero(t, n)
+	assert.ErrorIs(t, err, io.EOF)
+
+	// Read past EOF.
+	n, err = r.ReadAt(got, 1000)
+	assert.Zero(t, n)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestRangeReaderAt_NegativeOffset(t *testing.T) {
+	r, _ := newTestReader(t, 10, 64, 2)
+	_, err := r.ReadAt(make([]byte, 1), -1)
+	assert.Error(t, err)
+}
+
+func TestRangeReaderAt_EmptyBuffer(t *testing.T) {
+	r, _ := newTestReader(t, 10, 64, 2)
+	n, err := r.ReadAt(nil, 0)
+	assert.Zero(t, n)
+	assert.NoError(t, err)
+}
+
+func TestRangeReaderAt_Close(t *testing.T) {
+	r, _ := newTestReader(t, 10, 64, 2)
+	require.NoError(t, r.Close())
+	require.NoError(t, r.Close(), "close must be idempotent")
+
+	_, err := r.ReadAt(make([]byte, 1), 0)
+	assert.ErrorIs(t, err, ErrReaderClosed)
+}
+
+func TestRangeReaderAt_SizeAndKey(t *testing.T) {
+	r, _ := newTestReader(t, 123, 64, 2)
+	assert.Equal(t, int64(123), r.Size())
+	assert.Equal(t, "obj.zip", r.Key())
+}
+
+func TestRangeReaderAt_ETagMismatchSurfaces(t *testing.T) {
+	fake := &rangeFakeStorage{data: testPattern(100), etag: `"current"`, failEtag: true}
+	r := NewRangeReaderAt(context.Background(), fake, "k", 100, &RangeReaderAtOptions{
+		BlockSize: 64,
+		ETag:      `"stale"`,
+	})
+
+	_, err := r.ReadAt(make([]byte, 10), 0)
+	assert.ErrorIs(t, err, ErrPreconditionFailed)
+}
+
+func TestRangeReaderAt_ShortRangeResponse(t *testing.T) {
+	// A backend returning fewer bytes than the requested range (object
+	// shrank mid-read) must surface io.ErrUnexpectedEOF, not silence.
+	fake := &rangeFakeStorage{data: testPattern(50)}
+	r := NewRangeReaderAt(context.Background(), fake, "k", 100, &RangeReaderAtOptions{BlockSize: 64})
+
+	_, err := r.ReadAt(make([]byte, 10), 0)
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestRangeReaderAt_ConcurrentReads(t *testing.T) {
+	const size = 4096
+	r, _ := newTestReader(t, size, 256, 4)
+	want := testPattern(size)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 16)
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			buf := make([]byte, 128)
+			for i := 0; i < 32; i++ {
+				off := int64((seed*131 + i*97) % (size - len(buf)))
+				n, err := r.ReadAt(buf, off)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if string(buf[:n]) != string(want[off:off+int64(n)]) {
+					errs <- fmt.Errorf("mismatch at %d", off)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}
+
+func TestRangeReaderAt_Defaults(t *testing.T) {
+	fake := &rangeFakeStorage{data: testPattern(10)}
+	r := NewRangeReaderAt(nil, fake, "k", 10, nil) // nil ctx must be tolerated
+	assert.Equal(t, int64(DefaultReaderBlockSize), r.blockSize)
+	assert.Equal(t, DefaultReaderCacheBlocks, cap(r.blocks))
+
+	r2 := NewRangeReaderAt(context.Background(), fake, "k", 10, &RangeReaderAtOptions{CacheBlocks: 1000})
+	assert.Equal(t, MaxReaderCacheBlocks, cap(r2.blocks))
+}

--- a/api/cloudstorage/readerat_test.go
+++ b/api/cloudstorage/readerat_test.go
@@ -11,17 +11,21 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type rangeFakeStorage struct {
-	etag     string
-	data     []byte
-	mu       sync.Mutex
-	fetches  int
-	failEtag bool
+	etag      string
+	block     <-chan struct{}
+	started   chan<- struct{}
+	data      []byte
+	fetches   int
+	startOnce sync.Once
+	mu        sync.Mutex
+	failEtag  bool
 }
 
 func (f *rangeFakeStorage) fetchCount() int {
@@ -30,10 +34,20 @@ func (f *rangeFakeStorage) fetchCount() int {
 	return f.fetches
 }
 
-func (f *rangeFakeStorage) DownloadObject(_ context.Context, _ string, w io.Writer, opts *DownloadOptions) error {
+func (f *rangeFakeStorage) DownloadObject(ctx context.Context, _ string, w io.Writer, opts *DownloadOptions) error {
 	f.mu.Lock()
 	f.fetches++
 	f.mu.Unlock()
+	if f.started != nil {
+		f.startOnce.Do(func() { close(f.started) })
+	}
+	if f.block != nil {
+		select {
+		case <-f.block:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 
 	if f.failEtag && opts != nil && opts.IfMatch != "" && opts.IfMatch != f.etag {
 		return ErrPreconditionFailed
@@ -290,5 +304,59 @@ func TestRangeReaderAt_Defaults(t *testing.T) {
 	assert.Equal(t, DefaultReaderCacheBlocks, cap(r.blocks))
 
 	r2 := NewRangeReaderAt(context.Background(), fake, "k", 10, &RangeReaderAtOptions{CacheBlocks: 1000})
-	assert.Equal(t, MaxReaderCacheBlocks, cap(r2.blocks))
+	assert.Equal(t, MaxReaderCacheBytes/DefaultReaderBlockSize, cap(r2.blocks))
+
+	r3 := NewRangeReaderAt(context.Background(), fake, "k", 10, &RangeReaderAtOptions{
+		BlockSize:   MaxReaderBlockSize * 2,
+		CacheBlocks: MaxReaderCacheBlocks,
+	})
+	assert.Equal(t, int64(MaxReaderBlockSize), r3.blockSize)
+	assert.Equal(t, MaxReaderCacheBytes/MaxReaderBlockSize, cap(r3.blocks))
+}
+
+func TestRangeReaderAt_CloseCancelsInFlightFetch(t *testing.T) {
+	started := make(chan struct{})
+	fake := &rangeFakeStorage{
+		data:    testPattern(64),
+		block:   make(chan struct{}),
+		started: started,
+	}
+	r := NewRangeReaderAt(context.Background(), fake, "k", 64, &RangeReaderAtOptions{BlockSize: 64})
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := r.ReadAt(make([]byte, 1), 0)
+		readDone <- err
+	}()
+	<-started
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- r.Close() }()
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel the in-flight range request")
+	}
+	select {
+	case err := <-readDone:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("range request did not observe reader cancellation")
+	}
+}
+
+func TestRangeReaderAt_ParentCancellationRejectsCachedReads(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &rangeFakeStorage{data: testPattern(64)}
+	r := NewRangeReaderAt(ctx, fake, "k", 64, &RangeReaderAtOptions{BlockSize: 64})
+
+	_, err := r.ReadAt(make([]byte, 1), 0)
+	require.NoError(t, err)
+	cancel()
+
+	_, err = r.ReadAt(make([]byte, 1), 0)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, fake.fetchCount(), "cancelled reads must not refetch or use cached data")
 }

--- a/runtime/lua/modules/archive/external_source_test.go
+++ b/runtime/lua/modules/archive/external_source_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package archive
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// externalRA mimics a module-provided random-access source (the cloudstorage
+// ranged reader): io.ReaderAt + Size + Name, lifecycle owned by the provider.
+// bytes.Reader supplies ReadAt and Size.
+type externalRA struct {
+	*bytes.Reader
+	name string
+}
+
+func (e *externalRA) Name() string { return e.name }
+
+// nameless is the same source without the optional Name hint, forcing
+// format detection down the magic-byte sniff path.
+type namelessRA struct {
+	*bytes.Reader
+}
+
+func TestLuaOpenFromExternalReaderAt(t *testing.T) {
+	l, dir, _ := setupEngine(t)
+
+	run(t, l, `
+		local w = assert(archive.create(appfs, "ext.zip"))
+		assert(w:add("notes.txt", "hello world"))
+		assert(w:add("docs/data.bin", string.rep("z", 4096)))
+		assert(w:close())
+	`)
+	zipBytes, err := os.ReadFile(filepath.Join(dir, "ext.zip"))
+	require.NoError(t, err)
+
+	ud := l.NewUserData()
+	ud.Value = &externalRA{Reader: bytes.NewReader(zipBytes), name: "ext.zip"}
+	l.SetGlobal("extsrc", ud)
+
+	run(t, l, `
+		local r, err = archive.open(extsrc)
+		assert(r, tostring(err))
+
+		local names = {}
+		for e in r:entries() do names[e.name] = e end
+		assert(names["notes.txt"], "missing notes.txt")
+		assert(names["docs/data.bin"], "missing docs/data.bin")
+		assert(names["docs/data.bin"].size == 4096, "bad entry size")
+
+		assert(r:read("notes.txt") == "hello world", "read mismatch")
+
+		local s = assert(r:stream("docs/data.bin"))
+		assert(s.read, "stream has no read method")
+
+		local n = assert(r:extract_all(appfs, { prefix = "ext-out/" }))
+		assert(n == 2, "extracted "..tostring(n))
+		assert(r:close())
+	`)
+
+	got, err := os.ReadFile(filepath.Join(dir, "ext-out", "notes.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(got))
+}
+
+func TestLuaOpenFromExternalReaderAtSniffsWithoutName(t *testing.T) {
+	l, dir, _ := setupEngine(t)
+
+	run(t, l, `
+		local w = assert(archive.create(appfs, "sniff.zip"))
+		assert(w:add("a.txt", "alpha"))
+		assert(w:close())
+	`)
+	zipBytes, err := os.ReadFile(filepath.Join(dir, "sniff.zip"))
+	require.NoError(t, err)
+
+	ud := l.NewUserData()
+	ud.Value = &namelessRA{Reader: bytes.NewReader(zipBytes)}
+	l.SetGlobal("blindsrc", ud)
+
+	run(t, l, `
+		local r, err = archive.open(blindsrc)
+		assert(r, tostring(err))
+		assert(r:read("a.txt") == "alpha")
+		assert(r:close())
+	`)
+}
+
+func TestLuaOpenFromExternalReaderAtWithOptions(t *testing.T) {
+	l, dir, _ := setupEngine(t)
+
+	run(t, l, `
+		local w = assert(archive.create(appfs, "lim.zip"))
+		assert(w:add("big.txt", string.rep("x", 2048)))
+		assert(w:close())
+	`)
+	zipBytes, err := os.ReadFile(filepath.Join(dir, "lim.zip"))
+	require.NoError(t, err)
+
+	ud := l.NewUserData()
+	ud.Value = &externalRA{Reader: bytes.NewReader(zipBytes), name: "lim.zip"}
+	l.SetGlobal("limsrc", ud)
+
+	// Options land at arg 2 for external sources (no path argument).
+	run(t, l, `
+		local r, err = archive.open(limsrc, { max_inline_bytes = 16 })
+		assert(r, tostring(err))
+		local data, e = r:read("big.txt")
+		assert(data == nil and e ~= nil, "expected inline-size error")
+		assert(r:stream("big.txt"))
+		assert(r:close())
+	`)
+}
+
+func TestLuaOpenRejectsUnknownUserdata(t *testing.T) {
+	l, _, _ := setupEngine(t)
+
+	ud := l.NewUserData()
+	ud.Value = struct{ x int }{x: 1}
+	l.SetGlobal("junksrc", ud)
+
+	run(t, l, `
+		local r, err = archive.open(junksrc)
+		assert(r == nil and err ~= nil, "expected source-type error")
+	`)
+}
+
+// Interface conformance guards: the archive hook must keep accepting any
+// userdata that satisfies externalReaderAt.
+var (
+	_ externalReaderAt = (*externalRA)(nil)
+	_ externalReaderAt = (*namelessRA)(nil)
+)

--- a/runtime/lua/modules/archive/module.go
+++ b/runtime/lua/modules/archive/module.go
@@ -138,6 +138,11 @@ func maxTotalBytes(o archiveapi.Options) int64 {
 	return sysarchive.DefaultMaxTotalBytes
 }
 
+type externalReaderAt interface {
+	io.ReaderAt
+	Size() int64
+}
+
 // seekableSource resolves arg1..argN into a random-access source for open().
 // Returns the ReaderAt, total size, a name for sniffing, and a closer.
 func seekableSource(l *lua.LState) (ra io.ReaderAt, size int64, name string, closer io.Closer, optsIdx int, errCode int) {
@@ -179,9 +184,17 @@ func seekableSource(l *lua.LState) (ra io.ReaderAt, size int64, name string, clo
 				return nil, 0, "", nil, 0, internalError(l, err, "stat source")
 			}
 			return ra, info.Size(), "", nil, 2, 0
+		default:
+			if ext, ok := h.(externalReaderAt); ok {
+				name := ""
+				if named, nok := h.(interface{ Name() string }); nok {
+					name = named.Name()
+				}
+				return ext, ext.Size(), name, nil, 2, 0
+			}
 		}
 	}
-	return nil, 0, "", nil, 0, invalidError(l, "source must be an fs handle, an fs file, or bytes")
+	return nil, 0, "", nil, 0, invalidError(l, "source must be an fs handle, an fs file, bytes, or a random-access reader")
 }
 
 func resolveCodec(l *lua.LState, ra io.ReaderAt, name string, o archiveapi.Options) (archiveapi.Codec, int) {

--- a/runtime/lua/modules/archive/spec.md
+++ b/runtime/lua/modules/archive/spec.md
@@ -76,6 +76,14 @@ local r = archive.open(file)            -- file = fs:open("x.zip"), read off dis
 -- small, already-in-memory archives. For large zips use an fs file or a stream,
 -- never bytes:
 local r = archive.open(zip_bytes, { format = "zip" })  -- small archives only
+-- Or from any module-provided random-access source: a userdata whose value
+-- implements io.ReaderAt + Size() (and optionally Name() for sniffing by
+-- extension). cloudstorage's open_reader is one — random access over a
+-- multi-GB zip in object storage via ranged GETs, no local staging; the
+-- source's lifecycle stays with the module that created it (archive never
+-- closes it):
+local reader = assert(storage:open_reader("uploads/huge.zip"))
+local r = archive.open(reader)
 
 for e in r:entries() do                 -- iterate the directory (metadata only)
   print(e.name, e.size, e.is_dir)       -- e: {name,size,compressed_size,is_dir,mode,modified,method,crc32}

--- a/runtime/lua/modules/cloudstorage/module.go
+++ b/runtime/lua/modules/cloudstorage/module.go
@@ -4,6 +4,8 @@ package cloudstorage
 
 import (
 	"io"
+	"math"
+	"time"
 
 	lua "github.com/wippyai/go-lua"
 	csapi "github.com/wippyai/runtime/api/cloudstorage"
@@ -504,18 +506,32 @@ func checkStorageAndKey(l *lua.LState) (*storageWrapper, string, bool) {
 	return wrapper, key, true
 }
 
-func stringMap(v lua.LValue) map[string]string {
-	t, ok := v.(*lua.LTable)
-	if !ok {
-		return nil
-	}
+func stringMap(t *lua.LTable) map[string]string {
 	out := make(map[string]string, t.Len())
 	t.ForEach(func(k, mv lua.LValue) {
-		if ks, kok := k.(lua.LString); kok {
+		if ks, ok := k.(lua.LString); ok {
 			out[string(ks)] = mv.String()
 		}
 	})
 	return out
+}
+
+func boundedInteger(v lua.LValue, minValue, maxValue int64) (int64, bool) {
+	n, ok := v.(lua.LNumber)
+	if !ok {
+		return 0, false
+	}
+	f := float64(n)
+	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f || f < float64(minValue) || f > float64(maxValue) {
+		return 0, false
+	}
+	return int64(f), true
+}
+
+func pushInvalid(l *lua.LState, message string) int {
+	l.Push(lua.LNil)
+	l.Push(lua.NewLuaError(l, message).WithKind(lua.Invalid).WithRetryable(false))
+	return 2
 }
 
 func storageCreateMultipartUpload(l *lua.LState) int {
@@ -545,10 +561,20 @@ func storageCreateMultipartUpload(l *lua.LState) int {
 			mo.ContentEncoding = v.String()
 		}
 		if v := optsTable.RawGetString("metadata"); v != lua.LNil {
-			mo.Metadata = stringMap(v)
+			t, tok := v.(*lua.LTable)
+			if !tok {
+				ReleaseCreateMultipartUploadYield(yield)
+				return pushInvalid(l, "metadata must be a table")
+			}
+			mo.Metadata = stringMap(t)
 		}
 		if v := optsTable.RawGetString("headers"); v != lua.LNil {
-			mo.Headers = stringMap(v)
+			t, tok := v.(*lua.LTable)
+			if !tok {
+				ReleaseCreateMultipartUploadYield(yield)
+				return pushInvalid(l, "headers must be a table")
+			}
+			mo.Headers = stringMap(t)
 		}
 		yield.Options = mo
 	}
@@ -572,40 +598,46 @@ func storagePresignedPartURLs(l *lua.LState) int {
 
 	optsTable := l.CheckTable(4)
 
+	partsValue := optsTable.RawGetString("parts")
+	countValue := optsTable.RawGetString("count")
+	if (partsValue == lua.LNil) == (countValue == lua.LNil) {
+		return pushInvalid(l, "options must set exactly one of parts or count")
+	}
+
 	var partNumbers []int32
-	if v := optsTable.RawGetString("parts"); v != lua.LNil {
+	if partsValue != lua.LNil {
+		v := partsValue
 		pt, tok := v.(*lua.LTable)
 		if !tok {
-			l.Push(lua.LNil)
-			l.Push(lua.NewLuaError(l, "parts must be an array of part numbers").WithKind(lua.Invalid).WithRetryable(false))
-			return 2
+			return pushInvalid(l, "parts must be an array of part numbers")
+		}
+		if pt.Len() == 0 || pt.Len() > csapi.MaxPresignPartBatch {
+			return pushInvalid(l, "parts must contain between 1 and 1000 part numbers")
 		}
 		partNumbers = make([]int32, 0, pt.Len())
+		seen := make(map[int32]struct{}, pt.Len())
 		for i := 1; i <= pt.Len(); i++ {
-			partNumbers = append(partNumbers, int32(lua.LVAsNumber(pt.RawGetInt(i))))
+			part, valid := boundedInteger(pt.RawGetInt(i), 1, csapi.MaxPartNumber)
+			if !valid {
+				return pushInvalid(l, "parts must contain integer part numbers from 1 to 10000")
+			}
+			partNumber := int32(part)
+			if _, duplicate := seen[partNumber]; duplicate {
+				return pushInvalid(l, "parts must not contain duplicate part numbers")
+			}
+			seen[partNumber] = struct{}{}
+			partNumbers = append(partNumbers, partNumber)
 		}
-	} else if v := optsTable.RawGetString("count"); v != lua.LNil {
-		count := int(lua.LVAsNumber(v))
-		if count < 1 {
-			l.Push(lua.LNil)
-			l.Push(lua.NewLuaError(l, "count must be at least 1").WithKind(lua.Invalid).WithRetryable(false))
-			return 2
+	} else {
+		countValue, valid := boundedInteger(countValue, 1, csapi.MaxPresignPartBatch)
+		if !valid {
+			return pushInvalid(l, "count must be an integer from 1 to 1000")
 		}
-		if count > csapi.MaxPresignPartBatch {
-			l.Push(lua.LNil)
-			l.Push(lua.NewLuaError(l, "count exceeds the per-call presign limit").WithKind(lua.Invalid).WithRetryable(false))
-			return 2
-		}
+		count := int(countValue)
 		partNumbers = make([]int32, count)
 		for i := range partNumbers {
 			partNumbers[i] = int32(i + 1)
 		}
-	}
-
-	if len(partNumbers) == 0 {
-		l.Push(lua.LNil)
-		l.Push(lua.NewLuaError(l, "options must set parts (array) or count (number)").WithKind(lua.Invalid).WithRetryable(false))
-		return 2
 	}
 
 	yield := AcquirePresignedPartURLsYield()
@@ -613,9 +645,22 @@ func storagePresignedPartURLs(l *lua.LState) int {
 	yield.Key = key
 	yield.UploadID = uploadID
 	yield.Options = &csapi.PresignedUploadPartOptions{PartNumbers: partNumbers}
+	if v := optsTable.RawGetString("headers"); v != lua.LNil {
+		t, tok := v.(*lua.LTable)
+		if !tok {
+			ReleasePresignedPartURLsYield(yield)
+			return pushInvalid(l, "headers must be a table")
+		}
+		yield.Options.Headers = stringMap(t)
+	}
 
 	if exp := optsTable.RawGetString("expiration"); exp != lua.LNil {
-		yield.Expiration = int64(lua.LVAsNumber(exp))
+		seconds, valid := boundedInteger(exp, 1, int64(math.MaxInt64/time.Second))
+		if !valid {
+			ReleasePresignedPartURLsYield(yield)
+			return pushInvalid(l, "expiration must be a positive integer number of seconds")
+		}
+		yield.Expiration = seconds
 	}
 
 	l.Push(yield)
@@ -636,17 +681,32 @@ func storageCompleteMultipartUpload(l *lua.LState) int {
 	}
 
 	partsTable := l.CheckTable(4)
+	if partsTable.Len() > csapi.MaxPartNumber {
+		return pushInvalid(l, "at most 10000 completed parts are allowed")
+	}
 	parts := make([]csapi.CompletedPart, 0, partsTable.Len())
+	seen := make(map[int32]struct{}, partsTable.Len())
 	for i := 1; i <= partsTable.Len(); i++ {
 		entry, tok := partsTable.RawGetInt(i).(*lua.LTable)
 		if !tok {
-			l.Push(lua.LNil)
-			l.Push(lua.NewLuaError(l, "parts must be an array of {part_number, etag} tables").WithKind(lua.Invalid).WithRetryable(false))
-			return 2
+			return pushInvalid(l, "parts must be an array of {part_number, etag} tables")
+		}
+		part, valid := boundedInteger(entry.RawGetString("part_number"), 1, csapi.MaxPartNumber)
+		if !valid {
+			return pushInvalid(l, "part_number must be an integer from 1 to 10000")
+		}
+		partNumber := int32(part)
+		if _, duplicate := seen[partNumber]; duplicate {
+			return pushInvalid(l, "parts must not contain duplicate part numbers")
+		}
+		seen[partNumber] = struct{}{}
+		etag, valid := entry.RawGetString("etag").(lua.LString)
+		if !valid || etag == "" {
+			return pushInvalid(l, "etag must be a non-empty string")
 		}
 		parts = append(parts, csapi.CompletedPart{
-			PartNumber: int32(lua.LVAsNumber(entry.RawGetString("part_number"))),
-			ETag:       entry.RawGetString("etag").String(),
+			PartNumber: partNumber,
+			ETag:       string(etag),
 		})
 	}
 	if len(parts) == 0 {
@@ -700,21 +760,34 @@ func storageOpenReader(l *lua.LState) int {
 	if l.Get(3) != lua.LNil {
 		optsTable := l.CheckTable(3)
 		if v := optsTable.RawGetString("block_size"); v != lua.LNil {
-			blockSize = int64(lua.LVAsNumber(v))
-			if blockSize < minReaderBlockSize || blockSize > maxReaderBlockSize {
+			var valid bool
+			blockSize, valid = boundedInteger(v, minReaderBlockSize, maxReaderBlockSize)
+			if !valid {
 				l.Push(lua.LNil)
-				l.Push(lua.NewLuaError(l, "block_size out of range").WithKind(lua.Invalid).WithRetryable(false))
+				l.Push(lua.NewLuaError(l, "block_size must be an integer from 64 KiB to 128 MiB").WithKind(lua.Invalid).WithRetryable(false))
 				return 2
 			}
 		}
 		if v := optsTable.RawGetString("cache_blocks"); v != lua.LNil {
-			cacheBlocks = int(lua.LVAsNumber(v))
-			if cacheBlocks < 1 || cacheBlocks > csapi.MaxReaderCacheBlocks {
+			blocks, valid := boundedInteger(v, 1, csapi.MaxReaderCacheBlocks)
+			if !valid {
 				l.Push(lua.LNil)
-				l.Push(lua.NewLuaError(l, "cache_blocks out of range").WithKind(lua.Invalid).WithRetryable(false))
+				l.Push(lua.NewLuaError(l, "cache_blocks must be an integer from 1 to 64").WithKind(lua.Invalid).WithRetryable(false))
 				return 2
 			}
+			cacheBlocks = int(blocks)
 		}
+	}
+	effectiveBlockSize := blockSize
+	if effectiveBlockSize == 0 {
+		effectiveBlockSize = csapi.DefaultReaderBlockSize
+	}
+	effectiveCacheBlocks := cacheBlocks
+	if effectiveCacheBlocks == 0 {
+		effectiveCacheBlocks = csapi.DefaultReaderCacheBlocks
+	}
+	if effectiveBlockSize*int64(effectiveCacheBlocks) > csapi.MaxReaderCacheBytes {
+		return pushInvalid(l, "reader cache may not exceed 256 MiB")
 	}
 
 	yield := AcquireOpenReaderYield()

--- a/runtime/lua/modules/cloudstorage/module.go
+++ b/runtime/lua/modules/cloudstorage/module.go
@@ -27,6 +27,7 @@ var Module = &luaapi.ModuleDef{
 		mod.Immutable = true
 
 		value.RegisterTypeMethods(nil, storageTypeName, storageMetamethods, storageMethods)
+		value.RegisterTypeMethods(nil, readerTypeName, readerMetamethods, readerMethods)
 
 		return mod, []luaapi.YieldType{
 			{Sample: &ListObjectsYield{}, CmdID: csapi.ListObjects},
@@ -36,6 +37,11 @@ var Module = &luaapi.ModuleDef{
 			{Sample: &PresignedGetURLYield{}, CmdID: csapi.PresignedGetURL},
 			{Sample: &PresignedPutURLYield{}, CmdID: csapi.PresignedPutURL},
 			{Sample: &HeadObjectYield{}, CmdID: csapi.HeadObject},
+			{Sample: &CreateMultipartUploadYield{}, CmdID: csapi.CreateMultipartUpload},
+			{Sample: &PresignedPartURLsYield{}, CmdID: csapi.PresignedUploadPartURLs},
+			{Sample: &CompleteMultipartUploadYield{}, CmdID: csapi.CompleteMultipartUpload},
+			{Sample: &AbortMultipartUploadYield{}, CmdID: csapi.AbortMultipartUpload},
+			{Sample: &OpenReaderYield{}, CmdID: csapi.OpenReader},
 		}
 	},
 	Types: ModuleTypes,
@@ -49,14 +55,19 @@ type storageWrapper struct {
 }
 
 var storageMethods = map[string]lua.LGoFunc{
-	"list_objects":      storageListObjects,
-	"head_object":       storageHeadObject,
-	"download_object":   storageDownloadObject,
-	"upload_object":     storageUploadObject,
-	"delete_objects":    storageDeleteObjects,
-	"presigned_get_url": storagePresignedGetURL,
-	"presigned_put_url": storagePresignedPutURL,
-	"release":           storageRelease,
+	"list_objects":              storageListObjects,
+	"head_object":               storageHeadObject,
+	"download_object":           storageDownloadObject,
+	"upload_object":             storageUploadObject,
+	"delete_objects":            storageDeleteObjects,
+	"presigned_get_url":         storagePresignedGetURL,
+	"presigned_put_url":         storagePresignedPutURL,
+	"create_multipart_upload":   storageCreateMultipartUpload,
+	"presigned_part_urls":       storagePresignedPartURLs,
+	"complete_multipart_upload": storageCompleteMultipartUpload,
+	"abort_multipart_upload":    storageAbortMultipartUpload,
+	"open_reader":               storageOpenReader,
+	"release":                   storageRelease,
 }
 
 var storageMetamethods = map[string]lua.LGoFunc{
@@ -297,6 +308,21 @@ func storageUploadObject(l *lua.LState) int {
 	yield.Key = key
 	yield.Content = content
 
+	if ud, ok := content.(*lua.LUserData); ok {
+		if _, direct := ud.Value.(io.Reader); !direct {
+			if rp, isProvider := ud.Value.(rtresource.ReaderProvider); isProvider {
+				r, rerr := rp.GetReader(l.Context())
+				if rerr != nil {
+					ReleaseUploadObjectYield(yield)
+					l.Push(lua.LNil)
+					l.Push(lua.WrapErrorWithLua(l, rerr, "failed to get reader").WithKind(lua.Internal).WithRetryable(false))
+					return 2
+				}
+				yield.ContentReader = r
+			}
+		}
+	}
+
 	if l.Get(4) != lua.LNil {
 		optsTable := l.CheckTable(4)
 		uo := &csapi.UploadOptions{}
@@ -451,6 +477,251 @@ func storagePresignedPutURL(l *lua.LState) int {
 			yield.ContentLength = int64(lua.LVAsNumber(cl))
 		}
 	}
+
+	l.Push(yield)
+	return -1
+}
+
+func checkStorageAndKey(l *lua.LState) (*storageWrapper, string, bool) {
+	wrapper := checkStorage(l, 1)
+	if wrapper == nil {
+		return nil, "", false
+	}
+
+	if wrapper.released {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "storage has been released").WithKind(lua.Invalid).WithRetryable(false))
+		return nil, "", false
+	}
+
+	key := l.CheckString(2)
+	if key == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "key is required").WithKind(lua.Invalid).WithRetryable(false))
+		return nil, "", false
+	}
+
+	return wrapper, key, true
+}
+
+func stringMap(v lua.LValue) map[string]string {
+	t, ok := v.(*lua.LTable)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, t.Len())
+	t.ForEach(func(k, mv lua.LValue) {
+		if ks, kok := k.(lua.LString); kok {
+			out[string(ks)] = mv.String()
+		}
+	})
+	return out
+}
+
+func storageCreateMultipartUpload(l *lua.LState) int {
+	wrapper, key, ok := checkStorageAndKey(l)
+	if !ok {
+		return 2
+	}
+
+	yield := AcquireCreateMultipartUploadYield()
+	yield.Storage = wrapper.storage
+	yield.Key = key
+
+	if l.Get(3) != lua.LNil {
+		optsTable := l.CheckTable(3)
+		mo := &csapi.CreateMultipartUploadOptions{}
+
+		if v := optsTable.RawGetString("content_type"); v != lua.LNil {
+			mo.ContentType = v.String()
+		}
+		if v := optsTable.RawGetString("cache_control"); v != lua.LNil {
+			mo.CacheControl = v.String()
+		}
+		if v := optsTable.RawGetString("content_disposition"); v != lua.LNil {
+			mo.ContentDisposition = v.String()
+		}
+		if v := optsTable.RawGetString("content_encoding"); v != lua.LNil {
+			mo.ContentEncoding = v.String()
+		}
+		if v := optsTable.RawGetString("metadata"); v != lua.LNil {
+			mo.Metadata = stringMap(v)
+		}
+		if v := optsTable.RawGetString("headers"); v != lua.LNil {
+			mo.Headers = stringMap(v)
+		}
+		yield.Options = mo
+	}
+
+	l.Push(yield)
+	return -1
+}
+
+func storagePresignedPartURLs(l *lua.LState) int {
+	wrapper, key, ok := checkStorageAndKey(l)
+	if !ok {
+		return 2
+	}
+
+	uploadID := l.CheckString(3)
+	if uploadID == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "upload_id is required").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	optsTable := l.CheckTable(4)
+
+	var partNumbers []int32
+	if v := optsTable.RawGetString("parts"); v != lua.LNil {
+		pt, tok := v.(*lua.LTable)
+		if !tok {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "parts must be an array of part numbers").WithKind(lua.Invalid).WithRetryable(false))
+			return 2
+		}
+		partNumbers = make([]int32, 0, pt.Len())
+		for i := 1; i <= pt.Len(); i++ {
+			partNumbers = append(partNumbers, int32(lua.LVAsNumber(pt.RawGetInt(i))))
+		}
+	} else if v := optsTable.RawGetString("count"); v != lua.LNil {
+		count := int(lua.LVAsNumber(v))
+		if count < 1 {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "count must be at least 1").WithKind(lua.Invalid).WithRetryable(false))
+			return 2
+		}
+		if count > csapi.MaxPresignPartBatch {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "count exceeds the per-call presign limit").WithKind(lua.Invalid).WithRetryable(false))
+			return 2
+		}
+		partNumbers = make([]int32, count)
+		for i := range partNumbers {
+			partNumbers[i] = int32(i + 1)
+		}
+	}
+
+	if len(partNumbers) == 0 {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "options must set parts (array) or count (number)").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	yield := AcquirePresignedPartURLsYield()
+	yield.Storage = wrapper.storage
+	yield.Key = key
+	yield.UploadID = uploadID
+	yield.Options = &csapi.PresignedUploadPartOptions{PartNumbers: partNumbers}
+
+	if exp := optsTable.RawGetString("expiration"); exp != lua.LNil {
+		yield.Expiration = int64(lua.LVAsNumber(exp))
+	}
+
+	l.Push(yield)
+	return -1
+}
+
+func storageCompleteMultipartUpload(l *lua.LState) int {
+	wrapper, key, ok := checkStorageAndKey(l)
+	if !ok {
+		return 2
+	}
+
+	uploadID := l.CheckString(3)
+	if uploadID == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "upload_id is required").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	partsTable := l.CheckTable(4)
+	parts := make([]csapi.CompletedPart, 0, partsTable.Len())
+	for i := 1; i <= partsTable.Len(); i++ {
+		entry, tok := partsTable.RawGetInt(i).(*lua.LTable)
+		if !tok {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "parts must be an array of {part_number, etag} tables").WithKind(lua.Invalid).WithRetryable(false))
+			return 2
+		}
+		parts = append(parts, csapi.CompletedPart{
+			PartNumber: int32(lua.LVAsNumber(entry.RawGetString("part_number"))),
+			ETag:       entry.RawGetString("etag").String(),
+		})
+	}
+	if len(parts) == 0 {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "at least one completed part is required").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	yield := AcquireCompleteMultipartUploadYield()
+	yield.Storage = wrapper.storage
+	yield.Key = key
+	yield.UploadID = uploadID
+	yield.Parts = parts
+
+	l.Push(yield)
+	return -1
+}
+
+func storageAbortMultipartUpload(l *lua.LState) int {
+	wrapper, key, ok := checkStorageAndKey(l)
+	if !ok {
+		return 2
+	}
+
+	uploadID := l.CheckString(3)
+	if uploadID == "" {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "upload_id is required").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+
+	yield := AcquireAbortMultipartUploadYield()
+	yield.Storage = wrapper.storage
+	yield.Key = key
+	yield.UploadID = uploadID
+
+	l.Push(yield)
+	return -1
+}
+
+func storageOpenReader(l *lua.LState) int {
+	wrapper, key, ok := checkStorageAndKey(l)
+	if !ok {
+		return 2
+	}
+
+	var (
+		blockSize   int64
+		cacheBlocks int
+	)
+	if l.Get(3) != lua.LNil {
+		optsTable := l.CheckTable(3)
+		if v := optsTable.RawGetString("block_size"); v != lua.LNil {
+			blockSize = int64(lua.LVAsNumber(v))
+			if blockSize < minReaderBlockSize || blockSize > maxReaderBlockSize {
+				l.Push(lua.LNil)
+				l.Push(lua.NewLuaError(l, "block_size out of range").WithKind(lua.Invalid).WithRetryable(false))
+				return 2
+			}
+		}
+		if v := optsTable.RawGetString("cache_blocks"); v != lua.LNil {
+			cacheBlocks = int(lua.LVAsNumber(v))
+			if cacheBlocks < 1 || cacheBlocks > csapi.MaxReaderCacheBlocks {
+				l.Push(lua.LNil)
+				l.Push(lua.NewLuaError(l, "cache_blocks out of range").WithKind(lua.Invalid).WithRetryable(false))
+				return 2
+			}
+		}
+	}
+
+	yield := AcquireOpenReaderYield()
+	yield.Storage = wrapper.storage
+	yield.Key = key
+	yield.BlockSize = blockSize
+	yield.CacheBlocks = cacheBlocks
 
 	l.Push(yield)
 	return -1

--- a/runtime/lua/modules/cloudstorage/module_test.go
+++ b/runtime/lua/modules/cloudstorage/module_test.go
@@ -19,8 +19,8 @@ func TestModuleLoads(t *testing.T) {
 		t.Fatal("expected module table to be non-nil")
 	}
 
-	if len(yields) != 7 {
-		t.Errorf("expected 7 yield types, got %d", len(yields))
+	if len(yields) != 12 {
+		t.Errorf("expected 12 yield types, got %d", len(yields))
 	}
 }
 
@@ -45,13 +45,18 @@ func TestYieldTypes(t *testing.T) {
 	_, yields := Module.Build()
 
 	expectedCmds := map[int]bool{
-		int(csapi.ListObjects):     false,
-		int(csapi.DownloadObject):  false,
-		int(csapi.UploadObject):    false,
-		int(csapi.DeleteObjects):   false,
-		int(csapi.PresignedGetURL): false,
-		int(csapi.PresignedPutURL): false,
-		int(csapi.HeadObject):      false,
+		int(csapi.ListObjects):             false,
+		int(csapi.DownloadObject):          false,
+		int(csapi.UploadObject):            false,
+		int(csapi.DeleteObjects):           false,
+		int(csapi.PresignedGetURL):         false,
+		int(csapi.PresignedPutURL):         false,
+		int(csapi.HeadObject):              false,
+		int(csapi.CreateMultipartUpload):   false,
+		int(csapi.PresignedUploadPartURLs): false,
+		int(csapi.CompleteMultipartUpload): false,
+		int(csapi.AbortMultipartUpload):    false,
+		int(csapi.OpenReader):              false,
 	}
 
 	for _, y := range yields {
@@ -831,5 +836,152 @@ func TestListObjectsYieldHandleResult_Fields(t *testing.T) {
 	}
 	if owner.RawGetString("id").String() != "oid" {
 		t.Error("owner.id missing")
+	}
+}
+
+func TestCreateMultipartUploadYieldPool(t *testing.T) {
+	y1 := AcquireCreateMultipartUploadYield()
+	if y1 == nil || y1.CreateMultipartUploadCmd == nil {
+		t.Fatal("expected non-nil yield and command")
+	}
+	ReleaseCreateMultipartUploadYield(y1)
+
+	y2 := AcquireCreateMultipartUploadYield()
+	if y2 == nil || y2.CreateMultipartUploadCmd == nil {
+		t.Fatal("expected non-nil yield after release")
+	}
+	ReleaseCreateMultipartUploadYield(y2)
+}
+
+func TestPresignedPartURLsYieldPool(t *testing.T) {
+	y1 := AcquirePresignedPartURLsYield()
+	if y1 == nil || y1.PresignedPartURLsCmd == nil {
+		t.Fatal("expected non-nil yield and command")
+	}
+	ReleasePresignedPartURLsYield(y1)
+
+	y2 := AcquirePresignedPartURLsYield()
+	if y2 == nil || y2.PresignedPartURLsCmd == nil {
+		t.Fatal("expected non-nil yield after release")
+	}
+	if y2.Expiration != 0 {
+		t.Error("expiration not reset on release")
+	}
+	ReleasePresignedPartURLsYield(y2)
+}
+
+func TestCompleteMultipartUploadYieldPool(t *testing.T) {
+	y1 := AcquireCompleteMultipartUploadYield()
+	if y1 == nil || y1.CompleteMultipartUploadCmd == nil {
+		t.Fatal("expected non-nil yield and command")
+	}
+	ReleaseCompleteMultipartUploadYield(y1)
+
+	y2 := AcquireCompleteMultipartUploadYield()
+	if y2 == nil || y2.CompleteMultipartUploadCmd == nil {
+		t.Fatal("expected non-nil yield after release")
+	}
+	ReleaseCompleteMultipartUploadYield(y2)
+}
+
+func TestAbortMultipartUploadYieldPool(t *testing.T) {
+	y1 := AcquireAbortMultipartUploadYield()
+	if y1 == nil || y1.AbortMultipartUploadCmd == nil {
+		t.Fatal("expected non-nil yield and command")
+	}
+	ReleaseAbortMultipartUploadYield(y1)
+
+	y2 := AcquireAbortMultipartUploadYield()
+	if y2 == nil || y2.AbortMultipartUploadCmd == nil {
+		t.Fatal("expected non-nil yield after release")
+	}
+	ReleaseAbortMultipartUploadYield(y2)
+}
+
+func TestOpenReaderYieldPool(t *testing.T) {
+	y1 := AcquireOpenReaderYield()
+	if y1 == nil || y1.OpenReaderCmd == nil {
+		t.Fatal("expected non-nil yield and command")
+	}
+	y1.BlockSize = 1024
+	y1.CacheBlocks = 2
+	ReleaseOpenReaderYield(y1)
+
+	y2 := AcquireOpenReaderYield()
+	if y2 == nil || y2.OpenReaderCmd == nil {
+		t.Fatal("expected non-nil yield after release")
+	}
+	if y2.BlockSize != 0 || y2.CacheBlocks != 0 {
+		t.Error("tuning fields not reset on release")
+	}
+	ReleaseOpenReaderYield(y2)
+}
+
+func TestCreateMultipartUploadYield_HandleResult(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireCreateMultipartUploadYield()
+	defer ReleaseCreateMultipartUploadYield(y)
+
+	res := y.HandleResult(l, csapi.CreateMultipartUploadResponse{
+		Result: &csapi.CreateMultipartUploadResult{UploadID: "up-42"},
+	}, nil)
+	tbl, ok := res[0].(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected table, got %T", res[0])
+	}
+	if tbl.RawGetString("upload_id").String() != "up-42" {
+		t.Error("upload_id missing")
+	}
+}
+
+func TestPresignedPartURLsYield_HandleResult(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquirePresignedPartURLsYield()
+	defer ReleasePresignedPartURLsYield(y)
+
+	res := y.HandleResult(l, csapi.PresignedPartURLsResponse{
+		URLs: []csapi.PresignedPartURL{
+			{PartNumber: 1, URL: "https://p1"},
+			{PartNumber: 7, URL: "https://p7"},
+		},
+	}, nil)
+	arr, ok := res[0].(*lua.LTable)
+	if !ok {
+		t.Fatalf("expected table, got %T", res[0])
+	}
+	if arr.Len() != 2 {
+		t.Fatalf("expected 2 urls, got %d", arr.Len())
+	}
+	second := arr.RawGetInt(2).(*lua.LTable)
+	if int(lua.LVAsNumber(second.RawGetString("part_number"))) != 7 {
+		t.Error("part_number mismatch")
+	}
+	if second.RawGetString("url").String() != "https://p7" {
+		t.Error("url mismatch")
+	}
+}
+
+func TestMultipartYields_UnsupportedError(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+
+	y := AcquireCreateMultipartUploadYield()
+	defer ReleaseCreateMultipartUploadYield(y)
+
+	res := y.HandleResult(l, csapi.CreateMultipartUploadResponse{
+		Error: csapi.ErrMultipartUnsupported,
+	}, nil)
+	if res[0] != lua.LNil {
+		t.Fatal("expected nil result on unsupported")
+	}
+	if res[1] == lua.LNil {
+		t.Fatal("expected error value on unsupported")
+	}
+	if !strings.Contains(res[1].String(), "multipart") {
+		t.Fatalf("expected multipart-unsupported message, got %q", res[1].String())
 	}
 }

--- a/runtime/lua/modules/cloudstorage/module_test.go
+++ b/runtime/lua/modules/cloudstorage/module_test.go
@@ -985,3 +985,129 @@ func TestMultipartYields_UnsupportedError(t *testing.T) {
 		t.Fatalf("expected multipart-unsupported message, got %q", res[1].String())
 	}
 }
+
+func newStorageCallState(t *testing.T) (*lua.LState, *lua.LUserData) {
+	t.Helper()
+	l := lua.NewState()
+	t.Cleanup(l.Close)
+	ud := l.NewUserData()
+	ud.Value = &storageWrapper{}
+	return l, ud
+}
+
+func TestStoragePresignedPartURLs_ValidatesAndPreservesHeaders(t *testing.T) {
+	t.Run("requires exactly one selector", func(t *testing.T) {
+		l, storage := newStorageCallState(t)
+		opts := l.CreateTable(0, 2)
+		opts.RawSetString("parts", l.CreateTable(0, 0))
+		opts.RawSetString("count", lua.LNumber(1))
+		l.Push(storage)
+		l.Push(lua.LString("key"))
+		l.Push(lua.LString("upload"))
+		l.Push(opts)
+
+		assertInvalidLuaResult(t, l, storagePresignedPartURLs(l))
+	})
+
+	t.Run("rejects fractional and duplicate parts", func(t *testing.T) {
+		for _, parts := range [][]lua.LValue{
+			{lua.LNumber(1.5)},
+			{lua.LNumber(1), lua.LNumber(1)},
+		} {
+			l, storage := newStorageCallState(t)
+			partTable := l.CreateTable(len(parts), 0)
+			for i, part := range parts {
+				partTable.RawSetInt(i+1, part)
+			}
+			opts := l.CreateTable(0, 1)
+			opts.RawSetString("parts", partTable)
+			l.Push(storage)
+			l.Push(lua.LString("key"))
+			l.Push(lua.LString("upload"))
+			l.Push(opts)
+
+			assertInvalidLuaResult(t, l, storagePresignedPartURLs(l))
+		}
+	})
+
+	t.Run("preserves string headers", func(t *testing.T) {
+		l, storage := newStorageCallState(t)
+		headers := l.CreateTable(0, 1)
+		headers.RawSetString("x-amz-request-payer", lua.LString("requester"))
+		opts := l.CreateTable(0, 2)
+		opts.RawSetString("count", lua.LNumber(1))
+		opts.RawSetString("headers", headers)
+		l.Push(storage)
+		l.Push(lua.LString("key"))
+		l.Push(lua.LString("upload"))
+		l.Push(opts)
+
+		if got := storagePresignedPartURLs(l); got != -1 {
+			t.Fatalf("expected yield result, got %d", got)
+		}
+		yield, ok := l.Get(-1).(*PresignedPartURLsYield)
+		if !ok {
+			t.Fatalf("expected PresignedPartURLsYield, got %T", l.Get(-1))
+		}
+		defer ReleasePresignedPartURLsYield(yield)
+		if got := yield.Options.Headers["x-amz-request-payer"]; got != "requester" {
+			t.Fatalf("header = %q, want requester", got)
+		}
+	})
+
+	t.Run("rejects non-table headers", func(t *testing.T) {
+		l, storage := newStorageCallState(t)
+		opts := l.CreateTable(0, 2)
+		opts.RawSetString("count", lua.LNumber(1))
+		opts.RawSetString("headers", lua.LString("invalid"))
+		l.Push(storage)
+		l.Push(lua.LString("key"))
+		l.Push(lua.LString("upload"))
+		l.Push(opts)
+
+		assertInvalidLuaResult(t, l, storagePresignedPartURLs(l))
+	})
+}
+
+func TestStorageCompleteMultipartUpload_RejectsMissingETag(t *testing.T) {
+	l, storage := newStorageCallState(t)
+	part := l.CreateTable(0, 1)
+	part.RawSetString("part_number", lua.LNumber(1))
+	parts := l.CreateTable(1, 0)
+	parts.RawSetInt(1, part)
+	l.Push(storage)
+	l.Push(lua.LString("key"))
+	l.Push(lua.LString("upload"))
+	l.Push(parts)
+
+	assertInvalidLuaResult(t, l, storageCompleteMultipartUpload(l))
+}
+
+func TestStorageOpenReader_RejectsOversizedCache(t *testing.T) {
+	l, storage := newStorageCallState(t)
+	opts := l.CreateTable(0, 2)
+	opts.RawSetString("block_size", lua.LNumber(csapi.MaxReaderBlockSize))
+	opts.RawSetString("cache_blocks", lua.LNumber(3))
+	l.Push(storage)
+	l.Push(lua.LString("key"))
+	l.Push(opts)
+
+	assertInvalidLuaResult(t, l, storageOpenReader(l))
+}
+
+func assertInvalidLuaResult(t *testing.T, l *lua.LState, returns int) {
+	t.Helper()
+	if returns != 2 {
+		t.Fatalf("return count = %d, want 2", returns)
+	}
+	if l.Get(-2) != lua.LNil {
+		t.Fatalf("first result = %v, want nil", l.Get(-2))
+	}
+	luaErr, ok := l.Get(-1).(*lua.Error)
+	if !ok {
+		t.Fatalf("error result = %T, want *lua.Error", l.Get(-1))
+	}
+	if luaErr.Kind() != lua.Invalid {
+		t.Fatalf("error kind = %s, want %s", luaErr.Kind(), lua.Invalid)
+	}
+}

--- a/runtime/lua/modules/cloudstorage/reader.go
+++ b/runtime/lua/modules/cloudstorage/reader.go
@@ -17,7 +17,7 @@ const readerTypeName = "cloudstorage.Reader"
 
 const (
 	minReaderBlockSize = 64 * 1024
-	maxReaderBlockSize = 128 * 1024 * 1024
+	maxReaderBlockSize = csapi.MaxReaderBlockSize
 )
 
 type luaRangeReader struct {

--- a/runtime/lua/modules/cloudstorage/reader.go
+++ b/runtime/lua/modules/cloudstorage/reader.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudstorage
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	lua "github.com/wippyai/go-lua"
+	csapi "github.com/wippyai/runtime/api/cloudstorage"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+const readerTypeName = "cloudstorage.Reader"
+
+const (
+	minReaderBlockSize = 64 * 1024
+	maxReaderBlockSize = 128 * 1024 * 1024
+)
+
+type luaRangeReader struct {
+	r             *csapi.RangeReaderAt
+	cancelCleanup func()
+	name          string
+	mu            sync.Mutex
+	closed        bool
+}
+
+func newLuaRangeReader(ctx context.Context, r *csapi.RangeReaderAt, name string) *luaRangeReader {
+	lr := &luaRangeReader{r: r, name: name}
+	if store := resource.GetStore(ctx); store != nil {
+		lr.cancelCleanup = store.AddCleanup(lr.closeOnce)
+	}
+	return lr
+}
+
+func (lr *luaRangeReader) ReadAt(p []byte, off int64) (int, error) { return lr.r.ReadAt(p, off) }
+
+func (lr *luaRangeReader) Size() int64 { return lr.r.Size() }
+
+func (lr *luaRangeReader) Name() string { return lr.name }
+
+func (lr *luaRangeReader) closeOnce() error {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	if lr.closed {
+		return nil
+	}
+	lr.closed = true
+	return lr.r.Close()
+}
+
+var readerMethods = map[string]lua.LGoFunc{
+	"size":  readerSize,
+	"key":   readerKey,
+	"close": readerClose,
+}
+
+var readerMetamethods = map[string]lua.LGoFunc{
+	"__tostring": readerToString,
+}
+
+func checkReader(l *lua.LState, idx int) *luaRangeReader {
+	ud := l.CheckUserData(idx)
+	if lr, ok := ud.Value.(*luaRangeReader); ok {
+		return lr
+	}
+	l.ArgError(idx, "cloudstorage.Reader expected")
+	return nil
+}
+
+func readerToString(l *lua.LState) int {
+	l.Push(lua.LString(readerTypeName))
+	return 1
+}
+
+func readerSize(l *lua.LState) int {
+	lr := checkReader(l, 1)
+	if lr == nil {
+		return 0
+	}
+	l.Push(lua.LNumber(lr.Size()))
+	return 1
+}
+
+func readerKey(l *lua.LState) int {
+	lr := checkReader(l, 1)
+	if lr == nil {
+		return 0
+	}
+	l.Push(lua.LString(lr.r.Key()))
+	return 1
+}
+
+func readerClose(l *lua.LState) int {
+	lr := checkReader(l, 1)
+	if lr == nil {
+		return 0
+	}
+	if lr.cancelCleanup != nil {
+		lr.cancelCleanup()
+		lr.cancelCleanup = nil
+	}
+	if err := lr.closeOnce(); err != nil {
+		l.Push(lua.LFalse)
+		l.Push(lua.WrapErrorWithLua(l, err, "close").WithKind(lua.Internal))
+		return 2
+	}
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func newRangeReaderValue(l *lua.LState, storage csapi.Storage, key string, size int64, etag string, blockSize int64, cacheBlocks int) *lua.LUserData {
+	opts := &csapi.RangeReaderAtOptions{
+		BlockSize:   blockSize,
+		CacheBlocks: cacheBlocks,
+		ETag:        etag,
+	}
+	ra := csapi.NewRangeReaderAt(l.Context(), storage, key, size, opts)
+
+	name := key
+	if i := strings.LastIndexByte(key, '/'); i >= 0 {
+		name = key[i+1:]
+	}
+
+	lr := newLuaRangeReader(l.Context(), ra, name)
+	return value.NewTypedUserData(l, lr, readerTypeName)
+}

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -462,6 +462,7 @@ response's `ETag` header must be collected for `complete_multipart_upload`.
 |-------|------|---------|-------|
 | parts | number[] | - | Explicit part numbers to presign (1-based, ≤ 10000) |
 | count | number | - | Convenience: presign parts 1..count |
+| headers | table<string,string> | nil | Headers required on each part request (for example SSE-C headers); they are included in the signature and must also be sent by the uploader |
 | expiration | number | 3600 | Seconds until the URLs expire |
 
 Exactly one of `parts` or `count` is required. At most 1000 URLs per call —
@@ -533,7 +534,7 @@ memory.
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
 | block_size | number | 8388608 | Ranged-GET unit in bytes (64 KiB – 128 MiB) |
-| cache_blocks | number | 4 | Resident LRU blocks (1 – 64). RAM = block_size × cache_blocks |
+| cache_blocks | number | 4 | Resident LRU blocks (1 – 64). `block_size × cache_blocks` may not exceed 256 MiB |
 
 **Returns:**
 - Success: `Reader` (see type below)
@@ -706,6 +707,7 @@ All additions are purely additive; pre-existing call signatures keep working unc
 
 **New method — ranged reader**:
 - `storage:open_reader(key, options?)` → `Reader` — random access over an object through ranged GETs with an LRU block cache (`block_size`, `cache_blocks`); pins the open-time ETag via `If-Match` so concurrent overwrites surface as `errors.CONFLICT`. Consumable by `archive.open` for reading large archives directly from object storage.
+- `open_reader` fails with `errors.UNAVAILABLE` when the provider cannot supply an ETag; it never serves an unpinned mixture of object versions.
 
 **New type**
 - `Reader` — `size()`, `key()`, `close()`; auto-closed at task end.

--- a/runtime/lua/modules/cloudstorage/spec.md
+++ b/runtime/lua/modules/cloudstorage/spec.md
@@ -54,6 +54,11 @@ Returned by `cloudstorage.get()`. Provides methods for cloud storage operations.
 | delete_objects | (keys: string[]) | boolean, error | Deletes multiple objects |
 | presigned_get_url | (key: string, options?: table) | string, error | Generates presigned download URL |
 | presigned_put_url | (key: string, options?: table) | string, error | Generates presigned upload URL |
+| create_multipart_upload | (key: string, options?: table) | table, error | Starts a presigned multipart upload |
+| presigned_part_urls | (key: string, upload_id: string, options: table) | table, error | Generates presigned URLs for upload parts |
+| complete_multipart_upload | (key: string, upload_id: string, parts: table) | table, error | Assembles the object from uploaded parts |
+| abort_multipart_upload | (key: string, upload_id: string) | boolean, error | Discards an in-progress multipart upload |
+| open_reader | (key: string, options?: table) | Reader, error | Opens a ranged random-access reader over an object |
 | release | () | boolean | Releases storage resource |
 
 #### storage:list_objects(options?: table) → table, error
@@ -263,6 +268,8 @@ preconditions.
 **Notes:**
 - String content is converted to bytes automatically
 - io.Reader content (e.g., fs.File) should be opened in read mode ("r")
+- stream.Stream content (request bodies, multipart files, archive entries)
+  is consumed as a stream — the object is never buffered whole in memory
 - File is read completely during upload
 
 ```lua
@@ -400,6 +407,172 @@ if err then error(err) end
 print("Upload URL:", url)
 ```
 
+#### storage:create_multipart_upload(key: string, options?: table) → table, error
+
+Starts a presigned multipart upload for objects too large for a single
+presigned PUT (S3 caps one PUT at 5 GiB; multipart objects go up to 5 TB).
+The provider must support the multipart capability; otherwise the call fails
+with `errors.UNAVAILABLE`.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| key | string | yes | - | Object key/path of the final object |
+| options | table | no | nil | Object attributes, see below |
+
+**options fields:** `content_type`, `cache_control`, `content_disposition`,
+`content_encoding`, `metadata` (table<string,string>), `headers`
+(table<string,string>, raw pass-through) — same semantics as
+`upload_object`. Preconditions (`if_match`) are not part of the multipart
+protocol.
+
+**Returns:**
+- Success: `table` with `upload_id` (string) — identifies the upload for all
+  subsequent part/complete/abort calls
+- Error: `nil, error`
+
+**Notes:**
+- An upload that is never completed keeps its parts stored (and billed)
+  until aborted. Always `abort_multipart_upload` on failure, and configure a
+  bucket lifecycle rule (`AbortIncompleteMultipartUpload`) as a backstop.
+
+```lua
+local mp, err = storage:create_multipart_upload("backups/huge.zip", {
+    content_type = "application/zip",
+    metadata = { source = "uploader" },
+})
+if err then error(err) end
+print("upload id:", mp.upload_id)
+```
+
+#### storage:presigned_part_urls(key: string, upload_id: string, options: table) → table, error
+
+Generates presigned PUT URLs for parts of an in-progress multipart upload.
+Each URL is uploaded to with a plain HTTP PUT (typically by a browser); the
+response's `ETag` header must be collected for `complete_multipart_upload`.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| key | string | yes | - | Object key |
+| upload_id | string | yes | - | From create_multipart_upload |
+| options | table | yes | - | Part selection, see below |
+
+**options fields:**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| parts | number[] | - | Explicit part numbers to presign (1-based, ≤ 10000) |
+| count | number | - | Convenience: presign parts 1..count |
+| expiration | number | 3600 | Seconds until the URLs expire |
+
+Exactly one of `parts` or `count` is required. At most 1000 URLs per call —
+presign in pages for very large objects.
+
+**Returns:**
+- Success: array of `{ part_number = number, url = string }`
+- Error: `nil, error`
+
+**Notes:**
+- Every part except the last must be at least 5 MiB (S3 protocol rule,
+  enforced at complete time). 10000 parts × part size bounds the object
+  size; 64 MiB parts cover objects up to 640 GiB.
+
+```lua
+local urls, err = storage:presigned_part_urls(key, mp.upload_id, {
+    count = 3, expiration = 900,
+})
+-- urls[1].part_number == 1, urls[1].url == "https://..."
+```
+
+#### storage:complete_multipart_upload(key: string, upload_id: string, parts: table) → table, error
+
+Assembles the final object from uploaded parts. Parts may be reported in any
+order; they are sorted by part number before completion.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| key | string | yes | - | Object key |
+| upload_id | string | yes | - | From create_multipart_upload |
+| parts | table | yes | - | Array of `{ part_number = number, etag = string }` |
+
+**Returns:**
+- Success: `table` with `etag` (string), plus `version_id` and `location`
+  when the provider reports them
+- Error: `nil, error` — unknown upload IDs map to `errors.NOT_FOUND`
+
+```lua
+local done, err = storage:complete_multipart_upload(key, mp.upload_id, {
+    { part_number = 1, etag = etag1 },
+    { part_number = 2, etag = etag2 },
+})
+```
+
+#### storage:abort_multipart_upload(key: string, upload_id: string) → boolean, error
+
+Discards an in-progress multipart upload and frees its stored parts.
+Aborting an unknown/already-completed upload maps to `errors.NOT_FOUND` on
+most providers.
+
+```lua
+local ok, err = storage:abort_multipart_upload(key, mp.upload_id)
+```
+
+#### storage:open_reader(key: string, options?: table) → Reader, error
+
+Opens a random-access reader over an object using ranged GETs — no local
+staging, no full download. The primary consumer is `archive.open(reader)`,
+which reads multi-GB zips straight out of object storage with bounded
+memory.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| key | string | yes | - | Object key |
+| options | table | no | nil | Block tuning, see below |
+
+**options fields:**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| block_size | number | 8388608 | Ranged-GET unit in bytes (64 KiB – 128 MiB) |
+| cache_blocks | number | 4 | Resident LRU blocks (1 – 64). RAM = block_size × cache_blocks |
+
+**Returns:**
+- Success: `Reader` (see type below)
+- Error: `nil, error` — missing objects map to `errors.NOT_FOUND`
+
+**Notes:**
+- The object's ETag is pinned at open time and sent as `If-Match` on every
+  ranged read: if the object is overwritten mid-read, reads fail with
+  `errors.CONFLICT` instead of silently mixing two object generations.
+  (Providers that ignore preconditions lose this protection — see
+  portability notes.)
+- Cache-miss reads perform blocking network IO in the calling task and
+  serialize concurrent readers; sequential per-entry access (the archive
+  pattern) is the intended shape.
+- The reader is closed automatically at task end if not closed explicitly.
+
+```lua
+local reader, err = storage:open_reader("uploads/huge.zip", {
+    block_size = 8 * 1024 * 1024,
+})
+if err then error(err) end
+
+local r = assert(archive.open(reader))     -- random access over S3
+for e in r:entries() do print(e.name, e.size) end
+r:close()
+reader:close()
+```
+
+### Reader
+
+Returned by `storage:open_reader()`. A random-access handle other modules
+can consume as a seekable source (`archive.open`).
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| size | () | number | Object size in bytes (from open-time stat) |
+| key | () | string | Object key the reader reads from |
+| close | () | boolean, error | Releases the block cache; idempotent |
+
 #### storage:release() → boolean
 
 Releases the storage resource.
@@ -520,6 +693,26 @@ The most important caveats:
   header conventions.
 
 ## Changelog
+
+### Presigned multipart uploads + ranged random-access reader
+
+All additions are purely additive; pre-existing call signatures keep working unchanged.
+
+**New methods — presigned multipart uploads** (provider capability; S3 implements it, others fail with `errors.UNAVAILABLE`):
+- `storage:create_multipart_upload(key, options?)` → `{ upload_id }` — start a multipart upload for objects beyond the 5 GiB single-PUT limit.
+- `storage:presigned_part_urls(key, upload_id, options)` → `[{ part_number, url }]` — presign part PUT URLs in batches (≤ 1000 per call), via `parts` array or `count` sugar.
+- `storage:complete_multipart_upload(key, upload_id, parts)` → `{ etag, version_id?, location? }` — parts accepted in any order.
+- `storage:abort_multipart_upload(key, upload_id)` → `boolean`.
+
+**New method — ranged reader**:
+- `storage:open_reader(key, options?)` → `Reader` — random access over an object through ranged GETs with an LRU block cache (`block_size`, `cache_blocks`); pins the open-time ETag via `If-Match` so concurrent overwrites surface as `errors.CONFLICT`. Consumable by `archive.open` for reading large archives directly from object storage.
+
+**New type**
+- `Reader` — `size()`, `key()`, `close()`; auto-closed at task end.
+
+**New error kinds surfaced**
+- `errors.UNAVAILABLE` — multipart operation on a provider without the capability.
+- `errors.CONFLICT` (message `precondition_failed`) — ranged read after the object was overwritten.
 
 ### [#264](https://github.com/wippyai/runtime/pull/264) — object metadata, ETag, conditional ops, headers escape-hatch
 

--- a/runtime/lua/modules/cloudstorage/types.go
+++ b/runtime/lua/modules/cloudstorage/types.go
@@ -71,6 +71,60 @@ var presignedURLOptionsType = typ.NewRecord().
 	OptField("content_length", typ.Number).
 	Build()
 
+// CreateMultipartUploadOptions type
+var createMultipartUploadOptionsType = typ.NewRecord().
+	OptField("content_type", typ.String).
+	OptField("cache_control", typ.String).
+	OptField("content_disposition", typ.String).
+	OptField("content_encoding", typ.String).
+	OptField("metadata", typ.Any).
+	OptField("headers", typ.Any).
+	Build()
+
+// CreateMultipartUploadResult type
+var createMultipartUploadResultType = typ.NewRecord().
+	Field("upload_id", typ.String).
+	Build()
+
+// PresignedPartURLsOptions type
+var presignedPartURLsOptionsType = typ.NewRecord().
+	OptField("parts", typ.NewArray(typ.Number)).
+	OptField("count", typ.Number).
+	OptField("expiration", typ.Number).
+	Build()
+
+// PresignedPartURL type
+var presignedPartURLType = typ.NewRecord().
+	Field("part_number", typ.Number).
+	Field("url", typ.String).
+	Build()
+
+// CompletedPart type
+var completedPartType = typ.NewRecord().
+	Field("part_number", typ.Number).
+	Field("etag", typ.String).
+	Build()
+
+// CompleteMultipartUploadResult type
+var completeMultipartUploadResultType = typ.NewRecord().
+	Field("etag", typ.String).
+	OptField("version_id", typ.String).
+	OptField("location", typ.String).
+	Build()
+
+// OpenReaderOptions type
+var openReaderOptionsType = typ.NewRecord().
+	OptField("block_size", typ.Number).
+	OptField("cache_blocks", typ.Number).
+	Build()
+
+// Reader type
+var readerType = typ.NewInterface("cloudstorage.Reader", []typ.Method{
+	{Name: "size", Type: typ.Func().Param("self", typ.Self).Returns(typ.Number).Build()},
+	{Name: "key", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
+	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+})
+
 // Storage type
 var storageType = typ.NewInterface("cloudstorage.Storage", []typ.Method{
 	{Name: "list_objects", Type: typ.Func().Param("self", typ.Self).OptParam("options", listObjectsOptionsType).Returns(listObjectsResultType, typ.NewOptional(typ.LuaError)).Build()},
@@ -80,6 +134,11 @@ var storageType = typ.NewInterface("cloudstorage.Storage", []typ.Method{
 	{Name: "delete_objects", Type: typ.Func().Param("self", typ.Self).Param("keys", typ.NewArray(typ.String)).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "presigned_get_url", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).OptParam("options", presignedURLOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "presigned_put_url", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).OptParam("options", presignedURLOptionsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "create_multipart_upload", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).OptParam("options", createMultipartUploadOptionsType).Returns(createMultipartUploadResultType, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "presigned_part_urls", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Param("upload_id", typ.String).Param("options", presignedPartURLsOptionsType).Returns(typ.NewArray(presignedPartURLType), typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "complete_multipart_upload", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Param("upload_id", typ.String).Param("parts", typ.NewArray(completedPartType)).Returns(completeMultipartUploadResultType, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "abort_multipart_upload", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).Param("upload_id", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "open_reader", Type: typ.Func().Param("self", typ.Self).Param("key", typ.String).OptParam("options", openReaderOptionsType).Returns(readerType, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "release", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
 })
 
@@ -88,6 +147,7 @@ func ModuleTypes() *io.Manifest {
 	m := io.NewManifest("cloudstorage")
 
 	m.DefineType("Storage", storageType)
+	m.DefineType("Reader", readerType)
 	m.DefineType("ListObjectsOptions", listObjectsOptionsType)
 	m.DefineType("ListObjectsResult", listObjectsResultType)
 	m.DefineType("Owner", ownerType)
@@ -95,6 +155,13 @@ func ModuleTypes() *io.Manifest {
 	m.DefineType("DownloadOptions", downloadOptionsType)
 	m.DefineType("UploadOptions", uploadOptionsType)
 	m.DefineType("PresignedURLOptions", presignedURLOptionsType)
+	m.DefineType("CreateMultipartUploadOptions", createMultipartUploadOptionsType)
+	m.DefineType("CreateMultipartUploadResult", createMultipartUploadResultType)
+	m.DefineType("PresignedPartURLsOptions", presignedPartURLsOptionsType)
+	m.DefineType("PresignedPartURL", presignedPartURLType)
+	m.DefineType("CompletedPart", completedPartType)
+	m.DefineType("CompleteMultipartUploadResult", completeMultipartUploadResultType)
+	m.DefineType("OpenReaderOptions", openReaderOptionsType)
 
 	moduleType := typ.NewInterface("cloudstorage", []typ.Method{
 		{Name: "get", Type: typ.Func().Param("name", typ.String).Returns(storageType, typ.NewOptional(typ.LuaError)).Build()},

--- a/runtime/lua/modules/cloudstorage/types.go
+++ b/runtime/lua/modules/cloudstorage/types.go
@@ -90,6 +90,7 @@ var createMultipartUploadResultType = typ.NewRecord().
 var presignedPartURLsOptionsType = typ.NewRecord().
 	OptField("parts", typ.NewArray(typ.Number)).
 	OptField("count", typ.Number).
+	OptField("headers", typ.Any).
 	OptField("expiration", typ.Number).
 	Build()
 

--- a/runtime/lua/modules/cloudstorage/yields.go
+++ b/runtime/lua/modules/cloudstorage/yields.go
@@ -162,7 +162,7 @@ func (y *DownloadObjectYield) HandleResult(l *lua.LState, data any, err error) [
 // UploadObjectYield wraps UploadObjectCmd for Lua.
 type UploadObjectYield struct {
 	*csapi.UploadObjectCmd
-	Content lua.LValue
+	Content       lua.LValue
 	ContentReader io.Reader
 }
 

--- a/runtime/lua/modules/cloudstorage/yields.go
+++ b/runtime/lua/modules/cloudstorage/yields.go
@@ -27,6 +27,16 @@ func wrapStorageError(l *lua.LState, err error, op string) lua.LValue {
 			WithKind(lua.NotFound).
 			WithRetryable(false)
 	}
+	if errors.Is(err, csapi.ErrMultipartUnsupported) {
+		return lua.NewLuaError(l, "multipart uploads not supported by this storage provider").
+			WithKind(lua.Unavailable).
+			WithRetryable(false)
+	}
+	if errors.Is(err, csapi.ErrNilUploadContent) {
+		return lua.NewLuaError(l, "upload content is not a readable source").
+			WithKind(lua.Invalid).
+			WithRetryable(false)
+	}
 	return lua.WrapErrorWithLua(l, err, op)
 }
 
@@ -153,6 +163,7 @@ func (y *DownloadObjectYield) HandleResult(l *lua.LState, data any, err error) [
 type UploadObjectYield struct {
 	*csapi.UploadObjectCmd
 	Content lua.LValue
+	ContentReader io.Reader
 }
 
 var uploadObjectYieldPool = sync.Pool{New: func() any { return &UploadObjectYield{} }}
@@ -169,6 +180,7 @@ func ReleaseUploadObjectYield(y *UploadObjectYield) {
 		y.UploadObjectCmd = nil
 	}
 	y.Content = nil
+	y.ContentReader = nil
 	uploadObjectYieldPool.Put(y)
 }
 
@@ -176,6 +188,10 @@ func (y *UploadObjectYield) String() string              { return "<cloudstorage
 func (y *UploadObjectYield) Type() lua.LValueType        { return lua.LTUserData }
 func (y *UploadObjectYield) CmdID() dispatcher.CommandID { return csapi.UploadObject }
 func (y *UploadObjectYield) ToCommand() dispatcher.Command {
+	if y.ContentReader != nil {
+		y.Reader = y.ContentReader
+		return y.UploadObjectCmd
+	}
 	switch v := y.Content.(type) {
 	case lua.LString:
 		y.Reader = bytes.NewReader([]byte(v))
@@ -416,4 +432,259 @@ func headObjectResultToLua(l *lua.LState, result *csapi.HeadObjectResult) lua.LV
 	}
 	t.RawSetString("headers", headersTbl)
 	return t
+}
+
+// CreateMultipartUploadYield wraps CreateMultipartUploadCmd for Lua.
+type CreateMultipartUploadYield struct {
+	*csapi.CreateMultipartUploadCmd
+}
+
+var createMultipartUploadYieldPool = sync.Pool{New: func() any { return &CreateMultipartUploadYield{} }}
+
+func AcquireCreateMultipartUploadYield() *CreateMultipartUploadYield {
+	y := createMultipartUploadYieldPool.Get().(*CreateMultipartUploadYield)
+	y.CreateMultipartUploadCmd = csapi.AcquireCreateMultipartUploadCmd()
+	return y
+}
+
+func ReleaseCreateMultipartUploadYield(y *CreateMultipartUploadYield) {
+	if y.CreateMultipartUploadCmd != nil {
+		y.CreateMultipartUploadCmd.Release()
+		y.CreateMultipartUploadCmd = nil
+	}
+	createMultipartUploadYieldPool.Put(y)
+}
+
+func (y *CreateMultipartUploadYield) String() string {
+	return "<cloudstorage_create_multipart_upload_yield>"
+}
+func (y *CreateMultipartUploadYield) Type() lua.LValueType        { return lua.LTUserData }
+func (y *CreateMultipartUploadYield) CmdID() dispatcher.CommandID { return csapi.CreateMultipartUpload }
+func (y *CreateMultipartUploadYield) ToCommand() dispatcher.Command {
+	return y.CreateMultipartUploadCmd
+}
+func (y *CreateMultipartUploadYield) Release() { ReleaseCreateMultipartUploadYield(y) }
+
+func (y *CreateMultipartUploadYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "create_multipart_upload")}
+	}
+	resp, ok := data.(csapi.CreateMultipartUploadResponse)
+	if !ok {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
+	}
+	if resp.Error != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "create_multipart_upload")}
+	}
+	t := l.CreateTable(0, 1)
+	t.RawSetString("upload_id", lua.LString(resp.Result.UploadID))
+	return []lua.LValue{t, lua.LNil}
+}
+
+// PresignedPartURLsYield wraps PresignedPartURLsCmd for Lua.
+type PresignedPartURLsYield struct {
+	*csapi.PresignedPartURLsCmd
+	Expiration int64
+}
+
+var presignedPartURLsYieldPool = sync.Pool{New: func() any { return &PresignedPartURLsYield{} }}
+
+func AcquirePresignedPartURLsYield() *PresignedPartURLsYield {
+	y := presignedPartURLsYieldPool.Get().(*PresignedPartURLsYield)
+	y.PresignedPartURLsCmd = csapi.AcquirePresignedPartURLsCmd()
+	return y
+}
+
+func ReleasePresignedPartURLsYield(y *PresignedPartURLsYield) {
+	if y.PresignedPartURLsCmd != nil {
+		y.PresignedPartURLsCmd.Release()
+		y.PresignedPartURLsCmd = nil
+	}
+	y.Expiration = 0
+	presignedPartURLsYieldPool.Put(y)
+}
+
+func (y *PresignedPartURLsYield) String() string              { return "<cloudstorage_presigned_part_urls_yield>" }
+func (y *PresignedPartURLsYield) Type() lua.LValueType        { return lua.LTUserData }
+func (y *PresignedPartURLsYield) CmdID() dispatcher.CommandID { return csapi.PresignedUploadPartURLs }
+func (y *PresignedPartURLsYield) ToCommand() dispatcher.Command {
+	if y.Options == nil {
+		y.Options = &csapi.PresignedUploadPartOptions{}
+	}
+	if y.Expiration > 0 {
+		y.Options.Expiration = time.Duration(y.Expiration) * time.Second
+	} else {
+		y.Options.Expiration = time.Hour
+	}
+	return y.PresignedPartURLsCmd
+}
+func (y *PresignedPartURLsYield) Release() { ReleasePresignedPartURLsYield(y) }
+
+func (y *PresignedPartURLsYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "presigned_part_urls")}
+	}
+	resp, ok := data.(csapi.PresignedPartURLsResponse)
+	if !ok {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
+	}
+	if resp.Error != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "presigned_part_urls")}
+	}
+	urls := l.CreateTable(len(resp.URLs), 0)
+	for i, u := range resp.URLs {
+		urlTbl := l.CreateTable(0, 2)
+		urlTbl.RawSetString("part_number", lua.LNumber(u.PartNumber))
+		urlTbl.RawSetString("url", lua.LString(u.URL))
+		urls.RawSetInt(i+1, urlTbl)
+	}
+	return []lua.LValue{urls, lua.LNil}
+}
+
+// CompleteMultipartUploadYield wraps CompleteMultipartUploadCmd for Lua.
+type CompleteMultipartUploadYield struct {
+	*csapi.CompleteMultipartUploadCmd
+}
+
+var completeMultipartUploadYieldPool = sync.Pool{New: func() any { return &CompleteMultipartUploadYield{} }}
+
+func AcquireCompleteMultipartUploadYield() *CompleteMultipartUploadYield {
+	y := completeMultipartUploadYieldPool.Get().(*CompleteMultipartUploadYield)
+	y.CompleteMultipartUploadCmd = csapi.AcquireCompleteMultipartUploadCmd()
+	return y
+}
+
+func ReleaseCompleteMultipartUploadYield(y *CompleteMultipartUploadYield) {
+	if y.CompleteMultipartUploadCmd != nil {
+		y.CompleteMultipartUploadCmd.Release()
+		y.CompleteMultipartUploadCmd = nil
+	}
+	completeMultipartUploadYieldPool.Put(y)
+}
+
+func (y *CompleteMultipartUploadYield) String() string {
+	return "<cloudstorage_complete_multipart_upload_yield>"
+}
+func (y *CompleteMultipartUploadYield) Type() lua.LValueType { return lua.LTUserData }
+func (y *CompleteMultipartUploadYield) CmdID() dispatcher.CommandID {
+	return csapi.CompleteMultipartUpload
+}
+func (y *CompleteMultipartUploadYield) ToCommand() dispatcher.Command {
+	return y.CompleteMultipartUploadCmd
+}
+func (y *CompleteMultipartUploadYield) Release() { ReleaseCompleteMultipartUploadYield(y) }
+
+func (y *CompleteMultipartUploadYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "complete_multipart_upload")}
+	}
+	resp, ok := data.(csapi.CompleteMultipartUploadResponse)
+	if !ok {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
+	}
+	if resp.Error != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "complete_multipart_upload")}
+	}
+	t := l.CreateTable(0, 3)
+	t.RawSetString("etag", lua.LString(resp.Result.ETag))
+	if resp.Result.VersionID != "" {
+		t.RawSetString("version_id", lua.LString(resp.Result.VersionID))
+	}
+	if resp.Result.Location != "" {
+		t.RawSetString("location", lua.LString(resp.Result.Location))
+	}
+	return []lua.LValue{t, lua.LNil}
+}
+
+// AbortMultipartUploadYield wraps AbortMultipartUploadCmd for Lua.
+type AbortMultipartUploadYield struct {
+	*csapi.AbortMultipartUploadCmd
+}
+
+var abortMultipartUploadYieldPool = sync.Pool{New: func() any { return &AbortMultipartUploadYield{} }}
+
+func AcquireAbortMultipartUploadYield() *AbortMultipartUploadYield {
+	y := abortMultipartUploadYieldPool.Get().(*AbortMultipartUploadYield)
+	y.AbortMultipartUploadCmd = csapi.AcquireAbortMultipartUploadCmd()
+	return y
+}
+
+func ReleaseAbortMultipartUploadYield(y *AbortMultipartUploadYield) {
+	if y.AbortMultipartUploadCmd != nil {
+		y.AbortMultipartUploadCmd.Release()
+		y.AbortMultipartUploadCmd = nil
+	}
+	abortMultipartUploadYieldPool.Put(y)
+}
+
+func (y *AbortMultipartUploadYield) String() string {
+	return "<cloudstorage_abort_multipart_upload_yield>"
+}
+func (y *AbortMultipartUploadYield) Type() lua.LValueType        { return lua.LTUserData }
+func (y *AbortMultipartUploadYield) CmdID() dispatcher.CommandID { return csapi.AbortMultipartUpload }
+func (y *AbortMultipartUploadYield) ToCommand() dispatcher.Command {
+	return y.AbortMultipartUploadCmd
+}
+func (y *AbortMultipartUploadYield) Release() { ReleaseAbortMultipartUploadYield(y) }
+
+func (y *AbortMultipartUploadYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "abort_multipart_upload")}
+	}
+	resp, ok := data.(csapi.AbortMultipartUploadResponse)
+	if !ok {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
+	}
+	if resp.Error != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "abort_multipart_upload")}
+	}
+	return []lua.LValue{lua.LTrue, lua.LNil}
+}
+
+type OpenReaderYield struct {
+	*csapi.OpenReaderCmd
+	BlockSize   int64
+	CacheBlocks int
+}
+
+var openReaderYieldPool = sync.Pool{New: func() any { return &OpenReaderYield{} }}
+
+func AcquireOpenReaderYield() *OpenReaderYield {
+	y := openReaderYieldPool.Get().(*OpenReaderYield)
+	y.OpenReaderCmd = csapi.AcquireOpenReaderCmd()
+	return y
+}
+
+func ReleaseOpenReaderYield(y *OpenReaderYield) {
+	if y.OpenReaderCmd != nil {
+		y.OpenReaderCmd.Release()
+		y.OpenReaderCmd = nil
+	}
+	y.BlockSize = 0
+	y.CacheBlocks = 0
+	openReaderYieldPool.Put(y)
+}
+
+func (y *OpenReaderYield) String() string                { return "<cloudstorage_open_reader_yield>" }
+func (y *OpenReaderYield) Type() lua.LValueType          { return lua.LTUserData }
+func (y *OpenReaderYield) CmdID() dispatcher.CommandID   { return csapi.OpenReader }
+func (y *OpenReaderYield) ToCommand() dispatcher.Command { return y.OpenReaderCmd }
+func (y *OpenReaderYield) Release()                      { ReleaseOpenReaderYield(y) }
+
+func (y *OpenReaderYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, err, "open_reader")}
+	}
+	resp, ok := data.(csapi.OpenReaderResponse)
+	if !ok {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").WithKind(lua.Internal)}
+	}
+	if resp.Error != nil {
+		return []lua.LValue{lua.LNil, wrapStorageError(l, resp.Error, "open_reader")}
+	}
+	ud := newRangeReaderValue(l, y.Storage, y.Key, resp.Size, resp.ETag, y.BlockSize, y.CacheBlocks)
+	if ud == nil {
+		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "reader type not registered").WithKind(lua.Internal)}
+	}
+	return []lua.LValue{ud, lua.LNil}
 }

--- a/runtime/lua/modules/cloudstorage/yields.go
+++ b/runtime/lua/modules/cloudstorage/yields.go
@@ -37,6 +37,11 @@ func wrapStorageError(l *lua.LState, err error, op string) lua.LValue {
 			WithKind(lua.Invalid).
 			WithRetryable(false)
 	}
+	if errors.Is(err, csapi.ErrReaderUnpinned) {
+		return lua.NewLuaError(l, "storage provider cannot pin the object for consistent range reads").
+			WithKind(lua.Unavailable).
+			WithRetryable(false)
+	}
 	return lua.WrapErrorWithLua(l, err, op)
 }
 

--- a/service/aws/s3/multipart.go
+++ b/service/aws/s3/multipart.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go/middleware"
+	"github.com/wippyai/runtime/api/cloudstorage"
+	"go.uber.org/zap"
+)
+
+var _ cloudstorage.MultipartStorage = (*Storage)(nil)
+
+func (s *Storage) CreateMultipartUpload(ctx context.Context, key string, opts *cloudstorage.CreateMultipartUploadOptions) (*cloudstorage.CreateMultipartUploadResult, error) {
+	input := &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	}
+
+	var apiOptions []func(*s3.Options)
+	if opts != nil {
+		if opts.ContentType != "" {
+			input.ContentType = aws.String(opts.ContentType)
+		}
+		if opts.CacheControl != "" {
+			input.CacheControl = aws.String(opts.CacheControl)
+		}
+		if opts.ContentDisposition != "" {
+			input.ContentDisposition = aws.String(opts.ContentDisposition)
+		}
+		if opts.ContentEncoding != "" {
+			input.ContentEncoding = aws.String(opts.ContentEncoding)
+		}
+		if len(opts.Metadata) > 0 {
+			input.Metadata = make(map[string]string, len(opts.Metadata))
+			for k, v := range opts.Metadata {
+				input.Metadata[k] = v
+			}
+		}
+		if len(opts.Headers) > 0 {
+			mw := &addRequestHeadersMiddleware{headers: opts.Headers}
+			apiOptions = append(apiOptions, func(o *s3.Options) {
+				o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+					return stack.Build.Add(mw, middleware.After)
+				})
+			})
+		}
+	}
+
+	output, err := s.client.CreateMultipartUpload(ctx, input, apiOptions...)
+	if err != nil {
+		s.log.Error("create multipart upload failed",
+			zap.String("key", key),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return &cloudstorage.CreateMultipartUploadResult{
+		UploadID: aws.ToString(output.UploadId),
+	}, nil
+}
+
+func (s *Storage) PresignedUploadPartURLs(ctx context.Context, key, uploadID string, opts *cloudstorage.PresignedUploadPartOptions) ([]cloudstorage.PresignedPartURL, error) {
+	if uploadID == "" {
+		return nil, errors.New("upload ID is required")
+	}
+	if opts == nil || len(opts.PartNumbers) == 0 {
+		return nil, errors.New("at least one part number is required")
+	}
+	if len(opts.PartNumbers) > cloudstorage.MaxPresignPartBatch {
+		return nil, fmt.Errorf("at most %d part URLs per call, got %d",
+			cloudstorage.MaxPresignPartBatch, len(opts.PartNumbers))
+	}
+
+	expiration := DefaultPresignExpiration
+	if opts.Expiration > 0 {
+		expiration = opts.Expiration
+	}
+
+	presigner := s3.NewPresignClient(s.client)
+
+	urls := make([]cloudstorage.PresignedPartURL, 0, len(opts.PartNumbers))
+	for _, partNumber := range opts.PartNumbers {
+		if partNumber < 1 || partNumber > cloudstorage.MaxPartNumber {
+			return nil, fmt.Errorf("part number %d out of range [1, %d]",
+				partNumber, cloudstorage.MaxPartNumber)
+		}
+
+		input := &s3.UploadPartInput{
+			Bucket:     aws.String(s.bucket),
+			Key:        aws.String(key),
+			UploadId:   aws.String(uploadID),
+			PartNumber: aws.Int32(partNumber),
+		}
+
+		result, err := presigner.PresignUploadPart(ctx, input, func(options *s3.PresignOptions) {
+			options.Expires = expiration
+		})
+		if err != nil {
+			s.log.Error("generate pre-signed upload part URL failed",
+				zap.String("key", key),
+				zap.Int32("partNumber", partNumber),
+				zap.Error(err))
+			return nil, err
+		}
+
+		urls = append(urls, cloudstorage.PresignedPartURL{
+			PartNumber: partNumber,
+			URL:        result.URL,
+		})
+	}
+
+	return urls, nil
+}
+
+func (s *Storage) CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []cloudstorage.CompletedPart) (*cloudstorage.CompleteMultipartUploadResult, error) {
+	if uploadID == "" {
+		return nil, errors.New("upload ID is required")
+	}
+	if len(parts) == 0 {
+		return nil, errors.New("at least one completed part is required")
+	}
+
+	completed := make([]types.CompletedPart, len(parts))
+	for i, p := range parts {
+		if p.PartNumber < 1 || p.PartNumber > cloudstorage.MaxPartNumber {
+			return nil, fmt.Errorf("part number %d out of range [1, %d]",
+				p.PartNumber, cloudstorage.MaxPartNumber)
+		}
+		if p.ETag == "" {
+			return nil, fmt.Errorf("part %d is missing its etag", p.PartNumber)
+		}
+		completed[i] = types.CompletedPart{
+			ETag:       aws.String(p.ETag),
+			PartNumber: aws.Int32(p.PartNumber),
+		}
+	}
+
+	sort.Slice(completed, func(i, j int) bool {
+		return aws.ToInt32(completed[i].PartNumber) < aws.ToInt32(completed[j].PartNumber)
+	})
+
+	input := &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(s.bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: completed,
+		},
+	}
+
+	output, err := s.client.CompleteMultipartUpload(ctx, input)
+	if err != nil {
+		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrNotFound) {
+			return nil, mapped
+		}
+		s.log.Error("complete multipart upload failed",
+			zap.String("key", key),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return &cloudstorage.CompleteMultipartUploadResult{
+		ETag:      aws.ToString(output.ETag),
+		VersionID: aws.ToString(output.VersionId),
+		Location:  aws.ToString(output.Location),
+	}, nil
+}
+
+func (s *Storage) AbortMultipartUpload(ctx context.Context, key, uploadID string) error {
+	if uploadID == "" {
+		return errors.New("upload ID is required")
+	}
+
+	input := &s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(s.bucket),
+		Key:      aws.String(key),
+		UploadId: aws.String(uploadID),
+	}
+
+	if _, err := s.client.AbortMultipartUpload(ctx, input); err != nil {
+		if mapped := mapKnownError(err); errors.Is(mapped, cloudstorage.ErrNotFound) {
+			return mapped
+		}
+		s.log.Error("abort multipart upload failed",
+			zap.String("key", key),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}

--- a/service/aws/s3/multipart.go
+++ b/service/aws/s3/multipart.go
@@ -87,11 +87,16 @@ func (s *Storage) PresignedUploadPartURLs(ctx context.Context, key, uploadID str
 	presigner := s3.NewPresignClient(s.client)
 
 	urls := make([]cloudstorage.PresignedPartURL, 0, len(opts.PartNumbers))
+	seen := make(map[int32]struct{}, len(opts.PartNumbers))
 	for _, partNumber := range opts.PartNumbers {
 		if partNumber < 1 || partNumber > cloudstorage.MaxPartNumber {
 			return nil, fmt.Errorf("part number %d out of range [1, %d]",
 				partNumber, cloudstorage.MaxPartNumber)
 		}
+		if _, duplicate := seen[partNumber]; duplicate {
+			return nil, fmt.Errorf("part number %d is duplicated", partNumber)
+		}
+		seen[partNumber] = struct{}{}
 
 		input := &s3.UploadPartInput{
 			Bucket:     aws.String(s.bucket),
@@ -102,6 +107,14 @@ func (s *Storage) PresignedUploadPartURLs(ctx context.Context, key, uploadID str
 
 		result, err := presigner.PresignUploadPart(ctx, input, func(options *s3.PresignOptions) {
 			options.Expires = expiration
+			if len(opts.Headers) > 0 {
+				mw := &addRequestHeadersMiddleware{headers: opts.Headers}
+				options.ClientOptions = append(options.ClientOptions, func(o *s3.Options) {
+					o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+						return stack.Build.Add(mw, middleware.After)
+					})
+				})
+			}
 		})
 		if err != nil {
 			s.log.Error("generate pre-signed upload part URL failed",
@@ -129,6 +142,7 @@ func (s *Storage) CompleteMultipartUpload(ctx context.Context, key, uploadID str
 	}
 
 	completed := make([]types.CompletedPart, len(parts))
+	seen := make(map[int32]struct{}, len(parts))
 	for i, p := range parts {
 		if p.PartNumber < 1 || p.PartNumber > cloudstorage.MaxPartNumber {
 			return nil, fmt.Errorf("part number %d out of range [1, %d]",
@@ -137,6 +151,10 @@ func (s *Storage) CompleteMultipartUpload(ctx context.Context, key, uploadID str
 		if p.ETag == "" {
 			return nil, fmt.Errorf("part %d is missing its etag", p.PartNumber)
 		}
+		if _, duplicate := seen[p.PartNumber]; duplicate {
+			return nil, fmt.Errorf("part number %d is duplicated", p.PartNumber)
+		}
+		seen[p.PartNumber] = struct{}{}
 		completed[i] = types.CompletedPart{
 			ETag:       aws.String(p.ETag),
 			PartNumber: aws.Int32(p.PartNumber),

--- a/service/aws/s3/multipart_integration_test.go
+++ b/service/aws/s3/multipart_integration_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cloudstorage"
+)
+
+func putPresigned(t *testing.T, url string, body []byte) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	payload, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "part PUT failed: %s", payload)
+	etag := strings.Trim(resp.Header.Get("ETag"), `"`)
+	require.NotEmpty(t, etag, "part PUT returned no ETag")
+	return etag
+}
+
+func TestMultipartUploadIntegration(t *testing.T) {
+	storage := newIntegrationStorage(t)
+	ctx := context.Background()
+
+	key := "integration/multipart.bin"
+	t.Cleanup(func() { _ = storage.DeleteObjects(context.Background(), []string{key}) })
+
+	part1 := bytes.Repeat([]byte{'a'}, 5<<20)
+	part2 := bytes.Repeat([]byte{'b'}, 1024)
+
+	created, err := storage.CreateMultipartUpload(ctx, key, &cloudstorage.CreateMultipartUploadOptions{
+		ContentType: "application/octet-stream",
+		Metadata:    map[string]string{"source": "multipart-integration"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.UploadID)
+
+	urls, err := storage.PresignedUploadPartURLs(ctx, key, created.UploadID, &cloudstorage.PresignedUploadPartOptions{
+		PartNumbers: []int32{1, 2},
+	})
+	require.NoError(t, err)
+	require.Len(t, urls, 2)
+
+	etag1 := putPresigned(t, urls[0].URL, part1)
+	etag2 := putPresigned(t, urls[1].URL, part2)
+
+	done, err := storage.CompleteMultipartUpload(ctx, key, created.UploadID, []cloudstorage.CompletedPart{
+		{PartNumber: 2, ETag: etag2},
+		{PartNumber: 1, ETag: etag1},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, done.ETag)
+
+	head, err := storage.HeadObject(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(part1)+len(part2)), head.Size)
+	assert.Equal(t, "multipart-integration", head.UserMetadata["source"])
+
+	var buf bytes.Buffer
+	require.NoError(t, storage.DownloadObject(ctx, key, &buf, &cloudstorage.DownloadOptions{
+		Range: "bytes=5242876-5242883", // last 4 bytes of part1 + first 4 of part2
+	}))
+	assert.Equal(t, "aaaabbbb", buf.String())
+}
+
+func TestMultipartAbortIntegration(t *testing.T) {
+	storage := newIntegrationStorage(t)
+	ctx := context.Background()
+
+	key := "integration/multipart-aborted.bin"
+	created, err := storage.CreateMultipartUpload(ctx, key, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, storage.AbortMultipartUpload(ctx, key, created.UploadID))
+
+	_, err = storage.CompleteMultipartUpload(ctx, key, created.UploadID, []cloudstorage.CompletedPart{
+		{PartNumber: 1, ETag: "deadbeef"},
+	})
+	assert.Error(t, err, "completing an aborted upload must fail")
+}
+
+func TestRangeReaderZipIntegration(t *testing.T) {
+	storage := newIntegrationStorage(t)
+	ctx := context.Background()
+
+	big := bytes.Repeat([]byte("0123456789abcdef"), 20*1024) // 320 KiB
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w1, err := zw.Create("hello.txt")
+	require.NoError(t, err)
+	_, err = w1.Write([]byte("hello from s3"))
+	require.NoError(t, err)
+	w2, err := zw.Create("data/big.bin")
+	require.NoError(t, err)
+	_, err = w2.Write(big)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	key := "integration/reader.zip"
+	t.Cleanup(func() { _ = storage.DeleteObjects(context.Background(), []string{key}) })
+	require.NoError(t, storage.UploadObject(ctx, key, bytes.NewReader(zipBuf.Bytes()), &cloudstorage.UploadOptions{
+		ContentType: "application/zip",
+	}))
+
+	head, err := storage.HeadObject(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, int64(zipBuf.Len()), head.Size)
+
+	reader := cloudstorage.NewRangeReaderAt(ctx, storage, key, head.Size, &cloudstorage.RangeReaderAtOptions{
+		BlockSize:   64 * 1024,
+		CacheBlocks: 2,
+		ETag:        head.ETag,
+	})
+	defer func() { _ = reader.Close() }()
+
+	zr, err := zip.NewReader(reader, head.Size)
+	require.NoError(t, err, "zip central directory must parse over ranged reads")
+	require.Len(t, zr.File, 2)
+
+	rc, err := zr.Open("hello.txt")
+	require.NoError(t, err)
+	small, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	assert.Equal(t, "hello from s3", string(small))
+
+	rc, err = zr.Open("data/big.bin")
+	require.NoError(t, err)
+	gotBig, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	assert.True(t, bytes.Equal(big, gotBig), "big entry must round-trip byte-identical")
+}

--- a/service/aws/s3/multipart_integration_test.go
+++ b/service/aws/s3/multipart_integration_test.go
@@ -18,7 +18,7 @@ import (
 
 func putPresigned(t *testing.T, url string, body []byte) string {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, url, bytes.NewReader(body))
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/service/aws/s3/multipart_test.go
+++ b/service/aws/s3/multipart_test.go
@@ -5,6 +5,7 @@ package s3
 import (
 	"context"
 	neturl "net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,6 +67,22 @@ func TestStorage_PresignedUploadPartURLs(t *testing.T) {
 		assert.Equal(t, "900", u.Query().Get("X-Amz-Expires"))
 	})
 
+	t.Run("signs required part headers", func(t *testing.T) {
+		urls, err := storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{
+			PartNumbers: []int32{1},
+			Headers: map[string]string{
+				"x-amz-server-side-encryption-customer-algorithm": "AES256",
+				"x-amz-meta-object-only":                          "ignored",
+			},
+		})
+		require.NoError(t, err)
+		u, err := neturl.Parse(urls[0].URL)
+		require.NoError(t, err)
+		signedHeaders := strings.Split(u.Query().Get("X-Amz-SignedHeaders"), ";")
+		assert.Contains(t, signedHeaders, "x-amz-server-side-encryption-customer-algorithm")
+		assert.NotContains(t, signedHeaders, "x-amz-meta-object-only")
+	})
+
 	t.Run("validation", func(t *testing.T) {
 		_, err := storage.PresignedUploadPartURLs(ctx, "k", "", &cloudstorage.PresignedUploadPartOptions{PartNumbers: []int32{1}})
 		assert.Error(t, err, "empty upload ID")
@@ -81,6 +98,9 @@ func TestStorage_PresignedUploadPartURLs(t *testing.T) {
 
 		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{PartNumbers: []int32{cloudstorage.MaxPartNumber + 1}})
 		assert.Error(t, err, "part number above range")
+
+		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{PartNumbers: []int32{1, 1}})
+		assert.Error(t, err, "duplicate part number")
 
 		tooMany := make([]int32, cloudstorage.MaxPresignPartBatch+1)
 		for i := range tooMany {
@@ -106,6 +126,12 @@ func TestStorage_CompleteMultipartUpload_Validation(t *testing.T) {
 
 	_, err = storage.CompleteMultipartUpload(ctx, "k", "u", []cloudstorage.CompletedPart{{PartNumber: 0, ETag: "e"}})
 	assert.Error(t, err, "part number out of range")
+
+	_, err = storage.CompleteMultipartUpload(ctx, "k", "u", []cloudstorage.CompletedPart{
+		{PartNumber: 1, ETag: "a"},
+		{PartNumber: 1, ETag: "b"},
+	})
+	assert.Error(t, err, "duplicate part number")
 }
 
 func TestStorage_AbortMultipartUpload_Validation(t *testing.T) {

--- a/service/aws/s3/multipart_test.go
+++ b/service/aws/s3/multipart_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"context"
+	neturl "net/url"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cloudstorage"
+	"go.uber.org/zap"
+)
+
+func presignTestStorage(t *testing.T) *Storage {
+	t.Helper()
+	creds := aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+		return aws.Credentials{AccessKeyID: "AKID", SecretAccessKey: "SECRET"}, nil
+	})
+	client := s3.New(s3.Options{Region: "us-east-1", Credentials: creds})
+	return NewStorage(client, "test-bucket", zap.NewNop())
+}
+
+func TestStorage_ImplementsMultipartStorage(t *testing.T) {
+	var s any = presignTestStorage(t)
+	_, ok := s.(cloudstorage.MultipartStorage)
+	assert.True(t, ok, "Storage must implement cloudstorage.MultipartStorage")
+}
+
+func TestStorage_PresignedUploadPartURLs(t *testing.T) {
+	storage := presignTestStorage(t)
+	ctx := context.Background()
+
+	t.Run("generates signed URLs per part", func(t *testing.T) {
+		urls, err := storage.PresignedUploadPartURLs(ctx, "big/archive.zip", "upload-123", &cloudstorage.PresignedUploadPartOptions{
+			PartNumbers: []int32{1, 2, 7},
+			Expiration:  5 * time.Minute,
+		})
+		require.NoError(t, err)
+		require.Len(t, urls, 3)
+
+		for i, want := range []int32{1, 2, 7} {
+			assert.Equal(t, want, urls[i].PartNumber)
+
+			u, err := neturl.Parse(urls[i].URL)
+			require.NoError(t, err)
+			q := u.Query()
+			assert.Equal(t, "upload-123", q.Get("uploadId"))
+			assert.Equal(t, "300", q.Get("X-Amz-Expires"))
+			assert.NotEmpty(t, q.Get("X-Amz-Signature"))
+			assert.Equal(t, int64(want), mustParseInt(t, q.Get("partNumber")))
+		}
+	})
+
+	t.Run("default expiration", func(t *testing.T) {
+		urls, err := storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{
+			PartNumbers: []int32{1},
+		})
+		require.NoError(t, err)
+		u, err := neturl.Parse(urls[0].URL)
+		require.NoError(t, err)
+		assert.Equal(t, "900", u.Query().Get("X-Amz-Expires"))
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		_, err := storage.PresignedUploadPartURLs(ctx, "k", "", &cloudstorage.PresignedUploadPartOptions{PartNumbers: []int32{1}})
+		assert.Error(t, err, "empty upload ID")
+
+		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", nil)
+		assert.Error(t, err, "nil options")
+
+		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{})
+		assert.Error(t, err, "no part numbers")
+
+		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{PartNumbers: []int32{0}})
+		assert.Error(t, err, "part number below range")
+
+		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{PartNumbers: []int32{cloudstorage.MaxPartNumber + 1}})
+		assert.Error(t, err, "part number above range")
+
+		tooMany := make([]int32, cloudstorage.MaxPresignPartBatch+1)
+		for i := range tooMany {
+			tooMany[i] = int32(i + 1)
+		}
+		_, err = storage.PresignedUploadPartURLs(ctx, "k", "u", &cloudstorage.PresignedUploadPartOptions{PartNumbers: tooMany})
+		assert.Error(t, err, "batch over limit")
+	})
+}
+
+func TestStorage_CompleteMultipartUpload_Validation(t *testing.T) {
+	storage := presignTestStorage(t)
+	ctx := context.Background()
+
+	_, err := storage.CompleteMultipartUpload(ctx, "k", "", []cloudstorage.CompletedPart{{PartNumber: 1, ETag: "e"}})
+	assert.Error(t, err, "empty upload ID")
+
+	_, err = storage.CompleteMultipartUpload(ctx, "k", "u", nil)
+	assert.Error(t, err, "no parts")
+
+	_, err = storage.CompleteMultipartUpload(ctx, "k", "u", []cloudstorage.CompletedPart{{PartNumber: 1}})
+	assert.Error(t, err, "missing etag")
+
+	_, err = storage.CompleteMultipartUpload(ctx, "k", "u", []cloudstorage.CompletedPart{{PartNumber: 0, ETag: "e"}})
+	assert.Error(t, err, "part number out of range")
+}
+
+func TestStorage_AbortMultipartUpload_Validation(t *testing.T) {
+	storage := presignTestStorage(t)
+	assert.Error(t, storage.AbortMultipartUpload(context.Background(), "k", ""), "empty upload ID")
+}
+
+func mustParseInt(t *testing.T, s string) int64 {
+	t.Helper()
+	var v int64
+	for _, c := range s {
+		require.True(t, c >= '0' && c <= '9', "non-digit in %q", s)
+		v = v*10 + int64(c-'0')
+	}
+	return v
+}

--- a/service/aws/s3/storage.go
+++ b/service/aws/s3/storage.go
@@ -573,6 +573,10 @@ func mapKnownError(err error) error {
 	if errors.As(err, &notFound) {
 		return cloudstorage.ErrNotFound
 	}
+	var noSuchUpload *types.NoSuchUpload
+	if errors.As(err, &noSuchUpload) {
+		return cloudstorage.ErrNotFound
+	}
 
 	var respErr *awshttp.ResponseError
 	if errors.As(err, &respErr) {

--- a/service/cloudstorage/dispatcher.go
+++ b/service/cloudstorage/dispatcher.go
@@ -31,6 +31,20 @@ func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispat
 	register(csapi.PresignedGetURL, dispatcher.HandlerFunc(d.handlePresignedGetURL))
 	register(csapi.PresignedPutURL, dispatcher.HandlerFunc(d.handlePresignedPutURL))
 	register(csapi.HeadObject, dispatcher.HandlerFunc(d.handleHeadObject))
+	register(csapi.CreateMultipartUpload, dispatcher.HandlerFunc(d.handleCreateMultipartUpload))
+	register(csapi.PresignedUploadPartURLs, dispatcher.HandlerFunc(d.handlePresignedPartURLs))
+	register(csapi.CompleteMultipartUpload, dispatcher.HandlerFunc(d.handleCompleteMultipartUpload))
+	register(csapi.AbortMultipartUpload, dispatcher.HandlerFunc(d.handleAbortMultipartUpload))
+	register(csapi.OpenReader, dispatcher.HandlerFunc(d.handleOpenReader))
+}
+
+// multipartStorage asserts the optional multipart capability on a provider.
+func multipartStorage(s csapi.Storage) (csapi.MultipartStorage, error) {
+	mp, ok := s.(csapi.MultipartStorage)
+	if !ok {
+		return nil, csapi.ErrMultipartUnsupported
+	}
+	return mp, nil
 }
 
 func (d *Dispatcher) handleListObjects(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
@@ -111,6 +125,84 @@ func (d *Dispatcher) handlePresignedPutURL(ctx context.Context, cmd dispatcher.C
 		url, err := c.Storage.PresignedPutURL(ctx, c.Key, opts)
 		if ctx.Err() == nil {
 			receiver.CompleteYield(tag, csapi.PresignedPutURLResponse{URL: url, Error: err}, nil)
+		}
+	}()
+	return nil
+}
+
+func (d *Dispatcher) handleCreateMultipartUpload(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := cmd.(*csapi.CreateMultipartUploadCmd)
+	go func() {
+		var result *csapi.CreateMultipartUploadResult
+		mp, err := multipartStorage(c.Storage)
+		if err == nil {
+			result, err = mp.CreateMultipartUpload(ctx, c.Key, c.Options)
+		}
+		if ctx.Err() == nil {
+			receiver.CompleteYield(tag, csapi.CreateMultipartUploadResponse{Result: result, Error: err}, nil)
+		}
+	}()
+	return nil
+}
+
+func (d *Dispatcher) handlePresignedPartURLs(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := cmd.(*csapi.PresignedPartURLsCmd)
+	go func() {
+		var urls []csapi.PresignedPartURL
+		mp, err := multipartStorage(c.Storage)
+		if err == nil {
+			urls, err = mp.PresignedUploadPartURLs(ctx, c.Key, c.UploadID, c.Options)
+		}
+		if ctx.Err() == nil {
+			receiver.CompleteYield(tag, csapi.PresignedPartURLsResponse{URLs: urls, Error: err}, nil)
+		}
+	}()
+	return nil
+}
+
+func (d *Dispatcher) handleCompleteMultipartUpload(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := cmd.(*csapi.CompleteMultipartUploadCmd)
+	go func() {
+		var result *csapi.CompleteMultipartUploadResult
+		mp, err := multipartStorage(c.Storage)
+		if err == nil {
+			result, err = mp.CompleteMultipartUpload(ctx, c.Key, c.UploadID, c.Parts)
+		}
+		if ctx.Err() == nil {
+			receiver.CompleteYield(tag, csapi.CompleteMultipartUploadResponse{Result: result, Error: err}, nil)
+		}
+	}()
+	return nil
+}
+
+func (d *Dispatcher) handleAbortMultipartUpload(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := cmd.(*csapi.AbortMultipartUploadCmd)
+	go func() {
+		mp, err := multipartStorage(c.Storage)
+		if err == nil {
+			err = mp.AbortMultipartUpload(ctx, c.Key, c.UploadID)
+		}
+		if ctx.Err() == nil {
+			receiver.CompleteYield(tag, csapi.AbortMultipartUploadResponse{Error: err}, nil)
+		}
+	}()
+	return nil
+}
+
+func (d *Dispatcher) handleOpenReader(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := cmd.(*csapi.OpenReaderCmd)
+	go func() {
+		var (
+			size int64
+			etag string
+		)
+		head, err := c.Storage.HeadObject(ctx, c.Key)
+		if err == nil {
+			size = head.Size
+			etag = head.ETag
+		}
+		if ctx.Err() == nil {
+			receiver.CompleteYield(tag, csapi.OpenReaderResponse{Size: size, ETag: etag, Error: err}, nil)
 		}
 	}()
 	return nil

--- a/service/cloudstorage/dispatcher.go
+++ b/service/cloudstorage/dispatcher.go
@@ -198,8 +198,15 @@ func (d *Dispatcher) handleOpenReader(ctx context.Context, cmd dispatcher.Comman
 		)
 		head, err := c.Storage.HeadObject(ctx, c.Key)
 		if err == nil {
-			size = head.Size
-			etag = head.ETag
+			switch {
+			case head == nil:
+				err = csapi.ErrReaderUnpinned
+			case head.ETag == "":
+				err = csapi.ErrReaderUnpinned
+			default:
+				size = head.Size
+				etag = head.ETag
+			}
 		}
 		if ctx.Err() == nil {
 			receiver.CompleteYield(tag, csapi.OpenReaderResponse{Size: size, ETag: etag, Error: err}, nil)

--- a/service/cloudstorage/dispatcher_test.go
+++ b/service/cloudstorage/dispatcher_test.go
@@ -98,7 +98,7 @@ func TestDispatcher_RegisterAll(t *testing.T) {
 
 	d.RegisterAll(register)
 
-	assert.Len(t, registered, 7)
+	assert.Len(t, registered, 12)
 	assert.Contains(t, registered, csapi.ListObjects)
 	assert.Contains(t, registered, csapi.DownloadObject)
 	assert.Contains(t, registered, csapi.UploadObject)
@@ -106,6 +106,218 @@ func TestDispatcher_RegisterAll(t *testing.T) {
 	assert.Contains(t, registered, csapi.PresignedGetURL)
 	assert.Contains(t, registered, csapi.PresignedPutURL)
 	assert.Contains(t, registered, csapi.HeadObject)
+	assert.Contains(t, registered, csapi.CreateMultipartUpload)
+	assert.Contains(t, registered, csapi.PresignedUploadPartURLs)
+	assert.Contains(t, registered, csapi.CompleteMultipartUpload)
+	assert.Contains(t, registered, csapi.AbortMultipartUpload)
+	assert.Contains(t, registered, csapi.OpenReader)
+}
+
+type mockMultipartStorage struct {
+	mockStorage
+	createResult   *csapi.CreateMultipartUploadResult
+	completeResult *csapi.CompleteMultipartUploadResult
+	partURLs       []csapi.PresignedPartURL
+	createErr      error
+	partsErr       error
+	completeErr    error
+	abortErr       error
+	lastParts      []csapi.CompletedPart
+}
+
+func (m *mockMultipartStorage) CreateMultipartUpload(_ context.Context, _ string, _ *csapi.CreateMultipartUploadOptions) (*csapi.CreateMultipartUploadResult, error) {
+	return m.createResult, m.createErr
+}
+
+func (m *mockMultipartStorage) PresignedUploadPartURLs(_ context.Context, _, _ string, _ *csapi.PresignedUploadPartOptions) ([]csapi.PresignedPartURL, error) {
+	return m.partURLs, m.partsErr
+}
+
+func (m *mockMultipartStorage) CompleteMultipartUpload(_ context.Context, _, _ string, parts []csapi.CompletedPart) (*csapi.CompleteMultipartUploadResult, error) {
+	m.lastParts = parts
+	return m.completeResult, m.completeErr
+}
+
+func (m *mockMultipartStorage) AbortMultipartUpload(_ context.Context, _, _ string) error {
+	return m.abortErr
+}
+
+func dispatchHandlers(t *testing.T) map[dispatcher.CommandID]dispatcher.Handler {
+	t.Helper()
+	d := NewDispatcher()
+	handlers := make(map[dispatcher.CommandID]dispatcher.Handler)
+	d.RegisterAll(func(id dispatcher.CommandID, h dispatcher.Handler) {
+		handlers[id] = h
+	})
+	return handlers
+}
+
+func TestDispatcher_MultipartUnsupported(t *testing.T) {
+	handlers := dispatchHandlers(t)
+	storage := &mockStorage{} // base Storage only, no multipart capability
+
+	t.Run("create", func(t *testing.T) {
+		done := make(chan csapi.CreateMultipartUploadResponse, 1)
+		cmd := &csapi.CreateMultipartUploadCmd{Storage: storage, Key: "k"}
+		require.NoError(t, handlers[csapi.CreateMultipartUpload].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.CreateMultipartUploadResponse)
+			})))
+		select {
+		case resp := <-done:
+			assert.ErrorIs(t, resp.Error, csapi.ErrMultipartUnsupported)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("parts", func(t *testing.T) {
+		done := make(chan csapi.PresignedPartURLsResponse, 1)
+		cmd := &csapi.PresignedPartURLsCmd{Storage: storage, Key: "k", UploadID: "u"}
+		require.NoError(t, handlers[csapi.PresignedUploadPartURLs].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.PresignedPartURLsResponse)
+			})))
+		select {
+		case resp := <-done:
+			assert.ErrorIs(t, resp.Error, csapi.ErrMultipartUnsupported)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		done := make(chan csapi.CompleteMultipartUploadResponse, 1)
+		cmd := &csapi.CompleteMultipartUploadCmd{Storage: storage, Key: "k", UploadID: "u"}
+		require.NoError(t, handlers[csapi.CompleteMultipartUpload].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.CompleteMultipartUploadResponse)
+			})))
+		select {
+		case resp := <-done:
+			assert.ErrorIs(t, resp.Error, csapi.ErrMultipartUnsupported)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("abort", func(t *testing.T) {
+		done := make(chan csapi.AbortMultipartUploadResponse, 1)
+		cmd := &csapi.AbortMultipartUploadCmd{Storage: storage, Key: "k", UploadID: "u"}
+		require.NoError(t, handlers[csapi.AbortMultipartUpload].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.AbortMultipartUploadResponse)
+			})))
+		select {
+		case resp := <-done:
+			assert.ErrorIs(t, resp.Error, csapi.ErrMultipartUnsupported)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+}
+
+func TestDispatcher_MultipartSupported(t *testing.T) {
+	handlers := dispatchHandlers(t)
+	storage := &mockMultipartStorage{
+		createResult:   &csapi.CreateMultipartUploadResult{UploadID: "upload-1"},
+		partURLs:       []csapi.PresignedPartURL{{PartNumber: 1, URL: "https://p1"}, {PartNumber: 2, URL: "https://p2"}},
+		completeResult: &csapi.CompleteMultipartUploadResult{ETag: `"final"`},
+	}
+
+	done := make(chan csapi.CreateMultipartUploadResponse, 1)
+	cmd := &csapi.CreateMultipartUploadCmd{Storage: storage, Key: "k"}
+	require.NoError(t, handlers[csapi.CreateMultipartUpload].Handle(context.Background(), cmd, 1,
+		newTestReceiver(func(_ uint64, data any, _ error) {
+			done <- data.(csapi.CreateMultipartUploadResponse)
+		})))
+	select {
+	case resp := <-done:
+		require.NoError(t, resp.Error)
+		assert.Equal(t, "upload-1", resp.Result.UploadID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	partsDone := make(chan csapi.PresignedPartURLsResponse, 1)
+	partsCmd := &csapi.PresignedPartURLsCmd{
+		Storage:  storage,
+		Key:      "k",
+		UploadID: "upload-1",
+		Options:  &csapi.PresignedUploadPartOptions{PartNumbers: []int32{1, 2}},
+	}
+	require.NoError(t, handlers[csapi.PresignedUploadPartURLs].Handle(context.Background(), partsCmd, 1,
+		newTestReceiver(func(_ uint64, data any, _ error) {
+			partsDone <- data.(csapi.PresignedPartURLsResponse)
+		})))
+	select {
+	case resp := <-partsDone:
+		require.NoError(t, resp.Error)
+		require.Len(t, resp.URLs, 2)
+		assert.Equal(t, int32(1), resp.URLs[0].PartNumber)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	completeDone := make(chan csapi.CompleteMultipartUploadResponse, 1)
+	completeCmd := &csapi.CompleteMultipartUploadCmd{
+		Storage:  storage,
+		Key:      "k",
+		UploadID: "upload-1",
+		Parts:    []csapi.CompletedPart{{PartNumber: 1, ETag: `"a"`}},
+	}
+	require.NoError(t, handlers[csapi.CompleteMultipartUpload].Handle(context.Background(), completeCmd, 1,
+		newTestReceiver(func(_ uint64, data any, _ error) {
+			completeDone <- data.(csapi.CompleteMultipartUploadResponse)
+		})))
+	select {
+	case resp := <-completeDone:
+		require.NoError(t, resp.Error)
+		assert.Equal(t, `"final"`, resp.Result.ETag)
+		assert.Len(t, storage.lastParts, 1)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestDispatcher_OpenReader(t *testing.T) {
+	handlers := dispatchHandlers(t)
+
+	t.Run("success", func(t *testing.T) {
+		storage := &mockStorage{
+			headResult: &csapi.HeadObjectResult{Size: 4096, ETag: `"v1"`},
+		}
+		done := make(chan csapi.OpenReaderResponse, 1)
+		cmd := &csapi.OpenReaderCmd{Storage: storage, Key: "big.zip"}
+		require.NoError(t, handlers[csapi.OpenReader].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.OpenReaderResponse)
+			})))
+		select {
+		case resp := <-done:
+			require.NoError(t, resp.Error)
+			assert.Equal(t, int64(4096), resp.Size)
+			assert.Equal(t, `"v1"`, resp.ETag)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		storage := &mockStorage{headErr: csapi.ErrNotFound}
+		done := make(chan csapi.OpenReaderResponse, 1)
+		cmd := &csapi.OpenReaderCmd{Storage: storage, Key: "missing.zip"}
+		require.NoError(t, handlers[csapi.OpenReader].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.OpenReaderResponse)
+			})))
+		select {
+		case resp := <-done:
+			assert.ErrorIs(t, resp.Error, csapi.ErrNotFound)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
 }
 
 func TestDispatcher_ListObjects(t *testing.T) {

--- a/service/cloudstorage/dispatcher_test.go
+++ b/service/cloudstorage/dispatcher_test.go
@@ -318,6 +318,22 @@ func TestDispatcher_OpenReader(t *testing.T) {
 			t.Fatal("timeout")
 		}
 	})
+
+	t.Run("requires consistency token", func(t *testing.T) {
+		storage := &mockStorage{headResult: &csapi.HeadObjectResult{Size: 4096}}
+		done := make(chan csapi.OpenReaderResponse, 1)
+		cmd := &csapi.OpenReaderCmd{Storage: storage, Key: "mutable.zip"}
+		require.NoError(t, handlers[csapi.OpenReader].Handle(context.Background(), cmd, 1,
+			newTestReceiver(func(_ uint64, data any, _ error) {
+				done <- data.(csapi.OpenReaderResponse)
+			})))
+		select {
+		case resp := <-done:
+			assert.ErrorIs(t, resp.Error, csapi.ErrReaderUnpinned)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
 }
 
 func TestDispatcher_ListObjects(t *testing.T) {

--- a/tests/app/src/test/cloudstorage/_index.yaml
+++ b/tests/app/src/test/cloudstorage/_index.yaml
@@ -180,3 +180,34 @@ entries:
       - cloudstorage
     imports:
       assert_primitives: app.lib:assert
+
+  # presigned multipart upload round trip
+  - name: multipart
+    kind: function.lua
+    meta:
+      type: test
+      suite: cloudstorage
+      description: cloudstorage presigned multipart upload create/parts/complete/abort round trip
+    source: file://multipart.lua
+    method: main
+    modules:
+      - cloudstorage
+      - http_client
+    imports:
+      assert_primitives: app.lib:assert
+
+  # ranged reader + archive.open over an object
+  - name: reader
+    kind: function.lua
+    meta:
+      type: test
+      suite: cloudstorage
+      description: open_reader ranged random access and archive.open over an S3-stored zip
+    source: file://reader.lua
+    method: main
+    modules:
+      - cloudstorage
+      - archive
+      - fs
+    imports:
+      assert_primitives: app.lib:assert

--- a/tests/app/src/test/cloudstorage/multipart.lua
+++ b/tests/app/src/test/cloudstorage/multipart.lua
@@ -1,0 +1,112 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: cloudstorage presigned multipart upload round trip
+local assert = require("assert_primitives")
+
+-- ETag header casing differs between providers; scan case-insensitively.
+local function etag_of(resp)
+	for k, v in pairs(resp.headers or {}) do
+		if string.lower(k) == "etag" then
+			return (tostring(v):gsub('"', ""))
+		end
+	end
+	return nil
+end
+
+local function main()
+	local cloudstorage = require("cloudstorage")
+	local http_client = require("http_client")
+
+	local storage, err = cloudstorage.get("app.test.cloudstorage:minio")
+	assert.is_nil(err, "should get storage without error")
+	assert.not_nil(storage, "should have storage connection")
+
+	local key = "multipart-test/big.bin"
+
+	-- Parts before the last must be at least 5 MiB (S3 protocol minimum).
+	local part1 = string.rep("a", 5 * 1024 * 1024)
+	local part2 = string.rep("b", 1024)
+
+	-- Start the multipart upload
+	local created, cerr = storage:create_multipart_upload(key, {
+		content_type = "application/octet-stream",
+		metadata = { source = "multipart-e2e" },
+	})
+	assert.is_nil(cerr, "create_multipart_upload should not error")
+	assert.not_nil(created, "should have create result")
+	assert.eq(type(created.upload_id), "string", "upload_id should be string")
+	assert.eq(#created.upload_id > 0, true, "upload_id should be non-empty")
+
+	-- Presign both parts in one batch
+	local urls, perr = storage:presigned_part_urls(key, created.upload_id, {
+		parts = { 1, 2 },
+		expiration = 900,
+	})
+	assert.is_nil(perr, "presigned_part_urls should not error")
+	assert.eq(#urls, 2, "should have 2 part URLs")
+	assert.eq(urls[1].part_number, 1, "first URL part_number")
+	assert.eq(urls[2].part_number, 2, "second URL part_number")
+	assert.eq(urls[1].url:match("^https?://") ~= nil, true, "part URL should be http(s)")
+
+	-- Upload both parts through the presigned URLs (as a browser would)
+	local r1, e1 = http_client.put(urls[1].url, { body = part1 })
+	assert.is_nil(e1, "part 1 PUT should not error")
+	assert.eq(r1.status_code, 200, "part 1 PUT status")
+	local etag1 = etag_of(r1)
+	assert.not_nil(etag1, "part 1 should return an ETag")
+
+	local r2, e2 = http_client.put(urls[2].url, { body = part2 })
+	assert.is_nil(e2, "part 2 PUT should not error")
+	assert.eq(r2.status_code, 200, "part 2 PUT status")
+	local etag2 = etag_of(r2)
+	assert.not_nil(etag2, "part 2 should return an ETag")
+
+	-- Complete with parts deliberately out of order — the runtime sorts them
+	local done, derr = storage:complete_multipart_upload(key, created.upload_id, {
+		{ part_number = 2, etag = etag2 },
+		{ part_number = 1, etag = etag1 },
+	})
+	assert.is_nil(derr, "complete_multipart_upload should not error")
+	assert.not_nil(done, "should have completion result")
+	assert.eq(type(done.etag), "string", "final etag should be string")
+
+	-- The assembled object must have the combined size and content
+	local head, herr = storage:head_object(key)
+	assert.is_nil(herr, "head_object should not error")
+	assert.eq(head.size, #part1 + #part2, "assembled size should match")
+	assert.eq(head.metadata.source, "multipart-e2e", "metadata should survive")
+
+	-- Spot-check the stitched content across the part boundary
+	local url, uerr = storage:presigned_get_url(key)
+	assert.is_nil(uerr, "presigned_get_url should not error")
+	local got, gerr = http_client.get(url, {
+		headers = { Range = "bytes=" .. (#part1 - 4) .. "-" .. (#part1 + 3) },
+	})
+	assert.is_nil(gerr, "ranged GET should not error")
+	assert.eq(got.body, "aaaabbbb", "content across part boundary")
+
+	-- Abort flow: a second upload discarded before completion
+	local created2, cerr2 = storage:create_multipart_upload("multipart-test/aborted.bin")
+	assert.is_nil(cerr2, "second create should not error")
+	local ok, aerr = storage:abort_multipart_upload("multipart-test/aborted.bin", created2.upload_id)
+	assert.is_nil(aerr, "abort should not error")
+	assert.eq(ok, true, "abort should return true")
+
+	-- Completing an aborted upload must fail
+	local _, failerr = storage:complete_multipart_upload("multipart-test/aborted.bin", created2.upload_id, {
+		{ part_number = 1, etag = "deadbeef" },
+	})
+	assert.not_nil(failerr, "completing an aborted upload should fail")
+
+	-- Validation errors surface without network calls
+	local _, verr = storage:presigned_part_urls(key, created.upload_id, {})
+	assert.not_nil(verr, "missing parts/count should error")
+
+	-- Cleanup
+	storage:delete_objects({ key })
+	storage:release()
+
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/cloudstorage/reader.lua
+++ b/tests/app/src/test/cloudstorage/reader.lua
@@ -1,0 +1,98 @@
+-- SPDX-License-Identifier: MPL-2.0
+
+-- Test: open_reader ranged random access + archive.open over an S3 object
+local assert = require("assert_primitives")
+
+local function main()
+	local cloudstorage = require("cloudstorage")
+	local archive = require("archive")
+	local fs = require("fs")
+
+	local storage, err = cloudstorage.get("app.test.cloudstorage:minio")
+	assert.is_nil(err, "should get storage without error")
+
+	local vol, ferr = fs.get("app:temp")
+	assert.is_nil(ferr, "temp fs error")
+
+	-- Build a zip locally: a small text entry plus one spanning many blocks
+	local big = string.rep("0123456789abcdef", 20 * 1024) -- 320 KiB
+	local w, cerr = archive.create(vol, "/reader-e2e.zip")
+	assert.is_nil(cerr, "create zip error")
+	assert.ok(w:add("hello.txt", "hello from s3"), "add text entry")
+	assert.ok(w:add("data/big.bin", big), "add big entry")
+	assert.ok(w:close(), "close writer")
+
+	local zip_bytes, rerr = vol:readfile("/reader-e2e.zip")
+	assert.is_nil(rerr, "read zip bytes error")
+
+	-- Park the archive in object storage
+	local key = "reader-test/archive.zip"
+	local ok, uerr = storage:upload_object(key, zip_bytes, { content_type = "application/zip" })
+	assert.is_nil(uerr, "upload zip should not error")
+	assert.eq(ok, true, "upload should return true")
+
+	-- Open a ranged reader over the object; small blocks force several
+	-- ranged GETs so the cache path is actually exercised.
+	local reader, oerr = storage:open_reader(key, { block_size = 65536, cache_blocks = 2 })
+	assert.is_nil(oerr, "open_reader should not error")
+	assert.not_nil(reader, "should have reader")
+	assert.eq(reader:size(), #zip_bytes, "reader size should match object size")
+	assert.eq(reader:key(), key, "reader key should match")
+
+	-- Random access straight from object storage — no local staging
+	local r, aerr = archive.open(reader)
+	assert.is_nil(aerr, "archive.open over reader should not error")
+
+	local names = {}
+	for e in r:entries() do
+		names[e.name] = e
+	end
+	assert.not_nil(names["hello.txt"], "entries include hello.txt")
+	assert.not_nil(names["data/big.bin"], "entries include data/big.bin")
+	assert.eq(names["data/big.bin"].size, #big, "big entry size")
+
+	assert.eq(r:read("hello.txt"), "hello from s3", "read small entry")
+
+	-- Stream the large entry and verify content end to end
+	local es, serr = r:stream("data/big.bin")
+	assert.is_nil(serr, "stream entry error")
+	local chunks = {}
+	while true do
+		local chunk = es:read(65536)
+		if not chunk then
+			break
+		end
+		chunks[#chunks + 1] = chunk
+	end
+	assert.eq(table.concat(chunks), big, "streamed big entry content")
+
+	-- Fan-out path used by extraction workers: an archive entry stream is
+	-- uploaded straight back to object storage (ReaderProvider source),
+	-- without materializing the entry in memory.
+	local es2, serr2 = r:stream("data/big.bin")
+	assert.is_nil(serr2, "second stream open error")
+	local child_key = "reader-test/child/big.bin"
+	local ok2, uerr2 = storage:upload_object(child_key, es2, { content_type = "application/octet-stream" })
+	assert.is_nil(uerr2, "upload from entry stream should not error")
+	assert.eq(ok2, true, "stream upload should return true")
+
+	local child_head, cherr = storage:head_object(child_key)
+	assert.is_nil(cherr, "child head_object error")
+	assert.eq(child_head.size, #big, "child object size matches entry")
+
+	assert.ok(r:close(), "close archive reader")
+	assert.ok(reader:close(), "close ranged reader")
+
+	-- Missing objects surface as errors at open time
+	local missing, merr = storage:open_reader("reader-test/missing.zip")
+	assert.is_nil(missing, "missing object should not return a reader")
+	assert.not_nil(merr, "missing object should error")
+
+	-- Cleanup
+	storage:delete_objects({ key, "reader-test/child/big.bin" })
+	storage:release()
+
+	return true
+end
+
+return { main = main }


### PR DESCRIPTION
## Summary

- add provider-optional multipart upload operations to the cloud-storage API, dispatcher, Lua module, and S3 service
- generate presigned part URLs and complete or abort multipart uploads
- add an ETag-pinned, range-cached `io.ReaderAt` for cloud objects and allow it as an `archive.open` source
- allow stream-backed readers as cloud-storage upload sources

## Reliability

- cancel in-flight ranged GETs on explicit close or process cancellation
- cap each reader cache at 256 MiB and reject unsafe Lua configurations
- refuse unpinned range readers when a provider cannot supply an ETag
- validate integer part selectors, batch limits, required ETags, and duplicate part numbers before provider calls
- include required per-part headers in S3 signatures while retaining the existing operation-specific header allowlist
- register reader cleanup with process resource ownership

## Validation

- repository-wide lint
- full race-enabled Runtime test suite
- focused race tests for cloud-storage API, dispatcher, Lua bindings, archive integration, and S3
- S3 multipart and range-reader integration tests
