### PR TITLE
fix(di): validate contract changes at the transaction boundary

### DIFF
--- a/service/di/manager.go
+++ b/service/di/manager.go
@@ -24,7 +24,86 @@ type Manager struct {
 
 	definitions map[registry.ID]*contract.Definition
 	bindings    map[registry.ID]*contract.Binding
+	tx          *txState
 	mu          sync.RWMutex
+}
+
+// Manager participates in registry transactions so that a changeset updating a
+// contract definition together with its bindings can be validated as a whole.
+var _ registry.TransactionListener = (*Manager)(nil)
+
+// txState stages contract mutations for the duration of one registry
+// transaction. Entries are validated structurally as they arrive, but
+// cross-entry validation (binding completeness against definitions, unique
+// defaults, definition-in-use) is deferred to Commit, when the complete
+// post-transaction state is known. That is what makes a definition update and
+// its binding updates applicable in one changeset: neither half is valid
+// against the pre-change peer, but the pair is valid together.
+type txState struct {
+	definitions        map[registry.ID]*contract.Definition
+	bindings           map[registry.ID]*contract.Binding
+	deletedDefinitions map[registry.ID]struct{}
+	deletedBindings    map[registry.ID]struct{}
+	events             []event.Event
+}
+
+func newTxState() *txState {
+	return &txState{
+		definitions:        make(map[registry.ID]*contract.Definition),
+		bindings:           make(map[registry.ID]*contract.Binding),
+		deletedDefinitions: make(map[registry.ID]struct{}),
+		deletedBindings:    make(map[registry.ID]struct{}),
+	}
+}
+
+func (tx *txState) stageDefinition(id registry.ID, def *contract.Definition, evt event.Event) {
+	tx.definitions[id] = def
+	delete(tx.deletedDefinitions, id)
+	tx.events = append(tx.events, evt)
+}
+
+func (tx *txState) deleteDefinition(id registry.ID, evt event.Event) {
+	delete(tx.definitions, id)
+	tx.deletedDefinitions[id] = struct{}{}
+	tx.events = append(tx.events, evt)
+}
+
+func (tx *txState) stageBinding(id registry.ID, binding *contract.Binding, evt event.Event) {
+	tx.bindings[id] = binding
+	delete(tx.deletedBindings, id)
+	tx.events = append(tx.events, evt)
+}
+
+func (tx *txState) deleteBinding(id registry.ID, evt event.Event) {
+	delete(tx.bindings, id)
+	tx.deletedBindings[id] = struct{}{}
+	tx.events = append(tx.events, evt)
+}
+
+func (tx *txState) effectiveDefinitions(base map[registry.ID]*contract.Definition) map[registry.ID]*contract.Definition {
+	out := make(map[registry.ID]*contract.Definition, len(base)+len(tx.definitions))
+	for id, def := range base {
+		if _, gone := tx.deletedDefinitions[id]; !gone {
+			out[id] = def
+		}
+	}
+	for id, def := range tx.definitions {
+		out[id] = def
+	}
+	return out
+}
+
+func (tx *txState) effectiveBindings(base map[registry.ID]*contract.Binding) map[registry.ID]*contract.Binding {
+	out := make(map[registry.ID]*contract.Binding, len(base)+len(tx.bindings))
+	for id, binding := range base {
+		if _, gone := tx.deletedBindings[id]; !gone {
+			out[id] = binding
+		}
+	}
+	for id, binding := range tx.bindings {
+		out[id] = binding
+	}
+	return out
 }
 
 // NewManager creates a new contract manager
@@ -79,6 +158,94 @@ func (m *Manager) Delete(ctx context.Context, entry registry.Entry) error {
 	default:
 		return NewUnsupportedEntryKindError(entry.Kind)
 	}
+}
+
+// --- registry.TransactionListener ---
+
+// Begin opens a staging area. Until Commit, entry operations are validated
+// structurally, staged, and their contract-plane events queued.
+func (m *Manager) Begin(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tx = newTxState()
+	return nil
+}
+
+// Commit validates the complete staged state and applies it atomically. On a
+// validation failure nothing is applied and no event is emitted; the registry
+// runner rolls the changeset back and discards the transaction.
+func (m *Manager) Commit(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tx := m.tx
+	if tx == nil {
+		return nil
+	}
+	definitions := tx.effectiveDefinitions(m.definitions)
+	bindings := tx.effectiveBindings(m.bindings)
+	for bindingID, binding := range bindings {
+		if err := validateBindingAgainstDefinitions(binding, bindingID, definitions); err != nil {
+			m.tx = nil
+			return err
+		}
+		if err := validateUniqueDefaults(binding, bindingID, bindings); err != nil {
+			m.tx = nil
+			return err
+		}
+	}
+	m.definitions = definitions
+	m.bindings = bindings
+	events := tx.events
+	m.tx = nil
+	for _, evt := range events {
+		m.bus.Send(ctx, evt)
+	}
+	if len(events) > 0 {
+		m.log.Info("contract transaction committed",
+			zap.Int("staged_events", len(events)),
+			zap.Int("definitions", len(definitions)),
+			zap.Int("bindings", len(bindings)))
+	}
+	return nil
+}
+
+// Discard drops the staged state without applying it. After a failed Commit
+// the staging area is already gone and this is a no-op.
+func (m *Manager) Discard(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tx = nil
+	return nil
+}
+
+// definitionInEffect reports whether a definition exists in the state this
+// transaction would produce; outside a transaction it reads committed state.
+// Callers hold m.mu.
+func (m *Manager) definitionInEffect(id registry.ID) bool {
+	if m.tx != nil {
+		if _, staged := m.tx.definitions[id]; staged {
+			return true
+		}
+		if _, gone := m.tx.deletedDefinitions[id]; gone {
+			return false
+		}
+	}
+	_, exists := m.definitions[id]
+	return exists
+}
+
+// bindingInEffect mirrors definitionInEffect for bindings. Callers hold m.mu.
+func (m *Manager) bindingInEffect(id registry.ID) bool {
+	if m.tx != nil {
+		if _, staged := m.tx.bindings[id]; staged {
+			return true
+		}
+		if _, gone := m.tx.deletedBindings[id]; gone {
+			return false
+		}
+	}
+	_, exists := m.bindings[id]
+	return exists
 }
 
 // --- Validation Helpers ---
@@ -140,12 +307,12 @@ func (m *Manager) validateDefinitionStructure(def *contract.Definition, defID re
 
 // validateBindingAgainstDefinitions checks if a binding is valid with the current set of definitions.
 // Assumes m.mu is RLock'd or Lock'd by the caller appropriately for m.definitions access.
-func (m *Manager) validateBindingAgainstDefinitions(binding *contract.Binding, bindingID registry.ID) error {
+func validateBindingAgainstDefinitions(binding *contract.Binding, bindingID registry.ID, definitions map[registry.ID]*contract.Definition) error {
 	if len(binding.Contracts) == 0 {
 		return NewBindingNoContractsError(bindingID)
 	}
 	for i, bc := range binding.Contracts {
-		contractDef, exists := m.definitions[bc.Contract]
+		contractDef, exists := definitions[bc.Contract]
 		if !exists {
 			return NewContractNotFoundError(bindingID, i, bc.Contract)
 		}
@@ -172,12 +339,11 @@ func (m *Manager) validateBindingAgainstDefinitions(binding *contract.Binding, b
 // validateUniqueDefaults checks that no contract has multiple default bindings
 // This ensures that each contract can have at most one default binding, preventing conflicts
 // when using default binding resolution (contract:open() without binding ID)
-// Assumes m.mu is RLock'd or Lock'd by the caller appropriately for m.bindings access.
-func (m *Manager) validateUniqueDefaults(binding *contract.Binding, bindingID registry.ID) error {
+func validateUniqueDefaults(binding *contract.Binding, bindingID registry.ID, bindings map[registry.ID]*contract.Binding) error {
 	for _, bc := range binding.Contracts {
 		if bc.Default {
 			// Check if another binding already has default for this contract
-			for otherBindingID, otherBinding := range m.bindings {
+			for otherBindingID, otherBinding := range bindings {
 				if otherBindingID == bindingID {
 					continue // Skip self
 				}
@@ -212,18 +378,23 @@ func (m *Manager) handleDefinitionAdd(ctx context.Context, entry registry.Entry)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.definitions[entry.ID]; exists {
+	if m.definitionInEffect(entry.ID) {
 		return NewDefinitionAlreadyExistsError(entry.ID)
 	}
 
-	m.definitions[entry.ID] = definition
-
-	m.bus.Send(ctx, event.Event{
+	registerEvent := event.Event{
 		System: contract.System,
 		Kind:   contract.RegisterDefinition,
 		Path:   entry.ID.String(),
 		Data:   definition,
-	})
+	}
+	if m.tx != nil {
+		m.tx.stageDefinition(entry.ID, definition, registerEvent)
+		return nil
+	}
+
+	m.definitions[entry.ID] = definition
+	m.bus.Send(ctx, registerEvent)
 
 	m.log.Debug("contract definition registered",
 		zap.String("id", entry.ID.String()),
@@ -249,10 +420,25 @@ func (m *Manager) handleDefinitionUpdate(ctx context.Context, entry registry.Ent
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	originalDefinition, exists := m.definitions[entry.ID]
-	if !exists {
+	if !m.definitionInEffect(entry.ID) {
 		return NewDefinitionNotFoundForUpdateError(entry.ID)
 	}
+
+	if m.tx != nil {
+		// Cross-binding validation is deferred to Commit: the binding updates
+		// this definition change pairs with may arrive later in the same
+		// transaction, and against the pre-change bindings the update is not
+		// yet valid.
+		m.tx.stageDefinition(entry.ID, updatedDefinition, event.Event{
+			System: contract.System,
+			Kind:   contract.UpdateDefinition,
+			Path:   entry.ID.String(),
+			Data:   updatedDefinition,
+		})
+		return nil
+	}
+
+	originalDefinition := m.definitions[entry.ID]
 
 	// Temporarily apply the update to check dependent bindings
 	m.definitions[entry.ID] = updatedDefinition
@@ -267,7 +453,7 @@ func (m *Manager) handleDefinitionUpdate(ctx context.Context, entry registry.Ent
 		}
 		if usesUpdatedDef {
 			// Re-validate this binding against the *new* definition
-			if err := m.validateBindingAgainstDefinitions(binding, bindingID); err != nil {
+			if err := validateBindingAgainstDefinitions(binding, bindingID, m.definitions); err != nil {
 				validationError = NewUpdateWouldInvalidateBindingError(entry.ID, bindingID, err)
 				break
 			}
@@ -297,8 +483,20 @@ func (m *Manager) handleDefinitionDelete(ctx context.Context, entry registry.Ent
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.definitions[entry.ID]; !exists {
+	if !m.definitionInEffect(entry.ID) {
 		return NewDefinitionNotFoundForDeleteError(entry.ID)
+	}
+
+	if m.tx != nil {
+		// The in-use check is deferred to Commit: a binding referencing this
+		// definition may be deleted later in the same transaction, and Commit's
+		// full validation reports any survivor as an unresolved contract.
+		m.tx.deleteDefinition(entry.ID, event.Event{
+			System: contract.System,
+			Kind:   contract.DeleteDefinition,
+			Path:   entry.ID.String(),
+		})
+		return nil
 	}
 
 	// Check if any binding refers to this definition
@@ -338,18 +536,30 @@ func (m *Manager) handleBindingAdd(ctx context.Context, entry registry.Entry) er
 	m.mu.Lock() // Lock for m.bindings write and m.definitions read
 	defer m.mu.Unlock()
 
-	if _, exists := m.bindings[entry.ID]; exists {
+	if m.bindingInEffect(entry.ID) {
 		return NewBindingAlreadyExistsError(entry.ID)
 	}
 
+	if m.tx != nil {
+		// Validation against definitions is deferred to Commit, where the
+		// definitions this binding depends on are guaranteed staged.
+		m.tx.stageBinding(entry.ID, binding, event.Event{
+			System: contract.System,
+			Kind:   contract.RegisterBinding,
+			Path:   entry.ID.String(),
+			Data:   binding,
+		})
+		return nil
+	}
+
 	// validateBindingAgainstDefinitions needs read access to m.definitions, which is covered by the Lock
-	if err := m.validateBindingAgainstDefinitions(binding, entry.ID); err != nil {
+	if err := validateBindingAgainstDefinitions(binding, entry.ID, m.definitions); err != nil {
 		return err // Error from validateBinding already includes bindingID
 	}
 
 	// Validate unique defaults - needs read access to m.bindings, which is covered by the Lock
 	// This prevents multiple bindings from being marked as default for the same contract
-	if err := m.validateUniqueDefaults(binding, entry.ID); err != nil {
+	if err := validateUniqueDefaults(binding, entry.ID, m.bindings); err != nil {
 		return err
 	}
 
@@ -382,17 +592,27 @@ func (m *Manager) handleBindingUpdate(ctx context.Context, entry registry.Entry)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.bindings[entry.ID]; !exists {
+	if !m.bindingInEffect(entry.ID) {
 		return NewBindingNotFoundForUpdateError(entry.ID)
 	}
 
-	if err := m.validateBindingAgainstDefinitions(updatedBinding, entry.ID); err != nil {
+	if m.tx != nil {
+		m.tx.stageBinding(entry.ID, updatedBinding, event.Event{
+			System: contract.System,
+			Kind:   contract.UpdateBinding,
+			Path:   entry.ID.String(),
+			Data:   updatedBinding,
+		})
+		return nil
+	}
+
+	if err := validateBindingAgainstDefinitions(updatedBinding, entry.ID, m.definitions); err != nil {
 		return err // Error from validateBinding already includes bindingID
 	}
 
 	// Validate unique defaults for the updated binding
 	// This ensures that updating a binding to set default=true doesn't conflict with existing defaults
-	if err := m.validateUniqueDefaults(updatedBinding, entry.ID); err != nil {
+	if err := validateUniqueDefaults(updatedBinding, entry.ID, m.bindings); err != nil {
 		return err
 	}
 
@@ -415,8 +635,17 @@ func (m *Manager) handleBindingDelete(ctx context.Context, entry registry.Entry)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.bindings[entry.ID]; !exists {
+	if !m.bindingInEffect(entry.ID) {
 		return NewBindingNotFoundForDeleteError(entry.ID)
+	}
+
+	if m.tx != nil {
+		m.tx.deleteBinding(entry.ID, event.Event{
+			System: contract.System,
+			Kind:   contract.DeleteBinding,
+			Path:   entry.ID.String(),
+		})
+		return nil
 	}
 
 	delete(m.bindings, entry.ID)

--- a/service/di/manager.go
+++ b/service/di/manager.go
@@ -172,8 +172,8 @@ func (m *Manager) Begin(context.Context) error {
 }
 
 // Commit validates the complete staged state and applies it atomically. On a
-// validation failure nothing is applied and no event is emitted; the registry
-// runner rolls the changeset back and discards the transaction.
+// validation failure nothing is applied or emitted, and staging remains live
+// while the registry runner dispatches inverse operations before Discard.
 func (m *Manager) Commit(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -185,11 +185,9 @@ func (m *Manager) Commit(ctx context.Context) error {
 	bindings := tx.effectiveBindings(m.bindings)
 	for bindingID, binding := range bindings {
 		if err := validateBindingAgainstDefinitions(binding, bindingID, definitions); err != nil {
-			m.tx = nil
 			return err
 		}
 		if err := validateUniqueDefaults(binding, bindingID, bindings); err != nil {
-			m.tx = nil
 			return err
 		}
 	}
@@ -209,8 +207,8 @@ func (m *Manager) Commit(ctx context.Context) error {
 	return nil
 }
 
-// Discard drops the staged state without applying it. After a failed Commit
-// the staging area is already gone and this is a no-op.
+// Discard drops the staged state without applying it. This is also the final
+// step after a failed Commit and the runner's staged rollback operations.
 func (m *Manager) Discard(context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/service/di/manager_tx_test.go
+++ b/service/di/manager_tx_test.go
@@ -115,12 +115,36 @@ func TestManager_TransactionCommitRejectsIncompleteState(t *testing.T) {
 	requireAPIError(t, err, apierror.Invalid, "contract method is not bound")
 
 	assert.Len(t, manager.definitions[defID].Methods, 1)
-	assert.Nil(t, manager.tx)
+	assert.NotNil(t, manager.tx, "staging must survive until the runner finishes rollback")
 	assert.Equal(t, int32(0), updates.Load())
 
-	// The runner discards after a failed commit; with the staging gone this
-	// must be a clean no-op.
+	// The runner discards after it has dispatched rollback operations.
 	require.NoError(t, manager.Discard(ctx))
+	assert.Nil(t, manager.tx)
+}
+
+// TestManager_FailedCommitAcceptsRollbackBeforeDiscard covers the runner's
+// commit-failure protocol: inverse entry operations are dispatched before
+// TxDiscard. A failed Commit must therefore retain staging so those inverses
+// are accepted against the staged view; Discard then drops the whole attempt.
+func TestManager_FailedCommitAcceptsRollbackBeforeDiscard(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, _ := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Add(ctx, bindingEntry(bindingID, defID, "method1")))
+	err := manager.Commit(ctx)
+	requireAPIError(t, err, apierror.Invalid, "binding references undefined contract")
+
+	// This is the inverse of the accepted EntryCreate sent by BusRunner.rollback.
+	require.NoError(t, manager.Delete(ctx, registry.Entry{ID: bindingID, Kind: apidi.Binding}))
+	require.NoError(t, manager.Discard(ctx))
+
+	assert.Nil(t, manager.tx)
+	assert.Empty(t, manager.definitions)
+	assert.Empty(t, manager.bindings)
 }
 
 // TestManager_TransactionEventsFlushOnCommitOnly: staged operations emit their

--- a/service/di/manager_tx_test.go
+++ b/service/di/manager_tx_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package di
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	ctxapi "github.com/wippyai/runtime/api/context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/contract"
+	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/event"
+	"github.com/wippyai/runtime/api/registry"
+	apidi "github.com/wippyai/runtime/api/service/di"
+	"github.com/wippyai/runtime/system/eventbus"
+)
+
+func definitionEntry(id registry.ID, methods ...string) registry.Entry {
+	configs := make([]apidi.MethodConfig, 0, len(methods))
+	for _, name := range methods {
+		configs = append(configs, apidi.MethodConfig{Name: name})
+	}
+	return registry.Entry{
+		ID:   id,
+		Kind: apidi.Definition,
+		Data: NewMockPayload(&apidi.DefinitionConfig{Methods: configs}),
+	}
+}
+
+func bindingEntry(id, contractID registry.ID, methods ...string) registry.Entry {
+	bound := make(map[string]string, len(methods))
+	for _, name := range methods {
+		bound[name] = "app:impl." + name
+	}
+	return registry.Entry{
+		ID:   id,
+		Kind: apidi.Binding,
+		Data: NewMockPayload(&apidi.BindingConfig{
+			Contracts: []apidi.BoundContractConfig{
+				{Contract: contractID.String(), Methods: bound},
+			},
+		}),
+	}
+}
+
+// seedContract installs a definition and one binding outside any transaction,
+// mirroring a live instance's committed state before a module upgrade.
+func seedContract(t *testing.T, manager *Manager, defID, bindingID registry.ID, methods ...string) {
+	t.Helper()
+	ctx := ctxapi.NewRootContext()
+	require.NoError(t, manager.Add(ctx, definitionEntry(defID, methods...)))
+	require.NoError(t, manager.Add(ctx, bindingEntry(bindingID, defID, methods...)))
+}
+
+// TestManager_TransactionAddsMethodToLiveContract is the live-upgrade case:
+// one changeset carries a definition update that adds a method together with
+// the binding update that binds it. Per-entry each half is invalid against the
+// pre-change peer; as a transaction the pair must commit.
+func TestManager_TransactionAddsMethodToLiveContract(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+
+	t.Run("definition update first", func(t *testing.T) {
+		manager, _ := setupDIManagerTest()
+		seedContract(t, manager, defID, bindingID, "method1")
+
+		require.NoError(t, manager.Begin(ctx))
+		require.NoError(t, manager.Update(ctx, definitionEntry(defID, "method1", "method2")))
+		require.NoError(t, manager.Update(ctx, bindingEntry(bindingID, defID, "method1", "method2")))
+		require.NoError(t, manager.Commit(ctx))
+
+		assert.Len(t, manager.definitions[defID].Methods, 2)
+		assert.Len(t, manager.bindings[bindingID].Contracts[0].Methods, 2)
+	})
+
+	t.Run("binding update first", func(t *testing.T) {
+		manager, _ := setupDIManagerTest()
+		seedContract(t, manager, defID, bindingID, "method1")
+
+		require.NoError(t, manager.Begin(ctx))
+		require.NoError(t, manager.Update(ctx, bindingEntry(bindingID, defID, "method1", "method2")))
+		require.NoError(t, manager.Update(ctx, definitionEntry(defID, "method1", "method2")))
+		require.NoError(t, manager.Commit(ctx))
+
+		assert.Len(t, manager.definitions[defID].Methods, 2)
+		assert.Len(t, manager.bindings[bindingID].Contracts[0].Methods, 2)
+	})
+}
+
+// TestManager_TransactionCommitRejectsIncompleteState: a definition update
+// whose bindings never arrive must fail at Commit and leave committed state
+// untouched, with no contract-plane event emitted.
+func TestManager_TransactionCommitRejectsIncompleteState(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, bus := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+	seedContract(t, manager, defID, bindingID, "method1")
+
+	var updates atomic.Int32
+	sub, err := eventbus.NewSubscriber(ctx, bus, contract.System, contract.UpdateDefinition, func(event.Event) {
+		updates.Add(1)
+	})
+	require.NoError(t, err)
+	defer sub.Close()
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Update(ctx, definitionEntry(defID, "method1", "method2")))
+	err = manager.Commit(ctx)
+	requireAPIError(t, err, apierror.Invalid, "contract method is not bound")
+
+	assert.Len(t, manager.definitions[defID].Methods, 1)
+	assert.Nil(t, manager.tx)
+	assert.Equal(t, int32(0), updates.Load())
+
+	// The runner discards after a failed commit; with the staging gone this
+	// must be a clean no-op.
+	require.NoError(t, manager.Discard(ctx))
+}
+
+// TestManager_TransactionEventsFlushOnCommitOnly: staged operations emit their
+// contract-plane events at Commit and never before. Delivery order across two
+// independent subscribers is not asserted; the bus dispatches concurrently.
+func TestManager_TransactionEventsFlushOnCommitOnly(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, bus := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+	seedContract(t, manager, defID, bindingID, "method1")
+
+	var mu sync.Mutex
+	var kinds []string
+	var wg sync.WaitGroup
+	subscribe := func(kind string) *eventbus.Subscriber {
+		sub, err := eventbus.NewSubscriber(ctx, bus, contract.System, kind, func(event.Event) {
+			mu.Lock()
+			kinds = append(kinds, kind)
+			mu.Unlock()
+			wg.Done()
+		})
+		require.NoError(t, err)
+		return sub
+	}
+	defer subscribe(contract.UpdateDefinition).Close()
+	defer subscribe(contract.UpdateBinding).Close()
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Update(ctx, definitionEntry(defID, "method1", "method2")))
+	require.NoError(t, manager.Update(ctx, bindingEntry(bindingID, defID, "method1", "method2")))
+
+	mu.Lock()
+	assert.Empty(t, kinds, "no event may be emitted before Commit")
+	mu.Unlock()
+
+	wg.Add(2)
+	require.NoError(t, manager.Commit(ctx))
+	wg.Wait()
+
+	mu.Lock()
+	assert.ElementsMatch(t, []string{contract.UpdateDefinition, contract.UpdateBinding}, kinds)
+	mu.Unlock()
+}
+
+// TestManager_TransactionDiscard drops every staged mutation and leaves the
+// manager fully usable outside a transaction afterwards.
+func TestManager_TransactionDiscard(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, _ := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+	seedContract(t, manager, defID, bindingID, "method1")
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Update(ctx, definitionEntry(defID, "method1", "method2")))
+	require.NoError(t, manager.Discard(ctx))
+
+	assert.Len(t, manager.definitions[defID].Methods, 1)
+
+	// Non-transactional operation still behaves exactly as before.
+	err := manager.Update(ctx, definitionEntry(defID, "method1", "method2"))
+	requireAPIError(t, err, apierror.Invalid, "would invalidate")
+}
+
+// TestManager_TransactionDeletesDefinitionWithItsBindings: retiring a contract
+// and its binding in one changeset commits; retiring the definition while a
+// binding survives fails at Commit as an unresolved contract reference.
+func TestManager_TransactionDeletesDefinitionWithItsBindings(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+
+	t.Run("definition and binding together", func(t *testing.T) {
+		manager, _ := setupDIManagerTest()
+		seedContract(t, manager, defID, bindingID, "method1")
+
+		require.NoError(t, manager.Begin(ctx))
+		require.NoError(t, manager.Delete(ctx, registry.Entry{ID: defID, Kind: apidi.Definition}))
+		require.NoError(t, manager.Delete(ctx, registry.Entry{ID: bindingID, Kind: apidi.Binding}))
+		require.NoError(t, manager.Commit(ctx))
+
+		assert.Empty(t, manager.definitions)
+		assert.Empty(t, manager.bindings)
+	})
+
+	t.Run("definition alone leaves the binding unresolved", func(t *testing.T) {
+		manager, _ := setupDIManagerTest()
+		seedContract(t, manager, defID, bindingID, "method1")
+
+		require.NoError(t, manager.Begin(ctx))
+		require.NoError(t, manager.Delete(ctx, registry.Entry{ID: defID, Kind: apidi.Definition}))
+		err := manager.Commit(ctx)
+		requireAPIError(t, err, apierror.Invalid, "binding references undefined contract")
+
+		assert.Contains(t, manager.definitions, defID)
+		assert.Contains(t, manager.bindings, bindingID)
+	})
+}
+
+// TestManager_TransactionCreateOrderIndependence: within a transaction a
+// binding may arrive before the definition it references; Commit sees both.
+func TestManager_TransactionCreateOrderIndependence(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, _ := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+	bindingID := registry.NewID("test", "binding")
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Add(ctx, bindingEntry(bindingID, defID, "method1")))
+	require.NoError(t, manager.Add(ctx, definitionEntry(defID, "method1")))
+	require.NoError(t, manager.Commit(ctx))
+
+	assert.Contains(t, manager.definitions, defID)
+	assert.Contains(t, manager.bindings, bindingID)
+}
+
+// TestManager_TransactionDuplicateDefaultRejectedAtCommit: unique-default
+// enforcement holds across staged and committed bindings alike.
+func TestManager_TransactionDuplicateDefaultRejectedAtCommit(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, _ := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+
+	defaultBinding := func(id registry.ID) registry.Entry {
+		return registry.Entry{
+			ID:   id,
+			Kind: apidi.Binding,
+			Data: NewMockPayload(&apidi.BindingConfig{
+				Contracts: []apidi.BoundContractConfig{
+					{
+						Contract: defID.String(),
+						Default:  true,
+						Methods:  map[string]string{"method1": "app:impl.method1"},
+					},
+				},
+			}),
+		}
+	}
+
+	require.NoError(t, manager.Add(ctx, definitionEntry(defID, "method1")))
+	require.NoError(t, manager.Add(ctx, defaultBinding(registry.NewID("test", "binding1"))))
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Add(ctx, defaultBinding(registry.NewID("test", "binding2"))))
+	err := manager.Commit(ctx)
+	requireAPIError(t, err, apierror.AlreadyExists, "default binding")
+
+	assert.NotContains(t, manager.bindings, registry.NewID("test", "binding2"))
+}
+
+// TestManager_TransactionExistenceChecksSeeStagedState: staged mutations are
+// visible to subsequent operations in the same transaction.
+func TestManager_TransactionExistenceChecksSeeStagedState(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	manager, _ := setupDIManagerTest()
+	defID := registry.NewID("test", "contract")
+
+	require.NoError(t, manager.Begin(ctx))
+	require.NoError(t, manager.Add(ctx, definitionEntry(defID, "method1")))
+
+	err := manager.Add(ctx, definitionEntry(defID, "method1"))
+	requireAPIError(t, err, apierror.AlreadyExists, "already exists")
+
+	require.NoError(t, manager.Delete(ctx, registry.Entry{ID: defID, Kind: apidi.Definition}))
+	err = manager.Update(ctx, definitionEntry(defID, "method1"))
+	requireAPIError(t, err, apierror.NotFound, "not found for update")
+
+	require.NoError(t, manager.Discard(ctx))
+}


### PR DESCRIPTION
## The defect

Adding a method to a live contract definition is impossible. The module upgrade produces one changeset carrying the definition update and its binding updates, but `di.Manager` validates each entry against already-committed state:

- definition first (what the topo sort produces): `handleDefinitionUpdate` re-validates the still-old binding → `contract method is not bound`
- binding first: `handleBindingUpdate` validates against the still-old definition → `bound method is not defined in contract definition`

Both are `apierror.Invalid` → fatal to the runner → full rollback, every ordering. The self-healing deferral loop cannot rescue it — it retries only `NotFound`, and neither half is individually valid against the pre-change peer: the dependency is a genuine two-cycle at per-entry granularity.

Boot never hits this: a fresh load delivers everything as `EntryCreate` in dependency order, and `handleDefinitionAdd` does not cross-validate. The rejection is specific to `EntryUpdate` on a live instance — exactly the hub module-upgrade path. (Downstream, keeper surfaces any apply failure as HTTP 409, which is how this presents to operators.)

Encountered in production: upgrading `kickside/contract` to add a method to a live contract definition 409s in every ordering — single-module install, co-planned install with version floors, both directions.

## The fix

`di.Manager` now implements `registry.TransactionListener` — the mechanism the registry has offered since the tx protocol landed (Dec 2024), already used by `service/net` and the Lua code manager.

- **Begin** opens a staging area.
- **During the transaction** entry operations validate structurally, stage against an *effective view* (so same-transaction operations see each other — existence checks included), and queue their contract-plane events. Cross-entry validation defers.
- **Commit** validates the complete post-transaction state — every effective binding against every effective definition, plus unique defaults — then applies and flushes events atomically. A validation failure leaves committed state untouched, emits nothing, and returns the error; the runner rolls back and dispatches `TxDiscard`.
- **Discard** drops the staging, and tolerates running after a failed Commit (the runner discards after a commit failure).

**Outside a transaction, behaviour is unchanged** — per-entry validation, immediate apply, immediate events. All pre-existing tests pass untouched.

The definition-in-use check moves to Commit inside a transaction, where a definition deleted while a binding survives surfaces as `binding references undefined contract`; retiring a contract together with its bindings in one changeset now also works.

## Semantics notes for review

- Events are queued in staging order and flushed on Commit only, so the contract plane never observes an intermediate invalid state.
- If another participant fails Commit after this manager committed, the runner's rollback ops arrive outside a transaction and apply immediately — correct restoration; the trailing `TxDiscard` is a no-op.
- In-transaction `Add` no longer needs the runner's NotFound deferral for binding-before-definition ordering; Commit sees both.

## Testing

- New `manager_tx_test.go`: the live-upgrade case in both orders, commit rejection (state untouched, zero events emitted), discard, delete-together vs delete-alone, in-transaction create order independence, duplicate defaults across staged+committed bindings, staged-state visibility to existence checks.
- `go test ./service/di/ ./system/registry/... ./boot/... ./service/... ./internal/... ./api/... -race -short` — all pass.
- `golangci-lint v2.8.0 run --build-tags=race ./service/di/...` — 0 issues.
