### PR TITLE
fix(store): synchronize dispatcher shutdown

### DIFF
--- a/service/store/dispatcher.go
+++ b/service/store/dispatcher.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/store"
@@ -15,12 +14,15 @@ import (
 
 // Dispatcher handles store commands via async worker pool.
 type Dispatcher struct {
-	ctx     context.Context
-	jobs    chan job
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	workers int
-	stopped atomic.Bool
+	ctx      context.Context
+	jobs     chan job
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	submits  sync.WaitGroup
+	stopOnce sync.Once
+	stopped  bool
+	admitMu  sync.Mutex
+	workers  int
 }
 
 type job struct {
@@ -52,10 +54,16 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 
 // Stop shuts down the dispatcher and drains pending jobs.
 func (d *Dispatcher) Stop(_ context.Context) error {
-	d.stopped.Store(true)
-	d.cancel()
-	close(d.jobs)
-	d.wg.Wait()
+	d.stopOnce.Do(func() {
+		d.admitMu.Lock()
+		d.stopped = true
+		d.cancel()
+		d.admitMu.Unlock()
+
+		d.submits.Wait()
+		close(d.jobs)
+		d.wg.Wait()
+	})
 	return nil
 }
 
@@ -67,9 +75,15 @@ func (d *Dispatcher) worker() {
 }
 
 func (d *Dispatcher) submit(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) {
-	if d.stopped.Load() {
+	d.admitMu.Lock()
+	if d.stopped {
+		d.admitMu.Unlock()
 		return
 	}
+	d.submits.Add(1)
+	d.admitMu.Unlock()
+	defer d.submits.Done()
+
 	select {
 	case d.jobs <- job{ctx: ctx, cmd: cmd, tag: tag, receiver: receiver}:
 	case <-d.ctx.Done():

--- a/service/store/dispatcher_test.go
+++ b/service/store/dispatcher_test.go
@@ -35,6 +35,31 @@ type mockStore struct {
 	delay time.Duration
 }
 
+type blockingStore struct {
+	*mockStore
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingStore() *blockingStore {
+	return &blockingStore{
+		mockStore: newMockStore(),
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+}
+
+func (s *blockingStore) Set(ctx context.Context, entry storeapi.Entry) error {
+	s.once.Do(func() { close(s.started) })
+	select {
+	case <-s.release:
+		return s.mockStore.Set(ctx, entry)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func newMockStore() *mockStore {
 	return &mockStore{data: make(map[string]payload.Payload)}
 }
@@ -345,6 +370,67 @@ func TestDispatcher_GracefulShutdown(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestDispatcher_StopConcurrentWithSubmit(t *testing.T) {
+	d := NewDispatcher(1)
+	require.NoError(t, d.Start(context.Background()))
+
+	ms := newBlockingStore()
+	command := func(i int) *storeapi.SetCmd {
+		return &storeapi.SetCmd{
+			Store: ms,
+			Entry: storeapi.Entry{
+				Key:   registry.ID{NS: "test", Name: fmt.Sprintf("key-%d", i)},
+				Value: payload.New("value"),
+			},
+		}
+	}
+
+	require.NoError(t, d.handle(context.Background(), command(0), 0, &testReceiver{}))
+	<-ms.started
+
+	// Fill the queue so later submissions remain in admission while shutdown
+	// begins. Stop must cancel those submissions before it closes the queue.
+	require.NoError(t, d.handle(context.Background(), command(1), 1, &testReceiver{}))
+	require.NoError(t, d.handle(context.Background(), command(2), 2, &testReceiver{}))
+
+	const submitters = 64
+	ready := make(chan struct{}, submitters)
+	start := make(chan struct{})
+	var submissions sync.WaitGroup
+	submissions.Add(submitters)
+	for i := 0; i < submitters; i++ {
+		go func(i int) {
+			defer submissions.Done()
+			ready <- struct{}{}
+			<-start
+			_ = d.handle(context.Background(), command(i+3), uint64(i+3), &testReceiver{})
+		}(i)
+	}
+	for i := 0; i < submitters; i++ {
+		<-ready
+	}
+	close(start)
+
+	stopErrors := make(chan error, 2)
+	go func() { stopErrors <- d.Stop(context.Background()) }()
+	go func() { stopErrors <- d.Stop(context.Background()) }()
+
+	submissions.Wait()
+	close(ms.release)
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-stopErrors:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("dispatcher did not stop")
+		}
+	}
+	for i := 0; i < 3; i++ {
+		_, err := ms.Get(context.Background(), registry.ID{NS: "test", Name: fmt.Sprintf("key-%d", i)})
+		require.NoError(t, err, "accepted job %d was not drained", i)
 	}
 }
 


### PR DESCRIPTION
The store command dispatcher could close its job queue while a concurrent submission was sending, causing a `send on closed channel` panic during runtime shutdown.

Serialize admission with shutdown, cancel blocked submitters before closing the queue, wait for admitted submissions, then drain accepted jobs. Concurrent Stop calls are idempotent.

Tests cover a saturated queue with concurrent submissions and concurrent shutdown.

Validation:
- `go test ./service/store/...`
- `go test -race ./service/store`