### PR TITLE
fix(exec): read volume sources the way Docker does

### DIFF
--- a/service/exec/docker/docker.go
+++ b/service/exec/docker/docker.go
@@ -7,12 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	execapi "github.com/wippyai/runtime/api/service/exec"
@@ -182,25 +182,14 @@ func (p *Process) Start() error {
 
 	ctx := context.Background()
 
-	var mounts []mount.Mount
-	for _, vol := range p.volumes {
-		parts := strings.Split(vol, ":")
-		if len(parts) >= 2 {
-			m := mount.Mount{
-				Type:   mount.TypeBind,
-				Source: parts[0],
-				Target: parts[1],
-			}
-			if len(parts) >= 3 && parts[2] == "ro" {
-				m.ReadOnly = true
-			}
-			mounts = append(mounts, m)
-		}
+	binds, err := buildBinds(p.volumes)
+	if err != nil {
+		return err
 	}
 
 	hostConfig := &container.HostConfig{
 		AutoRemove:     p.autoRemove,
-		Mounts:         mounts,
+		Binds:          binds,
 		ReadonlyRootfs: p.readOnlyRootfs,
 		Tmpfs:          p.tmpfs,
 		CapDrop:        p.capDrop,
@@ -392,6 +381,40 @@ func (p *Process) Wait() error {
 	}
 
 	return nil
+}
+
+// buildBinds prepares Docker short-syntax volume specifications for the daemon.
+// Relative host paths are resolved client-side, matching Docker CLI behavior;
+// the daemon remains the authority for parsing and validating the full syntax.
+func buildBinds(volumes []string) ([]string, error) {
+	if len(volumes) == 0 {
+		return nil, nil
+	}
+
+	binds := make([]string, 0, len(volumes))
+	for _, volume := range volumes {
+		source, remainder, ok := strings.Cut(volume, ":")
+		if !ok {
+			continue
+		}
+
+		if !filepath.IsAbs(source) && isExplicitRelativePath(source) {
+			absolute, err := filepath.Abs(source)
+			if err != nil {
+				return nil, fmt.Errorf("resolve docker volume source %q: %w", source, err)
+			}
+			volume = absolute + ":" + remainder
+		}
+		binds = append(binds, volume)
+	}
+	return binds, nil
+}
+
+func isExplicitRelativePath(source string) bool {
+	if source == "." || source == ".." {
+		return true
+	}
+	return strings.HasPrefix(source, ".") && strings.ContainsAny(source, `/\`)
 }
 
 // parseCommand splits a command string into parts

--- a/service/exec/docker/docker_test.go
+++ b/service/exec/docker/docker_test.go
@@ -3,13 +3,17 @@
 package docker
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierror "github.com/wippyai/runtime/api/error"
@@ -559,4 +563,107 @@ func BenchmarkDockerProcess_StartAndWait(b *testing.B) {
 			b.Fatalf("failed to wait for process: %v", err)
 		}
 	}
+}
+
+func TestBuildBinds(t *testing.T) {
+	relative, err := filepath.Abs("./relative")
+	require.NoError(t, err)
+	windowsRelative, err := filepath.Abs(`.\relative`)
+	require.NoError(t, err)
+	hiddenRelative, err := filepath.Abs(".hidden/relative")
+	require.NoError(t, err)
+	current, err := filepath.Abs(".")
+	require.NoError(t, err)
+	parent, err := filepath.Abs("..")
+	require.NoError(t, err)
+
+	binds, err := buildBinds([]string{
+		"/host/data:/data",
+		"acp-home:/home/acp:ro,nocopy",
+		"./relative:/rel:ro,rshared",
+		`.\relative:/windows-relative`,
+		".hidden/relative:/hidden-relative",
+		".:/work",
+		"..:/parent",
+		".hidden:/invalid-volume-name",
+		"data/sub:/invalid-volume-name",
+		":/anonymous",
+		`C:\host\data:C:\container\data:ro`,
+		`\\server\share:C:\container\share`,
+		"malformed",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"/host/data:/data",
+		"acp-home:/home/acp:ro,nocopy",
+		relative + ":/rel:ro,rshared",
+		windowsRelative + ":/windows-relative",
+		hiddenRelative + ":/hidden-relative",
+		current + ":/work",
+		parent + ":/parent",
+		".hidden:/invalid-volume-name",
+		"data/sub:/invalid-volume-name",
+		":/anonymous",
+		`C:\host\data:C:\container\data:ro`,
+		`\\server\share:C:\container\share`,
+	}, binds)
+}
+
+func TestDockerProcess_NamedVolume(t *testing.T) {
+	skipIfNoDocker(t)
+
+	name := fmt.Sprintf("wippy-exec-test-%d", time.Now().UnixNano())
+	config := &execapi.DockerExecutorConfig{
+		Image:      "alpine:latest",
+		AutoRemove: true,
+		Volumes:    []string{name + ":/data"},
+	}
+	executor, err := NewDockerExecutor(zap.NewNop(), config)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = executor.cli.VolumeRemove(context.Background(), name, client.VolumeRemoveOptions{Force: true})
+		_ = executor.Close()
+	})
+
+	writer, err := executor.NewProcess("sh -c 'printf persisted >/data/value'", execapi.ProcessOptions{})
+	require.NoError(t, err)
+	require.NoError(t, writer.Start())
+	require.NoError(t, writer.Wait())
+
+	reader, err := executor.NewProcess("cat /data/value", execapi.ProcessOptions{})
+	require.NoError(t, err)
+	require.NoError(t, reader.Start())
+	output, err := io.ReadAll(reader.Stdout())
+	require.NoError(t, err)
+	require.NoError(t, reader.Wait())
+	require.Equal(t, "persisted", string(output))
+}
+
+func TestDockerProcess_RelativeBind(t *testing.T) {
+	skipIfNoDocker(t)
+
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	hostDirectory := t.TempDir()
+	relative, err := filepath.Rel(workingDirectory, hostDirectory)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(relative, "."), "test directory must be relative to the working directory")
+
+	config := &execapi.DockerExecutorConfig{
+		Image:      "alpine:latest",
+		AutoRemove: true,
+		Volumes:    []string{relative + ":/data"},
+	}
+	executor, err := NewDockerExecutor(zap.NewNop(), config)
+	require.NoError(t, err)
+	defer func() { _ = executor.Close() }()
+
+	process, err := executor.NewProcess("sh -c 'printf mounted >/data/value'", execapi.ProcessOptions{})
+	require.NoError(t, err)
+	require.NoError(t, process.Start())
+	require.NoError(t, process.Wait())
+
+	content, err := os.ReadFile(filepath.Join(hostDirectory, "value"))
+	require.NoError(t, err)
+	require.Equal(t, "mounted", string(content))
 }


### PR DESCRIPTION
The Docker executor converted every configured `source:target[:options]` entry into an API `Mount` with `TypeBind`. That bypassed Docker's short-syntax parser, so named volumes were sent as invalid bind paths and relative bind sources reached the daemon unresolved.

Use `HostConfig.Binds` as the canonical parsing boundary. Wippy preserves the original Docker volume specification—including named volumes, Windows paths, and mount options—and only resolves explicit `.`/`..` relative host paths before the request, matching the Docker CLI's client-side responsibility. Entries without a separator remain ignored, preserving the existing Wippy configuration contract.

Verified with:
- focused short and full Docker executor suites
- live named-volume persistence across containers
- live relative bind write-through to the host
- race detector
- Windows cross-compilation
- focused golangci-lint