### PR TITLE
fix(boot): locked manifest provider defers replaced modules instead of refusing offline evidence

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1310,7 +1310,7 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 	}
 	lockedDigests := h.lockedModuleDigests()
 	if regapi.DependencyAccessFromContext(ctx) == regapi.DependencyAccessVerifiedOffline {
-		provider = newLockedManifestProvider(h, lockedVersions, lockedDigests)
+		provider = newLockedManifestProvider(h, lockedVersions, lockedDigests, provider)
 	}
 	provider = &replacementManifestProvider{
 		base:           provider,
@@ -1333,8 +1333,12 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 			h.logger.Error("dependency resolution failed", zap.String("errors", formatResolutionErrors(result.Errors)))
 		}
 		if regapi.DependencyAccessFromContext(ctx) == regapi.DependencyAccessVerifiedOffline {
-			module := result.Errors[0].Org + "/" + result.Errors[0].Name
-			return nil, NewDependencyOfflineError("resolve", strings.Trim(module, "/"))
+			module := strings.Trim(result.Errors[0].Org+"/"+result.Errors[0].Name, "/")
+			// A replaced module resolves from its local tree, so its failure is
+			// never a missing-evidence failure: report what actually went wrong.
+			if _, replaced := h.replacementPath(module); !replaced {
+				return nil, NewDependencyOfflineError("resolve", module)
+			}
 		}
 		return nil, NewDependencyResolutionErrors(result.Errors)
 	}

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1310,7 +1310,7 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 	}
 	lockedDigests := h.lockedModuleDigests()
 	if regapi.DependencyAccessFromContext(ctx) == regapi.DependencyAccessVerifiedOffline {
-		provider = newLockedManifestProvider(h, lockedVersions, lockedDigests, provider)
+		provider = newLockedManifestProvider(h, lockedVersions, lockedDigests)
 	}
 	provider = &replacementManifestProvider{
 		base:           provider,
@@ -1333,10 +1333,11 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 			h.logger.Error("dependency resolution failed", zap.String("errors", formatResolutionErrors(result.Errors)))
 		}
 		if regapi.DependencyAccessFromContext(ctx) == regapi.DependencyAccessVerifiedOffline {
-			module := strings.Trim(result.Errors[0].Org+"/"+result.Errors[0].Name, "/")
-			// A replaced module resolves from its local tree, so its failure is
-			// never a missing-evidence failure: report what actually went wrong.
-			if _, replaced := h.replacementPath(module); !replaced {
+			// Missing evidence is the diagnosis only when it explains every
+			// failure. A replaced module resolves from its local tree, so its
+			// failure has another cause; reporting the whole set then keeps
+			// that cause visible whatever the failing modules are named.
+			if module, ok := h.offlineEvidenceFailure(result.Errors); ok {
 				return nil, NewDependencyOfflineError("resolve", module)
 			}
 		}
@@ -1615,10 +1616,17 @@ func validModuleIdentifier(value string) bool {
 	return true
 }
 
+// replacementZeroVersion labels a replacement tree that declares no version of
+// its own and has never been recorded under one. Its content identity is the
+// tree digest; the label only has to be a well-formed release.
+const replacementZeroVersion = "0.0.0"
+
 // replacementManifestProvider loads entries and declared dependencies from a
-// local replacement tree. A replacement with no explicit source version still
-// delegates release availability to the Hub; a satisfying lock avoids that call.
-// Non-replaced modules delegate to the base provider.
+// local replacement tree. A replacement with no explicit source version
+// delegates release availability to the Hub while startup may reach it; a
+// satisfying lock avoids that call, and a verified-offline startup never makes
+// it - see localReplacementVersion. Non-replaced modules delegate to the base
+// provider.
 type replacementManifestProvider struct {
 	base           ManifestProvider
 	handler        *DependencyHandler
@@ -1640,6 +1648,29 @@ func (p *replacementManifestProvider) replacementVersion(name, constraint string
 	return p.lockedVersions[name]
 }
 
+// localReplacementVersion labels a replaced module from local evidence alone.
+// A verified-offline startup has no Hub to resolve a label or a live range
+// against, and needs none: the tree is the module, so the only question is
+// which release it stands in for. The version already recorded for it answers
+// that; failing which, nothing has ever named one and the zero release does.
+//
+// The label still faces the graph's constraints like any other selection - a
+// durable resolution may not select a version its own declaration excludes -
+// so a range no local evidence satisfies fails the resolve rather than
+// silently binding the tree to a release it cannot be shown to be. Declaring
+// version in the replacement's wippy.yaml settles it offline.
+func (p *replacementManifestProvider) localReplacementVersion(name string) string {
+	if version := p.lockedVersions[name]; version != "" {
+		return version
+	}
+	return replacementZeroVersion
+}
+
+// offlineStartup reports that this resolution may not reach the Hub at all.
+func offlineStartup(ctx context.Context) bool {
+	return regapi.DependencyAccessFromContext(ctx) == regapi.DependencyAccessVerifiedOffline
+}
+
 func isExactModuleVersion(value string) bool {
 	_, err := hubsemver.ParseVersion(strings.TrimSpace(value))
 	return err == nil
@@ -1649,6 +1680,9 @@ func (p *replacementManifestProvider) GetManifest(ctx context.Context, org, modu
 	name := org + "/" + module
 	if path, ok := p.handler.replacementPath(name); ok {
 		version := p.replacementVersion(name, constraint)
+		if version == "" && offlineStartup(ctx) {
+			version = p.localReplacementVersion(name)
+		}
 		if version == "" {
 			// Labels do not identify a concrete release. Ask the Hub only to
 			// resolve the label, then keep the local replacement tree as the
@@ -1736,9 +1770,14 @@ func (p *replacementManifestProvider) ListAllVersions(ctx context.Context, org, 
 	if _, ok := p.handler.replacementPath(name); ok {
 		// An explicit source version is the complete candidate set. Without
 		// one, the local tree supplies bytes but the Hub remains authoritative
-		// for which released versions are available to satisfy live ranges.
+		// for which released versions are available to satisfy live ranges -
+		// until startup forbids reaching it, when local evidence is the whole
+		// candidate set.
 		if version := p.handler.replacementModuleVersion(name); version != "" {
 			return []VersionInfo{{Version: version}}, nil
+		}
+		if offlineStartup(ctx) {
+			return []VersionInfo{{Version: p.localReplacementVersion(name)}}, nil
 		}
 		return p.base.ListAllVersions(ctx, org, module)
 	}
@@ -2385,6 +2424,25 @@ func (h *DependencyHandler) replacementPath(moduleName string) (string, bool) {
 		path = filepath.Join(filepath.Dir(h.lock.Path()), path)
 	}
 	return path, true
+}
+
+// offlineEvidenceFailure reports the module to name in a missing-evidence
+// error, and whether missing evidence explains the failures at all. A replaced
+// module never resolves from evidence, so one failing among them means the set
+// must be reported as it is. The named module is the lowest-sorted failure, so
+// the diagnosis does not depend on the order the resolver emits.
+func (h *DependencyHandler) offlineEvidenceFailure(errs []ResolutionError) (string, bool) {
+	named := ""
+	for _, resolutionErr := range errs {
+		module := strings.Trim(resolutionErr.Org+"/"+resolutionErr.Name, "/")
+		if _, replaced := h.replacementPath(module); replaced {
+			return "", false
+		}
+		if named == "" || module < named {
+			named = module
+		}
+	}
+	return named, len(errs) > 0
 }
 
 // replacementModuleVersion reads the authoritative version of a locally-replaced

--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1333,10 +1333,9 @@ func (h *DependencyHandler) resolveModules(ctx context.Context, deps []Dependenc
 			h.logger.Error("dependency resolution failed", zap.String("errors", formatResolutionErrors(result.Errors)))
 		}
 		if regapi.DependencyAccessFromContext(ctx) == regapi.DependencyAccessVerifiedOffline {
-			// Missing evidence is the diagnosis only when it explains every
-			// failure. A replaced module resolves from its local tree, so its
-			// failure has another cause; reporting the whole set then keeps
-			// that cause visible whatever the failing modules are named.
+			// A replaced module resolves from its local tree, so its failure
+			// is never a missing-evidence failure; the full error set carries
+			// the actual cause.
 			if module, ok := h.offlineEvidenceFailure(result.Errors); ok {
 				return nil, NewDependencyOfflineError("resolve", module)
 			}
@@ -1616,9 +1615,9 @@ func validModuleIdentifier(value string) bool {
 	return true
 }
 
-// replacementZeroVersion labels a replacement tree that declares no version of
-// its own and has never been recorded under one. Its content identity is the
-// tree digest; the label only has to be a well-formed release.
+// replacementZeroVersion labels a replacement tree that declares no version
+// and has never been recorded under one. Identity is the tree digest; the
+// label only has to be a well-formed release.
 const replacementZeroVersion = "0.0.0"
 
 // replacementManifestProvider loads entries and declared dependencies from a
@@ -1648,17 +1647,12 @@ func (p *replacementManifestProvider) replacementVersion(name, constraint string
 	return p.lockedVersions[name]
 }
 
-// localReplacementVersion labels a replaced module from local evidence alone.
-// A verified-offline startup has no Hub to resolve a label or a live range
-// against, and needs none: the tree is the module, so the only question is
-// which release it stands in for. The version already recorded for it answers
-// that; failing which, nothing has ever named one and the zero release does.
-//
-// The label still faces the graph's constraints like any other selection - a
-// durable resolution may not select a version its own declaration excludes -
-// so a range no local evidence satisfies fails the resolve rather than
-// silently binding the tree to a release it cannot be shown to be. Declaring
-// version in the replacement's wippy.yaml settles it offline.
+// localReplacementVersion labels a replaced module from local evidence alone,
+// for a verified-offline startup that has no Hub to resolve against: the
+// version already recorded for the module, or the zero release when none was
+// ever recorded. The label faces the graph's constraints like any other
+// selection, so a range no local evidence satisfies fails the resolve.
+// Declaring version in the replacement's wippy.yaml settles it offline.
 func (p *replacementManifestProvider) localReplacementVersion(name string) string {
 	if version := p.lockedVersions[name]; version != "" {
 		return version
@@ -1770,9 +1764,9 @@ func (p *replacementManifestProvider) ListAllVersions(ctx context.Context, org, 
 	if _, ok := p.handler.replacementPath(name); ok {
 		// An explicit source version is the complete candidate set. Without
 		// one, the local tree supplies bytes but the Hub remains authoritative
-		// for which released versions are available to satisfy live ranges -
-		// until startup forbids reaching it, when local evidence is the whole
-		// candidate set.
+		// for which released versions satisfy live ranges. A verified-offline
+		// startup cannot reach it, so local evidence is the whole candidate
+		// set.
 		if version := p.handler.replacementModuleVersion(name); version != "" {
 			return []VersionInfo{{Version: version}}, nil
 		}
@@ -2427,10 +2421,9 @@ func (h *DependencyHandler) replacementPath(moduleName string) (string, bool) {
 }
 
 // offlineEvidenceFailure reports the module to name in a missing-evidence
-// error, and whether missing evidence explains the failures at all. A replaced
-// module never resolves from evidence, so one failing among them means the set
-// must be reported as it is. The named module is the lowest-sorted failure, so
-// the diagnosis does not depend on the order the resolver emits.
+// error, and whether missing evidence explains the failures at all. A failing
+// replaced module has another cause, so the set is reported as is. The named
+// module is the lowest-sorted failure, independent of resolver emit order.
 func (h *DependencyHandler) offlineEvidenceFailure(errs []ResolutionError) (string, bool) {
 	named := ""
 	for _, resolutionErr := range errs {

--- a/boot/deps/hub/locked_manifest_provider.go
+++ b/boot/deps/hub/locked_manifest_provider.go
@@ -12,31 +12,21 @@ import (
 )
 
 // lockedManifestProvider exposes only locally materialized, content-pinned
-// modules, so a verified-offline startup resolves the recorded deployment
-// without any network capability.
-//
-// A module a workspace replacement backs is source-controlled, not hub-signed:
-// the operator declared the local tree that supplies its content, and no lock
-// digest can describe it. The content-pinned evidence gate therefore does not
-// apply to it, and such a module is served by replaced - the provider the
-// replacement-aware layer resolved through before this fast path existed - so
-// a workspace using replacements starts up exactly as it always did.
+// modules. It lets the normal resolver validate a graph containing mutable
+// replacements without granting that resolver any network capability.
 type lockedManifestProvider struct {
-	handler  *DependencyHandler
-	replaced ManifestProvider
-	modules  map[string]ResolvedModule
+	handler *DependencyHandler
+	modules map[string]ResolvedModule
 }
 
 func newLockedManifestProvider(
 	handler *DependencyHandler,
 	materializedVersions map[string]string,
 	lockedDigests map[string]string,
-	replaced ManifestProvider,
 ) ManifestProvider {
 	provider := &lockedManifestProvider{
-		handler:  handler,
-		replaced: replaced,
-		modules:  make(map[string]ResolvedModule),
+		handler: handler,
+		modules: make(map[string]ResolvedModule),
 	}
 	if handler == nil || handler.lock == nil {
 		return provider
@@ -62,24 +52,8 @@ func newLockedManifestProvider(
 	return provider
 }
 
-// replacementProvider returns the provider serving a replaced module, if the
-// workspace replaces this one. A replacement outranks a lock entry for the same
-// module: the local tree, not the recorded artifact, is that module's content.
-func (p *lockedManifestProvider) replacementProvider(name string) (ManifestProvider, bool) {
-	if p.handler == nil || p.replaced == nil {
-		return nil, false
-	}
-	if _, replaced := p.handler.replacementPath(name); !replaced {
-		return nil, false
-	}
-	return p.replaced, true
-}
-
 func (p *lockedManifestProvider) GetManifest(ctx context.Context, org, module, constraint string) (*ModuleManifest, error) {
 	name := org + "/" + module
-	if base, replaced := p.replacementProvider(name); replaced {
-		return base.GetManifest(ctx, org, module, constraint)
-	}
 	mod, ok := p.modules[name]
 	if !ok || !storedVersionSatisfies(mod.Version, constraint) {
 		return nil, NewDependencyOfflineError("resolve manifest", name)
@@ -107,11 +81,8 @@ func (p *lockedManifestProvider) GetManifest(ctx context.Context, org, module, c
 	}, nil
 }
 
-func (p *lockedManifestProvider) ListAllVersions(ctx context.Context, org, module string) ([]VersionInfo, error) {
+func (p *lockedManifestProvider) ListAllVersions(_ context.Context, org, module string) ([]VersionInfo, error) {
 	name := org + "/" + module
-	if base, replaced := p.replacementProvider(name); replaced {
-		return base.ListAllVersions(ctx, org, module)
-	}
 	mod, ok := p.modules[name]
 	if !ok {
 		return nil, NewDependencyOfflineError("list versions", name)

--- a/boot/deps/hub/locked_manifest_provider.go
+++ b/boot/deps/hub/locked_manifest_provider.go
@@ -12,21 +12,31 @@ import (
 )
 
 // lockedManifestProvider exposes only locally materialized, content-pinned
-// modules. It lets the normal resolver validate a graph containing mutable
-// replacements without granting that resolver any network capability.
+// modules, so a verified-offline startup resolves the recorded deployment
+// without any network capability.
+//
+// A module a workspace replacement backs is source-controlled, not hub-signed:
+// the operator declared the local tree that supplies its content, and no lock
+// digest can describe it. The content-pinned evidence gate therefore does not
+// apply to it, and such a module is served by replaced - the provider the
+// replacement-aware layer resolved through before this fast path existed - so
+// a workspace using replacements starts up exactly as it always did.
 type lockedManifestProvider struct {
-	handler *DependencyHandler
-	modules map[string]ResolvedModule
+	handler  *DependencyHandler
+	replaced ManifestProvider
+	modules  map[string]ResolvedModule
 }
 
 func newLockedManifestProvider(
 	handler *DependencyHandler,
 	materializedVersions map[string]string,
 	lockedDigests map[string]string,
+	replaced ManifestProvider,
 ) ManifestProvider {
 	provider := &lockedManifestProvider{
-		handler: handler,
-		modules: make(map[string]ResolvedModule),
+		handler:  handler,
+		replaced: replaced,
+		modules:  make(map[string]ResolvedModule),
 	}
 	if handler == nil || handler.lock == nil {
 		return provider
@@ -52,8 +62,24 @@ func newLockedManifestProvider(
 	return provider
 }
 
+// replacementProvider returns the provider serving a replaced module, if the
+// workspace replaces this one. A replacement outranks a lock entry for the same
+// module: the local tree, not the recorded artifact, is that module's content.
+func (p *lockedManifestProvider) replacementProvider(name string) (ManifestProvider, bool) {
+	if p.handler == nil || p.replaced == nil {
+		return nil, false
+	}
+	if _, replaced := p.handler.replacementPath(name); !replaced {
+		return nil, false
+	}
+	return p.replaced, true
+}
+
 func (p *lockedManifestProvider) GetManifest(ctx context.Context, org, module, constraint string) (*ModuleManifest, error) {
 	name := org + "/" + module
+	if base, replaced := p.replacementProvider(name); replaced {
+		return base.GetManifest(ctx, org, module, constraint)
+	}
 	mod, ok := p.modules[name]
 	if !ok || !storedVersionSatisfies(mod.Version, constraint) {
 		return nil, NewDependencyOfflineError("resolve manifest", name)
@@ -81,8 +107,11 @@ func (p *lockedManifestProvider) GetManifest(ctx context.Context, org, module, c
 	}, nil
 }
 
-func (p *lockedManifestProvider) ListAllVersions(_ context.Context, org, module string) ([]VersionInfo, error) {
+func (p *lockedManifestProvider) ListAllVersions(ctx context.Context, org, module string) ([]VersionInfo, error) {
 	name := org + "/" + module
+	if base, replaced := p.replacementProvider(name); replaced {
+		return base.ListAllVersions(ctx, org, module)
+	}
 	mod, ok := p.modules[name]
 	if !ok {
 		return nil, NewDependencyOfflineError("list versions", name)

--- a/boot/deps/hub/replacement_offline_startup_test.go
+++ b/boot/deps/hub/replacement_offline_startup_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/runtime/internal/version"
+	registryimpl "github.com/wippyai/runtime/system/registry"
+	regexp "github.com/wippyai/runtime/system/registry/expansion"
+	"github.com/wippyai/runtime/system/registry/history/memory"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
+)
+
+const (
+	offlineReplacedModule = "local/mod"
+	offlineLockedModule   = "acme/lib"
+	offlineLockedVersion  = "1.0.0"
+)
+
+// offlineProviderFixture builds the verified-offline manifest provider over a
+// lock that pins one materialized module and a workspace that replaces another.
+func offlineProviderFixture(t *testing.T, replaced ...string) (ManifestProvider, *fakeManifestProvider) {
+	t.Helper()
+
+	digest := "sha256:" + lockedResolutionDigest
+	handler := lockedResolutionHandler(t, []lock.Module{
+		{Name: offlineLockedModule, Version: offlineLockedVersion, Hash: digest},
+	})
+	for _, module := range replaced {
+		handler.replacements[module] = lock.Replacement{From: module, To: t.TempDir()}
+	}
+
+	base := newFakeProvider()
+	base.addModule("local", "mod", "0.2.0")
+	base.addModule("acme", "lib", "9.9.9")
+
+	provider := newLockedManifestProvider(
+		handler,
+		map[string]string{offlineLockedModule: offlineLockedVersion},
+		map[string]string{offlineLockedModule + "@" + offlineLockedVersion: digest},
+		base,
+	)
+	return provider, base
+}
+
+func TestLockedManifestProviderResolvesReplacedModuleWithoutDigestEvidence(t *testing.T) {
+	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+	provider, base := offlineProviderFixture(t, offlineReplacedModule)
+
+	versions, err := provider.ListAllVersions(ctx, "local", "mod")
+	require.NoError(t, err)
+	require.Equal(t, []VersionInfo{{Version: "0.2.0"}}, versions)
+
+	manifest, err := provider.GetManifest(ctx, "local", "mod", "0.2.0")
+	require.NoError(t, err)
+	require.Equal(t, "0.2.0", manifest.Version)
+
+	assert.Equal(t, 1, base.listAllVersion[offlineReplacedModule])
+	assert.Equal(t, 1, base.getManifest[offlineReplacedModule])
+}
+
+func TestLockedManifestProviderKeepsFastPathForVerifiedLockedModule(t *testing.T) {
+	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+	provider, base := offlineProviderFixture(t, offlineReplacedModule)
+
+	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
+	require.NoError(t, err)
+	require.Equal(t, []VersionInfo{{Version: offlineLockedVersion}}, versions)
+	assert.Zero(t, base.listAllVersion[offlineLockedModule], "verified lock evidence must answer locally")
+}
+
+func TestLockedManifestProviderRefusesModuleNeitherLockedNorReplaced(t *testing.T) {
+	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+	provider, base := offlineProviderFixture(t, offlineReplacedModule)
+
+	_, listErr := provider.ListAllVersions(ctx, "acme", "unknown")
+	requireOfflineEvidenceError(t, listErr)
+
+	_, manifestErr := provider.GetManifest(ctx, "acme", "unknown", "1.0.0")
+	requireOfflineEvidenceError(t, manifestErr)
+
+	assert.Zero(t, base.listAllVersion["acme/unknown"], "an unverified module must not reach the network")
+	assert.Zero(t, base.getManifest["acme/unknown"])
+}
+
+func TestLockedManifestProviderPrefersReplacementOverLockEntry(t *testing.T) {
+	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+	provider, base := offlineProviderFixture(t, offlineLockedModule)
+
+	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
+	require.NoError(t, err)
+	require.Equal(t, []VersionInfo{{Version: "9.9.9"}}, versions, "the replacement owns the module, not the lock entry")
+	assert.Equal(t, 1, base.listAllVersion[offlineLockedModule])
+}
+
+func TestLockedManifestProviderWithoutReplacementsNeverLeavesTheLock(t *testing.T) {
+	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+	provider, base := offlineProviderFixture(t)
+
+	_, err := provider.ListAllVersions(ctx, "local", "mod")
+	requireOfflineEvidenceError(t, err)
+
+	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
+	require.NoError(t, err)
+	require.Equal(t, []VersionInfo{{Version: offlineLockedVersion}}, versions)
+
+	assert.Zero(t, base.listAllVersion[offlineReplacedModule])
+	assert.Zero(t, base.listAllVersion[offlineLockedModule])
+}
+
+func requireOfflineEvidenceError(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var apiErr apierror.Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, apierror.Invalid, apiErr.Kind())
+	require.Contains(t, apiErr.Error(), "verified dependency evidence is unavailable during offline startup")
+}
+
+// offlineStartupWorkspace writes a workspace whose deployment root is a
+// source-replaced module carrying a live range, plus one locked module the
+// replacement depends on transitively.
+type offlineStartupWorkspace struct {
+	hub           *fakeHub
+	registry      *registryimpl.Reg
+	listCalls     map[string]int
+	manifestCalls map[string]int
+	lockPath      string
+	vendorDir     string
+	baseline      regapi.State
+	downloadCalls int
+}
+
+func newOfflineStartupWorkspace(t *testing.T, replacementTarget string) *offlineStartupWorkspace {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	lockPath := filepath.Join(rootDir, "wippy.lock")
+	vendorDir := filepath.Join(rootDir, ".wippy")
+	replacementPath := filepath.Join(rootDir, "local-mod")
+
+	artifact := buildWappBytes(t, []wapp.Entry{{
+		ID: wapp.NewID("acme.lib", "service"), Kind: "service",
+	}})
+	sum := sha256.Sum256(artifact)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+	artifactPath := filepath.Join(vendorDir, "acme", "lib-"+offlineLockedVersion+".wapp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0o755))
+	require.NoError(t, os.WriteFile(artifactPath, artifact, 0o600))
+
+	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
+  modules: .wippy
+  src: ./src
+modules:
+  - name: `+offlineLockedModule+`
+    version: `+offlineLockedVersion+`
+    hash: `+digest+`
+replacements:
+  - from: `+offlineReplacedModule+`
+    to: `+replacementTarget+`
+`), 0o600))
+
+	require.NoError(t, os.MkdirAll(replacementPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementPath, "_index.json"), []byte(`{
+  "namespace": "local.mod",
+  "entries": [
+    {"name": "svc", "kind": "registry.entry", "data": {"generation": "one"}},
+    {"name": "lib", "kind": "ns.dependency", "data": {"component": "`+offlineLockedModule+`", "version": "`+offlineLockedVersion+`"}}
+  ]
+}`), 0o600))
+
+	workspace := &offlineStartupWorkspace{
+		lockPath:      lockPath,
+		vendorDir:     vendorDir,
+		listCalls:     make(map[string]int),
+		manifestCalls: make(map[string]int),
+	}
+	workspace.hub = &fakeHub{
+		listVersions: func(_ context.Context, org, module string) ([]VersionInfo, error) {
+			workspace.listCalls[org+"/"+module]++
+			return []VersionInfo{{Version: "0.2.0"}}, nil
+		},
+		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
+			name := org + "/" + module
+			workspace.manifestCalls[name]++
+			if name != offlineLockedModule {
+				return nil, apierror.New(apierror.NotFound, "module "+name+" is not published")
+			}
+			return &ModuleManifest{
+				Org: org, Name: module,
+				Version: offlineLockedVersion, VersionID: offlineLockedVersion,
+				Digest: digest,
+			}, nil
+		},
+		getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
+			workspace.downloadCalls++
+			return nil, apierror.New(apierror.NotFound, "hub downloads are not available to this workspace")
+		},
+	}
+	workspace.baseline = regapi.State{
+		{
+			ID:   regapi.NewID("app.deps", "local"),
+			Kind: regapi.NamespaceDependency,
+			Data: payload.New(map[string]any{"component": offlineReplacedModule, "version": "*"}),
+		},
+		markModuleIdentity(regapi.Entry{
+			ID: regapi.NewID("acme.lib", "service"), Kind: "service",
+		}, offlineLockedModule, offlineLockedVersion, digest),
+	}
+	return workspace
+}
+
+func (w *offlineStartupWorkspace) loadState(t *testing.T, access regapi.DependencyAccess) error {
+	t.Helper()
+
+	handler, err := NewDependencyHandler(DependencyHandlerOptions{
+		Hub:       w.hub,
+		Logger:    zap.NewNop(),
+		LockPath:  w.lockPath,
+		VendorDir: w.vendorDir,
+	})
+	require.NoError(t, err)
+
+	resolver := topology.NewResolver()
+	handler.resolver = resolver
+	registry := registryimpl.NewRegistry(
+		memory.New(),
+		&bootRecordingRunner{},
+		topology.NewStateBuilder(zap.NewNop(), resolver),
+		resolver,
+		zap.NewNop(),
+		registryimpl.WithKindDirective(
+			regapi.NamespaceDependency,
+			regexp.NewDependencyDirective(handler.Expand).WithResolutionTransition(handler.ReconcileResolution),
+		),
+	)
+	w.registry = registry
+
+	ctx := regapi.WithDependencyAccess(newTestContext(), access)
+	return registry.LoadState(ctx, w.baseline, version.New(0))
+}
+
+func TestVerifiedOfflineStartupBootsWorkspaceWithSourceReplacement(t *testing.T) {
+	workspace := newOfflineStartupWorkspace(t, "./local-mod")
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+
+	entry, err := workspace.registry.GetEntry(regapi.NewID("local.mod", "svc"))
+	require.NoError(t, err)
+	require.Equal(t, "one", entry.Data.Data().(map[string]any)["generation"])
+
+	_, err = workspace.registry.GetEntry(regapi.NewID("acme.lib", "service"))
+	require.NoError(t, err, "a locked transitive dependency of the replacement resolves from lock evidence")
+
+	assert.Equal(t, 1, workspace.listCalls[offlineReplacedModule], "only the replaced module's live range needs a candidate set")
+	assert.Zero(t, workspace.listCalls[offlineLockedModule], "verified lock evidence answers the transitive dependency")
+	assert.Empty(t, workspace.manifestCalls, "the local tree and the vendored artifact supply every manifest")
+	assert.Zero(t, workspace.downloadCalls)
+}
+
+func TestOnlineStartupBootsWorkspaceWithSourceReplacement(t *testing.T) {
+	workspace := newOfflineStartupWorkspace(t, "./local-mod")
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessOnline))
+
+	_, err := workspace.registry.GetEntry(regapi.NewID("local.mod", "svc"))
+	require.NoError(t, err)
+	_, err = workspace.registry.GetEntry(regapi.NewID("acme.lib", "service"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, workspace.manifestCalls[offlineLockedModule], "online startup keeps consulting the Hub for locked modules")
+	assert.Zero(t, workspace.downloadCalls)
+}
+
+func TestVerifiedOfflineStartupReportsMissingReplacementPathNotMissingEvidence(t *testing.T) {
+	workspace := newOfflineStartupWorkspace(t, "./absent-mod")
+
+	lockObj, err := lock.New(workspace.lockPath)
+	require.NoError(t, err)
+	validateErr := lock.Validate(lockObj)
+	require.Error(t, validateErr)
+	require.Contains(t, validateErr.Error(), "does not exist")
+
+	loadErr := workspace.loadState(t, regapi.DependencyAccessVerifiedOffline)
+	require.Error(t, loadErr)
+	require.NotContains(t, loadErr.Error(), "verified dependency evidence is unavailable during offline startup")
+}

--- a/boot/deps/hub/replacement_offline_startup_test.go
+++ b/boot/deps/hub/replacement_offline_startup_test.go
@@ -202,7 +202,7 @@ func sourceEntry(name, kind, data string) string {
 }
 
 func dependencyEntry(name, component, constraint string) string {
-	return sourceEntry(name, string(regapi.NamespaceDependency),
+	return sourceEntry(name, regapi.NamespaceDependency,
 		`{"component": "`+component+`", "version": "`+constraint+`"}`)
 }
 

--- a/boot/deps/hub/replacement_offline_startup_test.go
+++ b/boot/deps/hub/replacement_offline_startup_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,225 +21,129 @@ import (
 	registryimpl "github.com/wippyai/runtime/system/registry"
 	regexp "github.com/wippyai/runtime/system/registry/expansion"
 	"github.com/wippyai/runtime/system/registry/history/memory"
+	historysqlite "github.com/wippyai/runtime/system/registry/history/sqlite"
 	"github.com/wippyai/runtime/system/registry/topology"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
 
-const (
-	offlineReplacedModule = "local/mod"
-	offlineLockedModule   = "acme/lib"
-	offlineLockedVersion  = "1.0.0"
-)
+// offlineWorkspace is a runnable workspace on disk: a lock, local source trees
+// the lock replaces, vendored artifacts for the modules it pins, and a Hub that
+// is unreachable unless a test deliberately makes it answer. Verified-offline
+// startup must never need it.
+type offlineWorkspace struct {
+	hub          *fakeHub
+	registry     *registryimpl.Reg
+	history      regapi.History
+	hubCalls     map[string]int
+	root         string
+	lockPath     string
+	lockedDigest string
+	baseline     regapi.State
+}
 
-// offlineProviderFixture builds the verified-offline manifest provider over a
-// lock that pins one materialized module and a workspace that replaces another.
-func offlineProviderFixture(t *testing.T, replaced ...string) (ManifestProvider, *fakeManifestProvider) {
+func newOfflineWorkspace(t *testing.T) *offlineWorkspace {
 	t.Helper()
 
-	digest := "sha256:" + lockedResolutionDigest
-	handler := lockedResolutionHandler(t, []lock.Module{
-		{Name: offlineLockedModule, Version: offlineLockedVersion, Hash: digest},
-	})
-	for _, module := range replaced {
-		handler.replacements[module] = lock.Replacement{From: module, To: t.TempDir()}
+	workspace := &offlineWorkspace{
+		root:     t.TempDir(),
+		hubCalls: make(map[string]int),
 	}
-
-	base := newFakeProvider()
-	base.addModule("local", "mod", "0.2.0")
-	base.addModule("acme", "lib", "9.9.9")
-
-	provider := newLockedManifestProvider(
-		handler,
-		map[string]string{offlineLockedModule: offlineLockedVersion},
-		map[string]string{offlineLockedModule + "@" + offlineLockedVersion: digest},
-		base,
-	)
-	return provider, base
-}
-
-func TestLockedManifestProviderResolvesReplacedModuleWithoutDigestEvidence(t *testing.T) {
-	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
-	provider, base := offlineProviderFixture(t, offlineReplacedModule)
-
-	versions, err := provider.ListAllVersions(ctx, "local", "mod")
-	require.NoError(t, err)
-	require.Equal(t, []VersionInfo{{Version: "0.2.0"}}, versions)
-
-	manifest, err := provider.GetManifest(ctx, "local", "mod", "0.2.0")
-	require.NoError(t, err)
-	require.Equal(t, "0.2.0", manifest.Version)
-
-	assert.Equal(t, 1, base.listAllVersion[offlineReplacedModule])
-	assert.Equal(t, 1, base.getManifest[offlineReplacedModule])
-}
-
-func TestLockedManifestProviderKeepsFastPathForVerifiedLockedModule(t *testing.T) {
-	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
-	provider, base := offlineProviderFixture(t, offlineReplacedModule)
-
-	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
-	require.NoError(t, err)
-	require.Equal(t, []VersionInfo{{Version: offlineLockedVersion}}, versions)
-	assert.Zero(t, base.listAllVersion[offlineLockedModule], "verified lock evidence must answer locally")
-}
-
-func TestLockedManifestProviderRefusesModuleNeitherLockedNorReplaced(t *testing.T) {
-	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
-	provider, base := offlineProviderFixture(t, offlineReplacedModule)
-
-	_, listErr := provider.ListAllVersions(ctx, "acme", "unknown")
-	requireOfflineEvidenceError(t, listErr)
-
-	_, manifestErr := provider.GetManifest(ctx, "acme", "unknown", "1.0.0")
-	requireOfflineEvidenceError(t, manifestErr)
-
-	assert.Zero(t, base.listAllVersion["acme/unknown"], "an unverified module must not reach the network")
-	assert.Zero(t, base.getManifest["acme/unknown"])
-}
-
-func TestLockedManifestProviderPrefersReplacementOverLockEntry(t *testing.T) {
-	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
-	provider, base := offlineProviderFixture(t, offlineLockedModule)
-
-	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
-	require.NoError(t, err)
-	require.Equal(t, []VersionInfo{{Version: "9.9.9"}}, versions, "the replacement owns the module, not the lock entry")
-	assert.Equal(t, 1, base.listAllVersion[offlineLockedModule])
-}
-
-func TestLockedManifestProviderWithoutReplacementsNeverLeavesTheLock(t *testing.T) {
-	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
-	provider, base := offlineProviderFixture(t)
-
-	_, err := provider.ListAllVersions(ctx, "local", "mod")
-	requireOfflineEvidenceError(t, err)
-
-	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
-	require.NoError(t, err)
-	require.Equal(t, []VersionInfo{{Version: offlineLockedVersion}}, versions)
-
-	assert.Zero(t, base.listAllVersion[offlineReplacedModule])
-	assert.Zero(t, base.listAllVersion[offlineLockedModule])
-}
-
-func requireOfflineEvidenceError(t *testing.T, err error) {
-	t.Helper()
-	require.Error(t, err)
-	var apiErr apierror.Error
-	require.ErrorAs(t, err, &apiErr)
-	require.Equal(t, apierror.Invalid, apiErr.Kind())
-	require.Contains(t, apiErr.Error(), "verified dependency evidence is unavailable during offline startup")
-}
-
-// offlineStartupWorkspace writes a workspace whose deployment root is a
-// source-replaced module carrying a live range, plus one locked module the
-// replacement depends on transitively.
-type offlineStartupWorkspace struct {
-	hub           *fakeHub
-	registry      *registryimpl.Reg
-	listCalls     map[string]int
-	manifestCalls map[string]int
-	lockPath      string
-	vendorDir     string
-	baseline      regapi.State
-	downloadCalls int
-}
-
-func newOfflineStartupWorkspace(t *testing.T, replacementTarget string) *offlineStartupWorkspace {
-	t.Helper()
-
-	rootDir := t.TempDir()
-	lockPath := filepath.Join(rootDir, "wippy.lock")
-	vendorDir := filepath.Join(rootDir, ".wippy")
-	replacementPath := filepath.Join(rootDir, "local-mod")
-
-	artifact := buildWappBytes(t, []wapp.Entry{{
-		ID: wapp.NewID("acme.lib", "service"), Kind: "service",
-	}})
-	sum := sha256.Sum256(artifact)
-	digest := "sha256:" + hex.EncodeToString(sum[:])
-	artifactPath := filepath.Join(vendorDir, "acme", "lib-"+offlineLockedVersion+".wapp")
-	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0o755))
-	require.NoError(t, os.WriteFile(artifactPath, artifact, 0o600))
-
-	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
-  modules: .wippy
-  src: ./src
-modules:
-  - name: `+offlineLockedModule+`
-    version: `+offlineLockedVersion+`
-    hash: `+digest+`
-replacements:
-  - from: `+offlineReplacedModule+`
-    to: `+replacementTarget+`
-`), 0o600))
-
-	require.NoError(t, os.MkdirAll(replacementPath, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(replacementPath, "_index.json"), []byte(`{
-  "namespace": "local.mod",
-  "entries": [
-    {"name": "svc", "kind": "registry.entry", "data": {"generation": "one"}},
-    {"name": "lib", "kind": "ns.dependency", "data": {"component": "`+offlineLockedModule+`", "version": "`+offlineLockedVersion+`"}}
-  ]
-}`), 0o600))
-
-	workspace := &offlineStartupWorkspace{
-		lockPath:      lockPath,
-		vendorDir:     vendorDir,
-		listCalls:     make(map[string]int),
-		manifestCalls: make(map[string]int),
-	}
+	workspace.lockPath = filepath.Join(workspace.root, "wippy.lock")
 	workspace.hub = &fakeHub{
 		listVersions: func(_ context.Context, org, module string) ([]VersionInfo, error) {
-			workspace.listCalls[org+"/"+module]++
-			return []VersionInfo{{Version: "0.2.0"}}, nil
+			workspace.hubCalls["list "+org+"/"+module]++
+			return nil, apierror.New(apierror.Unavailable, "hub is unreachable")
 		},
 		getManifest: func(_ context.Context, org, module, _ string) (*ModuleManifest, error) {
-			name := org + "/" + module
-			workspace.manifestCalls[name]++
-			if name != offlineLockedModule {
-				return nil, apierror.New(apierror.NotFound, "module "+name+" is not published")
-			}
-			return &ModuleManifest{
-				Org: org, Name: module,
-				Version: offlineLockedVersion, VersionID: offlineLockedVersion,
-				Digest: digest,
-			}, nil
+			workspace.hubCalls["manifest "+org+"/"+module]++
+			return nil, apierror.New(apierror.Unavailable, "hub is unreachable")
 		},
-		getDownload: func(context.Context, *DownloadParams) (*DownloadInfo, error) {
-			workspace.downloadCalls++
-			return nil, apierror.New(apierror.NotFound, "hub downloads are not available to this workspace")
+		getDownload: func(_ context.Context, params *DownloadParams) (*DownloadInfo, error) {
+			workspace.hubCalls["download "+params.Org+"/"+params.Module]++
+			return nil, apierror.New(apierror.Unavailable, "hub is unreachable")
 		},
-	}
-	workspace.baseline = regapi.State{
-		{
-			ID:   regapi.NewID("app.deps", "local"),
-			Kind: regapi.NamespaceDependency,
-			Data: payload.New(map[string]any{"component": offlineReplacedModule, "version": "*"}),
+		downloadFile: func(context.Context, string, string) error {
+			workspace.hubCalls["download file"]++
+			return apierror.New(apierror.Unavailable, "hub is unreachable")
 		},
-		markModuleIdentity(regapi.Entry{
-			ID: regapi.NewID("acme.lib", "service"), Kind: "service",
-		}, offlineLockedModule, offlineLockedVersion, digest),
 	}
 	return workspace
 }
 
-func (w *offlineStartupWorkspace) loadState(t *testing.T, access regapi.DependencyAccess) error {
+func (w *offlineWorkspace) vendorDir() string {
+	return filepath.Join(w.root, ".wippy")
+}
+
+// writeSource writes a local module tree, optionally declaring its own version.
+func (w *offlineWorkspace) writeSource(t *testing.T, dir, namespace, sourceVersion, entries string) {
 	t.Helper()
 
+	path := filepath.Join(w.root, dir)
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(path, "_index.json"), []byte(
+		`{"namespace": "`+namespace+`", "entries": [`+entries+`]}`,
+	), 0o600))
+	if sourceVersion != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(path, "wippy.yaml"),
+			[]byte("version: "+sourceVersion+"\n"), 0o600))
+	}
+}
+
+// vendorModule materializes a published module the lock can pin, and returns
+// its artifact digest.
+func (w *offlineWorkspace) vendorModule(t *testing.T, org, name, moduleVersion string, entries []wapp.Entry) string {
+	t.Helper()
+
+	artifact := buildWappBytes(t, entries)
+	sum := sha256.Sum256(artifact)
+	path := filepath.Join(w.vendorDir(), org, name+"-"+moduleVersion+".wapp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, artifact, 0o600))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (w *offlineWorkspace) writeLock(t *testing.T, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(w.lockPath, []byte(
+		"directories:\n  modules: .wippy\n  src: ./src\n"+body,
+	), 0o600))
+}
+
+func (w *offlineWorkspace) rootDependency(name, component, constraint string) regapi.Entry {
+	return regapi.Entry{
+		ID:   regapi.NewID("app.deps", name),
+		Kind: regapi.NamespaceDependency,
+		Data: payload.New(map[string]any{"component": component, "version": constraint}),
+	}
+}
+
+// installedModule marks an entry as already materialized from a published
+// module, which is the evidence verified-offline startup resolves from.
+func (w *offlineWorkspace) installedModule(id regapi.ID, module, moduleVersion, digest string) regapi.Entry {
+	return markModuleIdentity(regapi.Entry{ID: id, Kind: "service"}, module, moduleVersion, digest)
+}
+
+func (w *offlineWorkspace) newHandler(t *testing.T) *DependencyHandler {
+	t.Helper()
 	handler, err := NewDependencyHandler(DependencyHandlerOptions{
 		Hub:       w.hub,
 		Logger:    zap.NewNop(),
 		LockPath:  w.lockPath,
-		VendorDir: w.vendorDir,
+		VendorDir: w.vendorDir(),
 	})
 	require.NoError(t, err)
+	return handler
+}
 
+func (w *offlineWorkspace) newRegistry(t *testing.T, history regapi.History) *registryimpl.Reg {
+	t.Helper()
+
+	handler := w.newHandler(t)
 	resolver := topology.NewResolver()
 	handler.resolver = resolver
-	registry := registryimpl.NewRegistry(
-		memory.New(),
+	return registryimpl.NewRegistry(
+		history,
 		&bootRecordingRunner{},
 		topology.NewStateBuilder(zap.NewNop(), resolver),
 		resolver,
@@ -248,53 +153,439 @@ func (w *offlineStartupWorkspace) loadState(t *testing.T, access regapi.Dependen
 			regexp.NewDependencyDirective(handler.Expand).WithResolutionTransition(handler.ReconcileResolution),
 		),
 	)
-	w.registry = registry
-
-	ctx := regapi.WithDependencyAccess(newTestContext(), access)
-	return registry.LoadState(ctx, w.baseline, version.New(0))
 }
 
-func TestVerifiedOfflineStartupBootsWorkspaceWithSourceReplacement(t *testing.T) {
-	workspace := newOfflineStartupWorkspace(t, "./local-mod")
+// loadState boots the workspace from its baseline, as a cold start does.
+func (w *offlineWorkspace) loadState(t *testing.T, access regapi.DependencyAccess) error {
+	t.Helper()
+
+	if w.history == nil {
+		w.history = memory.New()
+	}
+	w.registry = w.newRegistry(t, w.history)
+	ctx := regapi.WithDependencyAccess(newTestContext(), access)
+	return w.registry.LoadState(ctx, w.baseline, version.New(0))
+}
+
+func (w *offlineWorkspace) requireEntry(t *testing.T, namespace, name string) regapi.Entry {
+	t.Helper()
+
+	entry, err := w.registry.GetEntry(regapi.NewID(namespace, name))
+	require.NoError(t, err)
+	return entry
+}
+
+func (w *offlineWorkspace) requireHubUntouched(t *testing.T) {
+	t.Helper()
+	require.Empty(t, w.hubCalls, "verified-offline startup must not reach the Hub")
+}
+
+// rootAPIError returns the innermost api error in the chain: registry boot
+// wraps a directive failure, and the failure's own kind is what matters here.
+func rootAPIError(t *testing.T, err error) apierror.Error {
+	t.Helper()
+
+	var found apierror.Error
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		var apiErr apierror.Error
+		if errors.As(current, &apiErr) {
+			found = apiErr
+		}
+	}
+	require.NotNil(t, found, "expected an api error in %v", err)
+	return found
+}
+
+// sourceEntry renders one entry of a local module tree.
+func sourceEntry(name, kind, data string) string {
+	return `{"name": "` + name + `", "kind": "` + kind + `", "data": ` + data + `}`
+}
+
+func dependencyEntry(name, component, constraint string) string {
+	return sourceEntry(name, string(regapi.NamespaceDependency),
+		`{"component": "`+component+`", "version": "`+constraint+`"}`)
+}
+
+// singleReplacementWorkspace is the reported regression: a deployment root
+// backed by a local source tree that declares no version of its own, requested
+// through a live range, with one published module beneath it.
+func singleReplacementWorkspace(t *testing.T, constraint string) *offlineWorkspace {
+	t.Helper()
+
+	workspace := newOfflineWorkspace(t)
+	digest := workspace.vendorModule(t, "acme", "lib", "1.0.0", []wapp.Entry{{
+		ID: wapp.NewID("acme.lib", "service"), Kind: "service",
+	}})
+	workspace.lockedDigest = digest
+	workspace.writeSource(t, "local-mod", "local.mod", "",
+		sourceEntry("svc", "registry.entry", `{"generation": "one"}`)+","+
+			dependencyEntry("lib", "acme/lib", "1.0.0"),
+	)
+	workspace.writeLock(t, `modules:
+  - name: acme/lib
+    version: 1.0.0
+    hash: `+digest+`
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`)
+	workspace.baseline = regapi.State{
+		workspace.rootDependency("local", "local/mod", constraint),
+		workspace.installedModule(regapi.NewID("acme.lib", "service"), "acme/lib", "1.0.0", digest),
+	}
+	return workspace
+}
+
+func TestVerifiedOfflineStartupResolvesReplacementWithUnreachableHub(t *testing.T) {
+	workspace := singleReplacementWorkspace(t, "*")
 
 	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
 
-	entry, err := workspace.registry.GetEntry(regapi.NewID("local.mod", "svc"))
-	require.NoError(t, err)
+	entry := workspace.requireEntry(t, "local.mod", "svc")
 	require.Equal(t, "one", entry.Data.Data().(map[string]any)["generation"])
-
-	_, err = workspace.registry.GetEntry(regapi.NewID("acme.lib", "service"))
-	require.NoError(t, err, "a locked transitive dependency of the replacement resolves from lock evidence")
-
-	assert.Equal(t, 1, workspace.listCalls[offlineReplacedModule], "only the replaced module's live range needs a candidate set")
-	assert.Zero(t, workspace.listCalls[offlineLockedModule], "verified lock evidence answers the transitive dependency")
-	assert.Empty(t, workspace.manifestCalls, "the local tree and the vendored artifact supply every manifest")
-	assert.Zero(t, workspace.downloadCalls)
+	workspace.requireEntry(t, "acme.lib", "service")
+	workspace.requireHubUntouched(t)
 }
 
-func TestOnlineStartupBootsWorkspaceWithSourceReplacement(t *testing.T) {
-	workspace := newOfflineStartupWorkspace(t, "./local-mod")
+func TestVerifiedOfflineStartupResolvesReplacementUnderLabelConstraint(t *testing.T) {
+	workspace := singleReplacementWorkspace(t, "@latest")
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+
+	workspace.requireEntry(t, "local.mod", "svc")
+	workspace.requireHubUntouched(t)
+}
+
+func TestVerifiedOfflineStartupFailsWhenRangeOutrunsLocalEvidence(t *testing.T) {
+	workspace := newOfflineWorkspace(t)
+	digest := workspace.vendorModule(t, "local", "mod", "1.0.0", []wapp.Entry{{
+		ID: wapp.NewID("local.mod", "svc"), Kind: "registry.entry",
+		Data: map[string]any{"generation": "published"},
+	}})
+	workspace.writeSource(t, "local-mod", "local.mod", "",
+		sourceEntry("svc", "registry.entry", `{"generation": "local"}`))
+	workspace.writeLock(t, `modules:
+  - name: local/mod
+    version: 1.0.0
+    hash: `+digest+`
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`)
+	workspace.baseline = regapi.State{
+		workspace.rootDependency("local", "local/mod", ">=9.0.0"),
+		workspace.installedModule(regapi.NewID("local.mod", "other"), "local/mod", "1.0.0", digest),
+	}
+
+	err := workspace.loadState(t, regapi.DependencyAccessVerifiedOffline)
+
+	// Nothing local shows the tree is >=9.0.0, and a durable resolution may
+	// not select a version its own declaration excludes. Saying so beats both
+	// reaching for the Hub and binding the tree to a release on no evidence.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no available version of local/mod")
+	require.NotContains(t, err.Error(), "verified dependency evidence is unavailable during offline startup")
+	workspace.requireHubUntouched(t)
+}
+
+func TestVerifiedOfflineStartupUsesDeclaredSourceVersionForRange(t *testing.T) {
+	workspace := newOfflineWorkspace(t)
+	workspace.writeSource(t, "local-mod", "local.mod", "9.1.0",
+		sourceEntry("svc", "registry.entry", `{"generation": "local"}`))
+	workspace.writeLock(t, `replacements:
+  - from: local/mod
+    to: ./local-mod
+`)
+	workspace.baseline = regapi.State{workspace.rootDependency("local", "local/mod", ">=9.0.0")}
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+
+	entry := workspace.requireEntry(t, "local.mod", "svc")
+	require.Equal(t, "local", entry.Data.Data().(map[string]any)["generation"])
+	require.Equal(t, "9.1.0", entry.Meta["module_version"],
+		"the version the source declares settles a live range offline")
+	workspace.requireHubUntouched(t)
+}
+
+func TestVerifiedOfflineStartupKeepsRecordedLabelForReplacedLockedModule(t *testing.T) {
+	workspace := newOfflineWorkspace(t)
+	digest := workspace.vendorModule(t, "local", "mod", "1.0.0", []wapp.Entry{{
+		ID: wapp.NewID("local.mod", "svc"), Kind: "registry.entry",
+		Data: map[string]any{"generation": "published"},
+	}})
+	workspace.writeSource(t, "local-mod", "local.mod", "",
+		sourceEntry("svc", "registry.entry", `{"generation": "local"}`))
+	workspace.writeLock(t, `modules:
+  - name: local/mod
+    version: 1.0.0
+    hash: `+digest+`
+replacements:
+  - from: local/mod
+    to: ./local-mod
+`)
+	workspace.baseline = regapi.State{
+		workspace.rootDependency("local", "local/mod", ">=1.0.0"),
+		workspace.installedModule(regapi.NewID("local.mod", "other"), "local/mod", "1.0.0", digest),
+	}
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+
+	entry := workspace.requireEntry(t, "local.mod", "svc")
+	require.Equal(t, "local", entry.Data.Data().(map[string]any)["generation"],
+		"the replacement supplies the content of a module the lock also pins")
+	require.Equal(t, "1.0.0", entry.Meta["module_version"],
+		"the recorded label stays with it")
+	workspace.requireHubUntouched(t)
+}
+
+func TestVerifiedOfflineStartupResolvesTransitivelyReplacedDependency(t *testing.T) {
+	workspace := newOfflineWorkspace(t)
+	workspace.writeSource(t, "local-app", "local.app", "",
+		sourceEntry("svc", "registry.entry", `{"generation": "app"}`)+","+
+			dependencyEntry("lib", "local/lib", ">=2.0.0"),
+	)
+	workspace.writeSource(t, "local-lib", "local.lib", "2.5.0",
+		sourceEntry("svc", "registry.entry", `{"generation": "lib"}`))
+	workspace.writeLock(t, `replacements:
+  - from: local/app
+    to: ./local-app
+  - from: local/lib
+    to: ./local-lib
+`)
+	workspace.baseline = regapi.State{workspace.rootDependency("app", "local/app", "*")}
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+
+	workspace.requireEntry(t, "local.app", "svc")
+	entry := workspace.requireEntry(t, "local.lib", "svc")
+	require.Equal(t, "2.5.0", entry.Meta["module_version"],
+		"a replaced module's own source version labels it")
+	workspace.requireHubUntouched(t)
+}
+
+// failingReplacementWorkspace pairs a replaced module whose local tree is
+// invalid with a module that has no offline evidence at all. The names decide
+// which failure the resolver reports first.
+func failingReplacementWorkspace(t *testing.T, replacedOrg, unverifiedOrg string) *offlineWorkspace {
+	t.Helper()
+
+	workspace := newOfflineWorkspace(t)
+	workspace.writeSource(t, "local-mod", replacedOrg+".mod", "",
+		dependencyEntry("broken", "", "1.0.0"))
+	workspace.writeLock(t, `replacements:
+  - from: `+replacedOrg+`/mod
+    to: ./local-mod
+`)
+	workspace.baseline = regapi.State{
+		workspace.rootDependency("replaced", replacedOrg+"/mod", "*"),
+		workspace.rootDependency("unverified", unverifiedOrg+"/lib", ">=1.0.0"),
+	}
+	return workspace
+}
+
+func TestVerifiedOfflineStartupReportsReplacementFailureWhateverTheModuleOrder(t *testing.T) {
+	orders := []struct {
+		name          string
+		replacedOrg   string
+		unverifiedOrg string
+	}{
+		{name: "unverified module sorts first", replacedOrg: "zulu", unverifiedOrg: "alpha"},
+		{name: "replaced module sorts first", replacedOrg: "alpha", unverifiedOrg: "zulu"},
+	}
+
+	for _, order := range orders {
+		t.Run(order.name, func(t *testing.T) {
+			workspace := failingReplacementWorkspace(t, order.replacedOrg, order.unverifiedOrg)
+
+			err := workspace.loadState(t, regapi.DependencyAccessVerifiedOffline)
+
+			require.Error(t, err)
+			apiErr := rootAPIError(t, err)
+			require.Equal(t, apierror.Conflict, apiErr.Kind(),
+				"a replaced module's failure is never a missing-evidence failure")
+			require.Contains(t, apiErr.Error(), order.replacedOrg+"/mod@*: invalid dependency entry",
+				"the replacement's real failure stays visible")
+			require.Contains(t, apiErr.Error(), order.unverifiedOrg+"/lib",
+				"the module without evidence is still reported")
+		})
+	}
+}
+
+func TestVerifiedOfflineStartupKeepsEvidenceRefusalWithoutReplacements(t *testing.T) {
+	workspace := newOfflineWorkspace(t)
+	workspace.writeLock(t, "")
+	workspace.baseline = regapi.State{workspace.rootDependency("unverified", "acme/lib", ">=1.0.0")}
+
+	err := workspace.loadState(t, regapi.DependencyAccessVerifiedOffline)
+
+	require.Error(t, err)
+	apiErr := rootAPIError(t, err)
+	require.Equal(t, apierror.Invalid, apiErr.Kind())
+	require.Contains(t, apiErr.Error(), "verified dependency evidence is unavailable during offline startup")
+	require.Empty(t, workspace.hubCalls, "an unverified module must not fall back to the Hub")
+}
+
+func TestVerifiedOfflineStartupReportsMissingReplacementPath(t *testing.T) {
+	workspace := singleReplacementWorkspace(t, "*")
+	require.NoError(t, os.RemoveAll(filepath.Join(workspace.root, "local-mod")))
+
+	err := workspace.loadState(t, regapi.DependencyAccessVerifiedOffline)
+
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "verified dependency evidence is unavailable during offline startup")
+	require.Contains(t, err.Error(), "local-mod", "the unreadable replacement tree is named")
+	workspace.requireHubUntouched(t)
+}
+
+func TestVerifiedOfflineStartupResolvesFromLockAfterReplacementRemoved(t *testing.T) {
+	workspace := newOfflineWorkspace(t)
+	digest := workspace.vendorModule(t, "local", "mod", "1.0.0", []wapp.Entry{{
+		ID: wapp.NewID("local.mod", "svc"), Kind: "registry.entry",
+		Data: map[string]any{"generation": "published"},
+	}})
+	workspace.writeSource(t, "local-mod", "local.mod", "",
+		sourceEntry("svc", "registry.entry", `{"generation": "local"}`))
+	lockedModules := `modules:
+  - name: local/mod
+    version: 1.0.0
+    hash: ` + digest + `
+`
+	workspace.writeLock(t, lockedModules+`replacements:
+  - from: local/mod
+    to: ./local-mod
+`)
+	workspace.baseline = regapi.State{
+		workspace.rootDependency("local", "local/mod", "1.0.0"),
+		workspace.installedModule(regapi.NewID("local.mod", "other"), "local/mod", "1.0.0", digest),
+	}
+
+	historyPath := filepath.Join(workspace.root, "registry.db")
+	history, err := historysqlite.NewSQLite(historyPath, zap.NewNop())
+	require.NoError(t, err)
+	workspace.history = history
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+	replaced := workspace.requireEntry(t, "local.mod", "svc")
+	require.Equal(t, "local", replaced.Data.Data().(map[string]any)["generation"])
+	require.Contains(t, replaced.Meta["module_digest"], "sha256-tree-v1:",
+		"the tree's own identity pins a replaced module")
+	require.NoError(t, history.Close())
+
+	// The operator drops the replacement; the lock alone must carry the boot.
+	workspace.writeLock(t, lockedModules)
+	history, err = historysqlite.NewSQLite(historyPath, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = history.Close() })
+	workspace.history = history
+
+	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessVerifiedOffline))
+	entries, err := workspace.registry.GetAllEntries()
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if entry.Meta["module"] != "local/mod" {
+			continue
+		}
+		require.Equal(t, digest, entry.Meta["module_digest"],
+			"the lock's artifact backs the module once the replacement is gone")
+	}
+	workspace.requireHubUntouched(t)
+}
+
+func TestOnlineStartupResolvesReplacementThroughHub(t *testing.T) {
+	workspace := singleReplacementWorkspace(t, "*")
+	workspace.hub.listVersions = func(_ context.Context, org, module string) ([]VersionInfo, error) {
+		workspace.hubCalls["list "+org+"/"+module]++
+		return []VersionInfo{{Version: "0.2.0"}}, nil
+	}
+	workspace.hub.getManifest = func(_ context.Context, org, module, constraint string) (*ModuleManifest, error) {
+		workspace.hubCalls["manifest "+org+"/"+module]++
+		return &ModuleManifest{
+			Org: org, Name: module, Version: constraint, VersionID: constraint,
+			Digest: workspace.lockedDigest,
+		}, nil
+	}
 
 	require.NoError(t, workspace.loadState(t, regapi.DependencyAccessOnline))
 
-	_, err := workspace.registry.GetEntry(regapi.NewID("local.mod", "svc"))
-	require.NoError(t, err)
-	_, err = workspace.registry.GetEntry(regapi.NewID("acme.lib", "service"))
-	require.NoError(t, err)
-	assert.Equal(t, 1, workspace.manifestCalls[offlineLockedModule], "online startup keeps consulting the Hub for locked modules")
-	assert.Zero(t, workspace.downloadCalls)
+	entry := workspace.requireEntry(t, "local.mod", "svc")
+	require.Equal(t, "0.2.0", entry.Meta["module_version"],
+		"online resolution still lets the Hub label an unversioned replacement")
+	require.Equal(t, 1, workspace.hubCalls["list local/mod"])
 }
 
-func TestVerifiedOfflineStartupReportsMissingReplacementPathNotMissingEvidence(t *testing.T) {
-	workspace := newOfflineStartupWorkspace(t, "./absent-mod")
+// offlineReplacementProvider builds the production provider stack for a
+// replacement whose tree declares sourceVersion, over a base that fails if it
+// is consulted at all.
+func offlineReplacementProvider(t *testing.T, sourceVersion, recorded string) (*replacementManifestProvider, *fakeManifestProvider) {
+	t.Helper()
 
-	lockObj, err := lock.New(workspace.lockPath)
+	path := t.TempDir()
+	if sourceVersion != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(path, "wippy.yaml"),
+			[]byte("version: "+sourceVersion+"\n"), 0o600))
+	}
+	base := newFakeProvider()
+	base.addModule("local", "mod", "7.7.7")
+
+	return &replacementManifestProvider{
+		base: base,
+		handler: &DependencyHandler{
+			logger: zap.NewNop(),
+			replacements: map[string]lock.Replacement{
+				"local/mod": {From: "local/mod", To: path},
+			},
+		},
+		lockedVersions: map[string]string{"local/mod": recorded},
+	}, base
+}
+
+func TestReplacementProviderLabelsFromLocalEvidenceOffline(t *testing.T) {
+	tests := []struct {
+		name          string
+		sourceVersion string
+		recorded      string
+		want          string
+	}{
+		{name: "declared source version", sourceVersion: "2.5.0", recorded: "1.0.0", want: "2.5.0"},
+		{name: "recorded version", recorded: "1.0.0", want: "1.0.0"},
+		{name: "zero release when nothing names one", want: replacementZeroVersion},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+			provider, base := offlineReplacementProvider(t, test.sourceVersion, test.recorded)
+
+			versions, err := provider.ListAllVersions(ctx, "local", "mod")
+			require.NoError(t, err)
+			require.Equal(t, []VersionInfo{{Version: test.want}}, versions)
+
+			manifest, err := provider.GetManifest(ctx, "local", "mod", "@latest")
+			require.NoError(t, err)
+			require.Equal(t, test.want, manifest.Version)
+
+			assert.Zero(t, base.listAllVersion["local/mod"], "offline startup must not enumerate releases")
+			assert.Zero(t, base.getManifest["local/mod"], "offline startup must not resolve labels remotely")
+		})
+	}
+}
+
+func TestReplacementProviderStillDelegatesLabelsOnline(t *testing.T) {
+	provider, base := offlineReplacementProvider(t, "", "")
+
+	versions, err := provider.ListAllVersions(newTestContext(), "local", "mod")
 	require.NoError(t, err)
-	validateErr := lock.Validate(lockObj)
-	require.Error(t, validateErr)
-	require.Contains(t, validateErr.Error(), "does not exist")
+	require.Equal(t, []VersionInfo{{Version: "7.7.7"}}, versions)
+	assert.Equal(t, 1, base.listAllVersion["local/mod"])
+}
 
-	loadErr := workspace.loadState(t, regapi.DependencyAccessVerifiedOffline)
-	require.Error(t, loadErr)
-	require.NotContains(t, loadErr.Error(), "verified dependency evidence is unavailable during offline startup")
+func TestReplacementProviderLeavesUnreplacedModulesToTheBaseOffline(t *testing.T) {
+	ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessVerifiedOffline)
+	provider, base := offlineReplacementProvider(t, "", "")
+	base.addModule("acme", "lib", "1.0.0")
+
+	versions, err := provider.ListAllVersions(ctx, "acme", "lib")
+	require.NoError(t, err)
+	require.Equal(t, []VersionInfo{{Version: "1.0.0"}}, versions)
+	assert.Equal(t, 1, base.listAllVersion["acme/lib"],
+		"only replaced modules resolve from local evidence")
 }


### PR DESCRIPTION
## Root cause

#573 (`5fa850245e`, v0.3.30a) routes verified-offline startup through `lockedManifestProvider`, which admits a module only when the lock pins it to a version that is materialized locally **and** carries a validated artifact digest.

A module backed by a `workspace.replacements` entry (`from: spiralscout/crm` -> `to: ../crm`) satisfies neither condition by construction: its content comes from a local source tree the operator declared, and no lock digest can describe it. The provider refused it with the offline-evidence error instead of letting the replacement-aware layer resolve it — even though its own doc comment claimed it "lets the normal resolver validate a graph containing mutable replacements".

The refusal fires whenever the replaced module's candidate set has to be enumerated: a live range (`version: "*"`) with no explicit `version:` in the replacement source and no satisfying lock pin. An online `wippy update` does not clear it, because `wippy update` records no lock entry for a replaced module.

## Failing scenario

Any workspace with `workspace.replacements`, on every boot:

```
registry.dependency dependency resolution failed {"errors": "spiralscout/crm@*: list versions: verified dependency evidence is unavailable during offline startup"}
Error: failed to expand changeset: verified dependency evidence is unavailable during offline startup
```

Reproduced at `5fa850245e` against `spiralscout/crm/test` (a harness that replaces `spiralscout/crm` with `..`).

## Fix

`lockedManifestProvider` now carries `replaced ManifestProvider` — the provider the replacement-aware layer resolved through before this fast path existed — and serves any module covered by a replacement from it, in both `GetManifest` and `ListAllVersions`. `resolveModules` passes the pre-substitution provider when it installs the locked one.

- A replacement outranks a lock entry for the same module. This matches `lockedResolution`, which already declines the whole fast path when any replacement is present.
- A module that is neither locked nor replaced still gets the evidence refusal, so #573's deployment fast path and its no-network guarantee for locked modules are untouched.
- A failed resolution for a replaced module no longer gets relabelled as missing evidence: that module never resolved from evidence, so the real error is reported (for example a missing replacement path) instead of a misleading one.

Local evidence still short-circuits the Hub for a replaced module exactly as before — an explicit `version:` in the replacement's `wippy.yaml`, an exact constraint, or a satisfying lock pin all resolve without any network call.

## Test coverage

New `boot/deps/hub/replacement_offline_startup_test.go`:

| Test | Covers |
| --- | --- |
| `TestLockedManifestProviderResolvesReplacedModuleWithoutDigestEvidence` | replaced module resolves with no digest evidence |
| `TestLockedManifestProviderKeepsFastPathForVerifiedLockedModule` | locked + verified module still answered locally |
| `TestLockedManifestProviderRefusesModuleNeitherLockedNorReplaced` | the #573 guarantee is kept |
| `TestLockedManifestProviderPrefersReplacementOverLockEntry` | replacement outranks a lock entry |
| `TestLockedManifestProviderWithoutReplacementsNeverLeavesTheLock` | empty replacement set: pure #573 behavior |
| `TestVerifiedOfflineStartupBootsWorkspaceWithSourceReplacement` | fixture boot: real `wippy.lock` + `replacements` + baseline entries, live range on the replaced root, locked transitive dependency resolved from lock evidence alone |
| `TestOnlineStartupBootsWorkspaceWithSourceReplacement` | same workspace under online access |
| `TestVerifiedOfflineStartupReportsMissingReplacementPathNotMissingEvidence` | missing replacement path reports the replacement error |

Red-first at `5fa850245e` (fix reverted, provider call adapted to the old arity): 4 fail, 4 pass.

```
--- FAIL: TestLockedManifestProviderResolvesReplacedModuleWithoutDigestEvidence
        verified dependency evidence is unavailable during offline startup
--- PASS: TestLockedManifestProviderKeepsFastPathForVerifiedLockedModule
--- PASS: TestLockedManifestProviderRefusesModuleNeitherLockedNorReplaced
--- FAIL: TestLockedManifestProviderPrefersReplacementOverLockEntry
        expected: "9.9.9"  actual: "1.0.0"
--- PASS: TestLockedManifestProviderWithoutReplacementsNeverLeavesTheLock
--- FAIL: TestVerifiedOfflineStartupBootsWorkspaceWithSourceReplacement
        failed to expand changeset: verified dependency evidence is unavailable during offline startup
--- PASS: TestOnlineStartupBootsWorkspaceWithSourceReplacement
--- FAIL: TestVerifiedOfflineStartupReportsMissingReplacementPathNotMissingEvidence
```

The four that pass unfixed are exactly the ones asserting #573's guarantees are preserved.

## Validation

- `go test ./boot/...` clean; `go test ./boot/deps/hub/ -race` clean; `go test ./system/... ./api/...` clean
- `golangci-lint v2.8.0` on `./boot/deps/hub/...`: 0 issues
- `make build-wippy-local` clean
- Real workspace: `spiralscout/crm/test` (uses `workspace.replacements`) fails to boot with a `5fa850245e` binary and passes **98/98** with the patched binary

https://claude.ai/code/session_01P1t1gnD4Qwd4afzCwwmtQj
