### PR TITLE
fix(di): binding refusals name their entries

### DIFF
--- a/service/di/errors.go
+++ b/service/di/errors.go
@@ -50,13 +50,14 @@ func NewOutputSchemaMissingFormatError(index int, methodName string, defID regis
 }
 
 func NewBindingNoContractsError(bindingID registry.ID) error {
-	return apierror.New(apierror.Invalid, "binding must bind at least one contract").
+	return apierror.New(apierror.Invalid, "binding must bind at least one contract: "+bindingID.String()).
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{"binding_id": bindingID.String()}))
 }
 
 func NewContractNotFoundError(bindingID registry.ID, index int, contractID registry.ID) error {
-	return apierror.New(apierror.Invalid, "binding references undefined contract").
+	return apierror.New(apierror.Invalid,
+		"binding references undefined contract: "+bindingID.String()+" binds "+contractID.String()).
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{
 			"binding_id":     bindingID.String(),
@@ -66,7 +67,8 @@ func NewContractNotFoundError(bindingID registry.ID, index int, contractID regis
 }
 
 func NewMethodNotBoundError(bindingID, contractID registry.ID, methodName string) error {
-	return apierror.New(apierror.Invalid, "contract method is not bound").
+	return apierror.New(apierror.Invalid,
+		"contract method is not bound: "+bindingID.String()+" leaves "+contractID.String()+"."+methodName+" unbound").
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{
 			"binding_id":  bindingID.String(),
@@ -76,7 +78,8 @@ func NewMethodNotBoundError(bindingID, contractID registry.ID, methodName string
 }
 
 func NewMethodNotDefinedError(bindingID, contractID registry.ID, methodName string) error {
-	return apierror.New(apierror.Invalid, "bound method is not defined in contract definition").
+	return apierror.New(apierror.Invalid,
+		"bound method is not defined in contract definition: "+bindingID.String()+" binds "+contractID.String()+"."+methodName).
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{
 			"binding_id":  bindingID.String(),
@@ -86,7 +89,8 @@ func NewMethodNotDefinedError(bindingID, contractID registry.ID, methodName stri
 }
 
 func NewDuplicateDefaultBindingError(contractID, existingBindingID, newBindingID registry.ID) error {
-	return apierror.New(apierror.AlreadyExists, "contract already has default binding").
+	return apierror.New(apierror.AlreadyExists,
+		"contract already has default binding: "+contractID.String()+" is bound by "+existingBindingID.String()+", refused "+newBindingID.String()).
 		WithRetryable(apierror.False).
 		WithDetails(attrs.NewBagFrom(map[string]any{
 			"contract_id":         contractID.String(),

--- a/service/di/errors_identity_test.go
+++ b/service/di/errors_identity_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package di
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wippyai/runtime/api/registry"
+)
+
+// A refused binding names the binding and the contract in the error text
+// itself. The details bag carries the same identities for structured
+// consumers, but log lines and governance surfaces render only the message,
+// and a refusal that names no entry cannot be acted on.
+func TestBindingErrorsNameTheirEntries(t *testing.T) {
+	binding := registry.NewID("acme.app", "store_binding")
+	contract := registry.NewID("acme.platform", "store_contract")
+
+	assert.Contains(t, NewContractNotFoundError(binding, 0, contract).Error(), binding.String())
+	assert.Contains(t, NewContractNotFoundError(binding, 0, contract).Error(), contract.String())
+
+	assert.Contains(t, NewBindingNoContractsError(binding).Error(), binding.String())
+
+	assert.Contains(t, NewMethodNotBoundError(binding, contract, "get").Error(), binding.String())
+	assert.Contains(t, NewMethodNotBoundError(binding, contract, "get").Error(), "get")
+
+	assert.Contains(t, NewMethodNotDefinedError(binding, contract, "put").Error(), contract.String())
+	assert.Contains(t, NewMethodNotDefinedError(binding, contract, "put").Error(), "put")
+
+	existing := registry.NewID("acme.app", "first_binding")
+	assert.Contains(t, NewDuplicateDefaultBindingError(contract, existing, binding).Error(), contract.String())
+	assert.Contains(t, NewDuplicateDefaultBindingError(contract, existing, binding).Error(), existing.String())
+}

--- a/service/di/errors_identity_test.go
+++ b/service/di/errors_identity_test.go
@@ -16,19 +16,24 @@ import (
 func TestBindingErrorsNameTheirEntries(t *testing.T) {
 	binding := registry.NewID("acme.app", "store_binding")
 	contract := registry.NewID("acme.platform", "store_contract")
-
-	assert.Contains(t, NewContractNotFoundError(binding, 0, contract).Error(), binding.String())
-	assert.Contains(t, NewContractNotFoundError(binding, 0, contract).Error(), contract.String())
-
-	assert.Contains(t, NewBindingNoContractsError(binding).Error(), binding.String())
-
-	assert.Contains(t, NewMethodNotBoundError(binding, contract, "get").Error(), binding.String())
-	assert.Contains(t, NewMethodNotBoundError(binding, contract, "get").Error(), "get")
-
-	assert.Contains(t, NewMethodNotDefinedError(binding, contract, "put").Error(), contract.String())
-	assert.Contains(t, NewMethodNotDefinedError(binding, contract, "put").Error(), "put")
-
 	existing := registry.NewID("acme.app", "first_binding")
-	assert.Contains(t, NewDuplicateDefaultBindingError(contract, existing, binding).Error(), contract.String())
-	assert.Contains(t, NewDuplicateDefaultBindingError(contract, existing, binding).Error(), existing.String())
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{"empty contract list", NewBindingNoContractsError(binding), []string{binding.String()}},
+		{"undefined contract", NewContractNotFoundError(binding, 0, contract), []string{binding.String(), contract.String()}},
+		{"unbound method", NewMethodNotBoundError(binding, contract, "get"), []string{binding.String(), contract.String(), "get"}},
+		{"undefined method", NewMethodNotDefinedError(binding, contract, "put"), []string{binding.String(), contract.String(), "put"}},
+		{"duplicate default", NewDuplicateDefaultBindingError(contract, existing, binding), []string{contract.String(), existing.String(), binding.String()}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, want := range test.want {
+				assert.Contains(t, test.err.Error(), want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

A refused contract binding reported only its class of failure — `binding references undefined contract`, `contract method is not bound` — while the binding and contract identities lived in an error-details bag that log lines and governance surfaces never render. Diagnosing a failed install meant bisecting the changeset by hand.

The identities now live in the message itself: the binding, the contract, and the method where one is involved. The details bag is unchanged for structured consumers, and existing message assertions (all `Contains`) keep passing.

## Tests

`TestBindingErrorsNameTheirEntries` pins every constructor in the family: the rendered message names each identity the details bag carries.

https://claude.ai/code/session_01KqtSXDfDjEv6GYoAntvDhy