### PR TITLE
fix(deps): reconcile workspace replacements in lock graph

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1462,15 +1462,50 @@ func (h *DependencyHandler) ResolveWorkspaceDependencies(
 	ctx context.Context,
 	deps []DependencyDefinition,
 ) ([]ResolvedModule, error) {
+	lockedVersions := h.workspaceLockedVersions(nil, false)
+	return h.resolveModules(ctx, deps, lockedVersions, nil)
+}
+
+// UpdateWorkspaceDependencies resolves a workspace graph while releasing the
+// requested remote modules from their existing lock selections. An empty
+// updateModules slice releases every remote module. Replacement selections are
+// retained because a replacement changes source, not release identity; a new
+// unversioned replacement receives the local-only zero release until stronger
+// source or Hub evidence selects another version.
+func (h *DependencyHandler) UpdateWorkspaceDependencies(
+	ctx context.Context,
+	deps []DependencyDefinition,
+	updateModules []string,
+) ([]ResolvedModule, error) {
+	updates := make(map[string]struct{}, len(updateModules))
+	for _, name := range updateModules {
+		if name = strings.TrimSpace(name); name != "" {
+			updates[name] = struct{}{}
+		}
+	}
+	return h.resolveModules(ctx, deps, h.workspaceLockedVersions(updates, len(updateModules) == 0), nil)
+}
+
+func (h *DependencyHandler) workspaceLockedVersions(updates map[string]struct{}, updateAll bool) map[string]string {
 	lockedVersions := make(map[string]string)
 	if h.lock != nil {
 		for _, module := range h.lock.GetModules() {
-			if module.Name != "" && module.Version != "" {
+			if module.Name == "" || module.Version == "" {
+				continue
+			}
+			_, replacement := h.replacementPath(module.Name)
+			_, update := updates[module.Name]
+			if replacement || (!updateAll && !update) {
 				lockedVersions[module.Name] = module.Version
 			}
 		}
 	}
-	return h.resolveModules(ctx, deps, lockedVersions, nil)
+	for name := range h.replacements {
+		if lockedVersions[name] == "" && h.replacementModuleVersion(name) == "" {
+			lockedVersions[name] = replacementZeroVersion
+		}
+	}
+	return lockedVersions
 }
 
 // resolveEffectiveModules returns the complete module selection controlled by
@@ -1760,7 +1795,11 @@ func (p *replacementManifestProvider) replacementVersion(name, constraint string
 	if isExactModuleVersion(constraint) {
 		return constraint
 	}
-	return p.lockedVersions[name]
+	locked := p.lockedVersions[name]
+	if lockedVersionSatisfies(locked, constraint) {
+		return locked
+	}
+	return ""
 }
 
 // localReplacementVersion labels a replaced module from local evidence alone,
@@ -1843,8 +1882,11 @@ func loadReplacementEntries(
 	transcoder payload.Transcoder,
 ) ([]regapi.Entry, error) {
 	stat, err := os.Stat(path)
-	if err != nil || !stat.IsDir() {
-		return nil, nil
+	if err != nil {
+		return nil, NewDependencyLoadError(path, err)
+	}
+	if !stat.IsDir() {
+		return nil, NewDependencyLoadError(path, fmt.Errorf("replacement path is not a directory"))
 	}
 
 	cfg, _ := depconfig.Load(path)

--- a/boot/deps/hub/dependency_handler_test.go
+++ b/boot/deps/hub/dependency_handler_test.go
@@ -2553,6 +2553,7 @@ func TestDependencyHandler_ResolveModules_ToleratesReplacedModuleAbsentFromHub(t
 	ctx := newTestContext()
 	tmpDir := t.TempDir()
 	lockPath := filepath.Join(tmpDir, "wippy.lock")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "local-mod"), 0o755))
 	require.NoError(t, os.WriteFile(lockPath, []byte(`directories:
   modules: .wippy
   src: ./src

--- a/boot/deps/hub/locked_resolution_test.go
+++ b/boot/deps/hub/locked_resolution_test.go
@@ -122,6 +122,28 @@ func TestLockedResolutionRejectsMutableReplacements(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestWorkspaceLockedVersionPolicies(t *testing.T) {
+	handler := lockedResolutionHandler(t, []lock.Module{
+		{Name: "acme/a", Version: "1.0.0"},
+		{Name: "acme/b", Version: "2.0.0"},
+		{Name: "local/selected", Version: "3.0.0"},
+	})
+	handler.replacements["local/selected"] = lock.Replacement{From: "local/selected", To: t.TempDir()}
+	handler.replacements["local/new"] = lock.Replacement{From: "local/new", To: t.TempDir()}
+
+	require.Equal(t, map[string]string{
+		"acme/a": "1.0.0", "acme/b": "2.0.0",
+		"local/selected": "3.0.0", "local/new": replacementZeroVersion,
+	}, handler.workspaceLockedVersions(nil, false), "startup preserves the complete selected graph")
+	require.Equal(t, map[string]string{
+		"local/selected": "3.0.0", "local/new": replacementZeroVersion,
+	}, handler.workspaceLockedVersions(nil, true), "full update releases only remote selections")
+	require.Equal(t, map[string]string{
+		"acme/b": "2.0.0", "local/selected": "3.0.0", "local/new": replacementZeroVersion,
+	}, handler.workspaceLockedVersions(map[string]struct{}{"acme/a": {}}, false),
+		"targeted update releases its target and preserves other selections")
+}
+
 func TestVerifiedOfflineResolutionNeverFallsBackToHub(t *testing.T) {
 	handler := lockedResolutionHandler(t, []lock.Module{
 		{Name: "acme/app", Version: "1.2.3"}, // Missing digest: not verified.

--- a/boot/deps/hub/workspace_replacement_state_machine_test.go
+++ b/boot/deps/hub/workspace_replacement_state_machine_test.go
@@ -31,7 +31,7 @@ func TestWorkspaceReplacementStateMachine(t *testing.T) {
 
 	for seed := int64(0); seed < 16; seed++ {
 		t.Run(fmt.Sprintf("seed-%02d", seed), func(t *testing.T) {
-			rng := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic regression generator
+			rng := rand.New(rand.NewSource(seed))
 			root := t.TempDir()
 			lockPath := filepath.Join(root, lock.DefaultFilename)
 			replacementPath := filepath.Join(root, "local-component")
@@ -177,11 +177,12 @@ entries:
 				}
 
 				var resolved []ResolvedModule
-				if op == 6 || op == 0 || op == 1 || op == 2 {
+				switch op {
+				case 0, 1, 2, 6:
 					resolved, err = handler.UpdateWorkspaceDependencies(newTestContext(), roots, nil)
-				} else if op == 7 {
+				case 7:
 					resolved, err = handler.UpdateWorkspaceDependencies(newTestContext(), roots, []string{remoteModule})
-				} else {
+				default:
 					resolved, err = handler.ResolveWorkspaceDependencies(newTestContext(), roots)
 				}
 

--- a/boot/deps/hub/workspace_replacement_state_machine_test.go
+++ b/boot/deps/hub/workspace_replacement_state_machine_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
+)
+
+// TestWorkspaceReplacementStateMachine exercises the workspace resolver as a
+// persisted state machine, rather than as isolated calls. Every seed mixes
+// source-root changes, replacement configuration changes, tree drift, missing
+// paths, full/targeted updates, repeated updates, and lock-file restarts. A
+// failing seed prints the complete operation trace so it is reproducible.
+func TestWorkspaceReplacementStateMachine(t *testing.T) {
+	const (
+		localModule  = "local/component"
+		remoteModule = "acme/remote"
+		transitive   = "acme/runtime"
+	)
+
+	for seed := int64(0); seed < 16; seed++ {
+		t.Run(fmt.Sprintf("seed-%02d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic regression generator
+			root := t.TempDir()
+			lockPath := filepath.Join(root, lock.DefaultFilename)
+			replacementPath := filepath.Join(root, "local-component")
+			parkedPath := replacementPath + ".missing"
+			require.NoError(t, os.MkdirAll(replacementPath, 0o755))
+
+			provider := &fakeHub{
+				listVersions: func(_ context.Context, org, module string) ([]VersionInfo, error) {
+					name := org + "/" + module
+					switch name {
+					case localModule, remoteModule, transitive:
+						versions := []VersionInfo{{Version: "1.0.0"}}
+						if name == transitive {
+							versions = append(versions, VersionInfo{Version: "2.0.0"})
+						}
+						return versions, nil
+					default:
+						return nil, fmt.Errorf("unexpected module %s", name)
+					}
+				},
+				getManifest: func(_ context.Context, org, module, constraint string) (*ModuleManifest, error) {
+					name := org + "/" + module
+					valid := constraint == "1.0.0" || (name == transitive && constraint == "2.0.0")
+					if !valid {
+						return nil, fmt.Errorf("manifest %s@%s not found", name, constraint)
+					}
+					digestKey := name
+					if name == transitive {
+						digestKey += "@" + constraint
+					}
+					return &ModuleManifest{
+						Org: org, Name: module, Version: constraint,
+						Digest: "sha256:" + strings.Repeat(map[string]string{
+							localModule: "a", remoteModule: "b", transitive + "@1.0.0": "c", transitive + "@2.0.0": "d",
+						}[digestKey], 64),
+					}, nil
+				},
+			}
+
+			lockObj, err := lock.New(lockPath)
+			require.NoError(t, err)
+			lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "src"})
+			lockObj.SetReplacement(lock.Replacement{From: localModule, To: replacementPath})
+			require.NoError(t, lockObj.Write())
+
+			localRoot, remoteRoot := true, true
+			replacementConfigured, replacementAvailable := true, true
+			transitiveVersion := "1.0.0"
+			trace := make([]string, 0, 48)
+
+			writeReplacement := func() {
+				t.Helper()
+				content := fmt.Sprintf(`namespace: local.component
+entries:
+  - name: runtime
+    kind: ns.dependency
+    component: acme/runtime
+    version: %s
+`, transitiveVersion)
+				require.NoError(t, os.WriteFile(filepath.Join(replacementPath, "_index.yaml"), []byte(content), 0o600))
+			}
+			writeReplacement()
+
+			fail := func(step int, format string, args ...any) {
+				t.Helper()
+				t.Fatalf("seed=%d step=%d: %s\ntrace:\n  %s", seed, step, fmt.Sprintf(format, args...), strings.Join(trace, "\n  "))
+			}
+
+			for step := 0; step < 40; step++ {
+				op := rng.Intn(11)
+				switch op {
+				case 0:
+					localRoot = !localRoot
+					trace = append(trace, fmt.Sprintf("%02d toggle local root -> %t", step, localRoot))
+				case 1:
+					remoteRoot = !remoteRoot
+					trace = append(trace, fmt.Sprintf("%02d toggle remote root -> %t", step, remoteRoot))
+				case 2:
+					replacementConfigured = !replacementConfigured
+					if replacementConfigured {
+						lockObj.SetReplacement(lock.Replacement{From: localModule, To: replacementPath})
+					} else {
+						lockObj.RemoveReplacement(localModule)
+					}
+					trace = append(trace, fmt.Sprintf("%02d toggle replacement config -> %t", step, replacementConfigured))
+				case 3:
+					if replacementAvailable {
+						require.NoError(t, os.Rename(replacementPath, parkedPath))
+					} else {
+						require.NoError(t, os.Rename(parkedPath, replacementPath))
+					}
+					replacementAvailable = !replacementAvailable
+					trace = append(trace, fmt.Sprintf("%02d toggle replacement path -> %t", step, replacementAvailable))
+				case 4:
+					transitiveVersion = map[string]string{"1.0.0": "2.0.0", "2.0.0": "1.0.0"}[transitiveVersion]
+					if replacementAvailable {
+						writeReplacement()
+					} else {
+						content := fmt.Sprintf("namespace: local.component\nentries:\n  - name: runtime\n    kind: ns.dependency\n    component: acme/runtime\n    version: %s\n", transitiveVersion)
+						require.NoError(t, os.WriteFile(filepath.Join(parkedPath, "_index.yaml"), []byte(content), 0o600))
+					}
+					trace = append(trace, fmt.Sprintf("%02d replacement dependency -> %s", step, transitiveVersion))
+				case 5:
+					trace = append(trace, fmt.Sprintf("%02d restart from persisted lock", step))
+				case 6:
+					trace = append(trace, fmt.Sprintf("%02d full update", step))
+				case 7:
+					trace = append(trace, fmt.Sprintf("%02d targeted remote update", step))
+				case 8:
+					trace = append(trace, fmt.Sprintf("%02d lock roundtrip", step))
+				case 9:
+					trace = append(trace, fmt.Sprintf("%02d repeated resolution", step))
+				case 10:
+					lockObj.SetModule(lock.Module{Name: "history/only", Version: "9.9.9", Hash: strings.Repeat("e", 64)})
+					trace = append(trace, fmt.Sprintf("%02d inject history-only stale lock row", step))
+				}
+
+				require.NoError(t, lockObj.Write())
+				lockObj, err = lock.New(lockPath)
+				if err != nil {
+					fail(step, "reload lock: %v", err)
+				}
+
+				roots := make([]DependencyDefinition, 0, 2)
+				if localRoot {
+					roots = append(roots, DependencyDefinition{Component: localModule, Version: "*"})
+				}
+				if remoteRoot {
+					roots = append(roots, DependencyDefinition{Component: remoteModule, Version: "1.0.0"})
+				}
+				handler, handlerErr := NewDependencyHandler(DependencyHandlerOptions{
+					Hub: provider, Logger: zap.NewNop(), LockPath: lockPath,
+				})
+				if handlerErr != nil {
+					fail(step, "construct handler: %v", handlerErr)
+				}
+				expectedLocalVersion := "1.0.0"
+				if replacementConfigured {
+					expectedLocalVersion = replacementZeroVersion
+					if selected, ok := lockObj.GetModule(localModule); ok {
+						expectedLocalVersion = selected.Version
+					}
+				}
+
+				var resolved []ResolvedModule
+				if op == 6 || op == 0 || op == 1 || op == 2 {
+					resolved, err = handler.UpdateWorkspaceDependencies(newTestContext(), roots, nil)
+				} else if op == 7 {
+					resolved, err = handler.UpdateWorkspaceDependencies(newTestContext(), roots, []string{remoteModule})
+				} else {
+					resolved, err = handler.ResolveWorkspaceDependencies(newTestContext(), roots)
+				}
+
+				requiredMissing := localRoot && replacementConfigured && !replacementAvailable
+				if requiredMissing {
+					if err == nil || !strings.Contains(err.Error(), localModule) || !strings.Contains(err.Error(), replacementPath) {
+						fail(step, "required missing replacement error = %v; want module and path", err)
+					}
+					continue
+				}
+				if err != nil {
+					fail(step, "resolution failed: %v", err)
+				}
+
+				modules := make([]lock.Module, 0, len(resolved))
+				actual := make([]string, 0, len(resolved))
+				for _, module := range resolved {
+					name := module.Org + "/" + module.Name
+					actual = append(actual, name+"@"+module.Version)
+					modules = append(modules, lock.Module{Name: name, Version: module.Version, Hash: module.Digest})
+				}
+				lockObj.ReplaceModules(modules)
+				require.NoError(t, lockObj.Write())
+				lockObj, err = lock.New(lockPath)
+				if err != nil {
+					fail(step, "reload resolved lock: %v", err)
+				}
+
+				expected := make([]string, 0, 3)
+				if localRoot {
+					if replacementConfigured {
+						expected = append(expected, localModule+"@"+expectedLocalVersion, transitive+"@"+transitiveVersion)
+					} else {
+						expected = append(expected, localModule+"@1.0.0")
+					}
+				}
+				if remoteRoot {
+					expected = append(expected, remoteModule+"@1.0.0")
+				}
+				sort.Strings(actual)
+				sort.Strings(expected)
+				if strings.Join(actual, ",") != strings.Join(expected, ",") {
+					fail(step, "selected graph = %v; want %v", actual, expected)
+				}
+
+				replacementLoads := 0
+				for _, loadPath := range lockObj.GetModuleLoadPaths() {
+					if loadPath.Replacement {
+						replacementLoads++
+						if loadPath.Module != localModule || !localRoot || !replacementConfigured {
+							fail(step, "unexpected replacement load path: %+v", loadPath)
+						}
+					}
+				}
+				wantReplacementLoads := 0
+				if localRoot && replacementConfigured {
+					wantReplacementLoads = 1
+				}
+				if replacementLoads != wantReplacementLoads {
+					fail(step, "replacement load paths = %d; want %d", replacementLoads, wantReplacementLoads)
+				}
+			}
+		})
+	}
+}

--- a/cmd/wippy/cmd/run_dependencies.go
+++ b/cmd/wippy/cmd/run_dependencies.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
 	"github.com/wippyai/runtime/api/semver"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
@@ -73,17 +74,35 @@ func prepareRunDependencies(
 		return ErrTranscoderNotFound
 	}
 	roots := extractRootDependencies(loaded, transcoder)
-	if lockSatisfiesSource(lockObj, roots) {
-		return nil
-	}
+	sourceSatisfied := lockSatisfiesSource(lockObj, roots)
+	warnMissingRequiredWorkspaceReplacements(logger, lockObj, roots)
 
 	client, err := hubclient.New(hubclient.Options{RegistryURL: registryURL})
 	if err != nil {
 		return NewCreateHubClientError(err)
 	}
-	resolved, err := resolveRunDependencies(ctx, client, lockObj, roots)
-	if err != nil {
-		return err
+	var resolved *hub.ResolveDependenciesResult
+	if sourceSatisfied {
+		// Verify the complete source graph from local/installed evidence before
+		// trusting the lock. This catches both replacement dependency drift and
+		// stale rows that a previous restart temporarily promoted from a
+		// history-owned overlay into wippy.lock, without adding network I/O to a
+		// normal restart.
+		offlineCtx := regapi.WithDependencyAccess(ctx, regapi.DependencyAccessVerifiedOffline)
+		resolved, err = resolveRunDependencies(offlineCtx, client, lockObj, roots)
+		if err == nil && lockMatchesResolution(lockObj, resolved.Modules) {
+			return nil
+		}
+		if err != nil {
+			logger.Info("workspace dependency graph needs online completion",
+				zap.Error(err))
+		}
+	}
+	if resolved == nil || err != nil {
+		resolved, err = resolveRunDependencies(ctx, client, lockObj, roots)
+		if err != nil {
+			return err
+		}
 	}
 
 	modules := make([]lock.Module, 0, len(resolved.Modules))
@@ -97,9 +116,8 @@ func prepareRunDependencies(
 			Hash:    module.Digest,
 		})
 	}
-	// Replacements are intentionally absent from Hub resolution. Retain their
-	// selected rows so source ownership and deployment-root identity do not
-	// disappear while repairing unrelated dependencies.
+	// Retain selected replacement rows from legacy resolutions that did not
+	// return them while repairing unrelated dependencies.
 	for _, module := range lockObj.GetModules() {
 		if _, ok := selected[module.Name]; ok {
 			continue
@@ -128,6 +146,43 @@ func prepareRunDependencies(
 	return nil
 }
 
+func warnMissingRequiredWorkspaceReplacements(logger *zap.Logger, lockObj *lock.Lock, roots []dependencyRequest) {
+	if logger == nil || lockObj == nil {
+		return
+	}
+	for _, root := range roots {
+		name := root.Org + "/" + root.Module
+		if _, replaced := lockObj.GetReplacement(name); !replaced {
+			continue
+		}
+		if _, selected := lockObj.GetModule(name); !selected {
+			logger.Warn("required workspace replacement is absent from selected lock graph; repairing",
+				zap.String("module", name),
+				zap.String("constraint", root.Constraint))
+		}
+	}
+}
+
+func lockMatchesResolution(lockObj *lock.Lock, resolved []hub.ResolvedModule) bool {
+	if lockObj == nil || len(lockObj.GetModules()) != len(resolved) {
+		return false
+	}
+	for _, module := range resolved {
+		locked, ok := lockObj.GetModule(module.Org + "/" + module.Name)
+		if !ok || locked.Version != module.Version || !lockDigestsEqual(locked.Hash, module.Digest) {
+			return false
+		}
+	}
+	return true
+}
+
+func lockDigestsEqual(left, right string) bool {
+	normalize := func(value string) string {
+		return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(value)), "sha256:")
+	}
+	return normalize(left) == normalize(right)
+}
+
 func lockSatisfiesSource(lockObj *lock.Lock, roots []dependencyRequest) bool {
 	if lockObj == nil {
 		return false
@@ -135,12 +190,6 @@ func lockSatisfiesSource(lockObj *lock.Lock, roots []dependencyRequest) bool {
 	for _, root := range roots {
 		name := root.Org + "/" + root.Module
 		module, ok := lockObj.GetModule(name)
-		if _, replaced := lockObj.GetReplacement(name); replaced && !ok {
-			constraint := strings.TrimSpace(root.Constraint)
-			if constraint == "" || constraint == "*" || strings.HasPrefix(constraint, "@") {
-				continue
-			}
-		}
 		if !ok || !lockedVersionSatisfies(module.Version, root.Constraint) {
 			return false
 		}

--- a/cmd/wippy/cmd/run_dependencies_test.go
+++ b/cmd/wippy/cmd/run_dependencies_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestLockSatisfiesSource(t *testing.T) {
@@ -20,7 +22,7 @@ func TestLockSatisfiesSource(t *testing.T) {
 	lockObj.SetModule(lock.Module{Name: "acme/core", Version: "1.4.0", Hash: "sha256:core"})
 	lockObj.SetReplacement(lock.Replacement{From: "acme/local", To: t.TempDir()})
 
-	require.True(t, lockSatisfiesSource(lockObj, []dependencyRequest{
+	require.False(t, lockSatisfiesSource(lockObj, []dependencyRequest{
 		{Org: "acme", Module: "core", Constraint: "^1.2.0"},
 		{Org: "acme", Module: "local", Constraint: "*"},
 	}))
@@ -35,6 +37,41 @@ func TestLockSatisfiesSource(t *testing.T) {
 	require.False(t, lockSatisfiesSource(lockObj, []dependencyRequest{
 		{Org: "acme", Module: "core", Constraint: "^1.2.0"},
 	}))
+}
+
+func TestWarnMissingRequiredWorkspaceReplacementsNamesDiscardedModule(t *testing.T) {
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), "wippy.lock"))
+	require.NoError(t, err)
+	lockObj.SetReplacement(lock.Replacement{From: "acme/local", To: "../local"})
+
+	core, logs := observer.New(zap.WarnLevel)
+	warnMissingRequiredWorkspaceReplacements(zap.New(core), lockObj, []dependencyRequest{
+		{Org: "acme", Module: "local", Constraint: "*"},
+		{Org: "acme", Module: "remote", Constraint: "1.0.0"},
+	})
+
+	entries := logs.FilterMessage("required workspace replacement is absent from selected lock graph; repairing").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, "acme/local", entries[0].ContextMap()["module"])
+	require.Equal(t, "*", entries[0].ContextMap()["constraint"])
+}
+
+func TestWorkspaceResolutionCheckpointRejectsStaleRows(t *testing.T) {
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), "wippy.lock"))
+	require.NoError(t, err)
+	lockObj.SetReplacement(lock.Replacement{From: "acme/local", To: t.TempDir()})
+	lockObj.SetModule(lock.Module{Name: "acme/local", Version: "0.0.0"})
+
+	require.True(t, lockMatchesResolution(lockObj, []hub.ResolvedModule{{
+		Org: "acme", Name: "local", Version: "0.0.0",
+	}}))
+	require.False(t, lockMatchesResolution(lockObj, []hub.ResolvedModule{{
+		Org: "acme", Name: "local", Version: "1.0.0",
+	}}))
+	lockObj.SetModule(lock.Module{Name: "history/only", Version: "1.0.0"})
+	require.False(t, lockMatchesResolution(lockObj, []hub.ResolvedModule{{
+		Org: "acme", Name: "local", Version: "0.0.0",
+	}}), "history-only lock rows must force exact offline graph repair")
 }
 
 func TestResolveRunDependenciesKeepsCompatibleLockAndCompletesIt(t *testing.T) {
@@ -94,6 +131,43 @@ entries: []
 	require.NoError(t, err)
 	require.Len(t, result.Modules, 1)
 	require.Equal(t, "1.2.0", result.Modules[0].Version)
+}
+
+func TestResolveRunDependenciesSelectsNewUnpublishedWildcardReplacement(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	replacement := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(replacement, "_index.yaml"), []byte(`namespace: acme.local
+entries:
+  - name: service
+    kind: registry.entry
+`), 0o600))
+
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), "wippy.lock"))
+	require.NoError(t, err)
+	lockObj.SetReplacement(lock.Replacement{From: "acme/local", To: replacement})
+	require.NoError(t, lockObj.Write())
+
+	result, err := resolveRunDependencies(ctx, runManifestProvider{}, lockObj, []dependencyRequest{
+		{Org: "acme", Module: "local", Constraint: "*"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []hub.ResolvedModule{{Org: "acme", Name: "local", Version: "0.0.0"}}, result.Modules)
+}
+
+func TestResolveRunDependenciesNamesMissingRequiredReplacement(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	missing := filepath.Join(t.TempDir(), "missing-local")
+	lockObj, err := lock.New(filepath.Join(t.TempDir(), "wippy.lock"))
+	require.NoError(t, err)
+	lockObj.SetReplacement(lock.Replacement{From: "acme/local", To: missing})
+	require.NoError(t, lockObj.Write())
+
+	_, err = resolveRunDependencies(ctx, runManifestProvider{}, lockObj, []dependencyRequest{
+		{Org: "acme", Module: "local", Constraint: "*"},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "acme/local")
+	require.ErrorContains(t, err, missing)
 }
 
 type runManifestProvider struct {

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -137,9 +137,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Scan app source plus local replacement sources for dependency entries.
-	// Replacement modules are not resolved from the hub, but their transitive
-	// ns.dependency entries are part of the active application graph.
+	// Scan only application roots. Selected replacement modules expose their
+	// transitive declarations lazily through the replacement-aware resolver.
 	logger.Info("scanning dependency sources", zap.String("src_dir", srcDir))
 
 	entries, err := loadDependencyScanEntries(app.Ctx, app.Loader, srcDir, oldLockObj, logger)
@@ -151,45 +150,18 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	rootDeps := extractRootDependencies(entries, app.Transcoder)
 	logger.Info("found root dependencies", zap.Int("count", len(rootDeps)))
 
-	// Local replacements participate in the active graph but are never resolved
-	// from the Hub.
-	replacedModules := effectiveReplacementModules(oldLockObj)
-
 	resolvedModules := make([]hub.ResolvedModule, 0)
 	if len(rootDeps) == 0 {
 		logger.Info("no root dependencies found in source, pruning lock modules")
 	} else {
-		// Convert to hub dependency specs, skipping replaced modules
-		hubDeps := make([]hub.DependencySpec, 0, len(rootDeps))
-		for _, dep := range rootDeps {
-			depName := dep.Org + "/" + dep.Module
-			if replacedModules[depName] {
-				logger.Info("skipping replaced module from hub resolution", zap.String("module", depName))
-				continue
-			}
-			hubDeps = append(hubDeps, hub.DependencySpec{
-				Org:        dep.Org,
-				Name:       dep.Module,
-				Constraint: dep.Constraint,
-			})
-		}
-
 		logger.Info("resolving dependency graph")
-		result, err := hub.Resolve(app.Ctx, hubClient, hubDeps, nil)
+		result, err := resolveUpdatedWorkspaceDependencies(app.Ctx, hubClient, oldLockObj, lockFilePath, runtimeCfg, rootDeps, nil)
 		if err != nil {
-			return NewBuildDependencyGraphError(err)
+			return err
 		}
 
-		if len(result.Errors) > 0 {
-			logger.Error("dependency resolution errors", zap.Int("count", len(result.Errors)))
-			for _, resErr := range result.Errors {
-				logger.Error("error", zap.String("module", resErr.Org+"/"+resErr.Name), zap.String("reason", resErr.Message))
-			}
-			return newResolutionConflictsError("dependency conflicts detected", result.Errors)
-		}
-
-		logger.Info("dependency graph resolved", zap.Int("total_modules", len(result.Modules)))
-		resolvedModules = result.Modules
+		logger.Info("dependency graph resolved", zap.Int("total_modules", len(result)))
+		resolvedModules = result
 	}
 
 	// Convert resolved modules to lock file
@@ -233,6 +205,44 @@ type dependencyRequest struct {
 	Org        string
 	Module     string
 	Constraint string
+}
+
+func resolveUpdatedWorkspaceDependencies(
+	ctx context.Context,
+	provider hub.HubClient,
+	lockObj *lock.Lock,
+	lockPath string,
+	cfg boot.Config,
+	roots []dependencyRequest,
+	updateModules []string,
+) ([]hub.ResolvedModule, error) {
+	if lockObj == nil {
+		var err error
+		lockObj, err = lock.New(lockPath, lock.WithWorkspaceConfig(cfg))
+		if err != nil {
+			return nil, NewLoadLockFileError(fmt.Errorf("lock file %s: %w", lockPath, err))
+		}
+	}
+	definitions := make([]hub.DependencyDefinition, 0, len(roots))
+	for _, root := range roots {
+		definitions = append(definitions, hub.DependencyDefinition{
+			Component: root.Org + "/" + root.Module,
+			Version:   root.Constraint,
+		})
+	}
+	handler, err := hub.NewDependencyHandler(hub.DependencyHandlerOptions{
+		Hub:                   provider,
+		LockPath:              lockObj.Path(),
+		WorkspaceReplacements: lockObj.GetReplacements(),
+	})
+	if err != nil {
+		return nil, NewBuildDependencyGraphError(err)
+	}
+	modules, err := handler.UpdateWorkspaceDependencies(ctx, definitions, updateModules)
+	if err != nil {
+		return nil, NewBuildDependencyGraphError(err)
+	}
+	return modules, nil
 }
 
 func extractRootDependencies(entries []regapi.Entry, dtt payload.Transcoder) []dependencyRequest {
@@ -318,8 +328,6 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 
 	oldLockObj := lockObj
 
-	replacedModules := effectiveReplacementModules(lockObj)
-
 	effectiveTargets := make([]string, 0, len(targetModules))
 	for _, moduleName := range targetModules {
 		if repl, ok := lockObj.GetReplacement(moduleName); ok {
@@ -349,68 +357,28 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 		sourceConstraints[key] = dep.Constraint
 	}
 
-	// Build frozen constraints from lock file (all modules except targets and replaced)
+	// The shared workspace resolver prefers existing non-target selections and
+	// releases targets, while still allowing required transitive movement.
 	targetSet := make(map[string]bool)
 	for _, name := range effectiveTargets {
 		targetSet[name] = true
 	}
 
-	modules := lockObj.GetModules()
-	hubDeps := make([]hub.DependencySpec, 0, len(modules)+len(targetModules))
-
-	for _, mod := range modules {
-		parts := strings.SplitN(mod.Name, "/", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		if targetSet[mod.Name] || replacedModules[mod.Name] {
-			continue
-		}
-
-		hubDeps = append(hubDeps, hub.DependencySpec{
-			Org:        parts[0],
-			Name:       parts[1],
-			Constraint: "=" + mod.Version,
-		})
-	}
-
-	// Add target modules with source constraints
+	// Warn for requested modules that are not application dependency roots.
 	for _, moduleName := range effectiveTargets {
-		constraint, ok := sourceConstraints[moduleName]
-		if !ok {
+		if _, ok := sourceConstraints[moduleName]; !ok {
 			logger.Warn("module not found in source dependencies", zap.String("module", moduleName))
-			continue
 		}
-
-		parts := strings.SplitN(moduleName, "/", 2)
-		if len(parts) != 2 {
-			return NewParseModuleNameError(moduleName, fmt.Errorf("invalid format, expected org/module"))
-		}
-
-		hubDeps = append(hubDeps, hub.DependencySpec{
-			Org:        parts[0],
-			Name:       parts[1],
-			Constraint: constraint,
-		})
 	}
 
-	logger.Info("resolving with frozen dependencies")
-	result, err := hub.Resolve(app.Ctx, hubClient, hubDeps, nil)
+	logger.Info("resolving targeted dependency graph")
+	resolvedModules, err := resolveUpdatedWorkspaceDependencies(app.Ctx, hubClient, lockObj, lockFilePath, runtimeCfg, rootDeps, effectiveTargets)
 	if err != nil {
-		return NewBuildDependencyGraphError(err)
-	}
-
-	if len(result.Errors) > 0 {
-		logger.Error("resolution errors", zap.Int("count", len(result.Errors)))
-		for _, resErr := range result.Errors {
-			logger.Error("error", zap.String("module", resErr.Org+"/"+resErr.Name), zap.String("reason", resErr.Message))
-		}
-		return newResolutionConflictsError("update conflicts detected", result.Errors)
+		return err
 	}
 
 	// Build new lock file
-	newLockObj, err := convertResolvedToLock(lockFilePath, result.Modules, modulesDir, srcDir)
+	newLockObj, err := convertResolvedToLock(lockFilePath, resolvedModules, modulesDir, srcDir)
 	if err != nil {
 		return NewLoadLockFileError(err)
 	}
@@ -501,31 +469,6 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 		{label: "source", path: srcDir, root: moduleRoot},
 	}
 
-	if lockObj != nil {
-		// Update treats every effective replacement as a resolver input, even
-		// when its module is not selected by the current graph. Unlike boot and
-		// install, every declared source must therefore be present for this scan.
-		if err := lock.ValidateReplacements(lockObj.Path(), lockObj.GetReplacements()); err != nil {
-			return nil, fmt.Errorf("validate replacement dependency sources: %w", err)
-		}
-		lockDir := filepath.Dir(lockObj.Path())
-		for _, replacement := range lockObj.GetReplacements() {
-			if replacement.To == "" {
-				continue
-			}
-			replacementRoot := lock.ResolveLockPath(lockDir, replacement.To)
-			paths = append(paths, struct {
-				label string
-				path  string
-				root  string
-			}{
-				label: "replacement " + replacement.From,
-				path:  lock.ModuleEntryLoadPath(replacementRoot),
-				root:  replacementRoot,
-			})
-		}
-	}
-
 	seen := make(map[string]bool, len(paths))
 	entries := make([]regapi.Entry, 0)
 	for _, scanPath := range paths {
@@ -552,17 +495,6 @@ func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir stri
 	}
 
 	return entries, nil
-}
-
-func effectiveReplacementModules(lockObj *lock.Lock) map[string]bool {
-	modules := make(map[string]bool)
-	if lockObj == nil {
-		return modules
-	}
-	for _, replacement := range lockObj.GetReplacements() {
-		modules[replacement.From] = true
-	}
-	return modules
 }
 
 func logChanges(logger *zap.Logger, changes *lock.Changes) {

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wippyai/runtime/api/boot"
-	apierror "github.com/wippyai/runtime/api/error"
 	"github.com/wippyai/runtime/api/payload"
 	regapi "github.com/wippyai/runtime/api/registry"
 	bootauth "github.com/wippyai/runtime/boot/deps/auth"
@@ -581,18 +580,6 @@ func pruneModuleArtifacts(vendorDir, moduleName, moduleVersion string, removeCur
 			}
 		}
 	}
-}
-
-func newResolutionConflictsError(prefix string, errs []hub.ResolutionError) apierror.Error {
-	if len(errs) == 0 {
-		return apierror.New(apierror.Invalid, prefix+" (0)").WithRetryable(apierror.False)
-	}
-	details := make([]string, 0, len(errs))
-	for _, resErr := range errs {
-		details = append(details, formatResolutionError(resErr))
-	}
-	msg := fmt.Sprintf("%s (%d): %s", prefix, len(errs), strings.Join(details, "; "))
-	return apierror.New(apierror.Invalid, msg).WithRetryable(apierror.False)
 }
 
 func formatResolutionError(resErr hub.ResolutionError) string {

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
+	entryloader "github.com/wippyai/runtime/cmd/internal/entries"
 	"go.uber.org/zap"
 )
 
@@ -127,16 +128,7 @@ func TestPreserveReplacements_KeepsAll(t *testing.T) {
 	}
 }
 
-func TestEffectiveReplacementModulesIncludesWorkspaceOverlay(t *testing.T) {
-	lockObj, err := lock.New(filepath.Join(t.TempDir(), lock.DefaultFilename), lock.WithWorkspaceReplacements([]lock.Replacement{
-		{From: "local/component", To: "../component"},
-	}))
-	require.NoError(t, err)
-
-	require.Equal(t, map[string]bool{"local/component": true}, effectiveReplacementModules(lockObj))
-}
-
-func TestLoadDependencyScanEntriesIncludesWorkspaceReplacement(t *testing.T) {
+func TestLoadDependencyScanEntriesDefersWorkspaceReplacement(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	ldr := bootapi.GetLoader(ctx)
 	require.NotNil(t, ldr)
@@ -165,10 +157,10 @@ entries:
 	loaded, err := loadDependencyScanEntries(ctx, ldr, appDir, lockObj, zap.NewNop())
 	require.NoError(t, err)
 	dependencies := extractRootDependencies(loaded, payload.GetTranscoder(ctx))
-	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "runtime", Constraint: "v1.0.0"}}, dependencies)
+	require.Empty(t, dependencies)
 }
 
-func TestLoadDependencyScanEntriesRequiresUnselectedReplacementSource(t *testing.T) {
+func TestLoadDependencyScanEntriesIgnoresMissingUnselectedReplacementSource(t *testing.T) {
 	ctx := setupLoaderContext(t)
 	ldr := bootapi.GetLoader(ctx)
 	require.NotNil(t, ldr)
@@ -183,8 +175,114 @@ func TestLoadDependencyScanEntriesRequiresUnselectedReplacementSource(t *testing
 	require.NoError(t, err)
 	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "app"})
 
-	_, err = loadDependencyScanEntries(ctx, ldr, appDir, lockObj, zap.NewNop())
-	require.ErrorContains(t, err, "validate replacement dependency sources")
+	loaded, err := loadDependencyScanEntries(ctx, ldr, appDir, lockObj, zap.NewNop())
+	require.NoError(t, err)
+	require.Empty(t, loaded)
+}
+
+func TestUpdateWorkspaceResolutionSelectsReplacementAndItsTransitives(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	tmpDir := t.TempDir()
+	replacementDir := filepath.Join(tmpDir, "local", "component")
+	require.NoError(t, os.MkdirAll(replacementDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementDir, "_index.yaml"), []byte(`namespace: local.component
+entries:
+  - name: runtime
+    kind: ns.dependency
+    component: acme/runtime
+    version: 1.0.0
+`), 0o600))
+
+	lockPath := filepath.Join(tmpDir, lock.DefaultFilename)
+	lockObj, err := lock.New(lockPath, lock.WithWorkspaceReplacements([]lock.Replacement{{
+		From: "local/component",
+		To:   replacementDir,
+	}}))
+	require.NoError(t, err)
+	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "app"})
+	require.NoError(t, lockObj.Write())
+
+	provider := runManifestProvider{manifests: map[string]hub.ModuleManifest{
+		"acme/runtime@1.0.0": {
+			Org: "acme", Name: "runtime", Version: "1.0.0",
+			Digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	}}
+	resolved, err := resolveUpdatedWorkspaceDependencies(ctx, provider, lockObj, lockPath, nil, []dependencyRequest{{
+		Org: "local", Module: "component", Constraint: "*",
+	}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []hub.ResolvedModule{
+		{Org: "acme", Name: "runtime", Version: "1.0.0", Digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{Org: "local", Name: "component", Version: "0.0.0"},
+	}, resolved)
+
+	for _, module := range resolved {
+		lockObj.SetModule(lock.Module{
+			Name: module.Org + "/" + module.Name, Version: module.Version, Hash: module.Digest,
+		})
+	}
+	paths := lockObj.GetModuleLoadPaths()
+	require.Len(t, paths, 3)
+	require.Equal(t, "local/component", paths[1].Module)
+	require.True(t, paths[1].Replacement)
+	require.Equal(t, replacementDir, paths[1].SourceRoot)
+}
+
+func TestUpdateWorkspaceResolutionDoesNotTouchUnusedMissingReplacement(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, lock.DefaultFilename)
+	lockObj, err := lock.New(lockPath, lock.WithWorkspaceReplacements([]lock.Replacement{{
+		From: "local/unused",
+		To:   filepath.Join(tmpDir, "missing-unused"),
+	}}))
+	require.NoError(t, err)
+	require.NoError(t, lockObj.Write())
+
+	const digest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	provider := runManifestProvider{manifests: map[string]hub.ModuleManifest{
+		"acme/runtime@1.0.0": {Org: "acme", Name: "runtime", Version: "1.0.0", Digest: digest},
+	}}
+	resolved, err := resolveUpdatedWorkspaceDependencies(ctx, provider, lockObj, lockPath, nil, []dependencyRequest{{
+		Org: "acme", Module: "runtime", Constraint: "1.0.0",
+	}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []hub.ResolvedModule{{
+		Org: "acme", Name: "runtime", Version: "1.0.0", Digest: digest,
+	}}, resolved)
+}
+
+func TestSelectedWorkspaceReplacementIsPresentDuringNormalization(t *testing.T) {
+	ctx := setupLoaderContext(t)
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "app")
+	replacementDir := filepath.Join(tmpDir, "local", "component")
+	require.NoError(t, os.MkdirAll(appDir, 0o755))
+	require.NoError(t, os.MkdirAll(replacementDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementDir, "_index.yaml"), []byte(`namespace: local.component
+entries:
+  - name: service
+    kind: registry.entry
+    generation: old
+`), 0o600))
+
+	lockObj, err := lock.New(filepath.Join(tmpDir, lock.DefaultFilename), lock.WithWorkspaceReplacements([]lock.Replacement{{
+		From: "local/component",
+		To:   replacementDir,
+	}}))
+	require.NoError(t, err)
+	lockObj.SetDirectories(lock.Directories{Modules: ".wippy", Src: "app"})
+	lockObj.SetModule(lock.Module{Name: "local/component", Version: "0.0.0"})
+
+	ctx = bootapi.WithConfig(ctx, bootapi.NewConfig(bootapi.WithSection("override", map[string]any{
+		"local.component:service:generation": "new",
+	})))
+	loaded, err := entryloader.LoadEntriesFromModuleLoadPaths(ctx, lockObj.GetModuleLoadPaths(), zap.NewNop())
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	require.Equal(t, "local.component:service", loaded[0].ID.String())
+	require.Equal(t, "new", loaded[0].Data.Data().(map[string]any)["generation"])
 }
 
 func TestPruneStaleVendorArtifacts_RemovesStaleArtifacts(t *testing.T) {
@@ -363,8 +461,8 @@ entries:
 	if got["wippy/facade"] != ">=v0.5.39" {
 		t.Fatalf("app dependency missing: got %v", got)
 	}
-	if got["wippy/dataflow"] != ">=v0.4.10" {
-		t.Fatalf("replacement dependency missing: got %v", got)
+	if _, ok := got["wippy/dataflow"]; ok {
+		t.Fatalf("replacement dependencies must be discovered lazily by the graph resolver: got %v", got)
 	}
 	if _, ok := got["bad/module"]; ok {
 		t.Fatalf("replacement scan should use src subtree and ignore node_modules noise: got %v", got)

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/tree-sitter/tree-sitter-php v0.24.2
 	github.com/tree-sitter/tree-sitter-python v0.25.0
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
-	github.com/wippyai/go-lua v1.5.17
+	github.com/wippyai/go-lua v1.5.18
 	github.com/wippyai/module-registry-proto-go v0.0.1
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-github.com/wippyai/go-lua v1.5.17 h1:Nd/ym4A8dcmVWcOnu7x8qi22MlPmNbHgE6+Rb8As4DQ=
-github.com/wippyai/go-lua v1.5.17/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
+github.com/wippyai/go-lua v1.5.18 h1:EA8ee+Whq0zQiMjyBp0K/gg/TdCYdhNcZ3mVjKkb5yU=
+github.com/wippyai/go-lua v1.5.18/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/module-registry-proto-go v0.0.1 h1:EYnW8MTrI/gs7TJ0ilTVgJal3e0NWmXQigeamrXu0mk=
 github.com/wippyai/module-registry-proto-go v0.0.1/go.mod h1:p4ihYQKRQuqRVLxaH1YL0IEnkz4zKdyfVADOwvA5Tno=
 github.com/wippyai/tree-sitter-markdown v0.0.3 h1:u6e53+hzPSS848Xhm+I48SwtvWQHrC21wDrogdwCwuc=


### PR DESCRIPTION
## Summary

Fixes the workspace-replacement regression introduced between `v0.3.33a` and `v0.3.34a`.

`wippy update` excluded replaced modules from Hub resolution, while startup only loaded a replacement when the module also had a selected `wippy.lock` row. Update therefore omitted the row that startup required, silently discarded the replacement, and failed later when another entry depended on its contents.

Context: https://gist.github.com/butschster/b56d6f5b5d63d2f7bf0d505bdd0daf4a

## Resolution model

A replacement changes a selected module's source; it does not create a dependency.

- Every demanded replacement receives a selected lock row.
- Startup, full update, and targeted update use the same replacement-aware resolver.
- Replacement sources are opened lazily, only when the module is selected.
- A new unpublished wildcard replacement receives the local-only `0.0.0` version.
- A missing unused replacement is ignored.
- A missing required replacement fails immediately and names both the module and path.
- Startup warns when a required replacement is missing from the selected lock graph and repairs it.
- Offline startup verifies the exact graph, including replacement transitive dependencies, and rejects stale history-only lock rows before history restoration.

This removes the contradictory update/startup policies instead of preserving missing replacement rows as a special case.

## Regression coverage

Adds focused tests for:

- demanded replacement absent from the lock
- unpublished wildcard replacement selection
- required versus unused missing replacement paths
- replacement transitive dependencies
- startup, full-update, and targeted-update selection policies
- explicit repair warning and clear error details
- exact graph comparison and history-only row pruning
- replacement entry normalization and overrides

Also adds a deterministic persisted state-machine test: 16 seeds × 40 operations, covering root add/remove, replacement enable/disable, path disappear/restore, dependency drift, full and targeted updates, repeated resolution, restart, lock roundtrip, and injected stale history rows. Failures print the complete seed and operation trace.

## Validation

- `make lint`
- `go test ./...`
- state-machine suite repeated five times
- fresh published-Hub Kickside bootstrap
- Knowledge and KB10 install/delete ordering and restart persistence
- `wippy.lock` deletion and Hub rebootstrap
- `wippy.lock` plus `.wippy` deletion and cold rebootstrap
- source Kickside with active workspace replacements
- update, undo/redo, rollback/redo, delete, and final restart lifecycle

## Dependency

Bumps `github.com/wippyai/go-lua` from `v1.5.17` to `v1.5.18`.