### PR TITLE
feat(registry): add process-local overlays

### DIFF
--- a/api/registry/id.go
+++ b/api/registry/id.go
@@ -39,6 +39,18 @@ func NewID(ns, name string) ID {
 	return unique.Make(id).Value()
 }
 
+// Canonical returns the interned representation used for registry map keys.
+// It is allocation-free when the ID is already canonical and also normalizes
+// legacy name-only values that contain a namespace separator.
+func (t ID) Canonical() ID {
+	ns, name := canonicalIDParts(t)
+	canonicalString := ns + ":" + name
+	if t.NS == ns && t.Name == name && t.str == canonicalString {
+		return t
+	}
+	return NewID(ns, name)
+}
+
 func (t *ID) String() string {
 	if t.str != "" {
 		return t.str

--- a/api/registry/id_test.go
+++ b/api/registry/id_test.go
@@ -439,6 +439,32 @@ func TestNewID(t *testing.T) {
 	}
 }
 
+func TestID_Canonical(t *testing.T) {
+	canonical := NewID("ns", "name")
+	requireSameID := func(t *testing.T, expected, actual ID) {
+		t.Helper()
+		assert.Equal(t, expected, actual)
+		assert.Equal(t, expected.String(), actual.String())
+	}
+
+	t.Run("already canonical", func(t *testing.T) {
+		requireSameID(t, canonical, canonical.Canonical())
+		var got ID
+		assert.Zero(t, testing.AllocsPerRun(1000, func() {
+			got = canonical.Canonical()
+		}))
+		requireSameID(t, canonical, got)
+	})
+
+	t.Run("raw split form", func(t *testing.T) {
+		requireSameID(t, canonical, (ID{NS: "ns", Name: "name"}).Canonical())
+	})
+
+	t.Run("legacy qualified name", func(t *testing.T) {
+		requireSameID(t, canonical, (ID{Name: "ns:name"}).Canonical())
+	})
+}
+
 func TestID_String_WithCachedStr(t *testing.T) {
 	id := NewID("ns", "name")
 	assert.Equal(t, "ns:name", id.String())

--- a/api/registry/overlay_test.go
+++ b/api/registry/overlay_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalOverlayOwner(t *testing.T) {
+	owner, err := CanonicalOverlayOwner("  controller:one\t")
+	require.NoError(t, err)
+	assert.Equal(t, "controller:one", owner)
+
+	_, err = CanonicalOverlayOwner(" \n\t")
+	require.Error(t, err)
+}

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -153,6 +153,15 @@ type (
 		LoadState(context.Context, State, Version) error
 	}
 
+	// OverlayWriter manages process-local registry overlays. Overlay entries
+	// participate in normal topology and handler transitions but do
+	// not advance or appear in version history. They are empty after cold boot
+	// and must be reconciled by their owning control service.
+	OverlayWriter interface {
+		ApplyOverlay(context.Context, string, uint64, ChangeSet) (uint64, error)
+		GetOverlay(string) (State, uint64, error)
+	}
+
 	// StateMap is a map-based representation of registry state for efficient lookups
 	StateMap map[ID]Entry
 

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -5,11 +5,27 @@ package registry
 
 import (
 	"context"
+	"strings"
 
 	"github.com/wippyai/runtime/api/attrs"
+	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/event"
 	"github.com/wippyai/runtime/api/payload"
 )
+
+// ErrOverlayOwnerRequired rejects empty logical overlay identities.
+var ErrOverlayOwnerRequired = apierror.New(apierror.Invalid, "registry overlay owner is required").
+	WithRetryable(apierror.False)
+
+// CanonicalOverlayOwner returns the identity used for both overlay storage and
+// authorization. Callers must authorize only the returned value.
+func CanonicalOverlayOwner(owner string) (string, error) {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return "", ErrOverlayOwnerRequired
+	}
+	return owner, nil
+}
 
 // Registry system constants define the various event types and identifiers used throughout the registry.
 const (

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -50,11 +50,10 @@ type (
 
 	// Provider manages resource lifecycle and access control.
 	Provider interface {
-		// Acquire obtains access to a resource with the specified mode. A
-		// successful Resource remains owned by the caller and valid until Release,
-		// even if the provider is concurrently removed or replaced in a Registry.
-		// Implementations own that lifetime guarantee; the Registry only routes
-		// new acquisitions and tracks generations.
+		// Acquire obtains access to a resource with the specified mode. Providers
+		// define whether an acquired handle remains usable when their backing
+		// service is stopped or replaced. The Registry owns routing and exact
+		// generation accounting only; callers always own the matching Release.
 		Acquire(ctx context.Context, id registry.ID, mode AccessMode) (Resource[any], error)
 	}
 
@@ -88,7 +87,7 @@ func NewTrackedResource(inner Resource[any], onRelease func()) *TrackedResource 
 func (t *TrackedResource) Get() (any, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	if t.released {
+	if t.released || t.inner == nil {
 		return nil, ErrReleased
 	}
 	return t.inner.Get()
@@ -111,5 +110,7 @@ func (t *TrackedResource) Release() {
 	if onRelease != nil {
 		defer onRelease()
 	}
-	inner.Release()
+	if inner != nil {
+		inner.Release()
+	}
 }

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -6,7 +6,6 @@ package resource
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/event"
@@ -51,7 +50,11 @@ type (
 
 	// Provider manages resource lifecycle and access control.
 	Provider interface {
-		// Acquire obtains access to a resource with the specified mode.
+		// Acquire obtains access to a resource with the specified mode. A
+		// successful Resource remains owned by the caller and valid until Release,
+		// even if the provider is concurrently removed or replaced in a Registry.
+		// Implementations own that lifetime guarantee; the Registry only routes
+		// new acquisitions and tracks generations.
 		Acquire(ctx context.Context, id registry.ID, mode AccessMode) (Resource[any], error)
 	}
 
@@ -72,27 +75,20 @@ type (
 type TrackedResource struct {
 	inner     Resource[any]
 	onRelease func()
-	released  atomic.Bool
-}
-
-var trackedResourcePool = sync.Pool{
-	New: func() any {
-		return &TrackedResource{}
-	},
+	mu        sync.RWMutex
+	released  bool
 }
 
 // NewTrackedResource creates a tracked wrapper around a resource.
 func NewTrackedResource(inner Resource[any], onRelease func()) *TrackedResource {
-	tr := trackedResourcePool.Get().(*TrackedResource)
-	tr.inner = inner
-	tr.onRelease = onRelease
-	tr.released.Store(false)
-	return tr
+	return &TrackedResource{inner: inner, onRelease: onRelease}
 }
 
 // Get returns the managed resource instance.
 func (t *TrackedResource) Get() (any, error) {
-	if t.released.Load() {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.released {
 		return nil, ErrReleased
 	}
 	return t.inner.Get()
@@ -100,13 +96,20 @@ func (t *TrackedResource) Get() (any, error) {
 
 // Release frees the resource and invalidates access.
 func (t *TrackedResource) Release() {
-	if t.released.CompareAndSwap(false, true) {
-		t.inner.Release()
-		if t.onRelease != nil {
-			t.onRelease()
-		}
-		t.inner = nil
-		t.onRelease = nil
-		trackedResourcePool.Put(t)
+	t.mu.Lock()
+	if t.released {
+		t.mu.Unlock()
+		return
 	}
+	t.released = true
+	inner := t.inner
+	onRelease := t.onRelease
+	t.inner = nil
+	t.onRelease = nil
+	t.mu.Unlock()
+
+	if onRelease != nil {
+		defer onRelease()
+	}
+	inner.Release()
 }

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -317,3 +317,10 @@ func TestTrackedResourceStaleReleaseCannotAffectLaterWrapper(t *testing.T) {
 	second.Release()
 	assert.Equal(t, 1, secondReleases)
 }
+
+func TestTrackedResourceHandlesNilInner(t *testing.T) {
+	tracked := NewTrackedResource(nil, nil)
+	_, err := tracked.Get()
+	assert.ErrorIs(t, err, ErrReleased)
+	assert.NotPanics(t, tracked.Release)
+}

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -270,7 +271,7 @@ func TestTrackedResource(t *testing.T) {
 		assert.True(t, inner.released)
 	})
 
-	t.Run("PoolReuse", func(t *testing.T) {
+	t.Run("RepeatedAllocation", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			inner := &mockResource{value: i}
 			tr := NewTrackedResource(inner, nil)
@@ -279,4 +280,40 @@ func TestTrackedResource(t *testing.T) {
 			tr.Release()
 		}
 	})
+}
+
+func TestTrackedResourceConcurrentReleaseIsIdempotent(t *testing.T) {
+	inner := &mockResource{value: "value"}
+	releaseCount := 0
+	tracked := NewTrackedResource(inner, func() { releaseCount++ })
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracked.Release()
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, releaseCount)
+	_, err := tracked.Get()
+	assert.ErrorIs(t, err, ErrReleased)
+}
+
+func TestTrackedResourceStaleReleaseCannotAffectLaterWrapper(t *testing.T) {
+	firstInner := &mockResource{value: "first"}
+	first := NewTrackedResource(firstInner, nil)
+	first.Release()
+
+	secondInner := &mockResource{value: "second"}
+	secondReleases := 0
+	second := NewTrackedResource(secondInner, func() { secondReleases++ })
+	first.Release()
+
+	value, err := second.Get()
+	require.NoError(t, err)
+	assert.Equal(t, "second", value)
+	assert.Zero(t, secondReleases)
+	second.Release()
+	assert.Equal(t, 1, secondReleases)
 }

--- a/runtime/lua/modules/registry/changes.go
+++ b/runtime/lua/modules/registry/changes.go
@@ -152,33 +152,47 @@ func changesDelete(l *lua.LState) int {
 }
 
 func deleteIDs(value lua.LValue) ([]regapi.ID, error) {
-	switch v := value.(type) {
-	case lua.LString:
-		return []regapi.ID{regapi.ParseID(string(v))}, nil
-	case *lua.LTable:
-		if idValue := v.RawGetString("id"); idValue != lua.LNil {
-			return deleteIDs(idValue)
-		}
-		ns := v.RawGetString("ns")
-		name := v.RawGetString("name")
-		if ns != lua.LNil && name != lua.LNil {
-			return []regapi.ID{regapi.NewID(ns.String(), name.String())}, nil
-		}
-		ids := make([]regapi.ID, 0, v.Len())
-		for i := 1; i <= v.Len(); i++ {
-			itemIDs, err := deleteIDs(v.RawGetInt(i))
-			if err != nil {
-				return nil, fmt.Errorf("delete item %d: %w", i, err)
+	// Walk iteratively: Lua tables are graphs and may contain themselves. A
+	// recursive decoder lets an untrusted self-reference exhaust the Go stack.
+	stack := []lua.LValue{value}
+	seenTables := make(map[*lua.LTable]struct{})
+	ids := make([]regapi.ID, 0, 1)
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		current := stack[last]
+		stack = stack[:last]
+		switch v := current.(type) {
+		case lua.LString:
+			ids = append(ids, regapi.ParseID(string(v)))
+		case *lua.LTable:
+			if _, seen := seenTables[v]; seen {
+				return nil, fmt.Errorf("cyclic or repeated ID table")
 			}
-			ids = append(ids, itemIDs...)
+			seenTables[v] = struct{}{}
+			if idValue := v.RawGetString("id"); idValue != lua.LNil {
+				stack = append(stack, idValue)
+				continue
+			}
+			ns := v.RawGetString("ns")
+			name := v.RawGetString("name")
+			if ns != lua.LNil && name != lua.LNil {
+				ids = append(ids, regapi.NewID(ns.String(), name.String()))
+				continue
+			}
+			if v.Len() == 0 {
+				return nil, fmt.Errorf("empty ID list")
+			}
+			for i := v.Len(); i >= 1; i-- {
+				stack = append(stack, v.RawGetInt(i))
+			}
+		default:
+			return nil, fmt.Errorf("unsupported ID value %s", current.Type())
 		}
-		if len(ids) == 0 {
-			return nil, fmt.Errorf("empty ID list")
-		}
-		return ids, nil
-	default:
-		return nil, fmt.Errorf("unsupported ID value %s", value.Type())
 	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("empty ID list")
+	}
+	return ids, nil
 }
 
 // changesApply applies the changeset to create a new version

--- a/runtime/lua/modules/registry/changes.go
+++ b/runtime/lua/modules/registry/changes.go
@@ -3,6 +3,8 @@
 package registry
 
 import (
+	"fmt"
+
 	lua "github.com/wippyai/go-lua"
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
@@ -22,6 +24,9 @@ func changesOps(l *lua.LState) int {
 	changes := checkChanges(l)
 	if changes == nil {
 		return 0
+	}
+	if !authorizeSnapshotRead(l, changes.snapshot) {
+		return 2
 	}
 
 	opsTable := l.CreateTable(len(changes.ops), 0)
@@ -121,17 +126,8 @@ func changesDelete(l *lua.LState) int {
 		return 0
 	}
 
-	idVal := l.Get(2)
-	var id regapi.ID
-
-	switch v := idVal.(type) {
-	case lua.LString:
-		id = regapi.ParseID(string(v))
-	case *lua.LTable:
-		ns := v.RawGetString("ns")
-		name := v.RawGetString("name")
-		id = regapi.NewID(ns.String(), name.String())
-	default:
+	ids, parseErr := deleteIDs(l.Get(2))
+	if parseErr != nil {
 		err := lua.NewLuaError(l, "invalid ID format").
 			WithKind(lua.Invalid).
 			WithRetryable(false)
@@ -139,16 +135,50 @@ func changesDelete(l *lua.LState) int {
 		l.Push(err)
 		return 2
 	}
-
-	changes.ops = append(changes.ops, regapi.Operation{
-		Kind: regapi.EntryDelete,
-		Entry: regapi.Entry{
-			ID: id,
-		},
-	})
+	seen := make(map[regapi.ID]struct{}, len(ids))
+	for _, id := range ids {
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		changes.ops = append(changes.ops, regapi.Operation{
+			Kind:  regapi.EntryDelete,
+			Entry: regapi.Entry{ID: id},
+		})
+	}
 
 	l.Push(l.Get(1))
 	return 1
+}
+
+func deleteIDs(value lua.LValue) ([]regapi.ID, error) {
+	switch v := value.(type) {
+	case lua.LString:
+		return []regapi.ID{regapi.ParseID(string(v))}, nil
+	case *lua.LTable:
+		if idValue := v.RawGetString("id"); idValue != lua.LNil {
+			return deleteIDs(idValue)
+		}
+		ns := v.RawGetString("ns")
+		name := v.RawGetString("name")
+		if ns != lua.LNil && name != lua.LNil {
+			return []regapi.ID{regapi.NewID(ns.String(), name.String())}, nil
+		}
+		ids := make([]regapi.ID, 0, v.Len())
+		for i := 1; i <= v.Len(); i++ {
+			itemIDs, err := deleteIDs(v.RawGetInt(i))
+			if err != nil {
+				return nil, fmt.Errorf("delete item %d: %w", i, err)
+			}
+			ids = append(ids, itemIDs...)
+		}
+		if len(ids) == 0 {
+			return nil, fmt.Errorf("empty ID list")
+		}
+		return ids, nil
+	default:
+		return nil, fmt.Errorf("unsupported ID value %s", value.Type())
+	}
 }
 
 // changesApply applies the changeset to create a new version
@@ -164,6 +194,77 @@ func changesApply(l *lua.LState) int {
 			WithRetryable(false)
 		l.Push(lua.LNil)
 		l.Push(err)
+		return 2
+	}
+
+	if changes.snapshot.overlayOwner != "" {
+		owner := changes.snapshot.overlayOwner
+		if !security.IsAllowed(l.Context(), "registry.overlay.get", owner, nil) {
+			err := lua.NewLuaError(l, "not allowed to read registry overlay: "+owner).
+				WithKind(lua.PermissionDenied).
+				WithRetryable(false)
+			l.Push(lua.LNil)
+			l.Push(err)
+			return 2
+		}
+		if !security.IsAllowed(l.Context(), "registry.overlay.apply", owner, nil) {
+			err := lua.NewLuaError(l, "not allowed to apply registry overlay: "+owner).
+				WithKind(lua.PermissionDenied).
+				WithRetryable(false)
+			l.Push(lua.LNil)
+			l.Push(err)
+			return 2
+		}
+		for _, op := range changes.ops {
+			kind := op.Entry.Kind
+			if op.Kind == regapi.EntryUpdate || op.Kind == regapi.EntryDelete {
+				stored, err := changes.snapshot.GetEntry(op.Entry.ID)
+				if err != nil {
+					l.Push(lua.LNil)
+					l.Push(lua.WrapErrorWithLua(l, err, "resolve overlay entry kind"))
+					return 2
+				}
+				kind = stored.Kind
+			}
+			verb := "unknown"
+			switch op.Kind {
+			case regapi.EntryCreate:
+				verb = "create"
+			case regapi.EntryUpdate:
+				verb = "update"
+			case regapi.EntryDelete:
+				verb = "delete"
+			}
+			action := "registry.overlay." + verb + "." + kind
+			if !security.IsAllowed(l.Context(), action, op.Entry.ID.String(), nil) {
+				l.Push(lua.LNil)
+				l.Push(lua.NewLuaError(l, "not allowed to apply "+kind+" overlay entry: "+op.Entry.ID.String()).
+					WithKind(lua.PermissionDenied).
+					WithRetryable(false))
+				return 2
+			}
+		}
+		writer, ok := changes.snapshot.reg.(regapi.OverlayWriter)
+		if !ok {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "registry overlays are not supported").
+				WithKind(lua.Internal).
+				WithRetryable(false))
+			return 2
+		}
+		if _, applyErr := writer.ApplyOverlay(l.Context(), owner, changes.snapshot.overlayGen, changes.ops); applyErr != nil {
+			l.Push(lua.LNil)
+			l.Push(lua.WrapErrorWithLua(l, applyErr, "apply registry overlay"))
+			return 2
+		}
+		version, currentErr := changes.snapshot.reg.Current()
+		if currentErr != nil {
+			l.Push(lua.LNil)
+			l.Push(lua.WrapErrorWithLua(l, currentErr, "get current registry version"))
+			return 2
+		}
+		value.PushTypedUserData(l, version, typeVersion)
+		l.Push(lua.LNil)
 		return 2
 	}
 

--- a/runtime/lua/modules/registry/changes.go
+++ b/runtime/lua/modules/registry/changes.go
@@ -128,7 +128,7 @@ func changesDelete(l *lua.LState) int {
 
 	ids, parseErr := deleteIDs(l.Get(2))
 	if parseErr != nil {
-		err := lua.NewLuaError(l, "invalid ID format").
+		err := lua.WrapErrorWithLua(l, parseErr, "parse registry entry IDs").
 			WithKind(lua.Invalid).
 			WithRetryable(false)
 		l.Push(lua.LNil)
@@ -170,13 +170,22 @@ func deleteIDs(value lua.LValue) ([]regapi.ID, error) {
 			}
 			seenTables[v] = struct{}{}
 			if idValue := v.RawGetString("id"); idValue != lua.LNil {
-				stack = append(stack, idValue)
+				id, ok := idValue.(lua.LString)
+				if !ok {
+					return nil, fmt.Errorf("entry id must be a string, got %s", idValue.Type())
+				}
+				ids = append(ids, regapi.ParseID(string(id)))
 				continue
 			}
 			ns := v.RawGetString("ns")
 			name := v.RawGetString("name")
-			if ns != lua.LNil && name != lua.LNil {
-				ids = append(ids, regapi.NewID(ns.String(), name.String()))
+			if ns != lua.LNil || name != lua.LNil {
+				nsString, nsOK := ns.(lua.LString)
+				nameString, nameOK := name.(lua.LString)
+				if !nsOK || !nameOK {
+					return nil, fmt.Errorf("entry ns and name must both be strings")
+				}
+				ids = append(ids, regapi.NewID(string(nsString), string(nameString)))
 				continue
 			}
 			if v.Len() == 0 {
@@ -232,10 +241,13 @@ func changesApply(l *lua.LState) int {
 		for _, op := range changes.ops {
 			kind := op.Entry.Kind
 			if op.Kind == regapi.EntryUpdate || op.Kind == regapi.EntryDelete {
-				stored, err := changes.snapshot.GetEntry(op.Entry.ID)
-				if err != nil {
+				stored, getErr := changes.snapshot.GetEntry(op.Entry.ID)
+				if getErr != nil {
 					l.Push(lua.LNil)
-					l.Push(lua.WrapErrorWithLua(l, err, "resolve overlay entry kind"))
+					l.Push(lua.NewLuaError(l, "registry overlay entry not found: "+op.Entry.ID.String()).
+						WithKind(lua.NotFound).
+						WithRetryable(false).
+						WithDetails(map[string]any{"entry_id": op.Entry.ID.String(), "owner": owner}))
 					return 2
 				}
 				kind = stored.Kind

--- a/runtime/lua/modules/registry/changes_test.go
+++ b/runtime/lua/modules/registry/changes_test.go
@@ -82,6 +82,31 @@ func TestChangesToStringEmpty(t *testing.T) {
 	}
 }
 
+func TestDeleteIDsAcceptsEntryListsForBulkOverlayDelete(t *testing.T) {
+	l := newTestState()
+	defer l.Close()
+
+	entries := l.CreateTable(2, 0)
+	first := l.CreateTable(0, 1)
+	first.RawSetString("id", lua.LString("runtime.env:host"))
+	second := l.CreateTable(0, 2)
+	second.RawSetString("ns", lua.LString("runtime.db"))
+	second.RawSetString("name", lua.LString("source"))
+	entries.RawSetInt(1, first)
+	entries.RawSetInt(2, second)
+
+	ids, err := deleteIDs(entries)
+	if err != nil {
+		t.Fatalf("deleteIDs returned error: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected two IDs, got %d", len(ids))
+	}
+	if ids[0].String() != "runtime.env:host" || ids[1].String() != "runtime.db:source" {
+		t.Fatalf("unexpected IDs: %v", ids)
+	}
+}
+
 // A writer unaware of root status must not demote a deployment root. This is
 // the shape keeper takes on every dependency update: read the entry, change a
 // field, write it back. Absence of root on an update means unchanged.

--- a/runtime/lua/modules/registry/changes_test.go
+++ b/runtime/lua/modules/registry/changes_test.go
@@ -182,3 +182,14 @@ func TestChangesUpdateHonoursExplicitDemotion(t *testing.T) {
 		t.Error("expected an explicit root=false to demote the entry")
 	}
 }
+
+func TestDeleteIDsRejectsCyclicTables(t *testing.T) {
+	l := newTestState()
+	defer l.Close()
+	table := l.CreateTable(1, 0)
+	table.RawSetInt(1, table)
+
+	if _, err := deleteIDs(table); err == nil {
+		t.Fatal("expected cyclic ID table to be rejected")
+	}
+}

--- a/runtime/lua/modules/registry/changes_test.go
+++ b/runtime/lua/modules/registry/changes_test.go
@@ -3,11 +3,14 @@
 package registry
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/attrs"
 	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
 	"go.uber.org/zap"
 )
 
@@ -192,4 +195,53 @@ func TestDeleteIDsRejectsCyclicTables(t *testing.T) {
 	if _, err := deleteIDs(table); err == nil {
 		t.Fatal("expected cyclic ID table to be rejected")
 	}
+}
+
+func TestDeleteIDsRejectsMalformedEntryShapes(t *testing.T) {
+	l := newTestState()
+	defer l.Close()
+
+	tests := map[string]*lua.LTable{
+		"non-string id": func() *lua.LTable {
+			entry := l.CreateTable(0, 1)
+			entry.RawSetString("id", lua.LNumber(1))
+			return entry
+		}(),
+		"partial ns and name": func() *lua.LTable {
+			entry := l.CreateTable(0, 1)
+			entry.RawSetString("ns", lua.LString("runtime"))
+			return entry
+		}(),
+		"non-string ns and name": func() *lua.LTable {
+			entry := l.CreateTable(0, 2)
+			entry.RawSetString("ns", lua.LBool(true))
+			entry.RawSetString("name", lua.LString("source"))
+			return entry
+		}(),
+	}
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := deleteIDs(entry)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestChangesDeleteReturnsActionableInvalidError(t *testing.T) {
+	l := newTestState()
+	defer l.Close()
+	lua.OpenErrors(l)
+	value.PushTypedUserData(l, &Changes{ops: []regapi.Operation{}, log: zap.NewNop()}, typeChanges)
+	l.SetGlobal("changes", l.Get(-1))
+	l.Pop(1)
+
+	require.NoError(t, l.DoString(`
+		local _, err = changes:delete({ id = 1 })
+		assert(err ~= nil)
+		assert(err:kind() == errors.INVALID)
+		assert(err:retryable() == false)
+		message = err:message()
+	`))
+	message := string(l.GetGlobal("message").(lua.LString))
+	require.True(t, strings.Contains(message, "entry id must be a string"), message)
 }

--- a/runtime/lua/modules/registry/module.go
+++ b/runtime/lua/modules/registry/module.go
@@ -108,6 +108,14 @@ func NewModule(opts Options) *luaapi.ModuleDef {
 }
 
 func registryOverlay(l *lua.LState) int {
+	ctx := l.Context()
+	if ctx == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "no context").
+			WithKind(lua.Internal).
+			WithRetryable(false))
+		return 2
+	}
 	owner, ownerErr := regapi.CanonicalOverlayOwner(l.CheckString(1))
 	if ownerErr != nil {
 		l.Push(lua.LNil)
@@ -116,14 +124,21 @@ func registryOverlay(l *lua.LState) int {
 			WithRetryable(false))
 		return 2
 	}
-	if !security.IsAllowed(l.Context(), "registry.overlay.get", owner, nil) {
+	reg := regapi.GetRegistry(ctx)
+	if reg == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "registry not found in context").
+			WithKind(lua.Internal).
+			WithRetryable(false))
+		return 2
+	}
+	if !security.IsAllowed(ctx, "registry.overlay.get", owner, nil) {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, "not allowed to read registry overlay: "+owner).
 			WithKind(lua.PermissionDenied).
 			WithRetryable(false))
 		return 2
 	}
-	reg := regapi.GetRegistry(l.Context())
 	writer, ok := reg.(regapi.OverlayWriter)
 	if !ok {
 		l.Push(lua.LNil)

--- a/runtime/lua/modules/registry/module.go
+++ b/runtime/lua/modules/registry/module.go
@@ -108,7 +108,14 @@ func NewModule(opts Options) *luaapi.ModuleDef {
 }
 
 func registryOverlay(l *lua.LState) int {
-	owner := l.CheckString(1)
+	owner, ownerErr := regapi.CanonicalOverlayOwner(l.CheckString(1))
+	if ownerErr != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, ownerErr, "canonicalize registry overlay owner").
+			WithKind(lua.Invalid).
+			WithRetryable(false))
+		return 2
+	}
 	if !security.IsAllowed(l.Context(), "registry.overlay.get", owner, nil) {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, "not allowed to read registry overlay: "+owner).

--- a/runtime/lua/modules/registry/module.go
+++ b/runtime/lua/modules/registry/module.go
@@ -88,7 +88,7 @@ func NewModule(opts Options) *luaapi.ModuleDef {
 		Description: "Registry operations for entries, snapshots, and versioning",
 		Class:       []string{luaapi.ClassNondeterministic, luaapi.ClassStorage},
 		Build: func() (*lua.LTable, []luaapi.YieldType) {
-			mod := lua.CreateTable(0, 10)
+			mod := lua.CreateTable(0, 11)
 			mod.RawSetString("get", lua.LGoFunc(registryGet))
 			mod.RawSetString("find", lua.LGoFunc(registryFind))
 			mod.RawSetString("parse_id", lua.LGoFunc(parseID))
@@ -99,11 +99,54 @@ func NewModule(opts Options) *luaapi.ModuleDef {
 			mod.RawSetString("history", lua.LGoFunc(registryHistory))
 			mod.RawSetString("apply_version", lua.LGoFunc(registryApplyVersion))
 			mod.RawSetString("build_delta", makeBuildDelta(opts.Log))
+			mod.RawSetString("overlay", lua.LGoFunc(registryOverlay))
 			mod.Immutable = true
 			return mod, nil
 		},
 		Types: ModuleTypes,
 	}
+}
+
+func registryOverlay(l *lua.LState) int {
+	owner := l.CheckString(1)
+	if !security.IsAllowed(l.Context(), "registry.overlay.get", owner, nil) {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "not allowed to read registry overlay: "+owner).
+			WithKind(lua.PermissionDenied).
+			WithRetryable(false))
+		return 2
+	}
+	reg := regapi.GetRegistry(l.Context())
+	writer, ok := reg.(regapi.OverlayWriter)
+	if !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "registry overlays are not supported").
+			WithKind(lua.Internal).
+			WithRetryable(false))
+		return 2
+	}
+	entries, generation, err := writer.GetOverlay(owner)
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "get registry overlay"))
+		return 2
+	}
+	version, versionErr := reg.Current()
+	if versionErr != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, versionErr, "get current registry version"))
+		return 2
+	}
+	value.PushTypedUserData(l, &Snapshot{
+		reg:          reg,
+		version:      version,
+		log:          zap.NewNop(),
+		overlayOwner: owner,
+		overlayGen:   generation,
+		entries:      entries,
+	}, typeSnapshot)
+	l.Push(lua.LNil)
+	return 2
 }
 
 // Module functions

--- a/runtime/lua/modules/registry/module_test.go
+++ b/runtime/lua/modules/registry/module_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	envapi "github.com/wippyai/runtime/api/env"
 	"github.com/wippyai/runtime/api/payload"
@@ -39,7 +41,7 @@ func TestLoad(t *testing.T) {
 
 	functions := []string{
 		"snapshot", "current_version", "versions",
-		"parse_id", "history", "find", "get", "build_delta",
+		"parse_id", "history", "find", "get", "build_delta", "overlay",
 	}
 	for _, fn := range functions {
 		if modTbl.RawGetString(fn).Type() != lua.LTFunction {
@@ -599,7 +601,12 @@ func TestParseIDEdgeCases(t *testing.T) {
 
 // mockRegistry implements regapi.Registry for testing
 type mockRegistry struct {
-	entries map[string]regapi.Entry
+	currentVersion regapi.Version
+	entries        map[string]regapi.Entry
+	overlayEntries map[string]regapi.State
+	appliedOwner   string
+	appliedChanges regapi.ChangeSet
+	generation     uint64
 }
 
 func (m *mockRegistry) GetEntry(id regapi.ID) (regapi.Entry, error) {
@@ -615,7 +622,7 @@ func (m *mockRegistry) GetAllEntries() ([]regapi.Entry, error) {
 }
 
 func (m *mockRegistry) Current() (regapi.Version, error) {
-	return nil, nil
+	return m.currentVersion, nil
 }
 
 func (m *mockRegistry) Apply(_ context.Context, _ regapi.ChangeSet) (regapi.Version, error) {
@@ -638,6 +645,17 @@ func (m *mockRegistry) RegisterDependencyPattern(_ regapi.DependencyPattern) err
 	return nil
 }
 
+func (m *mockRegistry) ApplyOverlay(_ context.Context, owner string, _ uint64, changes regapi.ChangeSet) (uint64, error) {
+	m.appliedOwner = owner
+	m.appliedChanges = append(regapi.ChangeSet(nil), changes...)
+	m.generation++
+	return m.generation, nil
+}
+
+func (m *mockRegistry) GetOverlay(owner string) (regapi.State, uint64, error) {
+	return append(regapi.State(nil), m.overlayEntries[owner]...), m.generation, nil
+}
+
 func setupContextWithTranscoder() context.Context {
 	// Create app context
 	appCtx := ctxapi.NewAppContext()
@@ -653,6 +671,43 @@ func setupContextWithTranscoder() context.Context {
 	ctx = security.SetStrictMode(ctx, false)
 
 	return ctx
+}
+
+func TestRegistryOverlayUsesNormalSnapshotAndChanges(t *testing.T) {
+	ctx := setupContextWithTranscoder()
+	owner := "app.runtime:source-1"
+	entry := regapi.Entry{
+		ID:   regapi.NewID("app.runtime", "db"),
+		Kind: "db.sql.postgres",
+		Data: payload.NewPayload(map[string]any{"host_env": "app.env:host"}, payload.Golang),
+	}
+	mockReg := &mockRegistry{
+		entries:        map[string]regapi.Entry{},
+		overlayEntries: map[string]regapi.State{owner: {entry}},
+		currentVersion: &mockVersion{id: 7, str: "v7"},
+	}
+	ctx = regapi.WithRegistry(ctx, mockReg)
+
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+	lua.OpenErrors(l)
+	setupModule(l)
+	require.NoError(t, l.DoString(`
+		local snap, err = registry.overlay("app.runtime:source-1")
+		assert(err == nil and snap ~= nil)
+		local entries, entries_err = snap:entries()
+		assert(entries_err == nil and #entries == 1)
+		assert(snap:version():id() == 7)
+		entries[1].data.host_env = "app.env:rotated_host"
+		local changes = snap:changes()
+		changes:update(entries[1])
+		local _, apply_err = changes:apply()
+		assert(apply_err == nil)
+	`))
+	assert.Equal(t, owner, mockReg.appliedOwner)
+	require.Len(t, mockReg.appliedChanges, 1)
+	assert.Equal(t, regapi.EntryUpdate, mockReg.appliedChanges[0].Kind)
 }
 
 func TestRegistryGetWithEntryData(t *testing.T) {

--- a/runtime/lua/modules/registry/module_test.go
+++ b/runtime/lua/modules/registry/module_test.go
@@ -710,6 +710,55 @@ func TestRegistryOverlayUsesNormalSnapshotAndChanges(t *testing.T) {
 	assert.Equal(t, regapi.EntryUpdate, mockReg.appliedChanges[0].Kind)
 }
 
+func TestRegistryOverlayWithoutContextOrRegistry(t *testing.T) {
+	testMissingRegistry := func(t *testing.T, ctx context.Context) {
+		l := lua.NewState()
+		defer l.Close()
+		if ctx != nil {
+			l.SetContext(ctx)
+		}
+		lua.OpenErrors(l)
+		setupModule(l)
+		require.NoError(t, l.DoString(`
+				local snap, err = registry.overlay("runtime:owner")
+				assert(snap == nil and err ~= nil)
+				assert(err:kind() == errors.INTERNAL)
+				assert(err:retryable() == false)
+			`))
+	}
+	t.Run("context", func(t *testing.T) { testMissingRegistry(t, nil) })
+	t.Run("registry", func(t *testing.T) { testMissingRegistry(t, setupContextWithTranscoder()) })
+}
+
+func TestRegistryOverlayUpdateMissingEntryReturnsNotFound(t *testing.T) {
+	ctx := setupContextWithTranscoder()
+	mockReg := &mockRegistry{
+		entries:        map[string]regapi.Entry{},
+		overlayEntries: map[string]regapi.State{"runtime:owner": nil},
+		currentVersion: &mockVersion{id: 1, str: "v1"},
+	}
+	ctx = regapi.WithRegistry(ctx, mockReg)
+
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+	lua.OpenErrors(l)
+	setupModule(l)
+	require.NoError(t, l.DoString(`
+		local snap = assert(registry.overlay("runtime:owner"))
+		local changes = snap:changes()
+		changes:update({ id = "runtime:missing", kind = "registry.entry" })
+		local version, err = changes:apply()
+		assert(version == nil and err ~= nil)
+		assert(err:kind() == errors.NOT_FOUND)
+		assert(err:retryable() == false)
+		local details = err:details()
+		assert(details.entry_id == "runtime:missing")
+		assert(details.owner == "runtime:owner")
+	`))
+	assert.Empty(t, mockReg.appliedChanges)
+}
+
 func TestRegistryGetWithEntryData(t *testing.T) {
 	// Create context with transcoder
 	ctx := setupContextWithTranscoder()

--- a/runtime/lua/modules/registry/overlay_security_test.go
+++ b/runtime/lua/modules/registry/overlay_security_test.go
@@ -85,6 +85,31 @@ func TestOverlaySecurityRequiresOwnerRead(t *testing.T) {
 	assert.Empty(t, reg.appliedChanges)
 }
 
+func TestOverlaySecurityAuthorizesCanonicalOwnerIdentity(t *testing.T) {
+	const owner = "data-sources:one"
+
+	t.Run("canonical permission accepts padded input", func(t *testing.T) {
+		ctx, release := strictOverlayContext(t, "registry.overlay.get\x00"+owner)
+		defer release()
+		reg := overlayTestRegistry(owner, nil)
+		runOverlayLua(ctx, t, reg, `
+			local snap, err = registry.overlay("  data-sources:one  ")
+			assert(err == nil and snap ~= nil)
+		`)
+	})
+
+	t.Run("padded permission cannot alias canonical owner", func(t *testing.T) {
+		ctx, release := strictOverlayContext(t, "registry.overlay.get\x00  "+owner+"  ")
+		defer release()
+		reg := overlayTestRegistry(owner, nil)
+		runOverlayLua(ctx, t, reg, `
+			local snap, err = registry.overlay("  data-sources:one  ")
+			assert(snap == nil and err ~= nil)
+			assert(err:kind() == errors.PERMISSION_DENIED)
+		`)
+	})
+}
+
 func TestOverlaySecurityChecksKindAndRealEntryID(t *testing.T) {
 	const owner = "data-sources:one"
 	entry := regapi.Entry{

--- a/runtime/lua/modules/registry/overlay_security_test.go
+++ b/runtime/lua/modules/registry/overlay_security_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	secapi "github.com/wippyai/runtime/api/security"
+	luapayload "github.com/wippyai/runtime/runtime/lua/engine/payload"
+	transcoder "github.com/wippyai/runtime/system/payload"
+	"github.com/wippyai/runtime/system/payload/json"
+	secsystem "github.com/wippyai/runtime/system/security"
+)
+
+type overlayPolicy struct {
+	allowed map[string]struct{}
+}
+
+func (p overlayPolicy) ID() regapi.ID {
+	return regapi.NewID("test", "overlay_policy")
+}
+
+func (p overlayPolicy) Evaluate(_ secapi.Actor, action, resource string, _ attrs.Bag) secapi.Result {
+	if _, ok := p.allowed[action+"\x00"+resource]; ok {
+		return secapi.Allow
+	}
+	return secapi.Deny
+}
+
+func strictOverlayContext(t *testing.T, allowed ...string) (context.Context, func()) {
+	t.Helper()
+	ctx := ctxapi.NewRootContext()
+	dtt := transcoder.GlobalTranscoder()
+	json.Register(dtt)
+	luapayload.Register(dtt)
+	ctx = payload.WithTranscoder(ctx, dtt)
+	ctx = secapi.SetStrictMode(ctx, true)
+	ctx, frame := ctxapi.OpenFrameContext(ctx)
+	permissions := make(map[string]struct{}, len(allowed))
+	for _, permission := range allowed {
+		permissions[permission] = struct{}{}
+	}
+	require.NoError(t, secapi.SetActor(ctx, secapi.Actor{ID: "controller"}))
+	require.NoError(t, secapi.SetScope(ctx, secsystem.NewScope([]secapi.Policy{overlayPolicy{allowed: permissions}})))
+	return ctx, func() { ctxapi.ReleaseFrameContext(frame) }
+}
+
+func overlayTestRegistry(owner string, entries regapi.State) *mockRegistry {
+	return &mockRegistry{
+		entries:        map[string]regapi.Entry{},
+		overlayEntries: map[string]regapi.State{owner: entries},
+		currentVersion: &mockVersion{id: 3, str: "v3"},
+	}
+}
+
+func runOverlayLua(ctx context.Context, t *testing.T, reg *mockRegistry, source string) {
+	t.Helper()
+	ctx = regapi.WithRegistry(ctx, reg)
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+	lua.OpenErrors(l)
+	setupModule(l)
+	require.NoError(t, l.DoString(source))
+}
+
+func TestOverlaySecurityRequiresOwnerRead(t *testing.T) {
+	const owner = "data-sources:one"
+	ctx, release := strictOverlayContext(t)
+	defer release()
+	reg := overlayTestRegistry(owner, nil)
+	runOverlayLua(ctx, t, reg, `
+		local snap, err = registry.overlay("data-sources:one")
+		assert(snap == nil and err ~= nil)
+		assert(err:kind() == errors.PERMISSION_DENIED)
+	`)
+	assert.Empty(t, reg.appliedChanges)
+}
+
+func TestOverlaySecurityChecksKindAndRealEntryID(t *testing.T) {
+	const owner = "data-sources:one"
+	entry := regapi.Entry{
+		ID:   regapi.NewID("data-sources.runtime", "one"),
+		Kind: "db.sql.postgres",
+		Data: payload.NewPayload(map[string]any{"host": "db.internal"}, payload.Golang),
+	}
+	ctx, release := strictOverlayContext(t,
+		"registry.overlay.get\x00"+owner,
+		"registry.overlay.apply\x00"+owner,
+		"registry.overlay.update.db.sql.postgres\x00data-sources.runtime:other",
+	)
+	defer release()
+	reg := overlayTestRegistry(owner, regapi.State{entry})
+	runOverlayLua(ctx, t, reg, `
+		local snap = assert(registry.overlay("data-sources:one"))
+		local entries = assert(snap:entries())
+		entries[1].data.host = "changed.internal"
+		local changes = snap:changes()
+		changes:update(entries[1])
+		local version, err = changes:apply()
+		assert(version == nil and err ~= nil)
+		assert(err:kind() == errors.PERMISSION_DENIED)
+	`)
+	assert.Empty(t, reg.appliedChanges)
+}
+
+func TestOverlaySecurityBulkDeleteIsAuthorizedAndAtomic(t *testing.T) {
+	const owner = "data-sources:one"
+	db := regapi.Entry{ID: regapi.NewID("data-sources.runtime", "one"), Kind: "db.sql.postgres"}
+	env := regapi.Entry{ID: regapi.NewID("data-sources.env", "one_password"), Kind: "env.variable"}
+
+	t.Run("authorized", func(t *testing.T) {
+		ctx, release := strictOverlayContext(t,
+			"registry.overlay.get\x00"+owner,
+			"registry.overlay.apply\x00"+owner,
+			"registry.overlay.delete.db.sql.postgres\x00"+db.ID.String(),
+			"registry.overlay.delete.env.variable\x00"+env.ID.String(),
+		)
+		defer release()
+		reg := overlayTestRegistry(owner, regapi.State{db, env})
+		runOverlayLua(ctx, t, reg, `
+			local snap = assert(registry.overlay("data-sources:one"))
+			local entries = assert(snap:entries())
+			local changes = snap:changes()
+			changes:delete(entries)
+			local _, err = changes:apply()
+			assert(err == nil)
+		`)
+		require.Len(t, reg.appliedChanges, 2)
+		assert.Equal(t, regapi.EntryDelete, reg.appliedChanges[0].Kind)
+		assert.Equal(t, regapi.EntryDelete, reg.appliedChanges[1].Kind)
+	})
+
+	t.Run("one denied rejects entire changeset", func(t *testing.T) {
+		ctx, release := strictOverlayContext(t,
+			"registry.overlay.get\x00"+owner,
+			"registry.overlay.apply\x00"+owner,
+			"registry.overlay.delete.db.sql.postgres\x00"+db.ID.String(),
+		)
+		defer release()
+		reg := overlayTestRegistry(owner, regapi.State{db, env})
+		runOverlayLua(ctx, t, reg, `
+			local snap = assert(registry.overlay("data-sources:one"))
+			local entries = assert(snap:entries())
+			local changes = snap:changes()
+			changes:delete(entries)
+			local version, err = changes:apply()
+			assert(version == nil and err ~= nil)
+			assert(err:kind() == errors.PERMISSION_DENIED)
+		`)
+		assert.Empty(t, reg.appliedChanges)
+	})
+}
+
+func TestOverlayChangesOpsReauthorizesRetainedSnapshot(t *testing.T) {
+	const owner = "data-sources:one"
+	ctx, release := strictOverlayContext(t, "registry.overlay.get\x00"+owner)
+	defer release()
+	reg := overlayTestRegistry(owner, nil)
+	ctx = regapi.WithRegistry(ctx, reg)
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+	lua.OpenErrors(l)
+	setupModule(l)
+	require.NoError(t, l.DoString(`
+		snap = assert(registry.overlay("data-sources:one"))
+		changes = snap:changes()
+		changes:create({ id = "data-sources.runtime:one", kind = "db.sql.postgres" })
+	`))
+	require.NoError(t, secapi.SetScope(ctx, secsystem.NewScope([]secapi.Policy{overlayPolicy{allowed: map[string]struct{}{}}})))
+	require.NoError(t, l.DoString(`
+		local ops, err = changes:ops()
+		assert(ops == nil and err ~= nil)
+		assert(err:kind() == errors.PERMISSION_DENIED)
+	`))
+}

--- a/runtime/lua/modules/registry/snapshot.go
+++ b/runtime/lua/modules/registry/snapshot.go
@@ -15,10 +15,23 @@ import (
 
 // Snapshot represents a point-in-time view of the registry
 type Snapshot struct {
-	reg     regapi.Registry
-	version regapi.Version
-	log     *zap.Logger
-	entries []regapi.Entry
+	reg          regapi.Registry
+	version      regapi.Version
+	log          *zap.Logger
+	overlayOwner string
+	entries      []regapi.Entry
+	overlayGen   uint64
+}
+
+func authorizeSnapshotRead(l *lua.LState, snap *Snapshot) bool {
+	if snap.overlayOwner == "" || security.IsAllowed(l.Context(), "registry.overlay.get", snap.overlayOwner, nil) {
+		return true
+	}
+	l.Push(lua.LNil)
+	l.Push(lua.NewLuaError(l, "not allowed to read registry overlay: "+snap.overlayOwner).
+		WithKind(lua.PermissionDenied).
+		WithRetryable(false))
+	return false
 }
 
 // GetAllEntries returns all entries in the snapshot
@@ -42,6 +55,9 @@ func snapshotEntries(l *lua.LState) int {
 	if snap == nil {
 		return 0
 	}
+	if !authorizeSnapshotRead(l, snap) {
+		return 2
+	}
 
 	entries, getErr := snap.GetAllEntries()
 	if getErr != nil {
@@ -56,7 +72,7 @@ func snapshotEntries(l *lua.LState) int {
 	entriesTable := l.CreateTable(len(entries), 0)
 	idx := 1
 	for _, entry := range entries {
-		if !security.IsAllowed(l.Context(), "registry.get", entry.ID.String(), nil) {
+		if snap.overlayOwner == "" && !security.IsAllowed(l.Context(), "registry.get", entry.ID.String(), nil) {
 			continue
 		}
 
@@ -84,11 +100,14 @@ func snapshotGet(l *lua.LState) int {
 	if snap == nil {
 		return 0
 	}
+	if !authorizeSnapshotRead(l, snap) {
+		return 2
+	}
 
 	idStr := l.CheckString(2)
 	id := regapi.ParseID(idStr)
 
-	if !security.IsAllowed(l.Context(), "registry.get", id.String(), nil) {
+	if snap.overlayOwner == "" && !security.IsAllowed(l.Context(), "registry.get", id.String(), nil) {
 		err := lua.NewLuaError(l, "not allowed to access entry: "+id.String()).
 			WithKind(lua.PermissionDenied).
 			WithRetryable(false)
@@ -128,13 +147,16 @@ func snapshotNamespace(l *lua.LState) int {
 	if snap == nil {
 		return 0
 	}
+	if !authorizeSnapshotRead(l, snap) {
+		return 2
+	}
 
 	ns := l.CheckString(2)
 
 	var result []regapi.Entry
 	for _, entry := range snap.entries {
 		if entry.ID.NS == ns {
-			if security.IsAllowed(l.Context(), "registry.get", entry.ID.String(), nil) {
+			if snap.overlayOwner != "" || security.IsAllowed(l.Context(), "registry.get", entry.ID.String(), nil) {
 				result = append(result, entry)
 			}
 		}
@@ -164,6 +186,9 @@ func snapshotFind(l *lua.LState) int {
 	if snap == nil {
 		return 0
 	}
+	if !authorizeSnapshotRead(l, snap) {
+		return 2
+	}
 
 	filterTable := l.CheckTable(2)
 	meta := convertFilterToMetadata(l, filterTable)
@@ -192,7 +217,7 @@ func snapshotFind(l *lua.LState) int {
 	entriesTable := l.CreateTable(len(entries), 0)
 	idx := 1
 	for _, entry := range entries {
-		if !security.IsAllowed(l.Context(), "registry.get", entry.ID.String(), nil) {
+		if snap.overlayOwner == "" && !security.IsAllowed(l.Context(), "registry.get", entry.ID.String(), nil) {
 			continue
 		}
 
@@ -219,6 +244,9 @@ func snapshotChanges(l *lua.LState) int {
 	if snap == nil {
 		return 0
 	}
+	if !authorizeSnapshotRead(l, snap) {
+		return 2
+	}
 
 	changes := &Changes{
 		snapshot: snap,
@@ -235,6 +263,9 @@ func snapshotVersion(l *lua.LState) int {
 	snap := checkSnapshot(l)
 	if snap == nil {
 		return 0
+	}
+	if !authorizeSnapshotRead(l, snap) {
+		return 2
 	}
 
 	value.PushTypedUserData(l, snap.version, typeVersion)

--- a/runtime/lua/modules/registry/spec.md
+++ b/runtime/lua/modules/registry/spec.md
@@ -204,6 +204,7 @@ effective registry and continue to require their existing per-entry
 | Empty owner | errors.INVALID | no |
 | Owner read/apply denied | errors.PERMISSION_DENIED | no |
 | Entry operation denied | errors.PERMISSION_DENIED | no |
+| Updated/deleted entry absent from snapshot | errors.NOT_FOUND | no |
 | Stale overlay generation | errors.CONFLICT | yes |
 | Directive-owned kind | errors.INVALID | no |
 

--- a/runtime/lua/modules/registry/spec.md
+++ b/runtime/lua/modules/registry/spec.md
@@ -139,6 +139,58 @@ Creates a snapshot of the registry at a specific version.
 | Version not found | errors.NOT_FOUND | no |
 | Build snapshot state failed | errors.INTERNAL | no |
 
+### overlay(id: string) → Snapshot, error
+
+Opens the process-local registry overlay owned by `id`. It returns the regular
+`Snapshot` type, so callers use the existing `snapshot:changes()` and
+`changes:apply()` workflow. Overlay entries participate in normal registry
+topology and resource lifecycle, but never create a history version. They
+survive ordinary history commits and version selection, and are cleared by a
+cold boot or explicit state load; the owning controller must reconcile them.
+
+Applying changes uses generation-based optimistic concurrency. A stale snapshot
+fails atomically and must be reopened. One changeset may contain at most one
+operation for each entry ID.
+
+```lua
+local live, err = registry.overlay("spiralscout.data_sources:customer-db")
+if err then return nil, err end
+
+local changes = live:changes()
+changes:create({
+    id = "spiralscout.data_sources.runtime:customer-db",
+    kind = "db.sql.postgres",
+    data = { host = "db.example.com", database = "customer" },
+})
+local version, apply_err = changes:apply()
+
+-- Deprovision every entry in this overlay in one dependency-sorted apply.
+local current, open_err = registry.overlay("spiralscout.data_sources:customer-db")
+if open_err then return nil, open_err end
+local remove = current:changes()
+remove:delete(current:entries())
+local _, delete_err = remove:apply()
+```
+
+Authorization is checked when the overlay is opened and again on every
+snapshot operation and apply. Required actions are:
+
+- `registry.overlay.get` on the overlay ID
+- `registry.overlay.apply` on the overlay ID
+- `registry.overlay.create.<kind>`, `registry.overlay.update.<kind>`, or
+  `registry.overlay.delete.<kind>` on each real entry ID
+
+This second, per-entry check prevents a controller authorized for one overlay
+from creating arbitrary kinds or writing outside its allowed namespaces.
+
+The overlay ID is a logical, policy-controlled owner, not the caller's process
+ID. This lets a boot reconciler reopen resources created by an earlier control
+invocation. Grant exact or namespace-scoped owner policies deliberately; a
+wildcard owner grant authorizes that controller to manage every matching
+overlay. Ordinary `registry.get`, `find`, and `snapshot` read the composed
+effective registry and continue to require their existing per-entry
+`registry.get` permission—they do not use the owner-level overlay permission.
+
 ### current_version() → Version, error
 
 Returns the current registry version.
@@ -331,7 +383,7 @@ Returned by `snapshot:changes()`. Used to build and apply changesets.
 | ops | () | table[] | List of operations |
 | create | (entry: table) | Changes | Add create operation |
 | update | (entry: table) | Changes | Add update operation |
-| delete | (id: string \| table) | Changes | Add delete operation |
+| delete | (id or id[]) | Changes | Add one or more delete operations |
 | apply | () | Version, error | Apply changes |
 
 #### changes:ops() → table[]
@@ -376,13 +428,13 @@ Adds an update operation to the changeset.
 | Invalid entry format | errors.INVALID | no |
 | Conversion failed | errors.INVALID | no |
 
-#### changes:delete(id: string | table) → Changes
+#### changes:delete(id_or_ids: string | table | table[]) → Changes
 
 Adds a delete operation to the changeset.
 
 | Param | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
-| id | string \| table | yes | - | Entry ID string or table with ns/name |
+| id_or_ids | string \| table \| table[] | yes | - | ID, entry with `id`, ns/name table, or nested list of these |
 
 **Returns:** Changes object (for chaining)
 
@@ -398,11 +450,16 @@ changes:delete("app.test:example")
 
 -- Table ID
 changes:delete({ns = "app.test", name = "example"})
+
+-- Bulk delete (duplicates are ignored)
+changes:delete(snapshot:entries())
 ```
 
 #### changes:apply() → Version, error
 
-Applies the changeset to create a new registry version.
+Applies the changeset. A normal snapshot creates a registry version. An overlay
+snapshot changes only its process-local overlay and returns the unchanged
+current durable version.
 
 **Returns:**
 

--- a/runtime/lua/modules/registry/spec.md
+++ b/runtime/lua/modules/registry/spec.md
@@ -46,8 +46,8 @@ Retrieves a single entry by ID from the current registry state.
 
 `root` marks an `ns.dependency` selected as a deployment root. It is the sole
 authority for that status — `meta` is user space and carries no trust. Reads
-always return it; writes may omit it, and omitting it on an update demotes the
-entry, so carry it back on any read-modify-write.
+always return it. Updates preserve the stored value when `root` is omitted; set
+it explicitly only when changing root status.
 
 **Errors (structured):**
 
@@ -153,20 +153,25 @@ fails atomically with a retryable `errors.CONFLICT` and must be reopened. Owner
 IDs are trimmed to one canonical identity before authorization and storage. One
 changeset may contain at most one operation for each entry ID.
 
+Ownership is registry state, not entry metadata. Overlay application never adds
+an owner field to `meta` or otherwise changes user metadata. Kinds handled by a
+registry expansion directive are rejected because their generated entries and
+effects do not have process-local ownership semantics.
+
 ```lua
-local live, err = registry.overlay("spiralscout.data_sources:customer-db")
+local live, err = registry.overlay("controllers:customer-db")
 if err then return nil, err end
 
 local changes = live:changes()
 changes:create({
-    id = "spiralscout.data_sources.runtime:customer-db",
+    id = "runtime.data_sources:customer-db",
     kind = "db.sql.postgres",
     data = { host = "db.example.com", database = "customer" },
 })
 local version, apply_err = changes:apply()
 
 -- Deprovision every entry in this overlay in one dependency-sorted apply.
-local current, open_err = registry.overlay("spiralscout.data_sources:customer-db")
+local current, open_err = registry.overlay("controllers:customer-db")
 if open_err then return nil, open_err end
 local remove = current:changes()
 remove:delete(current:entries())
@@ -200,6 +205,7 @@ effective registry and continue to require their existing per-entry
 | Owner read/apply denied | errors.PERMISSION_DENIED | no |
 | Entry operation denied | errors.PERMISSION_DENIED | no |
 | Stale overlay generation | errors.CONFLICT | yes |
+| Directive-owned kind | errors.INVALID | no |
 
 ### current_version() → Version, error
 

--- a/runtime/lua/modules/registry/spec.md
+++ b/runtime/lua/modules/registry/spec.md
@@ -149,8 +149,9 @@ survive ordinary history commits and version selection, and are cleared by a
 cold boot or explicit state load; the owning controller must reconcile them.
 
 Applying changes uses generation-based optimistic concurrency. A stale snapshot
-fails atomically and must be reopened. One changeset may contain at most one
-operation for each entry ID.
+fails atomically with a retryable `errors.CONFLICT` and must be reopened. Owner
+IDs are trimmed to one canonical identity before authorization and storage. One
+changeset may contain at most one operation for each entry ID.
 
 ```lua
 local live, err = registry.overlay("spiralscout.data_sources:customer-db")
@@ -190,6 +191,15 @@ wildcard owner grant authorizes that controller to manage every matching
 overlay. Ordinary `registry.get`, `find`, and `snapshot` read the composed
 effective registry and continue to require their existing per-entry
 `registry.get` permission—they do not use the owner-level overlay permission.
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| Empty owner | errors.INVALID | no |
+| Owner read/apply denied | errors.PERMISSION_DENIED | no |
+| Entry operation denied | errors.PERMISSION_DENIED | no |
+| Stale overlay generation | errors.CONFLICT | yes |
 
 ### current_version() → Version, error
 

--- a/runtime/lua/modules/registry/types.go
+++ b/runtime/lua/modules/registry/types.go
@@ -46,7 +46,7 @@ func init() {
 		{Name: "ops", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewArray(typ.Any)).Build()},
 		{Name: "create", Type: typ.Func().Param("self", typ.Self).Param("op", typ.Any).Returns(typ.Self, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "update", Type: typ.Func().Param("self", typ.Self).Param("op", typ.Any).Returns(typ.Self, typ.NewOptional(typ.LuaError)).Build()},
-		{Name: "delete", Type: typ.Func().Param("self", typ.Self).Param("op", typ.Any).Returns(typ.Self, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "delete", Type: typ.Func().Param("self", typ.Self).Param("op_or_ops", typ.Any).Returns(typ.Self, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "apply", Type: typ.Func().Param("self", typ.Self).Returns(versionType, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
@@ -90,6 +90,7 @@ func ModuleTypes() *typio.Manifest {
 		{Name: "history", Type: typ.Func().Returns(historyType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "apply_version", Type: typ.Func().Param("version", versionType).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "build_delta", Type: typ.Func().Param("from", versionType).Param("to", versionType).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "overlay", Type: typ.Func().Param("id", typ.String).Returns(snapshotType, typ.NewOptional(typ.LuaError)).Build()},
 	})
 
 	m.SetExport(moduleType)

--- a/system/registry/errors.go
+++ b/system/registry/errors.go
@@ -109,6 +109,22 @@ func NewOverlayGenerationConflictError(owner string, expected, actual uint64) ap
 		}))
 }
 
+// NewOverlayValidationError reports an invalid overlay request. Ownership is
+// maintained by Reg and is never inferred from entry metadata.
+func NewOverlayValidationError(message string, details map[string]any) apierror.Error {
+	return apierror.New(apierror.Invalid, message).
+		WithRetryable(apierror.False).
+		WithDetails(attrs.NewBagFrom(details))
+}
+
+// NewOverlayConflictError reports a request that conflicts with the current
+// durable or owner-scoped registry state.
+func NewOverlayConflictError(message string, details map[string]any) apierror.Error {
+	return apierror.New(apierror.Conflict, message).
+		WithRetryable(apierror.False).
+		WithDetails(attrs.NewBagFrom(details))
+}
+
 // NewGetVersionsError creates an error when getting versions fails
 func NewGetVersionsError(err error) apierror.Error {
 	return apierror.New(apierror.Internal, "failed to get versions from history").

--- a/system/registry/errors.go
+++ b/system/registry/errors.go
@@ -97,6 +97,18 @@ func NewConcurrentApplyError(expected, actual uint) apierror.Error {
 		WithDetails(attrs.NewBagFrom(map[string]any{"expected_version": expected, "actual_version": actual}))
 }
 
+// NewOverlayGenerationConflictError reports an optimistic-concurrency conflict
+// against one process-local overlay.
+func NewOverlayGenerationConflictError(owner string, expected, actual uint64) apierror.Error {
+	return apierror.New(apierror.Conflict, "registry overlay changed during apply").
+		WithRetryable(apierror.True).
+		WithDetails(attrs.NewBagFrom(map[string]any{
+			"owner":               owner,
+			"expected_generation": expected,
+			"actual_generation":   actual,
+		}))
+}
+
 // NewGetVersionsError creates an error when getting versions fails
 func NewGetVersionsError(err error) apierror.Error {
 	return apierror.New(apierror.Internal, "failed to get versions from history").

--- a/system/registry/load_state_duplicate_test.go
+++ b/system/registry/load_state_duplicate_test.go
@@ -107,5 +107,8 @@ func TestRegistry_LoadStateCanonicalizesBaselineWithoutMutatingCaller(t *testing
 	stored, err := reg.GetEntry(canonicalID)
 	require.NoError(t, err)
 	require.Equal(t, canonicalID, stored.ID)
+	stored, err = reg.GetEntry(rawID)
+	require.NoError(t, err)
+	require.Equal(t, canonicalID, stored.ID)
 	require.Equal(t, rawID, baseline[0].ID)
 }

--- a/system/registry/load_state_duplicate_test.go
+++ b/system/registry/load_state_duplicate_test.go
@@ -83,3 +83,29 @@ func TestRegistry_LoadState_RejectsHydratedDuplicateBaselineIDs(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate entry id")
 }
+
+func TestRegistry_LoadStateCanonicalizesBaselineWithoutMutatingCaller(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	hist := history.NewMemory()
+	resolver := topology.NewResolver()
+	reg := NewRegistry(
+		hist,
+		NewTestRunner(),
+		topology.NewStateBuilder(logger, resolver),
+		resolver,
+		logger,
+	)
+
+	rawID := registry.ID{NS: "app", Name: "service"}
+	canonicalID := registry.NewID("app", "service")
+	baseline := registry.State{{ID: rawID, Kind: registry.EntryKind}}
+	head, err := reg.Current()
+	require.NoError(t, err)
+	require.NoError(t, reg.LoadState(ctx, baseline, head))
+
+	stored, err := reg.GetEntry(canonicalID)
+	require.NoError(t, err)
+	require.Equal(t, canonicalID, stored.ID)
+	require.Equal(t, rawID, baseline[0].ID)
+}

--- a/system/registry/overlay.go
+++ b/system/registry/overlay.go
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/system/registry/topology"
+)
+
+const overlayOwnerMeta = "overlay_owner"
+
+// ApplyOverlay applies an owner-scoped process-local changeset without
+// advancing registry history. The entries remain part of effective state until
+// explicitly cleared or the process exits.
+func (r *Reg) ApplyOverlay(ctx context.Context, owner string, expectedGeneration uint64, changes registry.ChangeSet) (uint64, error) {
+	r.applyMu.Lock()
+	defer r.applyMu.Unlock()
+	return r.applyOverlayLocked(ctx, owner, expectedGeneration, changes)
+}
+
+// GetOverlay returns a copy of one owner's live entries and generation.
+func (r *Reg) GetOverlay(owner string) (registry.State, uint64, error) {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return nil, 0, fmt.Errorf("registry overlay owner is required")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	state, ok := r.overlays[owner]
+	if !ok {
+		return nil, r.overlayGeneration[owner], nil
+	}
+	return cloneOverlayState(state), r.overlayGeneration[owner], nil
+}
+
+func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGeneration uint64, changes registry.ChangeSet) (uint64, error) {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return 0, fmt.Errorf("registry overlay owner is required")
+	}
+	if len(changes) == 0 {
+		return 0, fmt.Errorf("registry overlay changes are required")
+	}
+	changes = append(registry.ChangeSet(nil), changes...)
+	canonicalizeChangeSetIDs(changes)
+
+	r.mu.RLock()
+	snapshot := append(registry.State(nil), r.state...)
+	currentGeneration := r.overlayGeneration[owner]
+	owners := make(map[registry.ID]string, len(r.overlayOwners))
+	for id, value := range r.overlayOwners {
+		owners[id] = value
+	}
+	r.mu.RUnlock()
+	if currentGeneration != expectedGeneration {
+		return 0, fmt.Errorf("registry overlay %s changed: expected generation %d, current generation %d", owner, expectedGeneration, currentGeneration)
+	}
+
+	effective := canonicalStateMap(snapshot)
+	candidateOwners := make(map[registry.ID]string, len(owners)+len(changes))
+	for id, entryOwner := range owners {
+		candidateOwners[canonicalEntryID(id)] = entryOwner
+	}
+	seen := make(map[registry.ID]struct{}, len(changes))
+	deleted := make(map[registry.ID]struct{})
+	for i := range changes {
+		op := &changes[i]
+		op.Entry = cloneOverlayEntry(op.Entry)
+		if op.OriginalEntry != nil {
+			original := cloneOverlayEntry(*op.OriginalEntry)
+			op.OriginalEntry = &original
+		}
+		if _, duplicate := seen[op.Entry.ID]; duplicate {
+			return 0, fmt.Errorf("registry overlay changes contain duplicate entry %s", op.Entry.ID)
+		}
+		seen[op.Entry.ID] = struct{}{}
+		entryOwner, overlayEntry := candidateOwners[op.Entry.ID]
+		switch op.Kind {
+		case registry.EntryCreate:
+			if overlayEntry {
+				return 0, fmt.Errorf("overlay entry %s is owned by %s", op.Entry.ID, entryOwner)
+			}
+			if _, exists := effective[op.Entry.ID]; exists {
+				return 0, fmt.Errorf("overlay entry %s shadows durable state", op.Entry.ID)
+			}
+		case registry.EntryUpdate, registry.EntryDelete:
+			if !overlayEntry || entryOwner != owner {
+				return 0, fmt.Errorf("overlay owner %s cannot mutate entry %s", owner, op.Entry.ID)
+			}
+		default:
+			return 0, fmt.Errorf("unknown overlay operation %s", op.Kind)
+		}
+		if op.Kind != registry.EntryDelete {
+			if err := validateOverlayEntryProvenance(op.Entry); err != nil {
+				return 0, err
+			}
+			op.Entry.Meta = attrs.NewBagFrom(op.Entry.Meta)
+			op.Entry.Meta[overlayOwnerMeta] = owner
+		}
+		switch op.Kind {
+		case registry.EntryCreate, registry.EntryUpdate:
+			effective[op.Entry.ID] = op.Entry
+			candidateOwners[op.Entry.ID] = owner
+		case registry.EntryDelete:
+			delete(effective, op.Entry.ID)
+			delete(candidateOwners, op.Entry.ID)
+			deleted[op.Entry.ID] = struct{}{}
+		}
+	}
+	if err := r.validateRemovedOverlayDependencies(canonicalStateMap(snapshot), effective, deleted); err != nil {
+		return 0, err
+	}
+	if err := r.validateOverlayComposition(effective, candidateOwners); err != nil {
+		return 0, err
+	}
+
+	sorted, err := r.sortWithIndex(snapshot, changes)
+	if err != nil {
+		return 0, NewSortChangesError(err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	newState, err := r.runner.Transition(ctx, r.state, sorted)
+	if err != nil {
+		if newState != nil && ctx.Err() == nil {
+			if rollbackErr := r.rollback(ctx, newState, r.state); rollbackErr != nil {
+				r.reconcileOverlayIndexesAfterFailedRollback(owner, owners, changes)
+				return 0, NewApplyChangesError(err, rollbackErr)
+			}
+		}
+		return 0, NewApplyChangesError(err, nil)
+	}
+
+	r.rebuildOverlayIndexes(candidateOwners, newState)
+	r.overlayGeneration[owner]++
+	r.state = newState
+	r.rebuildIndex()
+	r.patchDepIndex(sorted)
+	return r.overlayGeneration[owner], nil
+}
+
+func (r *Reg) validateRemovedOverlayDependencies(before, after registry.StateMap, deleted map[registry.ID]struct{}) error {
+	if len(deleted) == 0 {
+		return nil
+	}
+	for _, entry := range before {
+		if _, survives := after[entry.ID]; !survives {
+			continue
+		}
+		for _, dependencyID := range r.overlayDependencyIDs(entry, before) {
+			if _, removed := deleted[dependencyID]; removed {
+				return fmt.Errorf("overlay deletion removes %s required by live entry %s", dependencyID, entry.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func canonicalStateMap(state registry.State) registry.StateMap {
+	stateMap := make(registry.StateMap, len(state))
+	for _, entry := range state {
+		entry.ID = canonicalEntryID(entry.ID)
+		stateMap[entry.ID] = entry
+	}
+	return stateMap
+}
+
+func cloneOverlayState(state registry.State) registry.State {
+	if len(state) == 0 {
+		return nil
+	}
+	cloned := make(registry.State, len(state))
+	for i, entry := range state {
+		cloned[i] = cloneOverlayEntry(entry)
+	}
+	return cloned
+}
+
+func cloneOverlayEntry(entry registry.Entry) registry.Entry {
+	meta := attrs.NewBag()
+	for key, value := range entry.Meta {
+		meta[key] = payload.SnapshotData(value)
+	}
+	entry.Meta = meta
+	entry.Data = payload.Snapshot(entry.Data)
+	return entry
+}
+
+func validateOverlayEntryProvenance(entry registry.Entry) error {
+	if entry.DependencyRoot {
+		return fmt.Errorf("overlay entry %s cannot be a deployment root", entry.ID)
+	}
+	for _, key := range []string{"module", "module_version", "module_digest"} {
+		if _, exists := entry.Meta[key]; exists {
+			return fmt.Errorf("overlay entry %s cannot set managed metadata %s", entry.ID, key)
+		}
+	}
+	return nil
+}
+
+func (r *Reg) validateOverlayComposition(effective registry.StateMap, owners map[registry.ID]string) error {
+	if len(owners) == 0 {
+		return nil
+	}
+	for _, entry := range effective {
+		sourceOwner, sourceOverlay := owners[entry.ID]
+		for _, dependencyID := range r.overlayDependencyIDs(entry, effective) {
+			targetOwner, targetOverlay := owners[dependencyID]
+			switch {
+			case sourceOverlay && targetOverlay && sourceOwner != targetOwner:
+				return fmt.Errorf("overlay entry %s owned by %s depends on entry %s owned by %s", entry.ID, sourceOwner, dependencyID, targetOwner)
+			case !sourceOverlay && targetOverlay:
+				return fmt.Errorf("durable entry %s depends on overlay entry %s owned by %s", entry.ID, dependencyID, targetOwner)
+			}
+		}
+	}
+	return nil
+}
+
+// overlayDependencyIDs mirrors topology's dependency semantics: relative
+// direct IDs inherit the source namespace, group and namespace references
+// expand against the effective state, and dangling references are ignored.
+func (r *Reg) overlayDependencyIDs(entry registry.Entry, effective registry.StateMap) []registry.ID {
+	declarations := entry.Meta.GetSlice(registry.TagDependsOn)
+	if r.resolver != nil {
+		declarations = append(declarations, r.resolver.Extract(entry)...)
+	}
+	seen := make(map[registry.ID]struct{}, len(declarations))
+	result := make([]registry.ID, 0, len(declarations))
+	add := func(id registry.ID) {
+		id = canonicalEntryID(id)
+		if id.Equal(entry.ID) {
+			return
+		}
+		if _, exists := effective[id]; !exists {
+			return
+		}
+		if _, exists := seen[id]; exists {
+			return
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	for _, declaration := range declarations {
+		switch {
+		case strings.HasPrefix(declaration, "group:"):
+			group := strings.TrimPrefix(declaration, "group:")
+			for _, candidate := range effective {
+				for _, candidateGroup := range candidate.Meta.GetSlice(registry.TagGroups) {
+					if candidateGroup == group {
+						add(candidate.ID)
+					}
+				}
+			}
+		case strings.HasPrefix(declaration, "ns:"):
+			namespace := strings.TrimPrefix(declaration, "ns:")
+			for id := range effective {
+				if id.NS == namespace {
+					add(id)
+				}
+			}
+		default:
+			if strings.Contains(declaration, ":") {
+				add(registry.ParseID(declaration))
+			} else {
+				add(registry.NewID(entry.ID.NS, declaration))
+			}
+		}
+	}
+	return result
+}
+
+func (r *Reg) validateDurableTransitionAgainstOverlays(allOps, historyOps registry.ChangeSet) error {
+	_ = historyOps
+	if len(r.overlayOwners) == 0 {
+		return nil
+	}
+	for _, op := range allOps {
+		id := canonicalEntryID(op.Entry.ID)
+		if owner, ok := r.overlayOwners[id]; ok {
+			return fmt.Errorf("durable transition targets overlay entry %s owned by %s", op.Entry.ID, owner)
+		}
+	}
+	current := canonicalStateMap(r.state)
+	deleted := make(map[registry.ID]struct{})
+	for _, op := range allOps {
+		if op.Kind == registry.EntryDelete {
+			deleted[canonicalEntryID(op.Entry.ID)] = struct{}{}
+		}
+	}
+	for owner, entries := range r.overlays {
+		for _, entry := range entries {
+			for _, dep := range r.overlayDependencyIDs(entry, current) {
+				if _, ok := deleted[dep]; ok {
+					return fmt.Errorf("durable transition deletes %s required by overlay entry %s owned by %s", dep, entry.ID, owner)
+				}
+			}
+		}
+	}
+	applyStateOperations(current, allOps)
+	return r.validateOverlayComposition(current, r.overlayOwners)
+}
+
+func (r *Reg) composeOverlays(stateMap registry.StateMap) error {
+	for id, entry := range stateMap {
+		canonicalID := canonicalEntryID(id)
+		entry.ID = canonicalEntryID(entry.ID)
+		if !canonicalID.Equal(entry.ID) {
+			return fmt.Errorf("durable state key %s does not match entry %s", id, entry.ID)
+		}
+		if canonicalID != id {
+			delete(stateMap, id)
+			if _, duplicate := stateMap[canonicalID]; duplicate {
+				return fmt.Errorf("selected durable version contains duplicate entry %s", canonicalID)
+			}
+			stateMap[canonicalID] = entry
+		}
+	}
+	for owner, entries := range r.overlays {
+		for _, entry := range entries {
+			entry.ID = canonicalEntryID(entry.ID)
+			if _, exists := stateMap[entry.ID]; exists {
+				return fmt.Errorf("overlay entry %s owned by %s conflicts with selected durable version", entry.ID, owner)
+			}
+			stateMap[entry.ID] = entry
+		}
+	}
+	return r.validateOverlayComposition(stateMap, r.overlayOwners)
+}
+
+func (r *Reg) reconcileOverlayIndexesAfterFailedRollback(owner string, previousOwners map[registry.ID]string, changes registry.ChangeSet) {
+	knownOwners := make(map[registry.ID]string, len(previousOwners)+len(changes))
+	ownerGenerationInvalidated := false
+	for id, entryOwner := range previousOwners {
+		knownOwners[canonicalEntryID(id)] = entryOwner
+		if entryOwner == owner {
+			ownerGenerationInvalidated = true
+		}
+	}
+	for _, op := range changes {
+		if op.Kind != registry.EntryDelete {
+			knownOwners[canonicalEntryID(op.Entry.ID)] = owner
+		}
+	}
+
+	r.rebuildOverlayIndexes(knownOwners, r.state)
+	if !ownerGenerationInvalidated {
+		r.overlayGeneration[owner]++
+	}
+}
+
+func (r *Reg) reconcileKnownOverlaysAfterFailedRollback() {
+	owners := make(map[string]struct{})
+	knownOwners := make(map[registry.ID]string, len(r.overlayOwners))
+	for id, owner := range r.overlayOwners {
+		knownOwners[canonicalEntryID(id)] = owner
+		owners[owner] = struct{}{}
+	}
+	r.rebuildOverlayIndexes(knownOwners, r.state)
+	for owner := range owners {
+		r.overlayGeneration[owner]++
+	}
+}
+
+func (r *Reg) rebuildOverlayIndexes(knownOwners map[registry.ID]string, effective registry.State) {
+	nextOwners := make(map[registry.ID]string)
+	nextOverlays := make(map[string]registry.StateMap)
+	for _, entry := range effective {
+		id := canonicalEntryID(entry.ID)
+		entryOwner, isOverlay := knownOwners[id]
+		if !isOverlay {
+			continue
+		}
+		entry.ID = id
+		nextOwners[id] = entryOwner
+		if nextOverlays[entryOwner] == nil {
+			nextOverlays[entryOwner] = make(registry.StateMap)
+		}
+		nextOverlays[entryOwner][id] = cloneOverlayEntry(entry)
+	}
+	r.overlayOwners = nextOwners
+	r.overlays = make(map[string]registry.State, len(nextOverlays))
+	for entryOwner, entries := range nextOverlays {
+		r.overlays[entryOwner] = topology.StateMapToSlice(entries)
+	}
+}
+
+var _ registry.OverlayWriter = (*Reg)(nil)

--- a/system/registry/overlay.go
+++ b/system/registry/overlay.go
@@ -96,7 +96,7 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 				return 0, NewOverlayConflictError("registry overlay owner cannot mutate entry", map[string]any{"entry_id": op.Entry.ID.String(), "owner": owner})
 			}
 		default:
-			return 0, NewOverlayValidationError("unknown registry overlay operation", map[string]any{"operation": string(op.Kind)})
+			return 0, NewOverlayValidationError("unknown registry overlay operation", map[string]any{"operation": op.Kind})
 		}
 		if op.Kind != registry.EntryDelete {
 			if err := validateOverlayEntryProvenance(op.Entry); err != nil {

--- a/system/registry/overlay.go
+++ b/system/registry/overlay.go
@@ -12,8 +12,6 @@ import (
 	"github.com/wippyai/runtime/system/registry/topology"
 )
 
-const overlayOwnerMeta = "overlay_owner"
-
 // ApplyOverlay applies an owner-scoped process-local changeset without
 // advancing registry history. The entries remain part of effective state until
 // explicitly cleared or the process exits.
@@ -32,11 +30,11 @@ func (r *Reg) GetOverlay(owner string) (registry.State, uint64, error) {
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	state, ok := r.overlays[owner]
-	if !ok {
-		return nil, r.overlayEpoch, nil
+	generation, knownOwner := r.overlayGeneration[owner]
+	if !knownOwner {
+		generation = r.overlayFloor
 	}
-	return cloneOverlayState(state), r.overlayGeneration[owner], nil
+	return cloneOverlayState(r.overlays[owner]), generation, nil
 }
 
 func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGeneration uint64, changes registry.ChangeSet) (uint64, error) {
@@ -46,7 +44,7 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 		return 0, err
 	}
 	if len(changes) == 0 {
-		return 0, fmt.Errorf("registry overlay changes are required")
+		return 0, NewOverlayValidationError("registry overlay changes are required", nil)
 	}
 	changes = append(registry.ChangeSet(nil), changes...)
 	canonicalizeChangeSetIDs(changes)
@@ -55,7 +53,7 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 	snapshot := append(registry.State(nil), r.state...)
 	currentGeneration, activeOwner := r.overlayGeneration[owner]
 	if !activeOwner {
-		currentGeneration = r.overlayEpoch
+		currentGeneration = r.overlayFloor
 	}
 	owners := make(map[registry.ID]string, len(r.overlayOwners))
 	for id, value := range r.overlayOwners {
@@ -66,10 +64,10 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 		return 0, NewOverlayGenerationConflictError(owner, expectedGeneration, currentGeneration)
 	}
 
-	effective := canonicalStateMap(snapshot)
+	effective := topology.NewStateMap(snapshot)
 	candidateOwners := make(map[registry.ID]string, len(owners)+len(changes))
 	for id, entryOwner := range owners {
-		candidateOwners[canonicalEntryID(id)] = entryOwner
+		candidateOwners[id] = entryOwner
 	}
 	seen := make(map[registry.ID]struct{}, len(changes))
 	deleted := make(map[registry.ID]struct{})
@@ -81,31 +79,35 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 			op.OriginalEntry = &original
 		}
 		if _, duplicate := seen[op.Entry.ID]; duplicate {
-			return 0, fmt.Errorf("registry overlay changes contain duplicate entry %s", op.Entry.ID)
+			return 0, NewOverlayValidationError("registry overlay changes contain a duplicate entry", map[string]any{"entry_id": op.Entry.ID.String()})
 		}
 		seen[op.Entry.ID] = struct{}{}
 		entryOwner, overlayEntry := candidateOwners[op.Entry.ID]
 		switch op.Kind {
 		case registry.EntryCreate:
 			if overlayEntry {
-				return 0, fmt.Errorf("overlay entry %s is owned by %s", op.Entry.ID, entryOwner)
+				return 0, NewOverlayConflictError("registry overlay entry is already owned", map[string]any{"entry_id": op.Entry.ID.String(), "owner": entryOwner})
 			}
 			if _, exists := effective[op.Entry.ID]; exists {
-				return 0, fmt.Errorf("overlay entry %s shadows durable state", op.Entry.ID)
+				return 0, NewOverlayConflictError("registry overlay entry conflicts with durable state", map[string]any{"entry_id": op.Entry.ID.String()})
 			}
 		case registry.EntryUpdate, registry.EntryDelete:
 			if !overlayEntry || entryOwner != owner {
-				return 0, fmt.Errorf("overlay owner %s cannot mutate entry %s", owner, op.Entry.ID)
+				return 0, NewOverlayConflictError("registry overlay owner cannot mutate entry", map[string]any{"entry_id": op.Entry.ID.String(), "owner": owner})
 			}
 		default:
-			return 0, fmt.Errorf("unknown overlay operation %s", op.Kind)
+			return 0, NewOverlayValidationError("unknown registry overlay operation", map[string]any{"operation": string(op.Kind)})
 		}
 		if op.Kind != registry.EntryDelete {
 			if err := validateOverlayEntryProvenance(op.Entry); err != nil {
 				return 0, err
 			}
-			op.Entry.Meta = attrs.NewBagFrom(op.Entry.Meta)
-			op.Entry.Meta[overlayOwnerMeta] = owner
+			if len(r.directivesByKind[op.Entry.Kind]) != 0 {
+				return 0, NewOverlayValidationError("registry overlay entries cannot use directive-owned kinds", map[string]any{
+					"entry_id": op.Entry.ID.String(),
+					"kind":     op.Entry.Kind,
+				})
+			}
 		}
 		switch op.Kind {
 		case registry.EntryCreate, registry.EntryUpdate:
@@ -117,8 +119,10 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 			deleted[op.Entry.ID] = struct{}{}
 		}
 	}
-	if err := r.validateRemovedOverlayDependencies(canonicalStateMap(snapshot), effective, deleted); err != nil {
-		return 0, err
+	if len(deleted) != 0 {
+		if err := r.validateRemovedOverlayDependencies(topology.NewStateMap(snapshot), effective, deleted); err != nil {
+			return 0, err
+		}
 	}
 	if err := r.validateOverlayComposition(effective, candidateOwners); err != nil {
 		return 0, err
@@ -150,16 +154,11 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 	return nextGeneration, nil
 }
 
-// bumpOverlayGeneration issues process-unique generation tokens without
-// retaining tombstones for owners whose overlays are empty. An absent owner
-// observes the global epoch, so a snapshot opened before a create/delete cycle
-// cannot resurrect stale state.
+// bumpOverlayGeneration issues process-unique generation tokens and retains a
+// tombstone only for owners that mutated. This prevents ABA after a complete
+// delete without making unrelated owners conflict or growing state on reads.
 func (r *Reg) bumpOverlayGeneration(owner string) uint64 {
 	r.overlayEpoch++
-	if len(r.overlays[owner]) == 0 {
-		delete(r.overlayGeneration, owner)
-		return r.overlayEpoch
-	}
 	r.overlayGeneration[owner] = r.overlayEpoch
 	return r.overlayEpoch
 }
@@ -168,27 +167,18 @@ func (r *Reg) validateRemovedOverlayDependencies(before, after registry.StateMap
 	if len(deleted) == 0 {
 		return nil
 	}
-	dependencies := topology.ResolveDependencies(before, r.resolver)
-	for _, entry := range before {
-		if _, survives := after[entry.ID]; !survives {
-			continue
+	return topology.VisitDependencies(before, r.resolver, func(source, target registry.ID) error {
+		if _, survives := after[source]; !survives {
+			return nil
 		}
-		for _, dependencyID := range dependencies[entry.ID] {
-			if _, removed := deleted[dependencyID]; removed {
-				return fmt.Errorf("overlay deletion removes %s required by live entry %s", dependencyID, entry.ID)
-			}
+		if _, removed := deleted[target]; removed {
+			return NewOverlayConflictError("registry overlay deletion removes a live dependency", map[string]any{
+				"dependency_id": target.String(),
+				"entry_id":      source.String(),
+			})
 		}
-	}
-	return nil
-}
-
-func canonicalStateMap(state registry.State) registry.StateMap {
-	stateMap := make(registry.StateMap, len(state))
-	for _, entry := range state {
-		entry.ID = canonicalEntryID(entry.ID)
-		stateMap[entry.ID] = entry
-	}
-	return stateMap
+		return nil
+	})
 }
 
 func cloneOverlayState(state registry.State) registry.State {
@@ -214,11 +204,14 @@ func cloneOverlayEntry(entry registry.Entry) registry.Entry {
 
 func validateOverlayEntryProvenance(entry registry.Entry) error {
 	if entry.DependencyRoot {
-		return fmt.Errorf("overlay entry %s cannot be a deployment root", entry.ID)
+		return NewOverlayValidationError("registry overlay entry cannot be a deployment root", map[string]any{"entry_id": entry.ID.String()})
 	}
 	for _, key := range []string{"module", "module_version", "module_digest"} {
 		if _, exists := entry.Meta[key]; exists {
-			return fmt.Errorf("overlay entry %s cannot set managed metadata %s", entry.ID, key)
+			return NewOverlayValidationError("registry overlay entry cannot set managed metadata", map[string]any{
+				"entry_id": entry.ID.String(),
+				"key":      key,
+			})
 		}
 	}
 	return nil
@@ -228,49 +221,60 @@ func (r *Reg) validateOverlayComposition(effective registry.StateMap, owners map
 	if len(owners) == 0 {
 		return nil
 	}
-	dependencies := topology.ResolveDependencies(effective, r.resolver)
-	for _, entry := range effective {
-		sourceOwner, sourceOverlay := owners[entry.ID]
-		for _, dependencyID := range dependencies[entry.ID] {
-			targetOwner, targetOverlay := owners[dependencyID]
-			switch {
-			case sourceOverlay && targetOverlay && sourceOwner != targetOwner:
-				return fmt.Errorf("overlay entry %s owned by %s depends on entry %s owned by %s", entry.ID, sourceOwner, dependencyID, targetOwner)
-			case !sourceOverlay && targetOverlay:
-				return fmt.Errorf("durable entry %s depends on overlay entry %s owned by %s", entry.ID, dependencyID, targetOwner)
-			}
+	return topology.VisitDependencies(effective, r.resolver, func(source, target registry.ID) error {
+		sourceOwner, sourceOverlay := owners[source]
+		targetOwner, targetOverlay := owners[target]
+		switch {
+		case sourceOverlay && targetOverlay && sourceOwner != targetOwner:
+			return NewOverlayConflictError("registry overlay dependency crosses owner boundary", map[string]any{
+				"entry_id":      source.String(),
+				"owner":         sourceOwner,
+				"dependency_id": target.String(),
+				"target_owner":  targetOwner,
+			})
+		case !sourceOverlay && targetOverlay:
+			return NewOverlayConflictError("durable registry entry depends on process-local overlay", map[string]any{
+				"entry_id":      source.String(),
+				"dependency_id": target.String(),
+				"owner":         targetOwner,
+			})
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
-func (r *Reg) validateDurableTransitionAgainstOverlays(allOps, historyOps registry.ChangeSet) error {
-	_ = historyOps
+func (r *Reg) validateDurableTransitionAgainstOverlays(allOps registry.ChangeSet) error {
 	if len(r.overlayOwners) == 0 {
 		return nil
 	}
 	for _, op := range allOps {
 		id := canonicalEntryID(op.Entry.ID)
 		if owner, ok := r.overlayOwners[id]; ok {
-			return fmt.Errorf("durable transition targets overlay entry %s owned by %s", op.Entry.ID, owner)
+			return NewOverlayConflictError("durable transition targets a process-local overlay entry", map[string]any{
+				"entry_id": op.Entry.ID.String(),
+				"owner":    owner,
+			})
 		}
 	}
-	current := canonicalStateMap(r.state)
+	current := topology.NewStateMap(r.state)
 	deleted := make(map[registry.ID]struct{})
 	for _, op := range allOps {
 		if op.Kind == registry.EntryDelete {
 			deleted[canonicalEntryID(op.Entry.ID)] = struct{}{}
 		}
 	}
-	dependencies := topology.ResolveDependencies(current, r.resolver)
-	for owner, entries := range r.overlays {
-		for _, entry := range entries {
-			for _, dep := range dependencies[entry.ID] {
-				if _, ok := deleted[dep]; ok {
-					return fmt.Errorf("durable transition deletes %s required by overlay entry %s owned by %s", dep, entry.ID, owner)
-				}
-			}
+	if err := topology.VisitDependencies(current, r.resolver, func(source, target registry.ID) error {
+		owner, overlay := r.overlayOwners[source]
+		if _, removed := deleted[target]; overlay && removed {
+			return NewOverlayConflictError("durable transition removes an overlay dependency", map[string]any{
+				"dependency_id": target.String(),
+				"entry_id":      source.String(),
+				"owner":         owner,
+			})
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	applyStateOperations(current, allOps)
 	return r.validateOverlayComposition(current, r.overlayOwners)
@@ -307,7 +311,7 @@ func (r *Reg) reconcileOverlayIndexesAfterFailedRollback(owner string, previousO
 	knownOwners := make(map[registry.ID]string, len(previousOwners)+len(changes))
 	ownerGenerationInvalidated := false
 	for id, entryOwner := range previousOwners {
-		knownOwners[canonicalEntryID(id)] = entryOwner
+		knownOwners[id] = entryOwner
 		if entryOwner == owner {
 			ownerGenerationInvalidated = true
 		}
@@ -328,7 +332,7 @@ func (r *Reg) reconcileKnownOverlaysAfterFailedRollback() {
 	owners := make(map[string]struct{})
 	knownOwners := make(map[registry.ID]string, len(r.overlayOwners))
 	for id, owner := range r.overlayOwners {
-		knownOwners[canonicalEntryID(id)] = owner
+		knownOwners[id] = owner
 		owners[owner] = struct{}{}
 	}
 	r.rebuildOverlayIndexes(knownOwners, r.state)
@@ -341,7 +345,7 @@ func (r *Reg) rebuildOverlayIndexes(knownOwners map[registry.ID]string, effectiv
 	nextOwners := make(map[registry.ID]string)
 	nextOverlays := make(map[string]registry.StateMap)
 	for _, entry := range effective {
-		id := canonicalEntryID(entry.ID)
+		id := entry.ID
 		entryOwner, isOverlay := knownOwners[id]
 		if !isOverlay {
 			continue

--- a/system/registry/overlay.go
+++ b/system/registry/overlay.go
@@ -5,7 +5,6 @@ package registry
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/wippyai/runtime/api/attrs"
 	"github.com/wippyai/runtime/api/payload"
@@ -26,23 +25,25 @@ func (r *Reg) ApplyOverlay(ctx context.Context, owner string, expectedGeneration
 
 // GetOverlay returns a copy of one owner's live entries and generation.
 func (r *Reg) GetOverlay(owner string) (registry.State, uint64, error) {
-	owner = strings.TrimSpace(owner)
-	if owner == "" {
-		return nil, 0, fmt.Errorf("registry overlay owner is required")
+	var err error
+	owner, err = registry.CanonicalOverlayOwner(owner)
+	if err != nil {
+		return nil, 0, err
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	state, ok := r.overlays[owner]
 	if !ok {
-		return nil, r.overlayGeneration[owner], nil
+		return nil, r.overlayEpoch, nil
 	}
 	return cloneOverlayState(state), r.overlayGeneration[owner], nil
 }
 
 func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGeneration uint64, changes registry.ChangeSet) (uint64, error) {
-	owner = strings.TrimSpace(owner)
-	if owner == "" {
-		return 0, fmt.Errorf("registry overlay owner is required")
+	var err error
+	owner, err = registry.CanonicalOverlayOwner(owner)
+	if err != nil {
+		return 0, err
 	}
 	if len(changes) == 0 {
 		return 0, fmt.Errorf("registry overlay changes are required")
@@ -52,14 +53,17 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 
 	r.mu.RLock()
 	snapshot := append(registry.State(nil), r.state...)
-	currentGeneration := r.overlayGeneration[owner]
+	currentGeneration, activeOwner := r.overlayGeneration[owner]
+	if !activeOwner {
+		currentGeneration = r.overlayEpoch
+	}
 	owners := make(map[registry.ID]string, len(r.overlayOwners))
 	for id, value := range r.overlayOwners {
 		owners[id] = value
 	}
 	r.mu.RUnlock()
 	if currentGeneration != expectedGeneration {
-		return 0, fmt.Errorf("registry overlay %s changed: expected generation %d, current generation %d", owner, expectedGeneration, currentGeneration)
+		return 0, NewOverlayGenerationConflictError(owner, expectedGeneration, currentGeneration)
 	}
 
 	effective := canonicalStateMap(snapshot)
@@ -139,22 +143,37 @@ func (r *Reg) applyOverlayLocked(ctx context.Context, owner string, expectedGene
 	}
 
 	r.rebuildOverlayIndexes(candidateOwners, newState)
-	r.overlayGeneration[owner]++
+	nextGeneration := r.bumpOverlayGeneration(owner)
 	r.state = newState
 	r.rebuildIndex()
 	r.patchDepIndex(sorted)
-	return r.overlayGeneration[owner], nil
+	return nextGeneration, nil
+}
+
+// bumpOverlayGeneration issues process-unique generation tokens without
+// retaining tombstones for owners whose overlays are empty. An absent owner
+// observes the global epoch, so a snapshot opened before a create/delete cycle
+// cannot resurrect stale state.
+func (r *Reg) bumpOverlayGeneration(owner string) uint64 {
+	r.overlayEpoch++
+	if len(r.overlays[owner]) == 0 {
+		delete(r.overlayGeneration, owner)
+		return r.overlayEpoch
+	}
+	r.overlayGeneration[owner] = r.overlayEpoch
+	return r.overlayEpoch
 }
 
 func (r *Reg) validateRemovedOverlayDependencies(before, after registry.StateMap, deleted map[registry.ID]struct{}) error {
 	if len(deleted) == 0 {
 		return nil
 	}
+	dependencies := topology.ResolveDependencies(before, r.resolver)
 	for _, entry := range before {
 		if _, survives := after[entry.ID]; !survives {
 			continue
 		}
-		for _, dependencyID := range r.overlayDependencyIDs(entry, before) {
+		for _, dependencyID := range dependencies[entry.ID] {
 			if _, removed := deleted[dependencyID]; removed {
 				return fmt.Errorf("overlay deletion removes %s required by live entry %s", dependencyID, entry.ID)
 			}
@@ -209,9 +228,10 @@ func (r *Reg) validateOverlayComposition(effective registry.StateMap, owners map
 	if len(owners) == 0 {
 		return nil
 	}
+	dependencies := topology.ResolveDependencies(effective, r.resolver)
 	for _, entry := range effective {
 		sourceOwner, sourceOverlay := owners[entry.ID]
-		for _, dependencyID := range r.overlayDependencyIDs(entry, effective) {
+		for _, dependencyID := range dependencies[entry.ID] {
 			targetOwner, targetOverlay := owners[dependencyID]
 			switch {
 			case sourceOverlay && targetOverlay && sourceOwner != targetOwner:
@@ -222,59 +242,6 @@ func (r *Reg) validateOverlayComposition(effective registry.StateMap, owners map
 		}
 	}
 	return nil
-}
-
-// overlayDependencyIDs mirrors topology's dependency semantics: relative
-// direct IDs inherit the source namespace, group and namespace references
-// expand against the effective state, and dangling references are ignored.
-func (r *Reg) overlayDependencyIDs(entry registry.Entry, effective registry.StateMap) []registry.ID {
-	declarations := entry.Meta.GetSlice(registry.TagDependsOn)
-	if r.resolver != nil {
-		declarations = append(declarations, r.resolver.Extract(entry)...)
-	}
-	seen := make(map[registry.ID]struct{}, len(declarations))
-	result := make([]registry.ID, 0, len(declarations))
-	add := func(id registry.ID) {
-		id = canonicalEntryID(id)
-		if id.Equal(entry.ID) {
-			return
-		}
-		if _, exists := effective[id]; !exists {
-			return
-		}
-		if _, exists := seen[id]; exists {
-			return
-		}
-		seen[id] = struct{}{}
-		result = append(result, id)
-	}
-	for _, declaration := range declarations {
-		switch {
-		case strings.HasPrefix(declaration, "group:"):
-			group := strings.TrimPrefix(declaration, "group:")
-			for _, candidate := range effective {
-				for _, candidateGroup := range candidate.Meta.GetSlice(registry.TagGroups) {
-					if candidateGroup == group {
-						add(candidate.ID)
-					}
-				}
-			}
-		case strings.HasPrefix(declaration, "ns:"):
-			namespace := strings.TrimPrefix(declaration, "ns:")
-			for id := range effective {
-				if id.NS == namespace {
-					add(id)
-				}
-			}
-		default:
-			if strings.Contains(declaration, ":") {
-				add(registry.ParseID(declaration))
-			} else {
-				add(registry.NewID(entry.ID.NS, declaration))
-			}
-		}
-	}
-	return result
 }
 
 func (r *Reg) validateDurableTransitionAgainstOverlays(allOps, historyOps registry.ChangeSet) error {
@@ -295,9 +262,10 @@ func (r *Reg) validateDurableTransitionAgainstOverlays(allOps, historyOps regist
 			deleted[canonicalEntryID(op.Entry.ID)] = struct{}{}
 		}
 	}
+	dependencies := topology.ResolveDependencies(current, r.resolver)
 	for owner, entries := range r.overlays {
 		for _, entry := range entries {
-			for _, dep := range r.overlayDependencyIDs(entry, current) {
+			for _, dep := range dependencies[entry.ID] {
 				if _, ok := deleted[dep]; ok {
 					return fmt.Errorf("durable transition deletes %s required by overlay entry %s owned by %s", dep, entry.ID, owner)
 				}
@@ -352,7 +320,7 @@ func (r *Reg) reconcileOverlayIndexesAfterFailedRollback(owner string, previousO
 
 	r.rebuildOverlayIndexes(knownOwners, r.state)
 	if !ownerGenerationInvalidated {
-		r.overlayGeneration[owner]++
+		r.bumpOverlayGeneration(owner)
 	}
 }
 
@@ -365,7 +333,7 @@ func (r *Reg) reconcileKnownOverlaysAfterFailedRollback() {
 	}
 	r.rebuildOverlayIndexes(knownOwners, r.state)
 	for owner := range owners {
-		r.overlayGeneration[owner]++
+		r.bumpOverlayGeneration(owner)
 	}
 }
 

--- a/system/registry/overlay_bench_test.go
+++ b/system/registry/overlay_bench_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"go.uber.org/zap"
+)
+
+func BenchmarkApplyOverlayChurn(b *testing.B) {
+	for _, stateSize := range []int{2_000, 10_000} {
+		b.Run(fmt.Sprintf("entries_%d", stateSize), func(b *testing.B) {
+			ctx := context.Background()
+			resolver := topology.NewResolver()
+			reg := NewRegistry(
+				historymem.New(),
+				NewTestRunner(),
+				topology.NewStateBuilder(zap.NewNop(), resolver),
+				resolver,
+				zap.NewNop(),
+			)
+			baseline := make(regapi.State, stateSize)
+			for i := range baseline {
+				baseline[i] = regapi.Entry{
+					ID:   regapi.NewID("bench", fmt.Sprintf("entry_%05d", i)),
+					Kind: regapi.EntryKind,
+				}
+			}
+			if err := reg.LoadState(ctx, baseline, version.FromParent(nil, regapi.RootVersion)); err != nil {
+				b.Fatal(err)
+			}
+			entry := regapi.Entry{ID: regapi.NewID("runtime", "source"), Kind: regapi.EntryKind}
+			generation, err := reg.ApplyOverlay(ctx, "bench:owner", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				entry.Data = payload.New(i)
+				generation, err = reg.ApplyOverlay(ctx, "bench:owner", generation, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: entry}})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkResolveDependenciesDenseGroups(b *testing.B) {
+	for _, stateSize := range []int{250, 1_000} {
+		b.Run(fmt.Sprintf("entries_%d", stateSize), func(b *testing.B) {
+			state := make(regapi.StateMap, stateSize)
+			for i := 0; i < stateSize; i++ {
+				entry := regapi.Entry{
+					ID:   regapi.NewID("bench", fmt.Sprintf("entry_%05d", i)),
+					Kind: regapi.EntryKind,
+					Meta: attrs.NewBagFrom(map[string]any{
+						regapi.TagGroups:    []any{"all"},
+						regapi.TagDependsOn: []any{"group:all"},
+					}),
+				}
+				state[entry.ID] = entry
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resolved := topology.ResolveDependencies(state, nil)
+				if len(resolved) != stateSize {
+					b.Fatalf("resolved %d entries", len(resolved))
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVisitDependenciesDenseGroups(b *testing.B) {
+	for _, stateSize := range []int{250, 1_000} {
+		b.Run(fmt.Sprintf("entries_%d", stateSize), func(b *testing.B) {
+			state := make(regapi.StateMap, stateSize)
+			for i := 0; i < stateSize; i++ {
+				entry := regapi.Entry{
+					ID:   regapi.NewID("bench", fmt.Sprintf("entry_%05d", i)),
+					Kind: regapi.EntryKind,
+					Meta: attrs.NewBagFrom(map[string]any{
+						regapi.TagGroups:    []any{"all"},
+						regapi.TagDependsOn: []any{"group:all"},
+					}),
+				}
+				state[entry.ID] = entry
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				edges := 0
+				err := topology.VisitDependencies(state, nil, func(_, _ regapi.ID) error {
+					edges++
+					return nil
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+				if edges != stateSize*(stateSize-1) {
+					b.Fatalf("visited %d edges", edges)
+				}
+			}
+		})
+	}
+}

--- a/system/registry/overlay_test.go
+++ b/system/registry/overlay_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/attrs"
+	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/internal/version"
@@ -251,9 +252,64 @@ func TestLoadStateClearsProcessLocalOverlays(t *testing.T) {
 	entries, generation, err := reg.GetOverlay("owner:a")
 	require.NoError(t, err)
 	assert.Empty(t, entries)
-	assert.Zero(t, generation)
+	assert.NotZero(t, generation)
 	_, err = reg.GetEntry(entry.ID)
 	require.Error(t, err)
+}
+
+func TestLoadStateInvalidatesAbsentOverlaySnapshot(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	v0 := version.FromParent(nil, regapi.RootVersion)
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+	_, staleGeneration, err := reg.GetOverlay("owner:a")
+	require.NoError(t, err)
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "stale"), Kind: regapi.EntryKind}
+	_, err = reg.ApplyOverlay(ctx, "owner:a", staleGeneration, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.Error(t, err)
+	var structured apierror.Error
+	require.ErrorAs(t, err, &structured)
+	assert.Equal(t, apierror.Conflict, structured.Kind())
+}
+
+func TestDeletedOverlayOwnersDoNotRetainGenerationTombstones(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "one"), Kind: regapi.EntryKind}
+	generation, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+	deletedGeneration, err := reg.ApplyOverlay(ctx, "owner:a", generation, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: entry}})
+	require.NoError(t, err)
+	assert.Greater(t, deletedGeneration, generation)
+	assert.Empty(t, reg.overlayGeneration)
+
+	// Neither a snapshot from the active generation nor one opened before the
+	// create/delete cycle may resurrect the removed owner.
+	_, err = reg.ApplyOverlay(ctx, "owner:a", generation, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.Error(t, err)
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.Error(t, err)
+}
+
+func TestOverlayGenerationConflictIsStructuredAndRetryable(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "one"), Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 1, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.Error(t, err)
+	var structured apierror.Error
+	require.ErrorAs(t, err, &structured)
+	assert.Equal(t, apierror.Conflict, structured.Kind())
+	assert.Equal(t, apierror.True, structured.Retryable())
+	expected, ok := structured.Details().Get("expected_generation")
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), expected)
+	actual, ok := structured.Details().Get("actual_generation")
+	require.True(t, ok)
+	assert.Equal(t, uint64(0), actual)
 }
 
 func TestOverlayRejectsIDAliasAndManagedProvenance(t *testing.T) {

--- a/system/registry/overlay_test.go
+++ b/system/registry/overlay_test.go
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"go.uber.org/zap"
+)
+
+func newOverlayTestRegistry(t *testing.T) (*Reg, *historymem.Storage) {
+	reg, history, _ := newOverlayTestRegistryWithRunner(t)
+	return reg, history
+}
+
+func newOverlayTestRegistryWithRunner(t *testing.T) (*Reg, *historymem.Storage, *TestRunner) {
+	t.Helper()
+	history := historymem.New()
+	resolver := topology.NewResolver()
+	require.NoError(t, resolver.RegisterPattern(regapi.DependencyPattern{
+		Path: "meta.depends_on", Description: "test dependencies", AllowWildcard: true,
+	}))
+	builder := topology.NewStateBuilder(zap.NewNop(), resolver)
+	runner := NewTestRunner()
+	return NewRegistry(history, runner, builder, resolver, zap.NewNop()), history, runner
+}
+
+func TestOverlayDoesNotAdvanceHistory(t *testing.T) {
+	ctx := context.Background()
+	reg, history := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+
+	entry := regapi.Entry{ID: regapi.NewID("runtime.db", "one"), Kind: "test.resource", Data: payload.New("live")}
+	generation, err := reg.ApplyOverlay(ctx, "data-sources:one", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), generation)
+	current, err := reg.Current()
+	require.NoError(t, err)
+	assert.Equal(t, uint(0), current.ID())
+	_, err = reg.GetEntry(entry.ID)
+	require.NoError(t, err)
+	head, err := history.Head()
+	require.NoError(t, err)
+	assert.Equal(t, uint(0), head.ID())
+}
+
+func TestOverlaySurvivesHistoryCommit(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	runtimeEntry := regapi.Entry{ID: regapi.NewID("runtime.db", "one"), Kind: "test.resource", Data: payload.New("live")}
+	_, err := reg.ApplyOverlay(ctx, "data-sources:one", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: runtimeEntry}})
+	require.NoError(t, err)
+
+	durable := regapi.Entry{ID: regapi.NewID("app", "setting"), Kind: regapi.EntryKind, Data: payload.New("v1")}
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: durable}})
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), v1.ID())
+	_, err = reg.GetEntry(runtimeEntry.ID)
+	require.NoError(t, err)
+	projection, generation, err := reg.GetOverlay("data-sources:one")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), generation)
+	assert.Len(t, projection, 1)
+}
+
+func TestOverlaySurvivesVersionSelection(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	durable := regapi.Entry{ID: regapi.NewID("app", "setting"), Kind: regapi.EntryKind, Data: payload.New("v1")}
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: durable}})
+	require.NoError(t, err)
+	durable.Data = payload.New("v2")
+	v2, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: durable}})
+	require.NoError(t, err)
+
+	runtimeEntry := regapi.Entry{ID: regapi.NewID("runtime.db", "one"), Kind: "test.resource", Data: payload.New("live")}
+	_, err = reg.ApplyOverlay(ctx, "data-sources:one", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: runtimeEntry}})
+	require.NoError(t, err)
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	_, err = reg.GetEntry(runtimeEntry.ID)
+	require.NoError(t, err)
+	require.NoError(t, reg.ApplyVersion(ctx, v2))
+	_, err = reg.GetEntry(runtimeEntry.ID)
+	require.NoError(t, err)
+}
+
+func TestOverlayCannotShadowOrLeakIntoHistory(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	base := regapi.Entry{ID: regapi.NewID("app", "base"), Kind: regapi.EntryKind, Data: payload.New("base")}
+	require.NoError(t, reg.LoadState(ctx, regapi.State{base}, version.FromParent(nil, regapi.RootVersion)))
+
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: base}})
+	require.Error(t, err)
+	runtimeEntry := regapi.Entry{ID: regapi.NewID("runtime", "one"), Kind: regapi.EntryKind, Data: payload.New("runtime")}
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: runtimeEntry}})
+	require.NoError(t, err)
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: runtimeEntry}})
+	require.Error(t, err)
+	_, err = reg.ApplyOverlay(ctx, "owner:b", 0, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: runtimeEntry}})
+	require.Error(t, err)
+}
+
+func TestOverlayRejectsStaleGeneration(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "one"), Kind: regapi.EntryKind, Data: payload.New("v1")}
+	generation, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), generation)
+	entry.Data = payload.New("stale")
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: entry}})
+	require.Error(t, err)
+	stored, err := reg.GetEntry(entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", stored.Data.Data())
+}
+
+func TestOverlayBulkDeleteUsesReverseDependencyOrder(t *testing.T) {
+	ctx := context.Background()
+	reg, _, runner := newOverlayTestRegistryWithRunner(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	envID := regapi.NewID("runtime.env", "password")
+	dbID := regapi.NewID("runtime.db", "source")
+	envEntry := regapi.Entry{ID: envID, Kind: "env.variable"}
+	dbEntry := regapi.Entry{ID: dbID, Kind: "db.sql.postgres", Meta: attrs.NewBagFrom(map[string]any{"depends_on": envID.String()})}
+	generation, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{
+		{Kind: regapi.EntryCreate, Entry: dbEntry},
+		{Kind: regapi.EntryCreate, Entry: envEntry},
+	})
+	require.NoError(t, err)
+	_, err = reg.ApplyOverlay(ctx, "owner:a", generation, regapi.ChangeSet{
+		{Kind: regapi.EntryDelete, Entry: envEntry},
+		{Kind: regapi.EntryDelete, Entry: dbEntry},
+	})
+	require.NoError(t, err)
+	last := runner.LastTransition()
+	require.Len(t, last, 2)
+	assert.Equal(t, dbID, last[0].Entry.ID)
+	assert.Equal(t, envID, last[1].Entry.ID)
+	entries, nextGeneration, err := reg.GetOverlay("owner:a")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Equal(t, uint64(2), nextGeneration)
+}
+
+func TestOverlayCannotDeleteDependencyWhileDependentSurvives(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	target := regapi.Entry{ID: regapi.NewID("runtime", "target"), Kind: regapi.EntryKind}
+	consumer := regapi.Entry{
+		ID: regapi.NewID("runtime", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{regapi.TagDependsOn: "target"}),
+	}
+	generation, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{
+		{Kind: regapi.EntryCreate, Entry: target},
+		{Kind: regapi.EntryCreate, Entry: consumer},
+	})
+	require.NoError(t, err)
+	_, err = reg.ApplyOverlay(ctx, "owner:a", generation, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: target}})
+	require.Error(t, err)
+	_, err = reg.GetEntry(target.ID)
+	require.NoError(t, err)
+}
+
+func TestOverlayRejectsCrossOwnerDependenciesInEitherCreationOrder(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	targetID := regapi.NewID("runtime", "target")
+	consumer := regapi.Entry{
+		ID: regapi.NewID("runtime", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"depends_on": targetID.String()}),
+	}
+	target := regapi.Entry{ID: targetID, Kind: regapi.EntryKind}
+
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: consumer}})
+	require.NoError(t, err, "a same-owner target may be added in a later changeset")
+	_, err = reg.ApplyOverlay(ctx, "owner:b", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: target}})
+	require.Error(t, err, "a later owner cannot claim an ID referenced by another overlay")
+
+	reg, _ = newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	_, err = reg.ApplyOverlay(ctx, "owner:b", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: target}})
+	require.NoError(t, err)
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: consumer}})
+	require.Error(t, err, "an overlay cannot depend on an existing foreign overlay")
+}
+
+func TestDurableHistoryCannotDependOnOrRemoveOverlayGraph(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	baseID := regapi.NewID("app", "base")
+	base := regapi.Entry{ID: baseID, Kind: regapi.EntryKind}
+	require.NoError(t, reg.LoadState(ctx, regapi.State{base}, version.FromParent(nil, regapi.RootVersion)))
+	overlayID := regapi.NewID("runtime", "one")
+	overlay := regapi.Entry{
+		ID: overlayID, Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"depends_on": baseID.String()}),
+	}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: overlay}})
+	require.NoError(t, err)
+
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: base}})
+	require.Error(t, err)
+	durable := regapi.Entry{
+		ID: regapi.NewID("app", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"depends_on": overlayID.String()}),
+	}
+	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: durable}})
+	require.Error(t, err)
+}
+
+func TestOverlayCannotClaimIDAlreadyReferencedByDurableState(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	overlayID := regapi.NewID("runtime", "future")
+	durable := regapi.Entry{
+		ID: regapi.NewID("app", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"depends_on": overlayID.String()}),
+	}
+	require.NoError(t, reg.LoadState(ctx, regapi.State{durable}, version.FromParent(nil, regapi.RootVersion)))
+	candidate := regapi.Entry{ID: overlayID, Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: candidate}})
+	require.Error(t, err)
+}
+
+func TestLoadStateClearsProcessLocalOverlays(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	v0 := version.FromParent(nil, regapi.RootVersion)
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "one"), Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+	entries, generation, err := reg.GetOverlay("owner:a")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Zero(t, generation)
+	_, err = reg.GetEntry(entry.ID)
+	require.Error(t, err)
+}
+
+func TestOverlayRejectsIDAliasAndManagedProvenance(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	base := regapi.Entry{ID: regapi.NewID("app", "base"), Kind: regapi.EntryKind}
+	require.NoError(t, reg.LoadState(ctx, regapi.State{base}, version.FromParent(nil, regapi.RootVersion)))
+	alias := regapi.Entry{ID: regapi.ID{Name: "app:base"}, Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: alias}})
+	require.Error(t, err)
+	managed := regapi.Entry{
+		ID: regapi.NewID("runtime", "managed"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"module": "acme/app"}),
+	}
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: managed}})
+	require.Error(t, err)
+}
+
+func TestVersionSelectionRejectsHistoricalDurableDependencyOnOverlay(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	overlayID := regapi.NewID("runtime", "dep")
+	consumer := regapi.Entry{
+		ID: regapi.NewID("app", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"depends_on": overlayID.String()}),
+	}
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: consumer}})
+	require.NoError(t, err)
+	v2, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: consumer}})
+	require.NoError(t, err)
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{
+		Kind:  regapi.EntryCreate,
+		Entry: regapi.Entry{ID: overlayID, Kind: regapi.EntryKind},
+	}})
+	require.NoError(t, err)
+	require.Error(t, reg.ApplyVersion(ctx, v1))
+	current, err := reg.Current()
+	require.NoError(t, err)
+	assert.Equal(t, v2.ID(), current.ID())
+}
+
+func TestVersionSelectionCannotRemoveDurableOverlayDependency(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	base := regapi.Entry{ID: regapi.NewID("app", "base"), Kind: regapi.EntryKind}
+	v1, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: base}})
+	require.NoError(t, err)
+	v2, err := reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: base}})
+	require.NoError(t, err)
+	require.NoError(t, reg.ApplyVersion(ctx, v1))
+	overlay := regapi.Entry{
+		ID: regapi.NewID("runtime", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{regapi.TagDependsOn: base.ID.String()}),
+	}
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: overlay}})
+	require.NoError(t, err)
+	require.Error(t, reg.ApplyVersion(ctx, v2))
+	current, err := reg.Current()
+	require.NoError(t, err)
+	assert.Equal(t, v1.ID(), current.ID())
+}
+
+func TestOverlayDependencyValidationUsesTopologySemantics(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		targetMeta attrs.Bag
+		name       string
+		dependency string
+	}{
+		{name: "relative ID", dependency: "target"},
+		{name: "group", dependency: "group:targets", targetMeta: attrs.NewBagFrom(map[string]any{regapi.TagGroups: []any{"targets"}})},
+		{name: "namespace", dependency: "ns:runtime"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg, _ := newOverlayTestRegistry(t)
+			require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+			target := regapi.Entry{ID: regapi.NewID("runtime", "target"), Kind: regapi.EntryKind, Meta: tt.targetMeta}
+			_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: target}})
+			require.NoError(t, err)
+			consumer := regapi.Entry{
+				ID: regapi.NewID("runtime", "consumer"), Kind: regapi.EntryKind,
+				Meta: attrs.NewBagFrom(map[string]any{"depends_on": tt.dependency}),
+			}
+			_, err = reg.ApplyOverlay(ctx, "owner:b", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: consumer}})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestOverlayExplicitDependenciesWorkWithoutResolver(t *testing.T) {
+	ctx := context.Background()
+	history := historymem.New()
+	builder := topology.NewStateBuilder(zap.NewNop(), nil)
+	reg := NewRegistry(history, NewTestRunner(), builder, nil, zap.NewNop())
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	target := regapi.Entry{ID: regapi.NewID("runtime", "target"), Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: target}})
+	require.NoError(t, err)
+	consumer := regapi.Entry{
+		ID: regapi.NewID("runtime", "consumer"), Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{regapi.TagDependsOn: "target"}),
+	}
+	_, err = reg.ApplyOverlay(ctx, "owner:b", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: consumer}})
+	require.Error(t, err)
+}
+
+func TestOverlayAllowsDanglingBarePlaceholder(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	entry := regapi.Entry{
+		ID: regapi.NewID("runtime", "source"), Kind: regapi.EntryKind,
+		Data: payload.New(map[string]any{"token": "${API_KEY}"}),
+	}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+}
+
+func TestOverlayRejectsDuplicateOperations(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "duplicate"), Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{
+		{Kind: regapi.EntryCreate, Entry: entry},
+		{Kind: regapi.EntryCreate, Entry: entry},
+	})
+	require.Error(t, err)
+}
+
+type failedCompensationRunner struct {
+	base  TestRunner
+	armed bool
+	calls int
+}
+
+func (r *failedCompensationRunner) Transition(ctx context.Context, from regapi.State, changes regapi.ChangeSet) (regapi.State, error) {
+	if !r.armed {
+		return r.base.Transition(ctx, from, changes)
+	}
+	r.calls++
+	if r.calls > 1 {
+		return from, errors.New("injected compensation failure")
+	}
+	partial, applyErr := r.base.Transition(ctx, from, changes)
+	if applyErr != nil {
+		partial = from
+	}
+	return partial, errors.New("injected transition failure")
+}
+
+func TestOverlayReconcilesIndexesAfterFailedCompensation(t *testing.T) {
+	ctx := context.Background()
+	history := historymem.New()
+	resolver := topology.NewResolver()
+	builder := topology.NewStateBuilder(zap.NewNop(), resolver)
+	runner := &failedCompensationRunner{}
+	reg := NewRegistry(history, runner, builder, resolver, zap.NewNop())
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	runner.armed = true
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "partial"), Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.Error(t, err)
+	assert.Equal(t, 2, runner.calls)
+	_, err = reg.GetEntry(entry.ID)
+	require.NoError(t, err)
+	overlay, generation, err := reg.GetOverlay("owner:a")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), generation)
+	require.Len(t, overlay, 1)
+	assert.Equal(t, entry.ID, overlay[0].ID)
+}
+
+func TestLoadStateReconcilesOverlaysAfterFailedCompensation(t *testing.T) {
+	ctx := context.Background()
+	history := historymem.New()
+	resolver := topology.NewResolver()
+	builder := topology.NewStateBuilder(zap.NewNop(), resolver)
+	runner := &failedCompensationRunner{}
+	reg := NewRegistry(history, runner, builder, resolver, zap.NewNop())
+	v0 := version.FromParent(nil, regapi.RootVersion)
+	require.NoError(t, reg.LoadState(ctx, nil, v0))
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "partial"), Kind: regapi.EntryKind}
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+	runner.armed = true
+	regErr := reg.LoadState(ctx, nil, v0)
+	require.Error(t, regErr)
+	_, err = reg.GetEntry(entry.ID)
+	require.Error(t, err)
+	overlay, generation, err := reg.GetOverlay("owner:a")
+	require.NoError(t, err)
+	assert.Empty(t, overlay)
+	assert.Equal(t, uint64(2), generation)
+}

--- a/system/registry/overlay_test.go
+++ b/system/registry/overlay_test.go
@@ -110,6 +110,9 @@ func TestOverlayCannotShadowOrLeakIntoHistory(t *testing.T) {
 	require.NoError(t, err)
 	_, err = reg.Apply(ctx, regapi.ChangeSet{{Kind: regapi.EntryUpdate, Entry: runtimeEntry}})
 	require.Error(t, err)
+	var structured apierror.Error
+	require.ErrorAs(t, err, &structured)
+	assert.Equal(t, apierror.Conflict, structured.Kind())
 	_, err = reg.ApplyOverlay(ctx, "owner:b", 0, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: runtimeEntry}})
 	require.Error(t, err)
 }
@@ -274,7 +277,7 @@ func TestLoadStateInvalidatesAbsentOverlaySnapshot(t *testing.T) {
 	assert.Equal(t, apierror.Conflict, structured.Kind())
 }
 
-func TestDeletedOverlayOwnersDoNotRetainGenerationTombstones(t *testing.T) {
+func TestDeletedOverlayOwnerRetainsGenerationTombstone(t *testing.T) {
 	ctx := context.Background()
 	reg, _ := newOverlayTestRegistry(t)
 	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
@@ -284,7 +287,7 @@ func TestDeletedOverlayOwnersDoNotRetainGenerationTombstones(t *testing.T) {
 	deletedGeneration, err := reg.ApplyOverlay(ctx, "owner:a", generation, regapi.ChangeSet{{Kind: regapi.EntryDelete, Entry: entry}})
 	require.NoError(t, err)
 	assert.Greater(t, deletedGeneration, generation)
-	assert.Empty(t, reg.overlayGeneration)
+	assert.Equal(t, deletedGeneration, reg.overlayGeneration["owner:a"])
 
 	// Neither a snapshot from the active generation nor one opened before the
 	// create/delete cycle may resurrect the removed owner.
@@ -292,6 +295,30 @@ func TestDeletedOverlayOwnersDoNotRetainGenerationTombstones(t *testing.T) {
 	require.Error(t, err)
 	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
 	require.Error(t, err)
+
+	empty, currentGeneration, err := reg.GetOverlay("owner:a")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+	assert.Equal(t, deletedGeneration, currentGeneration)
+	_, err = reg.ApplyOverlay(ctx, "owner:a", currentGeneration, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+}
+
+func TestOverlayGenerationDoesNotConflictAcrossOwners(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+
+	_, ownerBGeneration, err := reg.GetOverlay("owner:b")
+	require.NoError(t, err)
+
+	entryA := regapi.Entry{ID: regapi.NewID("runtime", "a"), Kind: regapi.EntryKind}
+	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entryA}})
+	require.NoError(t, err)
+
+	entryB := regapi.Entry{ID: regapi.NewID("runtime", "b"), Kind: regapi.EntryKind}
+	_, err = reg.ApplyOverlay(ctx, "owner:b", ownerBGeneration, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entryB}})
+	require.NoError(t, err)
 }
 
 func TestOverlayGenerationConflictIsStructuredAndRetryable(t *testing.T) {
@@ -326,6 +353,52 @@ func TestOverlayRejectsIDAliasAndManagedProvenance(t *testing.T) {
 	}
 	_, err = reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: managed}})
 	require.Error(t, err)
+}
+
+func TestOverlayOwnershipDoesNotMutateEntryMetadata(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newOverlayTestRegistry(t)
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	entry := regapi.Entry{
+		ID:   regapi.NewID("runtime", "owned"),
+		Kind: regapi.EntryKind,
+		Meta: attrs.NewBagFrom(map[string]any{"application": "value"}),
+	}
+
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.NoError(t, err)
+
+	stored, err := reg.GetEntry(entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, entry.Meta, stored.Meta)
+	_, leaked := stored.Meta["overlay_owner"]
+	assert.False(t, leaked)
+	assert.Equal(t, "owner:a", reg.overlayOwners[entry.ID])
+}
+
+func TestOverlayRejectsDirectiveOwnedKinds(t *testing.T) {
+	ctx := context.Background()
+	history := historymem.New()
+	resolver := topology.NewResolver()
+	builder := topology.NewStateBuilder(zap.NewNop(), resolver)
+	reg := NewRegistry(history, NewTestRunner(), builder, resolver, zap.NewNop(),
+		WithKindDirective("expanded.kind", overlayTestDirective{}))
+	require.NoError(t, reg.LoadState(ctx, nil, version.FromParent(nil, regapi.RootVersion)))
+	entry := regapi.Entry{ID: regapi.NewID("runtime", "declaration"), Kind: "expanded.kind"}
+
+	_, err := reg.ApplyOverlay(ctx, "owner:a", 0, regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: entry}})
+	require.Error(t, err)
+	var structured apierror.Error
+	require.ErrorAs(t, err, &structured)
+	assert.Equal(t, apierror.Invalid, structured.Kind())
+	_, getErr := reg.GetEntry(entry.ID)
+	require.Error(t, getErr)
+}
+
+type overlayTestDirective struct{}
+
+func (overlayTestDirective) Expand(context.Context, regapi.Operation, regapi.State) (regapi.DirectiveResult, error) {
+	return regapi.DirectiveResult{}, nil
 }
 
 func TestVersionSelectionRejectsHistoricalDurableDependencyOnOverlay(t *testing.T) {

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -138,6 +138,7 @@ func (r *Reg) GetAllEntries() ([]registry.Entry, error) {
 }
 
 func (r *Reg) GetEntry(path registry.ID) (registry.Entry, error) {
+	path = canonicalEntryID(path)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -42,6 +42,7 @@ type Reg struct {
 	baseline          registry.State
 	state             registry.State
 	overlayEpoch      uint64
+	overlayFloor      uint64
 	stateLoaded       bool
 	versionNum        atomic.Uint64
 	mu                sync.RWMutex
@@ -223,11 +224,11 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 		}
 		return nil, NewSortChangesError(sortErr)
 	}
-	if err := r.validateDurableTransitionAgainstOverlays(allOps, historyOps); err != nil {
+	if err := r.validateDurableTransitionAgainstOverlays(allOps); err != nil {
 		if planner != nil {
 			planner.RollbackEffects(ctx, preparedEff)
 		}
-		return nil, NewApplyChangesError(err, nil)
+		return nil, err
 	}
 
 	r.mu.Lock()
@@ -564,11 +565,11 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 		}
 		return NewSortChangesError(sortErr)
 	}
-	if preflightErr := r.validateDurableTransitionAgainstOverlays(allOps, allOps); preflightErr != nil {
+	if preflightErr := r.validateDurableTransitionAgainstOverlays(allOps); preflightErr != nil {
 		if planner != nil {
 			planner.RollbackEffects(ctx, preparedEff)
 		}
-		return NewComputeTransitionError(preflightErr)
+		return preflightErr
 	}
 
 	r.mu.Lock()
@@ -788,6 +789,13 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 		}
 	}
 
+	// Establish the registry's canonical-ID invariant once at the external
+	// state boundary. Internal indexes and overlay ownership maps can then use
+	// IDs directly without allocating and interning them on every scan.
+	baseline = append(registry.State(nil), baseline...)
+	for i := range baseline {
+		baseline[i].ID = canonicalEntryID(baseline[i].ID)
+	}
 	if err := topology.ValidateUniqueEntryIDs("baseline", baseline); err != nil {
 		return err
 	}
@@ -1002,6 +1010,7 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	if r.stateLoaded || r.overlayEpoch > 0 {
 		r.overlayEpoch++
 	}
+	r.overlayFloor = r.overlayEpoch
 	r.stateLoaded = true
 	r.rebuildIndex()
 	r.rebuildDepIndex()
@@ -1055,10 +1064,7 @@ func canonicalizeChangeSetIDs(changes registry.ChangeSet) {
 }
 
 func canonicalEntryID(id registry.ID) registry.ID {
-	if id.NS == "" {
-		return registry.ParseID(id.Name)
-	}
-	return registry.NewID(id.NS, id.Name)
+	return id.Canonical()
 }
 
 // rollback state desync between actual state in system and state in history

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -41,6 +41,8 @@ type Reg struct {
 	overlayGeneration map[string]uint64
 	baseline          registry.State
 	state             registry.State
+	overlayEpoch      uint64
+	stateLoaded       bool
 	versionNum        atomic.Uint64
 	mu                sync.RWMutex
 	applyMu           sync.Mutex
@@ -994,6 +996,13 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 	r.overlays = make(map[string]registry.State)
 	r.overlayOwners = make(map[registry.ID]string)
 	r.overlayGeneration = make(map[string]uint64)
+	// Invalidate snapshots retained across an explicit reload. A newly
+	// constructed registry starts at epoch zero; a live registry never reuses a
+	// generation token.
+	if r.stateLoaded || r.overlayEpoch > 0 {
+		r.overlayEpoch++
+	}
+	r.stateLoaded = true
 	r.rebuildIndex()
 	r.rebuildDepIndex()
 	r.currentVersion = targetVersion

--- a/system/registry/registry.go
+++ b/system/registry/registry.go
@@ -26,21 +26,24 @@ type indexedSortBuilder interface {
 }
 
 type Reg struct {
-	history           registry.History
+	currentVersion    registry.Version
 	runner            registry.Runner
 	builder           registry.StateBuilder
 	resolver          registry.DependencyResolver
-	directivesByKind  map[registry.Kind][]registry.Directive
-	currentVersion    registry.Version
+	history           registry.History
+	depIndex          *topology.DepIndex
 	currentResolution *registry.DependencyResolution
 	stateIndex        map[registry.ID]int
-	depIndex          *topology.DepIndex
+	directivesByKind  map[registry.Kind][]registry.Directive
 	log               *zap.Logger
+	overlays          map[string]registry.State
+	overlayOwners     map[registry.ID]string
+	overlayGeneration map[string]uint64
 	baseline          registry.State
 	state             registry.State
 	versionNum        atomic.Uint64
-	applyMu           sync.Mutex
 	mu                sync.RWMutex
+	applyMu           sync.Mutex
 }
 
 // NewRegistry creates a new registry instance.
@@ -56,14 +59,17 @@ func NewRegistry(
 		log = zap.NewNop()
 	}
 	reg := &Reg{
-		history:        history,
-		runner:         runner,
-		builder:        builder,
-		resolver:       resolver,
-		state:          registry.State{},
-		stateIndex:     make(map[registry.ID]int),
-		log:            log,
-		currentVersion: version.FromParent(nil, 0), // initial version
+		history:           history,
+		runner:            runner,
+		builder:           builder,
+		resolver:          resolver,
+		state:             registry.State{},
+		stateIndex:        make(map[registry.ID]int),
+		overlays:          make(map[string]registry.State),
+		overlayOwners:     make(map[registry.ID]string),
+		overlayGeneration: make(map[string]uint64),
+		log:               log,
+		currentVersion:    version.FromParent(nil, 0), // initial version
 	}
 
 	reg.versionNum.Store(0)
@@ -214,6 +220,12 @@ func (r *Reg) Apply(ctx context.Context, changes registry.ChangeSet) (registry.V
 			planner.RollbackEffects(ctx, preparedEff)
 		}
 		return nil, NewSortChangesError(sortErr)
+	}
+	if err := r.validateDurableTransitionAgainstOverlays(allOps, historyOps); err != nil {
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		return nil, NewApplyChangesError(err, nil)
 	}
 
 	r.mu.Lock()
@@ -461,6 +473,10 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			return NewExpandChangesError(errors.New("stored dependency resolution has no configured reconciler"))
 		}
 		var buildErr error
+		if composeErr := r.composeOverlays(stateMap); composeErr != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+			return NewComputeTransitionError(composeErr)
+		}
 		allOps, buildErr = r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
 		if buildErr != nil {
 			planner.RollbackEffects(ctx, preparedEff)
@@ -505,13 +521,21 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			}
 			applyStateOperations(stateMap, ops)
 		}
+		if composeErr := r.composeOverlays(stateMap); composeErr != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+			return NewComputeTransitionError(composeErr)
+		}
 		allOps, err = r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
 		if err != nil {
 			planner.RollbackEffects(ctx, preparedEff)
 			return NewComputeTransitionError(err)
 		}
 	} else {
-		delta, err := r.builder.BuildDelta(snapshot, targetState)
+		stateMap := topology.NewStateMap(targetState)
+		if composeErr := r.composeOverlays(stateMap); composeErr != nil {
+			return NewComputeTransitionError(composeErr)
+		}
+		delta, err := r.builder.BuildDelta(snapshot, topology.StateMapToSlice(stateMap))
 		if err != nil {
 			return NewComputeTransitionError(err)
 		}
@@ -537,6 +561,12 @@ func (r *Reg) ApplyVersion(ctx context.Context, v registry.Version) error {
 			planner.RollbackEffects(ctx, preparedEff)
 		}
 		return NewSortChangesError(sortErr)
+	}
+	if preflightErr := r.validateDurableTransitionAgainstOverlays(allOps, allOps); preflightErr != nil {
+		if planner != nil {
+			planner.RollbackEffects(ctx, preparedEff)
+		}
+		return NewComputeTransitionError(preflightErr)
 	}
 
 	r.mu.Lock()
@@ -959,6 +989,11 @@ func (r *Reg) LoadState(ctx context.Context, baseline registry.State, targetVers
 
 	r.state = newState
 	r.baseline = append(registry.State(nil), baseline...)
+	// LoadState is the cold/reinitialization boundary. Overlays are deliberately
+	// process-local and their owning controllers reconcile them after boot.
+	r.overlays = make(map[string]registry.State)
+	r.overlayOwners = make(map[registry.ID]string)
+	r.overlayGeneration = make(map[string]uint64)
 	r.rebuildIndex()
 	r.rebuildDepIndex()
 	r.currentVersion = targetVersion
@@ -988,7 +1023,7 @@ func reconcileStoredResolution(
 
 func applyStateOperations(stateMap registry.StateMap, ops registry.ChangeSet) {
 	for _, op := range ops {
-		id := registry.NewID(op.Entry.ID.NS, op.Entry.ID.Name)
+		id := canonicalEntryID(op.Entry.ID)
 		switch op.Kind {
 		case registry.EntryCreate, registry.EntryUpdate:
 			op.Entry.ID = id
@@ -1001,13 +1036,20 @@ func applyStateOperations(stateMap registry.StateMap, ops registry.ChangeSet) {
 
 func canonicalizeChangeSetIDs(changes registry.ChangeSet) {
 	for i := range changes {
-		changes[i].Entry.ID = registry.NewID(changes[i].Entry.ID.NS, changes[i].Entry.ID.Name)
+		changes[i].Entry.ID = canonicalEntryID(changes[i].Entry.ID)
 		if changes[i].OriginalEntry != nil {
 			original := *changes[i].OriginalEntry
-			original.ID = registry.NewID(original.ID.NS, original.ID.Name)
+			original.ID = canonicalEntryID(original.ID)
 			changes[i].OriginalEntry = &original
 		}
 	}
+}
+
+func canonicalEntryID(id registry.ID) registry.ID {
+	if id.NS == "" {
+		return registry.ParseID(id.Name)
+	}
+	return registry.NewID(id.NS, id.Name)
 }
 
 // rollback state desync between actual state in system and state in history
@@ -1022,6 +1064,7 @@ func (r *Reg) rollback(ctx context.Context, from, to registry.State) error {
 	r.state = partial // we remain in a desynced state
 	r.rebuildIndex()
 	r.rebuildDepIndex()
+	r.reconcileKnownOverlaysAfterFailedRollback()
 
 	return err
 }

--- a/system/registry/topology/dependencies.go
+++ b/system/registry/topology/dependencies.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"sort"
+
+	"github.com/wippyai/runtime/api/registry"
+)
+
+// ResolveDependencies materializes the canonical topology edges for a state.
+// Missing direct targets are ignored, matching the sorter. Group and namespace
+// membership is indexed once, so callers do not need to duplicate dependency
+// syntax or repeatedly scan the complete registry.
+func ResolveDependencies(state registry.StateMap, resolver registry.DependencyResolver) map[registry.ID][]registry.ID {
+	groups := make(map[string][]registry.ID)
+	namespaces := make(map[string][]registry.ID)
+	for id, entry := range state {
+		for _, group := range entry.Meta.GetSlice(registry.TagGroups) {
+			groups[group] = append(groups[group], id)
+		}
+		if id.NS != "" {
+			namespaces[id.NS] = append(namespaces[id.NS], id)
+		}
+	}
+
+	result := make(map[registry.ID][]registry.ID, len(state))
+	for id, entry := range state {
+		keys := extractDepKeys(entry, resolver)
+		seen := make(map[registry.ID]struct{}, len(keys.direct))
+		add := func(target registry.ID) {
+			if target.Equal(id) {
+				return
+			}
+			if _, exists := state[target]; !exists {
+				return
+			}
+			if _, exists := seen[target]; exists {
+				return
+			}
+			seen[target] = struct{}{}
+			result[id] = append(result[id], target)
+		}
+		for _, target := range keys.direct {
+			add(target)
+		}
+		for _, group := range keys.groups {
+			for _, target := range groups[group] {
+				add(target)
+			}
+		}
+		for _, namespace := range keys.ns {
+			for _, target := range namespaces[namespace] {
+				add(target)
+			}
+		}
+		sort.Slice(result[id], func(i, j int) bool {
+			return result[id][i].String() < result[id][j].String()
+		})
+	}
+	return result
+}

--- a/system/registry/topology/dependencies.go
+++ b/system/registry/topology/dependencies.go
@@ -8,55 +8,109 @@ import (
 	"github.com/wippyai/runtime/api/registry"
 )
 
+// VisitDependencies walks the canonical topology edges without retaining an
+// adjacency list. It is the low-allocation path for validation and auditing;
+// callers that need materialized edges should use ResolveDependencies.
+func VisitDependencies(state registry.StateMap, resolver registry.DependencyResolver, visit func(source, target registry.ID) error) error {
+	var (
+		keysBySource  map[registry.ID]entryDepKeys
+		needGroups    bool
+		needNamespace bool
+	)
+	for id, entry := range state {
+		keys := extractDepKeys(entry, resolver)
+		if len(keys.direct)+len(keys.groups)+len(keys.ns) == 0 {
+			continue
+		}
+		if keysBySource == nil {
+			keysBySource = make(map[registry.ID]entryDepKeys)
+		}
+		keysBySource[id] = keys
+		needGroups = needGroups || len(keys.groups) != 0
+		needNamespace = needNamespace || len(keys.ns) != 0
+	}
+	if len(keysBySource) == 0 {
+		return nil
+	}
+
+	var groups map[string][]registry.ID
+	var namespaces map[string][]registry.ID
+	if needGroups {
+		groups = make(map[string][]registry.ID)
+	}
+	if needNamespace {
+		namespaces = make(map[string][]registry.ID)
+	}
+	if needGroups || needNamespace {
+		for id, entry := range state {
+			if needGroups {
+				for _, group := range entry.Meta.GetSlice(registry.TagGroups) {
+					groups[group] = append(groups[group], id)
+				}
+			}
+			if needNamespace && id.NS != "" {
+				namespaces[id.NS] = append(namespaces[id.NS], id)
+			}
+		}
+	}
+
+	var (
+		seen      map[registry.ID]uint64
+		visitMark uint64
+	)
+	for id, keys := range keysBySource {
+		if seen == nil {
+			seen = make(map[registry.ID]uint64, len(state))
+		}
+		visitMark++
+		add := func(target registry.ID) error {
+			if target.Equal(id) {
+				return nil
+			}
+			if _, exists := state[target]; !exists {
+				return nil
+			}
+			if seen[target] == visitMark {
+				return nil
+			}
+			seen[target] = visitMark
+			return visit(id, target)
+		}
+		for _, target := range keys.direct {
+			if err := add(target); err != nil {
+				return err
+			}
+		}
+		for _, group := range keys.groups {
+			for _, target := range groups[group] {
+				if err := add(target); err != nil {
+					return err
+				}
+			}
+		}
+		for _, namespace := range keys.ns {
+			for _, target := range namespaces[namespace] {
+				if err := add(target); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // ResolveDependencies materializes the canonical topology edges for a state.
 // Missing direct targets are ignored, matching the sorter. Group and namespace
 // membership is indexed once, so callers do not need to duplicate dependency
 // syntax or repeatedly scan the complete registry.
 func ResolveDependencies(state registry.StateMap, resolver registry.DependencyResolver) map[registry.ID][]registry.ID {
-	groups := make(map[string][]registry.ID)
-	namespaces := make(map[string][]registry.ID)
-	for id, entry := range state {
-		for _, group := range entry.Meta.GetSlice(registry.TagGroups) {
-			groups[group] = append(groups[group], id)
-		}
-		if id.NS != "" {
-			namespaces[id.NS] = append(namespaces[id.NS], id)
-		}
-	}
-
 	result := make(map[registry.ID][]registry.ID, len(state))
-	for id, entry := range state {
-		keys := extractDepKeys(entry, resolver)
-		seen := make(map[registry.ID]struct{}, len(keys.direct))
-		add := func(target registry.ID) {
-			if target.Equal(id) {
-				return
-			}
-			if _, exists := state[target]; !exists {
-				return
-			}
-			if _, exists := seen[target]; exists {
-				return
-			}
-			seen[target] = struct{}{}
-			result[id] = append(result[id], target)
-		}
-		for _, target := range keys.direct {
-			add(target)
-		}
-		for _, group := range keys.groups {
-			for _, target := range groups[group] {
-				add(target)
-			}
-		}
-		for _, namespace := range keys.ns {
-			for _, target := range namespaces[namespace] {
-				add(target)
-			}
-		}
-		sort.Slice(result[id], func(i, j int) bool {
-			return result[id][i].String() < result[id][j].String()
-		})
+	_ = VisitDependencies(state, resolver, func(source, target registry.ID) error {
+		result[source] = append(result[source], target)
+		return nil
+	})
+	for id := range result {
+		sort.Slice(result[id], func(i, j int) bool { return result[id][i].String() < result[id][j].String() })
 	}
 	return result
 }

--- a/system/registry/topology/dependencies_test.go
+++ b/system/registry/topology/dependencies_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+func TestResolveDependenciesUsesCanonicalTopologySemantics(t *testing.T) {
+	direct := registry.Entry{ID: registry.NewID("app", "direct")}
+	grouped := registry.Entry{
+		ID:   registry.NewID("other", "grouped"),
+		Meta: attrs.NewBagFrom(map[string]any{registry.TagGroups: []string{"workers"}}),
+	}
+	namespaced := registry.Entry{ID: registry.NewID("services", "api")}
+	root := registry.Entry{ID: registry.NewID("", "root")}
+	consumer := registry.Entry{
+		ID: registry.NewID("app", "consumer"),
+		Meta: attrs.NewBagFrom(map[string]any{registry.TagDependsOn: []string{
+			"direct", "group:workers", "ns:services", "ns:", "missing",
+		}}),
+	}
+	state := registry.StateMap{
+		direct.ID: direct, grouped.ID: grouped, namespaced.ID: namespaced,
+		root.ID: root, consumer.ID: consumer,
+	}
+
+	resolved := ResolveDependencies(state, nil)
+	require.Len(t, resolved[consumer.ID], 3)
+	assert.Equal(t, []registry.ID{direct.ID, grouped.ID, namespaced.ID}, resolved[consumer.ID])
+}
+
+func BenchmarkResolveDependenciesGroups(b *testing.B) {
+	const entries = 2000
+	state := make(registry.StateMap, entries)
+	for i := 0; i < entries; i++ {
+		id := registry.NewID("bench", strconv.Itoa(i))
+		group := "partition-" + strconv.Itoa(i/20)
+		meta := attrs.NewBagFrom(map[string]any{registry.TagGroups: []string{group}})
+		if i%10 == 0 {
+			meta[registry.TagDependsOn] = []string{"group:" + group}
+		}
+		state[id] = registry.Entry{ID: id, Meta: meta}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ResolveDependencies(state, nil)
+	}
+}

--- a/system/registry/topology/resolver.go
+++ b/system/registry/topology/resolver.go
@@ -80,21 +80,22 @@ func (r *Resolver) Extract(entry registry.Entry) []string {
 // fetchDeps extracts dependencies using the registered patterns.
 // This function combines meta and data, then processes all patterns.
 func (r *Resolver) fetchDeps(entry registry.Entry) []string {
-	combined := make(map[string]any)
+	var payloadData any
+	if entry.Data != nil {
+		payloadData = entry.Data.Data()
+	}
+	if len(entry.Meta) == 0 && payloadData == nil {
+		return nil
+	}
+
+	combined := make(map[string]any, 2)
 
 	if len(entry.Meta) > 0 {
 		combined["meta"] = map[string]any(entry.Meta)
 	}
 
-	if entry.Data != nil {
-		payloadData := entry.Data.Data()
-		if payloadData != nil {
-			combined["data"] = payloadData
-		}
-	}
-
-	if len(combined) == 0 {
-		return nil
+	if payloadData != nil {
+		combined["data"] = payloadData
 	}
 
 	// Collect deduplicated dependencies in a slice so the output is independent

--- a/system/registry/topology/sort.go
+++ b/system/registry/topology/sort.go
@@ -51,68 +51,16 @@ func SortEntriesByDependency(entries []registry.Entry, resolver registry.Depende
 		return nil, nil
 	}
 
-	// Build dependency graph and mappings
+	// Build the graph from the canonical resolved dependency view.
 	g := graph.New[registry.ID, any]()
 	entryMap := make(map[registry.ID]registry.Entry, len(entries))
-	groupMap := make(map[string][]registry.ID)
-	nsMap := make(map[string][]registry.ID)
-
-	// First pass: build all mappings
 	for _, entry := range entries {
 		g.AddNode(entry.ID)
 		entryMap[entry.ID] = entry
-
-		// Build group mapping from explicit groups
-		explicitGroups := entry.Meta.GetSlice(registry.TagGroups)
-		for _, group := range explicitGroups {
-			groupMap[group] = append(groupMap[group], entry.ID)
-		}
-
-		// Build namespace mapping
-		if entry.ID.NS != "" {
-			nsMap[entry.ID.NS] = append(nsMap[entry.ID.NS], entry.ID)
-		}
 	}
-
-	// Second pass: process all dependencies
-	for _, entry := range entries {
-		dependencies := entry.Meta.GetSlice(registry.TagDependsOn)
-
-		if resolver != nil {
-			dependencies = append(dependencies, resolver.Extract(entry)...)
-		}
-
-		for _, dep := range dependencies {
-			depType, value := parseDependency(dep)
-
-			switch depType {
-			case "direct":
-				// Handle direct dependency, respecting source namespace
-				targetID := resolveDependencyID(entry.ID.NS, value)
-				if _, exists := entryMap[targetID]; exists {
-					g.AddEdge(targetID, entry.ID, 1, nil)
-				}
-
-			case "group":
-				// Handle group dependency
-				if members, exists := groupMap[value]; exists {
-					for _, memberID := range members {
-						if !memberID.Equal(entry.ID) { // Avoid self-dependency
-							g.AddEdge(memberID, entry.ID, 1, nil)
-						}
-					}
-				}
-
-			case "namespace":
-				// Handle namespace dependency
-				if members, exists := nsMap[value]; exists {
-					for _, memberID := range members {
-						if !memberID.Equal(entry.ID) { // Avoid self-dependency
-							g.AddEdge(memberID, entry.ID, 1, nil)
-						}
-					}
-				}
-			}
+	for source, dependencies := range ResolveDependencies(entryMap, resolver) {
+		for _, target := range dependencies {
+			g.AddEdge(target, source, 1, nil)
 		}
 	}
 
@@ -153,63 +101,16 @@ func LevelSortEntriesByDependency(entries []registry.Entry, resolver registry.De
 		return nil, nil
 	}
 
-	// Build dependency graph and mappings
+	// Build the graph from the canonical resolved dependency view.
 	g := graph.New[registry.ID, any]()
 	entryMap := make(map[registry.ID]registry.Entry, len(entries))
-	groupMap := make(map[string][]registry.ID)
-	nsMap := make(map[string][]registry.ID)
-
-	// First pass: build all mappings
 	for _, entry := range entries {
 		g.AddNode(entry.ID)
 		entryMap[entry.ID] = entry
-
-		explicitGroups := entry.Meta.GetSlice(registry.TagGroups)
-		for _, group := range explicitGroups {
-			groupMap[group] = append(groupMap[group], entry.ID)
-		}
-
-		if entry.ID.NS != "" {
-			nsMap[entry.ID.NS] = append(nsMap[entry.ID.NS], entry.ID)
-		}
 	}
-
-	// Second pass: process all dependencies
-	for _, entry := range entries {
-		dependencies := entry.Meta.GetSlice(registry.TagDependsOn)
-
-		if resolver != nil {
-			dependencies = append(dependencies, resolver.Extract(entry)...)
-		}
-
-		for _, dep := range dependencies {
-			depType, value := parseDependency(dep)
-
-			switch depType {
-			case "direct":
-				targetID := resolveDependencyID(entry.ID.NS, value)
-				if _, exists := entryMap[targetID]; exists {
-					g.AddEdge(targetID, entry.ID, 1, nil)
-				}
-
-			case "group":
-				if members, exists := groupMap[value]; exists {
-					for _, memberID := range members {
-						if !memberID.Equal(entry.ID) {
-							g.AddEdge(memberID, entry.ID, 1, nil)
-						}
-					}
-				}
-
-			case "namespace":
-				if members, exists := nsMap[value]; exists {
-					for _, memberID := range members {
-						if !memberID.Equal(entry.ID) {
-							g.AddEdge(memberID, entry.ID, 1, nil)
-						}
-					}
-				}
-			}
+	for source, dependencies := range ResolveDependencies(entryMap, resolver) {
+		for _, target := range dependencies {
+			g.AddEdge(target, source, 1, nil)
 		}
 	}
 

--- a/system/registry/topology/sort_changeset.go
+++ b/system/registry/topology/sort_changeset.go
@@ -109,12 +109,12 @@ func (b *StateBuilder) SortChangeSetWithIndex(fromState registry.State, changeSe
 
 	// Target-side dependencies: create/update dependencies before their
 	// dependents, but only when both sides are part of this changeset.
-	createUpdateUniverse := dependencyUniverse(createUpdateEntries)
+	createUpdateUniverse := dependencyUniverse(createUpdateEntries, b.resolver)
 	for i, operation := range changeSet {
 		if operation.Kind == registry.EntryDelete {
 			continue
 		}
-		for _, depID := range b.entryDependencyIDs(operation.Entry, createUpdateUniverse) {
+		for _, depID := range createUpdateUniverse[operation.Entry.ID] {
 			for _, depIndex := range createUpdateIndexesByID[depID] {
 				addConstraint(depIndex, i)
 			}
@@ -268,69 +268,12 @@ func clearIDSet(set map[registry.ID]struct{}) {
 	}
 }
 
-type dependencySet struct {
-	entries map[registry.ID]registry.Entry
-	groups  map[string][]registry.ID
-	ns      map[string][]registry.ID
-}
-
-func dependencyUniverse(entries []registry.Entry) dependencySet {
-	universe := dependencySet{
-		entries: make(map[registry.ID]registry.Entry, len(entries)),
-		groups:  make(map[string][]registry.ID),
-		ns:      make(map[string][]registry.ID),
-	}
+func dependencyUniverse(entries []registry.Entry, resolver registry.DependencyResolver) map[registry.ID][]registry.ID {
+	state := make(registry.StateMap, len(entries))
 	for _, entry := range entries {
-		universe.entries[entry.ID] = entry
-		for _, group := range entry.Meta.GetSlice(registry.TagGroups) {
-			universe.groups[group] = append(universe.groups[group], entry.ID)
-		}
-		if entry.ID.NS != "" {
-			universe.ns[entry.ID.NS] = append(universe.ns[entry.ID.NS], entry.ID)
-		}
+		state[entry.ID] = entry
 	}
-	return universe
-}
-
-func (b *StateBuilder) entryDependencyIDs(entry registry.Entry, universe dependencySet) []registry.ID {
-	dependencies := entry.Meta.GetSlice(registry.TagDependsOn)
-	if b.resolver != nil {
-		dependencies = append(dependencies, b.resolver.Extract(entry)...)
-	}
-
-	seen := make(map[registry.ID]struct{}, len(dependencies))
-	out := make([]registry.ID, 0, len(dependencies))
-	add := func(id registry.ID) {
-		if id.Equal(entry.ID) {
-			return
-		}
-		if _, ok := universe.entries[id]; !ok {
-			return
-		}
-		if _, ok := seen[id]; ok {
-			return
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-	}
-
-	for _, dep := range dependencies {
-		depType, value := parseDependency(dep)
-		switch depType {
-		case "direct":
-			add(resolveDependencyID(entry.ID.NS, value))
-		case "group":
-			for _, id := range universe.groups[value] {
-				add(id)
-			}
-		case "namespace":
-			for _, id := range universe.ns[value] {
-				add(id)
-			}
-		}
-	}
-
-	return out
+	return ResolveDependencies(state, resolver)
 }
 
 func stableTopologicalOrder(count int, constraints map[int]map[int]struct{}) ([]int, bool) {

--- a/system/registry/topology/sort_changeset_test.go
+++ b/system/registry/topology/sort_changeset_test.go
@@ -285,12 +285,12 @@ func applyWithIncomingDependencyCheck(builder *StateBuilder, fromState registry.
 
 	for _, op := range sorted {
 		if op.Kind == registry.EntryDelete {
-			universe := dependencyUniverse(StateMapToSlice(state))
+			universe := dependencyUniverse(StateMapToSlice(state), builder.resolver)
 			for _, entry := range StateMapToSlice(state) {
 				if entry.ID.Equal(op.Entry.ID) {
 					continue
 				}
-				for _, depID := range builder.entryDependencyIDs(entry, universe) {
+				for _, depID := range universe[entry.ID] {
 					if depID.Equal(op.Entry.ID) {
 						return fmt.Errorf("delete %s before dependent %s moved/deleted",
 							op.Entry.ID.String(), entry.ID.String())

--- a/system/resource/errors.go
+++ b/system/resource/errors.go
@@ -9,8 +9,9 @@ import (
 
 // Sentinel errors for resource operations.
 var (
-	ErrLocked = apierror.New(apierror.Unavailable, "resource is locked").WithRetryable(apierror.True)
-	ErrClosed = apierror.New(apierror.Unavailable, "resource provider is closed").WithRetryable(apierror.False)
+	ErrLocked          = apierror.New(apierror.Unavailable, "resource is locked").WithRetryable(apierror.True)
+	ErrClosed          = apierror.New(apierror.Unavailable, "resource provider is closed").WithRetryable(apierror.False)
+	ErrInvalidResource = apierror.New(apierror.Internal, "resource provider returned a nil resource").WithRetryable(apierror.False)
 )
 
 // NewSubscriberError creates an error for subscriber creation failure.

--- a/system/resource/registry.go
+++ b/system/resource/registry.go
@@ -140,8 +140,8 @@ func (s *Registry) handleUpdate(e event.Event) {
 		s.mu.Unlock()
 		return
 	}
-	_, exists := s.resources[entry.ID]
-	if !exists {
+	slot, exists := s.resources[entry.ID]
+	if !exists || slot.active == nil {
 		s.mu.Unlock()
 		s.logger.Warn("resource not found for update",
 			zap.String("id", entry.ID.String()))

--- a/system/resource/registry.go
+++ b/system/resource/registry.go
@@ -5,6 +5,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"sync"
 
@@ -113,6 +114,10 @@ func (s *Registry) handleRegister(e event.Event) {
 			zap.String("type", fmt.Sprintf("%T", e.Data)))
 		return
 	}
+	if isNilInterface(entry.Provider) {
+		s.logger.Error("resource entry has nil provider", zap.String("resource", e.Path))
+		return
+	}
 
 	s.mu.Lock()
 	if s.stopped {
@@ -132,6 +137,10 @@ func (s *Registry) handleUpdate(e event.Event) {
 		s.logger.Error("invalid resource entry payload",
 			zap.String("resource", e.Path),
 			zap.String("type", fmt.Sprintf("%T", e.Data)))
+		return
+	}
+	if isNilInterface(entry.Provider) {
+		s.logger.Error("resource entry has nil provider", zap.String("resource", e.Path))
 		return
 	}
 
@@ -202,10 +211,27 @@ func (s *Registry) Acquire(ctx context.Context, id registry.ID, mode resource.Ac
 		s.releaseBorrow(id, generation)
 		return nil, err
 	}
+	if isNilInterface(res) {
+		s.releaseBorrow(id, generation)
+		return nil, ErrInvalidResource
+	}
 
 	return resource.NewTrackedResource(res, func() {
 		s.releaseBorrow(id, generation)
 	}), nil
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 // activateLocked publishes a new acquisition generation. Older generations

--- a/system/resource/registry.go
+++ b/system/resource/registry.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/wippyai/runtime/api/resource"
 
@@ -18,12 +17,20 @@ import (
 
 // Registry manages resource registration and access
 type Registry struct {
-	ctx         context.Context
-	bus         event.Bus
-	logger      *zap.Logger
-	subscriber  *eventbus.Subscriber
-	resources   sync.Map
-	borrowCount sync.Map
+	ctx        context.Context
+	bus        event.Bus
+	logger     *zap.Logger
+	subscriber *eventbus.Subscriber
+	resources  map[registry.ID]*resourceSlot
+	mu         sync.Mutex
+	stopped    bool
+}
+
+type resourceSlot struct {
+	pending  *resource.Entry
+	entry    resource.Entry
+	borrows  int
+	draining bool
 }
 
 // NewRegistry creates a new resource registry instance
@@ -32,14 +39,18 @@ func NewRegistry(bus event.Bus, logger *zap.Logger) *Registry {
 		logger = zap.NewNop()
 	}
 	return &Registry{
-		bus:    bus,
-		logger: logger,
+		bus:       bus,
+		logger:    logger,
+		resources: make(map[registry.ID]*resourceSlot),
 	}
 }
 
 // Start initializes the service and begins listening for resource events
 func (s *Registry) Start(ctx context.Context) error {
 	s.ctx = ctx
+	s.mu.Lock()
+	s.stopped = false
+	s.mu.Unlock()
 
 	// Subscribe to resource events
 	sub, err := eventbus.NewSubscriber(
@@ -63,6 +74,17 @@ func (s *Registry) Stop() error {
 		s.subscriber.Close()
 		s.subscriber = nil
 	}
+	s.mu.Lock()
+	s.stopped = true
+	for id, slot := range s.resources {
+		slot.pending = nil
+		if slot.borrows == 0 {
+			delete(s.resources, id)
+		} else {
+			slot.draining = true
+		}
+	}
+	s.mu.Unlock()
 	return nil
 }
 
@@ -90,9 +112,26 @@ func (s *Registry) handleRegister(e event.Event) {
 		return
 	}
 
-	// Store the resource entry and initialize borrow counter
-	s.resources.Store(entry.ID, entry)
-	s.borrowCount.Store(entry.ID, new(atomic.Int32))
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	if slot, exists := s.resources[entry.ID]; exists && slot.draining {
+		pending := entry
+		slot.pending = &pending
+	} else if exists {
+		if slot.borrows > 0 {
+			pending := entry
+			slot.pending = &pending
+			slot.draining = true
+		} else {
+			slot.entry = entry
+		}
+	} else {
+		s.resources[entry.ID] = &resourceSlot{entry: entry}
+	}
+	s.mu.Unlock()
 	s.logger.Debug("resource registered",
 		zap.String("id", entry.ID.String()),
 		zap.Any("meta", entry.Meta))
@@ -107,14 +146,29 @@ func (s *Registry) handleUpdate(e event.Event) {
 		return
 	}
 
-	// Update existing resource
-	if _, exists := s.resources.Load(entry.ID); !exists {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	slot, exists := s.resources[entry.ID]
+	if !exists {
+		s.mu.Unlock()
 		s.logger.Warn("resource not found for update",
 			zap.String("id", entry.ID.String()))
 		return
 	}
-
-	s.resources.Store(entry.ID, entry)
+	if slot.draining {
+		pending := entry
+		slot.pending = &pending
+	} else if slot.borrows > 0 {
+		pending := entry
+		slot.pending = &pending
+		slot.draining = true
+	} else {
+		slot.entry = entry
+	}
+	s.mu.Unlock()
 	s.logger.Debug("resource updated",
 		zap.String("id", entry.ID.String()),
 		zap.Any("meta", entry.Meta))
@@ -129,26 +183,26 @@ func (s *Registry) handleRemove(e event.Event) {
 		return
 	}
 
-	// Check if resource exists
-	if _, exists := s.resources.Load(id); !exists {
+	s.mu.Lock()
+	slot, exists := s.resources[id]
+	if !exists {
+		s.mu.Unlock()
 		s.logger.Warn("resource not found for removal",
 			zap.String("id", id.String()))
 		return
 	}
-
-	// Check if resource is borrowed
-	if countVal, ok := s.borrowCount.Load(id); ok {
-		count := countVal.(*atomic.Int32).Load()
-		if count > 0 {
-			s.logger.Warn("cannot delete borrowed resource",
-				zap.String("id", id.String()),
-				zap.Int32("borrows", count))
-			return
-		}
+	slot.pending = nil
+	if slot.borrows > 0 {
+		slot.draining = true
+		borrows := slot.borrows
+		s.mu.Unlock()
+		s.logger.Debug("resource draining before removal",
+			zap.String("id", id.String()),
+			zap.Int("borrows", borrows))
+		return
 	}
-
-	s.resources.Delete(id)
-	s.borrowCount.Delete(id)
+	delete(s.resources, id)
+	s.mu.Unlock()
 	s.logger.Debug("resource removed",
 		zap.String("id", id.String()))
 }
@@ -159,52 +213,66 @@ func (s *Registry) Acquire(ctx context.Context, id registry.ID, mode resource.Ac
 		return nil, ctx.Err()
 	}
 
-	entryVal, ok := s.resources.Load(id)
-	if !ok {
+	s.mu.Lock()
+	slot, ok := s.resources[id]
+	if s.stopped || !ok || slot.draining {
+		s.mu.Unlock()
 		return nil, resource.ErrNotFound
 	}
-
-	entry, ok := entryVal.(resource.Entry)
-	if !ok {
-		return nil, resource.ErrNotFound
-	}
-
-	// Get or create borrow counter
-	countVal, _ := s.borrowCount.LoadOrStore(id, new(atomic.Int32))
-	counter, ok := countVal.(*atomic.Int32)
-	if !ok {
-		return nil, resource.ErrNotFound
-	}
-	counter.Add(1)
+	entry := slot.entry
+	slot.borrows++
+	s.mu.Unlock()
 
 	res, err := entry.Provider.Acquire(ctx, id, mode)
 	if err != nil {
-		counter.Add(-1)
+		s.releaseBorrow(id, slot)
 		return nil, err
 	}
 
-	// Wrap with tracking - decrement count on release
 	return resource.NewTrackedResource(res, func() {
-		counter.Add(-1)
+		s.releaseBorrow(id, slot)
 	}), nil
+}
+
+func (s *Registry) releaseBorrow(id registry.ID, borrowedSlot *resourceSlot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	slot, exists := s.resources[id]
+	if !exists || slot != borrowedSlot || slot.borrows == 0 {
+		return
+	}
+	slot.borrows--
+	if slot.borrows != 0 || !slot.draining {
+		return
+	}
+	if slot.pending != nil {
+		slot.entry = *slot.pending
+		slot.pending = nil
+		slot.draining = false
+		return
+	}
+	delete(s.resources, id)
 }
 
 // List returns all registered resource IDs
 func (s *Registry) List() ([]registry.ID, error) {
-	var resources []registry.ID
-	s.resources.Range(func(key, _ any) bool {
-		if id, ok := key.(registry.ID); ok {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	resources := make([]registry.ID, 0, len(s.resources))
+	for id, slot := range s.resources {
+		if !slot.draining {
 			resources = append(resources, id)
 		}
-		return true
-	})
+	}
 	return resources, nil
 }
 
 // Exists checks if a resource is registered
 func (s *Registry) Exists(id registry.ID) bool {
-	_, exists := s.resources.Load(id)
-	return exists
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	slot, exists := s.resources[id]
+	return exists && !slot.draining
 }
 
 // Implementation of Registry interface

--- a/system/resource/registry.go
+++ b/system/resource/registry.go
@@ -5,6 +5,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/wippyai/runtime/api/resource"
@@ -22,15 +23,18 @@ type Registry struct {
 	logger     *zap.Logger
 	subscriber *eventbus.Subscriber
 	resources  map[registry.ID]*resourceSlot
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	stopped    bool
 }
 
 type resourceSlot struct {
-	pending  *resource.Entry
-	entry    resource.Entry
-	borrows  int
-	draining bool
+	active  *resourceGeneration
+	retired map[*resourceGeneration]struct{}
+}
+
+type resourceGeneration struct {
+	entry   resource.Entry
+	borrows int
 }
 
 // NewRegistry creates a new resource registry instance
@@ -77,11 +81,9 @@ func (s *Registry) Stop() error {
 	s.mu.Lock()
 	s.stopped = true
 	for id, slot := range s.resources {
-		slot.pending = nil
-		if slot.borrows == 0 {
+		s.retireActiveLocked(slot)
+		if len(slot.retired) == 0 {
 			delete(s.resources, id)
-		} else {
-			slot.draining = true
 		}
 	}
 	s.mu.Unlock()
@@ -117,20 +119,7 @@ func (s *Registry) handleRegister(e event.Event) {
 		s.mu.Unlock()
 		return
 	}
-	if slot, exists := s.resources[entry.ID]; exists && slot.draining {
-		pending := entry
-		slot.pending = &pending
-	} else if exists {
-		if slot.borrows > 0 {
-			pending := entry
-			slot.pending = &pending
-			slot.draining = true
-		} else {
-			slot.entry = entry
-		}
-	} else {
-		s.resources[entry.ID] = &resourceSlot{entry: entry}
-	}
+	s.activateLocked(entry)
 	s.mu.Unlock()
 	s.logger.Debug("resource registered",
 		zap.String("id", entry.ID.String()),
@@ -151,23 +140,14 @@ func (s *Registry) handleUpdate(e event.Event) {
 		s.mu.Unlock()
 		return
 	}
-	slot, exists := s.resources[entry.ID]
+	_, exists := s.resources[entry.ID]
 	if !exists {
 		s.mu.Unlock()
 		s.logger.Warn("resource not found for update",
 			zap.String("id", entry.ID.String()))
 		return
 	}
-	if slot.draining {
-		pending := entry
-		slot.pending = &pending
-	} else if slot.borrows > 0 {
-		pending := entry
-		slot.pending = &pending
-		slot.draining = true
-	} else {
-		slot.entry = entry
-	}
+	s.activateLocked(entry)
 	s.mu.Unlock()
 	s.logger.Debug("resource updated",
 		zap.String("id", entry.ID.String()),
@@ -191,17 +171,10 @@ func (s *Registry) handleRemove(e event.Event) {
 			zap.String("id", id.String()))
 		return
 	}
-	slot.pending = nil
-	if slot.borrows > 0 {
-		slot.draining = true
-		borrows := slot.borrows
-		s.mu.Unlock()
-		s.logger.Debug("resource draining before removal",
-			zap.String("id", id.String()),
-			zap.Int("borrows", borrows))
-		return
+	s.retireActiveLocked(slot)
+	if len(slot.retired) == 0 {
+		delete(s.resources, id)
 	}
-	delete(s.resources, id)
 	s.mu.Unlock()
 	s.logger.Debug("resource removed",
 		zap.String("id", id.String()))
@@ -215,64 +188,95 @@ func (s *Registry) Acquire(ctx context.Context, id registry.ID, mode resource.Ac
 
 	s.mu.Lock()
 	slot, ok := s.resources[id]
-	if s.stopped || !ok || slot.draining {
+	if s.stopped || !ok || slot.active == nil {
 		s.mu.Unlock()
 		return nil, resource.ErrNotFound
 	}
-	entry := slot.entry
-	slot.borrows++
+	generation := slot.active
+	entry := generation.entry
+	generation.borrows++
 	s.mu.Unlock()
 
 	res, err := entry.Provider.Acquire(ctx, id, mode)
 	if err != nil {
-		s.releaseBorrow(id, slot)
+		s.releaseBorrow(id, generation)
 		return nil, err
 	}
 
 	return resource.NewTrackedResource(res, func() {
-		s.releaseBorrow(id, slot)
+		s.releaseBorrow(id, generation)
 	}), nil
 }
 
-func (s *Registry) releaseBorrow(id registry.ID, borrowedSlot *resourceSlot) {
+// activateLocked publishes a new acquisition generation. Older generations
+// remain reachable only by the resources that already borrowed them.
+func (s *Registry) activateLocked(entry resource.Entry) {
+	slot := s.resources[entry.ID]
+	if slot == nil {
+		slot = &resourceSlot{}
+		s.resources[entry.ID] = slot
+	}
+	s.retireActiveLocked(slot)
+	slot.active = &resourceGeneration{entry: entry}
+}
+
+func (s *Registry) retireActiveLocked(slot *resourceSlot) {
+	if slot.active == nil {
+		return
+	}
+	if slot.active.borrows > 0 {
+		if slot.retired == nil {
+			slot.retired = make(map[*resourceGeneration]struct{})
+		}
+		slot.retired[slot.active] = struct{}{}
+	}
+	slot.active = nil
+}
+
+func (s *Registry) releaseBorrow(id registry.ID, generation *resourceGeneration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	slot, exists := s.resources[id]
-	if !exists || slot != borrowedSlot || slot.borrows == 0 {
+	if !exists || generation.borrows == 0 {
 		return
 	}
-	slot.borrows--
-	if slot.borrows != 0 || !slot.draining {
+	if slot.active != generation {
+		if _, retired := slot.retired[generation]; !retired {
+			return
+		}
+	}
+	generation.borrows--
+	if generation.borrows != 0 || slot.active == generation {
 		return
 	}
-	if slot.pending != nil {
-		slot.entry = *slot.pending
-		slot.pending = nil
-		slot.draining = false
-		return
+	delete(slot.retired, generation)
+	if slot.active == nil && len(slot.retired) == 0 {
+		delete(s.resources, id)
 	}
-	delete(s.resources, id)
 }
 
 // List returns all registered resource IDs
 func (s *Registry) List() ([]registry.ID, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	resources := make([]registry.ID, 0, len(s.resources))
 	for id, slot := range s.resources {
-		if !slot.draining {
+		if slot.active != nil {
 			resources = append(resources, id)
 		}
 	}
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].String() < resources[j].String()
+	})
 	return resources, nil
 }
 
 // Exists checks if a resource is registered
 func (s *Registry) Exists(id registry.ID) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	slot, exists := s.resources[id]
-	return exists && !slot.draining
+	return exists && slot.active != nil
 }
 
 // Implementation of Registry interface

--- a/system/resource/registry_linearizability_test.go
+++ b/system/resource/registry_linearizability_test.go
@@ -115,6 +115,26 @@ func TestLaterDeleteCancelsPendingReplacement(t *testing.T) {
 	require.False(t, service.Exists(id))
 }
 
+func TestUpdateCannotResurrectRetiredResource(t *testing.T) {
+	service, _ := setupTest()
+	id := registry.NewID("test", "retired-update")
+	oldProvider := newMockResourceProvider()
+	oldProvider.resources[id] = "old"
+	newProvider := newMockResourceProvider()
+	newProvider.resources[id] = "new"
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: oldProvider}})
+	borrowed, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+
+	service.handleRemove(event.Event{Data: id})
+	service.handleUpdate(event.Event{Data: apiresource.Entry{ID: id, Provider: newProvider}})
+	require.False(t, service.Exists(id))
+	_, err = service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.ErrorIs(t, err, apiresource.ErrNotFound)
+	borrowed.Release()
+	require.Empty(t, service.resources)
+}
+
 func TestStopDrainsResourcesAndRejectsNewAcquires(t *testing.T) {
 	service, _ := setupTest()
 	id := registry.NewID("test", "stop-borrowed")

--- a/system/resource/registry_linearizability_test.go
+++ b/system/resource/registry_linearizability_test.go
@@ -12,7 +12,7 @@ import (
 	apiresource "github.com/wippyai/runtime/api/resource"
 )
 
-func TestY07ResourceReplaceWaitsForBorrowedGeneration(t *testing.T) {
+func TestY07ResourceReplacePublishesNewGenerationWhileOldIsBorrowed(t *testing.T) {
 	service, _ := setupTest()
 	id := registry.NewID("test", "replace-borrowed")
 	oldProvider := newMockResourceProvider()
@@ -26,11 +26,6 @@ func TestY07ResourceReplaceWaitsForBorrowedGeneration(t *testing.T) {
 
 	service.handleRemove(event.Event{Data: id})
 	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: newProvider}})
-	require.False(t, service.Exists(id), "replacement must wait for the outstanding borrow generation")
-	_, err = service.Acquire(context.Background(), id, apiresource.ModeNormal)
-	require.ErrorIs(t, err, apiresource.ErrNotFound)
-
-	borrowed.Release()
 	require.True(t, service.Exists(id))
 	replacement, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
 	require.NoError(t, err)
@@ -38,9 +33,13 @@ func TestY07ResourceReplaceWaitsForBorrowedGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "new", value)
 	replacement.Release()
+	borrowedValue, err := borrowed.Get()
+	require.NoError(t, err)
+	require.Equal(t, "old", borrowedValue)
+	borrowed.Release()
 }
 
-func TestResourceUpdateWaitsForBorrowedGeneration(t *testing.T) {
+func TestResourceUpdatePublishesNewGenerationWhileOldIsBorrowed(t *testing.T) {
 	service, _ := setupTest()
 	id := registry.NewID("test", "update-borrowed")
 	oldProvider := newMockResourceProvider()
@@ -52,17 +51,50 @@ func TestResourceUpdateWaitsForBorrowedGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	service.handleUpdate(event.Event{Data: apiresource.Entry{ID: id, Provider: newProvider}})
-	require.False(t, service.Exists(id))
-	_, err = service.Acquire(context.Background(), id, apiresource.ModeNormal)
-	require.ErrorIs(t, err, apiresource.ErrNotFound)
-	borrowed.Release()
-
+	require.True(t, service.Exists(id))
 	replacement, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
 	require.NoError(t, err)
 	value, err := replacement.Get()
 	require.NoError(t, err)
 	require.Equal(t, "new", value)
 	replacement.Release()
+	borrowedValue, err := borrowed.Get()
+	require.NoError(t, err)
+	require.Equal(t, "old", borrowedValue)
+	borrowed.Release()
+}
+
+func TestMultipleBorrowedGenerationsRetireIndependently(t *testing.T) {
+	service, _ := setupTest()
+	id := registry.NewID("test", "successive-updates")
+	providers := []*mockResourceProvider{
+		newMockResourceProvider(), newMockResourceProvider(), newMockResourceProvider(),
+	}
+	for i, provider := range providers {
+		provider.resources[id] = i + 1
+	}
+
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: providers[0]}})
+	first, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	service.handleUpdate(event.Event{Data: apiresource.Entry{ID: id, Provider: providers[1]}})
+	second, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	service.handleUpdate(event.Event{Data: apiresource.Entry{ID: id, Provider: providers[2]}})
+	third, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+
+	for expected, borrowed := range []apiresource.Resource[any]{first, second, third} {
+		value, getErr := borrowed.Get()
+		require.NoError(t, getErr)
+		require.Equal(t, expected+1, value)
+	}
+	first.Release()
+	second.Release()
+	require.True(t, service.Exists(id))
+	third.Release()
+	require.Len(t, service.resources, 1)
+	require.Empty(t, service.resources[id].retired)
 }
 
 func TestLaterDeleteCancelsPendingReplacement(t *testing.T) {

--- a/system/resource/registry_linearizability_test.go
+++ b/system/resource/registry_linearizability_test.go
@@ -12,7 +12,7 @@ import (
 	apiresource "github.com/wippyai/runtime/api/resource"
 )
 
-func TestY07ResourceReplacePreservesBorrow(t *testing.T) {
+func TestY07ResourceReplaceWaitsForBorrowedGeneration(t *testing.T) {
 	service, _ := setupTest()
 	id := registry.NewID("test", "replace-borrowed")
 	oldProvider := newMockResourceProvider()
@@ -24,11 +24,77 @@ func TestY07ResourceReplacePreservesBorrow(t *testing.T) {
 	borrowed, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
 	require.NoError(t, err)
 
-	service.handleUpdate(event.Event{Data: apiresource.Entry{ID: id, Provider: newProvider}})
 	service.handleRemove(event.Event{Data: id})
-	require.True(t, service.Exists(id), "replacement must retain the outstanding borrow generation")
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: newProvider}})
+	require.False(t, service.Exists(id), "replacement must wait for the outstanding borrow generation")
+	_, err = service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.ErrorIs(t, err, apiresource.ErrNotFound)
 
 	borrowed.Release()
-	service.handleRemove(event.Event{Data: id})
+	require.True(t, service.Exists(id))
+	replacement, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	value, err := replacement.Get()
+	require.NoError(t, err)
+	require.Equal(t, "new", value)
+	replacement.Release()
+}
+
+func TestResourceUpdateWaitsForBorrowedGeneration(t *testing.T) {
+	service, _ := setupTest()
+	id := registry.NewID("test", "update-borrowed")
+	oldProvider := newMockResourceProvider()
+	oldProvider.resources[id] = "old"
+	newProvider := newMockResourceProvider()
+	newProvider.resources[id] = "new"
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: oldProvider}})
+	borrowed, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+
+	service.handleUpdate(event.Event{Data: apiresource.Entry{ID: id, Provider: newProvider}})
 	require.False(t, service.Exists(id))
+	_, err = service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.ErrorIs(t, err, apiresource.ErrNotFound)
+	borrowed.Release()
+
+	replacement, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	value, err := replacement.Get()
+	require.NoError(t, err)
+	require.Equal(t, "new", value)
+	replacement.Release()
+}
+
+func TestLaterDeleteCancelsPendingReplacement(t *testing.T) {
+	service, _ := setupTest()
+	id := registry.NewID("test", "delete-pending")
+	provider := newMockResourceProvider()
+	provider.resources[id] = "old"
+	replacement := newMockResourceProvider()
+	replacement.resources[id] = "new"
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: provider}})
+	borrowed, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+
+	service.handleRemove(event.Event{Data: id})
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: replacement}})
+	service.handleRemove(event.Event{Data: id})
+	borrowed.Release()
+	require.False(t, service.Exists(id))
+}
+
+func TestStopDrainsResourcesAndRejectsNewAcquires(t *testing.T) {
+	service, _ := setupTest()
+	id := registry.NewID("test", "stop-borrowed")
+	provider := newMockResourceProvider()
+	provider.resources[id] = "value"
+	service.handleRegister(event.Event{Data: apiresource.Entry{ID: id, Provider: provider}})
+	borrowed, err := service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.NoError(t, err)
+	require.NoError(t, service.Stop())
+	require.False(t, service.Exists(id))
+	_, err = service.Acquire(context.Background(), id, apiresource.ModeNormal)
+	require.ErrorIs(t, err, apiresource.ErrNotFound)
+	borrowed.Release()
+	require.Empty(t, service.resources)
 }

--- a/system/resource/registry_test.go
+++ b/system/resource/registry_test.go
@@ -809,7 +809,8 @@ func TestService_DeleteBorrowedResource(t *testing.T) {
 	res, err := service.Acquire(ctx, id, resource.ModeNormal)
 	require.NoError(t, err)
 
-	// Try to delete while borrowed - should fail silently
+	// Delete while borrowed starts a drain: the existing borrower remains
+	// valid, while the resource disappears from discovery and new acquisition.
 	bus.Send(ctx, event.Event{
 		System: resource.System,
 		Kind:   resource.Delete,
@@ -818,19 +819,12 @@ func TestService_DeleteBorrowedResource(t *testing.T) {
 	})
 	time.Sleep(10 * time.Millisecond)
 
-	// Resource should still exist
-	assert.True(t, service.Exists(id))
+	assert.False(t, service.Exists(id))
+	_, err = service.Acquire(ctx, id, resource.ModeNormal)
+	assert.ErrorIs(t, err, resource.ErrNotFound)
 
-	// Release the resource
+	// Final release completes removal without requiring a second delete event.
 	res.Release()
-
-	// Now delete should succeed
-	bus.Send(ctx, event.Event{
-		System: resource.System,
-		Kind:   resource.Delete,
-		Path:   id.String(),
-		Data:   id,
-	})
 	time.Sleep(10 * time.Millisecond)
 
 	assert.False(t, service.Exists(id))

--- a/system/resource/registry_test.go
+++ b/system/resource/registry_test.go
@@ -809,8 +809,8 @@ func TestService_DeleteBorrowedResource(t *testing.T) {
 	res, err := service.Acquire(ctx, id, resource.ModeNormal)
 	require.NoError(t, err)
 
-	// Delete while borrowed starts a drain: the existing borrower remains
-	// valid, while the resource disappears from discovery and new acquisition.
+	// Delete while borrowed retires the routing generation immediately. The
+	// provider owns whether an already acquired handle remains usable.
 	bus.Send(ctx, event.Event{
 		System: resource.System,
 		Kind:   resource.Delete,
@@ -828,4 +828,24 @@ func TestService_DeleteBorrowedResource(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	assert.False(t, service.Exists(id))
+}
+
+type nilResourceProvider struct{}
+
+func (nilResourceProvider) Acquire(context.Context, registry.ID, resource.AccessMode) (resource.Resource[any], error) {
+	return nil, nil
+}
+
+func TestServiceRejectsNilProviderAndNilResource(t *testing.T) {
+	service, _ := setupTest()
+	id := registry.NewID("test", "invalid-provider")
+
+	service.handleRegister(event.Event{Path: id.String(), Data: resource.Entry{ID: id}})
+	assert.False(t, service.Exists(id))
+
+	service.handleRegister(event.Event{Path: id.String(), Data: resource.Entry{ID: id, Provider: nilResourceProvider{}}})
+	_, err := service.Acquire(context.Background(), id, resource.ModeNormal)
+	assert.ErrorIs(t, err, ErrInvalidResource)
+	require.Len(t, service.resources, 1)
+	assert.Zero(t, service.resources[id].active.borrows)
 }


### PR DESCRIPTION
## Summary

- add `registry.overlay(id)` through the existing Snapshot/Changes workflow
- keep owner-scoped process-local entries in effective registry state without writing history or entry metadata
- preserve overlays across durable commits and version selection; clear them at the `LoadState` boot boundary
- enforce generation CAS, owner isolation, durable/overlay dependency boundaries, directive boundaries, and per-kind permissions
- route resource acquisitions by exact active/retired generation so replacement and teardown do not corrupt outstanding borrows
- return structured, actionable overlay diagnostics, including generation conflicts and missing/malformed entry IDs

## Contract

Overlay IDs are logical, policy-controlled owners. Ownership is held only by the registry; it is never inferred from `Entry.Meta`, payloads, history, or module provenance. Overlay entries use normal topology and handler transitions, but do not advance durable versions. The owning control service reconciles its desired state after boot and deletes its entries during teardown.

Overlay changes use owner-scoped optimistic concurrency. Create/delete ABA cycles invalidate stale snapshots for that owner without conflicting with unrelated owners. Failed transitions reconcile registry-owned indexes and invalidate affected generations. Directive-owned kinds fail closed because expansion effects do not have overlay ownership semantics.

Required permissions:

- `registry.overlay.get` and `registry.overlay.apply` on the owner ID
- `registry.overlay.create.<kind>`, `registry.overlay.update.<kind>`, or `registry.overlay.delete.<kind>` on each entry ID

Durable entries cannot depend on overlays, overlays cannot cross owners, and durable transitions cannot mutate overlay entries or remove their live durable dependencies.

Resource replacement removes the old generation from discovery immediately. Existing acquired handles retain their matching `Release`; providers continue to own whether a handle remains usable after provider shutdown.

## Scale

The 10,000-entry single-overlay update benchmark runs in roughly 5–8 ms with 10.5 MB and 170 allocations per update on the benchmark host. IDs are canonicalized at registry ingress, and dependency validation streams edges with O(entries) retained memory, including dense group graphs.

## Verification

- full race-enabled `make test`
- focused registry, topology, resource, and Lua registry race suite repeated 10 times
- `make lint`
- overlay churn and dense-dependency allocation benchmarks
