### PR TITLE
fix(eventbus): make unsubscribe a terminal delivery barrier

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -31,12 +31,16 @@ type (
 	// Bus defines the functionality of an event bus.
 	Bus interface {
 		// Subscribe subscribes a channel to events from a specific system.
+		// The caller must not close the channel until Unsubscribe returns;
+		// that return is the barrier proving the bus can no longer send to it.
 		Subscribe(context.Context, System, chan<- Event) (SubscriberID, error)
 
-		// SubscribeP subscribes a channel to events matching a specific system and kind.
+		// SubscribeP has the same channel ownership and Unsubscribe barrier as Subscribe.
 		SubscribeP(context.Context, System, Kind, chan<- Event) (SubscriberID, error)
 
-		// Unsubscribe removes a subscription using its SubscriberID.
+		// Unsubscribe removes a subscription using its SubscriberID. It is a
+		// non-cancelable safety barrier: when it returns, no in-flight or future
+		// bus operation can send to that subscription.
 		Unsubscribe(context.Context, SubscriberID)
 
 		// Send publishes an event to the bus.

--- a/api/event/event.go
+++ b/api/event/event.go
@@ -33,6 +33,9 @@ type (
 		// Subscribe subscribes a channel to events from a specific system.
 		// The caller must not close the channel until Unsubscribe returns;
 		// that return is the barrier proving the bus can no longer send to it.
+		// Once the request is accepted for dispatch, Subscribe waits for the
+		// ownership decision even if the context is canceled. On error, the bus
+		// does not retain the channel.
 		Subscribe(context.Context, System, chan<- Event) (SubscriberID, error)
 
 		// SubscribeP has the same channel ownership and Unsubscribe barrier as Subscribe.
@@ -43,7 +46,9 @@ type (
 		// bus operation can send to that subscription.
 		Unsubscribe(context.Context, SubscriberID)
 
-		// Send publishes an event to the bus.
+		// Send publishes an event to the bus. Delivery remains ordered and
+		// lossless while the publisher and subscriber contexts stay active;
+		// cancellation may abort queued or in-progress delivery.
 		Send(context.Context, Event)
 	}
 )

--- a/cluster/raft/bootstrap.go
+++ b/cluster/raft/bootstrap.go
@@ -89,16 +89,17 @@ type BootstrapWatcherConfig struct {
 // (State is Leader or Follower with a known leader), the watcher
 // transitions itself to raft_status=in and exits.
 type BootstrapWatcher struct {
-	node    bootstrapNode
-	member  bootstrapMembership
-	bus     event.Bus
-	logger  *zap.Logger
-	stopCh  chan struct{}
-	doneCh  chan struct{}
-	localID string
-	state   string // "pre" or "in"
-	cfg     BootstrapWatcherConfig
-	mu      sync.Mutex
+	node      bootstrapNode
+	member    bootstrapMembership
+	bus       event.Bus
+	logger    *zap.Logger
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+	subCancel context.CancelFunc
+	localID   string
+	state     string // "pre" or "in"
+	cfg       BootstrapWatcherConfig
+	mu        sync.Mutex
 }
 
 // NewBootstrapWatcher wires the watcher. Start must be called separately
@@ -161,20 +162,29 @@ func (w *BootstrapWatcher) Start(ctx context.Context) error {
 		return nil
 	}
 
+	// Stop is allowed before the component context is canceled. Give the
+	// subscription an owned context so shutdown can release dispatcher
+	// backpressure before waiting for the unsubscribe barrier.
+	subCtx, subCancel := context.WithCancel(ctx)
 	ch := make(chan event.Event, bootstrapBusBufSize)
-	subID, err := w.bus.Subscribe(ctx, cluster.System, ch)
+	subID, err := w.bus.Subscribe(subCtx, cluster.System, ch)
 	if err != nil {
+		subCancel()
 		close(w.doneCh)
 		return err
 	}
+	w.subCancel = subCancel
 
-	go w.run(ctx, ch, subID)
+	go w.run(subCtx, ch, subID)
 	return nil
 }
 
 // Stop terminates the watcher. Idempotent. Blocks until the goroutine
 // exits.
 func (w *BootstrapWatcher) Stop() {
+	if w.subCancel != nil {
+		w.subCancel()
+	}
 	select {
 	case <-w.stopCh:
 	default:
@@ -188,6 +198,10 @@ func (w *BootstrapWatcher) Stop() {
 func (w *BootstrapWatcher) run(ctx context.Context, ch <-chan event.Event, subID event.SubscriberID) {
 	defer close(w.doneCh)
 	defer w.bus.Unsubscribe(ctx, subID)
+	// Natural completion (successful bootstrap or observing an existing Raft
+	// leader) also stops channel consumption, so release dispatcher
+	// backpressure before entering the unsubscribe barrier.
+	defer w.subCancel()
 
 	ticker := time.NewTicker(w.cfg.Poll)
 	defer ticker.Stop()

--- a/cluster/raft/membership.go
+++ b/cluster/raft/membership.go
@@ -113,6 +113,7 @@ type MembershipHandler struct {
 	churnMu    sync.Mutex
 	wg         sync.WaitGroup
 	stopOnce   sync.Once
+	subCancel  context.CancelFunc
 	cfg        HandlerConfig
 }
 
@@ -159,14 +160,20 @@ func (h *MembershipHandler) Start(ctx context.Context) error {
 		vc.SetVoterCap(h.cfg.MaxVoters)
 	}
 
+	// Own the subscription context independently of the component context.
+	// Stop may run before that parent is canceled; canceling this context first
+	// keeps a backlogged dispatcher from blocking behind an abandoned channel.
+	subCtx, subCancel := context.WithCancel(ctx)
 	ch := make(chan event.Event, busBuffer)
-	subID, err := h.bus.Subscribe(ctx, cluster.System, ch)
+	subID, err := h.bus.Subscribe(subCtx, cluster.System, ch)
 	if err != nil {
+		subCancel()
 		return fmt.Errorf("subscribe to cluster events: %w", err)
 	}
+	h.subCancel = subCancel
 
 	h.wg.Add(2)
-	go h.subscriberLoop(ctx, ch, subID)
+	go h.subscriberLoop(subCtx, ch, subID)
 	go h.reconcileLoop(ctx)
 
 	// Kick an immediate reconcile so peers already in gossip when we
@@ -179,6 +186,9 @@ func (h *MembershipHandler) Start(ctx context.Context) error {
 
 // Stop terminates the handler. Idempotent.
 func (h *MembershipHandler) Stop() {
+	if h.subCancel != nil {
+		h.subCancel()
+	}
 	h.stopOnce.Do(func() {
 		close(h.stopCh)
 	})

--- a/cluster/raft/membership.go
+++ b/cluster/raft/membership.go
@@ -107,13 +107,13 @@ type MembershipHandler struct {
 	// Reconcile coordination.
 	reconcileCh chan struct{}
 	stopCh      chan struct{}
+	subCancel   context.CancelFunc
 	// churnTimes records timestamps of recent voter ops so a sustained burst
 	// (>3 in 60s) can be flagged via the raft_voter_churn_burst counter.
 	churnTimes []time.Time
 	churnMu    sync.Mutex
 	wg         sync.WaitGroup
 	stopOnce   sync.Once
-	subCancel  context.CancelFunc
 	cfg        HandlerConfig
 }
 

--- a/cluster/raft/subscriber_shutdown_test.go
+++ b/cluster/raft/subscriber_shutdown_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"github.com/wippyai/runtime/api/event"
+	"go.uber.org/zap"
+)
+
+// cancelBarrierBus models a dispatcher stalled on a full subscriber channel:
+// Unsubscribe cannot complete until the subscription context is canceled.
+// Consumers with their own stop signal must therefore cancel before waiting
+// at the ownership barrier.
+type cancelBarrierBus struct {
+	ctx context.Context
+	mu  sync.Mutex
+}
+
+func (b *cancelBarrierBus) Subscribe(ctx context.Context, _ event.System, _ chan<- event.Event) (event.SubscriberID, error) {
+	b.mu.Lock()
+	b.ctx = ctx
+	b.mu.Unlock()
+	return "sub.cancel-barrier", nil
+}
+
+func (b *cancelBarrierBus) SubscribeP(ctx context.Context, system event.System, _ event.Kind, ch chan<- event.Event) (event.SubscriberID, error) {
+	return b.Subscribe(ctx, system, ch)
+}
+
+func (b *cancelBarrierBus) Unsubscribe(_ context.Context, _ event.SubscriberID) {
+	b.mu.Lock()
+	ctx := b.ctx
+	b.mu.Unlock()
+	<-ctx.Done()
+}
+
+func (*cancelBarrierBus) Send(context.Context, event.Event) {}
+
+func requireStopsAfterCancelingSubscription(t *testing.T, stop func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown waited at Unsubscribe without canceling its subscription context")
+	}
+}
+
+func TestBootstrapWatcherStopCancelsSubscriptionBeforeBarrier(t *testing.T) {
+	bus := &cancelBarrierBus{}
+	w := NewBootstrapWatcher(
+		"node-a",
+		BootstrapWatcherConfig{Expect: 0, Poll: time.Hour},
+		newNodeStub(),
+		newMemberStub("node-a"),
+		bus,
+		zap.NewNop(),
+	)
+
+	require.NoError(t, w.Start(context.Background()))
+	requireStopsAfterCancelingSubscription(t, w.Stop)
+}
+
+func TestBootstrapWatcherNaturalExitCancelsSubscriptionBeforeBarrier(t *testing.T) {
+	bus := &cancelBarrierBus{}
+	node := newNodeStub()
+	node.setEstablished("node-b")
+	w := NewBootstrapWatcher(
+		"node-a",
+		BootstrapWatcherConfig{Expect: 0, Poll: time.Millisecond},
+		node,
+		newMemberStub("node-a"),
+		bus,
+		zap.NewNop(),
+	)
+
+	require.NoError(t, w.Start(context.Background()))
+	select {
+	case <-w.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("natural completion waited at Unsubscribe without canceling its subscription context")
+	}
+}
+
+func TestMembershipHandlerStopCancelsSubscriptionBeforeBarrier(t *testing.T) {
+	bus := &cancelBarrierBus{}
+	member := mkNode("node-a", "127.0.0.1")
+	h := NewMembershipHandler(
+		newFakeRaft(false, nil),
+		&fakeMembership{local: member, nodes: []cluster.NodeInfo{member}},
+		bus,
+		HandlerConfig{ReconcileDebounce: time.Hour},
+		zap.NewNop(),
+	)
+
+	require.NoError(t, h.Start(context.Background()))
+	requireStopsAfterCancelingSubscription(t, h.Stop)
+}

--- a/system/eventbus/await_service_test.go
+++ b/system/eventbus/await_service_test.go
@@ -5,6 +5,7 @@ package eventbus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -143,6 +144,47 @@ func TestAwaitService_ConcurrentAwaiters(t *testing.T) {
 		}
 		if result.Error != nil {
 			t.Errorf("awaiter %d: unexpected error: %v", i, result.Error)
+		}
+	}
+}
+
+func TestAwaitService_CriticalReplyBurstHasNoLoss(t *testing.T) {
+	bus := NewBus()
+	defer bus.Stop()
+
+	svc := NewAwaitService(bus)
+	ctx := context.Background()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("failed to start service: %v", err)
+	}
+	defer func() { _ = svc.Stop() }()
+
+	const count = 128 // Exceeds the shared subscriber's channel buffer.
+	waiters := make([]event.AwaitWaiter, count)
+	for i := range waiters {
+		path := fmt.Sprintf("critical/%03d", i)
+		waiter, err := svc.Prepare(ctx, "critical", "operation.(accept|reject)", path, time.Second)
+		if err != nil {
+			t.Fatalf("prepare %d: %v", i, err)
+		}
+		waiters[i] = waiter
+	}
+
+	for i := range waiters {
+		bus.Send(ctx, event.Event{
+			System: "critical",
+			Kind:   "operation.accept",
+			Path:   fmt.Sprintf("critical/%03d", i),
+		})
+	}
+
+	for i, waiter := range waiters {
+		result := waiter.Wait()
+		if result.Error != nil || !result.Accepted {
+			t.Fatalf("reply %d = %#v, want accepted without error", i, result)
+		}
+		if want := fmt.Sprintf("critical/%03d", i); result.Event.Path != want {
+			t.Fatalf("reply %d path = %q, want %q", i, result.Event.Path, want)
 		}
 	}
 }

--- a/system/eventbus/bus.go
+++ b/system/eventbus/bus.go
@@ -195,11 +195,7 @@ func (b *Bus) SubscribeP(
 }
 
 // Unsubscribe removes the subscription identified by the given subscriber ID.
-func (b *Bus) Unsubscribe(ctx context.Context, subID event.SubscriberID) {
-	if ctx.Err() != nil {
-		return
-	}
-
+func (b *Bus) Unsubscribe(_ context.Context, subID event.SubscriberID) {
 	req := &unsubscribeRequest{
 		subID:  subID,
 		doneCh: make(chan struct{}, 1),
@@ -211,11 +207,10 @@ func (b *Bus) Unsubscribe(ctx context.Context, subID event.SubscriberID) {
 		unsubscribe: req,
 	})
 
-	// Wait for response
-	select {
-	case <-req.doneCh:
-	case <-ctx.Done():
-	}
+	// Unsubscribe is an ownership barrier. Returning early on cancellation
+	// would let the caller release the channel while the dispatcher can still
+	// hold an in-flight send reference.
+	<-req.doneCh
 }
 
 // Send publishes an event to all matching subscribers.
@@ -239,7 +234,10 @@ func (b *Bus) Stop() {
 	b.actionMu.Lock()
 	if b.closed.Swap(true) {
 		b.actionMu.Unlock()
-		return // Already closed
+		// A concurrent Stop may still be draining the dispatcher. Stop is a
+		// terminal barrier, not merely an idempotent state flip.
+		b.wg.Wait()
+		return
 	}
 	b.actionQueue = append(b.actionQueue, action{
 		kind: actStop,
@@ -262,11 +260,17 @@ func (b *Bus) enqueueAction(a action) error {
 
 	if b.closed.Load() {
 		b.actionMu.Unlock()
-		// Respond to control operations immediately
+		// Resolve control operations according to the terminal barrier.
 		switch a.kind {
 		case actSubscribe:
 			a.subscribe.doneCh <- ErrBusClosed
 		case actUnsubscribe:
+			// Stop may have marked the bus closed while the dispatcher is
+			// still delivering a previously drained send batch.  An
+			// unsubscribe acknowledgement is also permission for helpers to
+			// release their delivery channel, so do not acknowledge it until
+			// the sole sender has exited.
+			b.wg.Wait()
 			a.unsubscribe.doneCh <- struct{}{}
 		case actSend:
 			// Silently drop send operations when closed

--- a/system/eventbus/bus.go
+++ b/system/eventbus/bus.go
@@ -185,13 +185,13 @@ func (b *Bus) SubscribeP(
 		return "", err
 	}
 
-	// Wait for response
-	select {
-	case err := <-req.doneCh:
-		return subID, err
-	case <-ctx.Done():
-		return "", ctx.Err()
+	// Once enqueued, wait for the dispatcher to decide ownership. Returning on
+	// cancellation before that decision could leave an installed subscription
+	// whose ID was never returned to the caller.
+	if err := <-req.doneCh; err != nil {
+		return "", err
 	}
+	return subID, nil
 }
 
 // Unsubscribe removes the subscription identified by the given subscriber ID.
@@ -213,8 +213,10 @@ func (b *Bus) Unsubscribe(_ context.Context, subID event.SubscriberID) {
 	<-req.doneCh
 }
 
-// Send publishes an event to all matching subscribers.
-// This is guaranteed to never block and never lose messages.
+// Send publishes an event to all matching subscribers without blocking the
+// caller on delivery. Events are delivered in order while the publisher and
+// subscriber contexts remain active; cancellation may abort queued or
+// in-progress delivery. Calls made after Stop are ignored.
 func (b *Bus) Send(ctx context.Context, e event.Event) {
 	if ctx.Err() != nil {
 		return
@@ -326,6 +328,12 @@ func (b *Bus) processActions() bool {
 
 		switch a.kind {
 		case actSubscribe:
+			// Cancellation before the serialized ownership decision means the
+			// bus never takes ownership of the caller's channel.
+			if err := a.subscribe.sub.ctx.Err(); err != nil {
+				a.subscribe.doneCh <- err
+				continue
+			}
 			if b.maxSubscribers > 0 && len(b.subscribers) >= b.maxSubscribers {
 				// Cap reached. The metric+counter let the soak gate
 				// catch a runaway leak; the typed error gives the

--- a/system/eventbus/bus_test.go
+++ b/system/eventbus/bus_test.go
@@ -507,6 +507,120 @@ func TestUnsubscribeWithCanceledContextStillFencesDelivery(t *testing.T) {
 	b.Unsubscribe(context.Background(), "sub.delivery-barrier")
 }
 
+func TestCanceledQueuedSubscribeDoesNotRetainChannel(t *testing.T) {
+	b := NewBus()
+	defer b.Stop()
+
+	// Hold the sole dispatcher in a delivery so the next Subscribe remains
+	// queued until after its context is canceled.
+	block := make(chan event.Event)
+	blockID, err := b.Subscribe(context.Background(), "review.block", block)
+	require.NoError(t, err)
+	b.Send(context.Background(), event.Event{System: "review.block"})
+	require.Eventually(t, func() bool {
+		b.actionMu.Lock()
+		defer b.actionMu.Unlock()
+		return len(b.actionQueue) == 0
+	}, time.Second, time.Millisecond, "dispatcher did not begin blocked delivery")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type subscribeResult struct {
+		id  event.SubscriberID
+		err error
+	}
+	resultCh := make(chan subscribeResult, 1)
+	target := make(chan event.Event)
+	go func() {
+		id, err := b.Subscribe(ctx, "review.target", target)
+		resultCh <- subscribeResult{id: id, err: err}
+	}()
+	require.Eventually(t, func() bool {
+		b.actionMu.Lock()
+		defer b.actionMu.Unlock()
+		return len(b.actionQueue) == 1
+	}, time.Second, time.Millisecond, "subscribe was not queued")
+	cancel()
+
+	// Release the dispatcher so it can reject the canceled request at the
+	// serialized ownership point.
+	<-block
+	got := <-resultCh
+	require.Empty(t, got.id)
+	require.ErrorIs(t, got.err, context.Canceled)
+	close(target)
+
+	// This acknowledgement also proves the dispatcher is idle, making direct
+	// inspection of its subscriber map safe.
+	b.Unsubscribe(context.Background(), blockID)
+	require.Empty(t, b.subscribers)
+}
+
+func TestUnsubscribeBarrierPreservesAcceptedEventsInOrder(t *testing.T) {
+	b := NewBus()
+	defer b.Stop()
+
+	const count = 256
+	ch := make(chan event.Event, count)
+	subID, err := b.Subscribe(context.Background(), "critical", ch)
+	require.NoError(t, err)
+
+	for i := 0; i < count; i++ {
+		b.Send(context.Background(), event.Event{
+			System: "critical",
+			Path:   fmt.Sprintf("event-%03d", i),
+		})
+	}
+	b.Unsubscribe(context.Background(), subID)
+
+	require.Len(t, ch, count, "accepted events were lost before unsubscribe barrier")
+	for i := 0; i < count; i++ {
+		got := <-ch
+		require.Equal(t, fmt.Sprintf("event-%03d", i), got.Path)
+	}
+
+	// Serialize behind a post-unsubscribe send and prove the old subscriber
+	// receives neither that event nor a duplicate of an earlier event.
+	b.Send(context.Background(), event.Event{System: "critical", Path: "after"})
+	b.Unsubscribe(context.Background(), "sub.delivery-check")
+	require.Empty(t, ch)
+}
+
+func TestStopBarrierPreservesAcceptedEventsForAllSubscribers(t *testing.T) {
+	b := NewBus()
+
+	const count = 128
+	channels := []chan event.Event{
+		make(chan event.Event, count),
+		make(chan event.Event, count),
+	}
+	for _, ch := range channels {
+		_, err := b.Subscribe(context.Background(), "critical", ch)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < count; i++ {
+		b.Send(context.Background(), event.Event{
+			System: "critical",
+			Path:   fmt.Sprintf("event-%03d", i),
+		})
+	}
+	b.Stop()
+
+	for subscriber, ch := range channels {
+		require.Lenf(t, ch, count, "accepted events were lost for subscriber %d", subscriber)
+		for i := 0; i < count; i++ {
+			got := <-ch
+			require.Equal(t, fmt.Sprintf("event-%03d", i), got.Path,
+				"subscriber %d delivery order", subscriber)
+		}
+	}
+
+	b.Send(context.Background(), event.Event{System: "critical", Path: "after"})
+	for _, ch := range channels {
+		require.Empty(t, ch)
+	}
+}
+
 func TestClosedBusUnsubscribeWaitsForDispatcherExit(t *testing.T) {
 	b := &Bus{}
 	b.closed.Store(true)

--- a/system/eventbus/bus_test.go
+++ b/system/eventbus/bus_test.go
@@ -487,6 +487,76 @@ func TestUnsubscribeAfterStop(t *testing.T) {
 	b.Unsubscribe(context.Background(), subID)
 }
 
+func TestUnsubscribeWithCanceledContextStillFencesDelivery(t *testing.T) {
+	b := NewBus()
+	defer b.Stop()
+
+	ch := make(chan event.Event, 1)
+	subID, err := b.Subscribe(context.Background(), "test-system", ch)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	b.Unsubscribe(ctx, subID)
+
+	// Closing after the barrier is safe. The following missing-ID
+	// unsubscribe serializes behind Send and proves the dispatcher processed
+	// the send without retaining this channel.
+	close(ch)
+	b.Send(context.Background(), event.Event{System: "test-system", Kind: "after-fence"})
+	b.Unsubscribe(context.Background(), "sub.delivery-barrier")
+}
+
+func TestClosedBusUnsubscribeWaitsForDispatcherExit(t *testing.T) {
+	b := &Bus{}
+	b.closed.Store(true)
+	b.wg.Add(1)
+
+	done := make(chan struct{})
+	go func() {
+		b.Unsubscribe(context.Background(), "sub.in-flight")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("unsubscribe acknowledged while the dispatcher could still send")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	b.wg.Done()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("unsubscribe did not complete after dispatcher exit")
+	}
+}
+
+func TestRepeatedStopWaitsForDispatcherExit(t *testing.T) {
+	b := &Bus{}
+	b.closed.Store(true)
+	b.wg.Add(1)
+
+	done := make(chan struct{})
+	go func() {
+		b.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("repeated Stop returned before the dispatcher exited")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	b.wg.Done()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("repeated Stop did not complete after dispatcher exit")
+	}
+}
+
 func TestHighConcurrencyStress(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping stress test in short mode")

--- a/system/eventbus/bus_test.go
+++ b/system/eventbus/bus_test.go
@@ -525,8 +525,8 @@ func TestCanceledQueuedSubscribeDoesNotRetainChannel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	type subscribeResult struct {
-		id  event.SubscriberID
 		err error
+		id  event.SubscriberID
 	}
 	resultCh := make(chan subscribeResult, 1)
 	target := make(chan event.Event)

--- a/system/topology/namereg/global/event_shutdown_test.go
+++ b/system/topology/namereg/global/event_shutdown_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package global
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/event"
+	"go.uber.org/zap"
+)
+
+type cancelBarrierBus struct {
+	ctx context.Context
+	mu  sync.Mutex
+}
+
+func (b *cancelBarrierBus) Subscribe(ctx context.Context, _ event.System, _ chan<- event.Event) (event.SubscriberID, error) {
+	b.mu.Lock()
+	b.ctx = ctx
+	b.mu.Unlock()
+	return "sub.cancel-barrier", nil
+}
+
+func (b *cancelBarrierBus) SubscribeP(ctx context.Context, system event.System, _ event.Kind, ch chan<- event.Event) (event.SubscriberID, error) {
+	return b.Subscribe(ctx, system, ch)
+}
+
+func (b *cancelBarrierBus) Unsubscribe(_ context.Context, _ event.SubscriberID) {
+	b.mu.Lock()
+	ctx := b.ctx
+	b.mu.Unlock()
+	<-ctx.Done()
+}
+
+func (*cancelBarrierBus) Send(context.Context, event.Event) {}
+
+func TestServiceStopCancelsEventSubscriptionBeforeBarrier(t *testing.T) {
+	bus := &cancelBarrierBus{}
+	eventCtx, eventCancel := context.WithCancel(context.Background())
+	_, _ = bus.Subscribe(eventCtx, "cluster", make(chan event.Event))
+
+	s := &Service{
+		bus:         bus,
+		logger:      zap.NewNop(),
+		stopCh:      make(chan struct{}),
+		started:     true,
+		eventCancel: eventCancel,
+	}
+	s.eventWG.Add(1)
+	go func() {
+		defer s.eventWG.Done()
+		s.handleClusterEvents(eventCtx, make(chan event.Event), "sub.cancel-barrier")
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		_ = s.Stop(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Stop waited at Unsubscribe without canceling its event subscription context")
+	}
+}

--- a/system/topology/namereg/global/service.go
+++ b/system/topology/namereg/global/service.go
@@ -93,7 +93,6 @@ type Service struct {
 	logger           *zap.Logger
 	stopCh           chan struct{}
 	eventCancel      context.CancelFunc
-	eventWG          sync.WaitGroup
 	lookupPending    map[uint64]chan *lookupResponseEnvelope
 	ackerEpochs      map[pid.NodeID]uint64
 	strongExclusions map[string]strongExclusion
@@ -105,6 +104,7 @@ type Service struct {
 	monitorWatermark atomic.Uint64
 	nodeEpoch        atomic.Uint64
 	lookupMu         sync.Mutex
+	eventWG          sync.WaitGroup
 	mu               sync.Mutex
 	strongMu         sync.Mutex
 	reserveMu        sync.Mutex

--- a/system/topology/namereg/global/service.go
+++ b/system/topology/namereg/global/service.go
@@ -92,6 +92,8 @@ type Service struct {
 	fsm              *FSM
 	logger           *zap.Logger
 	stopCh           chan struct{}
+	eventCancel      context.CancelFunc
+	eventWG          sync.WaitGroup
 	lookupPending    map[uint64]chan *lookupResponseEnvelope
 	ackerEpochs      map[pid.NodeID]uint64
 	strongExclusions map[string]strongExclusion
@@ -284,12 +286,25 @@ func (s *Service) Start(ctx context.Context) (<-chan any, error) {
 	s.nodeEpoch.Add(1)
 	s.nameReady.Store(false)
 
+	// Stop can precede cancellation of the component context. Own the event
+	// subscription context so a full abandoned channel cannot pin the global
+	// event dispatcher behind our unsubscribe request.
+	eventCtx, eventCancel := context.WithCancel(ctx)
 	ch := make(chan event.Event, 32)
-	subID, err := s.bus.SubscribeP(ctx, cluster.System, cluster.NodeLeft, ch)
+	subID, err := s.bus.SubscribeP(eventCtx, cluster.System, cluster.NodeLeft, ch)
 	if err != nil {
+		eventCancel()
+		s.mu.Lock()
+		s.started = false
+		s.mu.Unlock()
 		return nil, fmt.Errorf("subscribe to cluster events: %w", err)
 	}
-	go s.handleClusterEvents(ctx, ch, subID)
+	s.eventCancel = eventCancel
+	s.eventWG.Add(1)
+	go func() {
+		defer s.eventWG.Done()
+		s.handleClusterEvents(eventCtx, ch, subID)
+	}()
 
 	// Rejoin trigger (#31): tie name-readiness to LEADER reachability, not peer
 	// membership churn. A debounced probe closes the gate on a sustained leader
@@ -361,6 +376,10 @@ func (s *Service) Stop(_ context.Context) error {
 	s.mu.Unlock()
 
 	close(s.stopCh)
+	if s.eventCancel != nil {
+		s.eventCancel()
+	}
+	s.eventWG.Wait()
 
 	// Stop the dissem plane's GC goroutine, which runs off its own stopCh
 	// (s.stopCh does not reach it).


### PR DESCRIPTION
## Problem

Event bus shutdown could panic with `send on closed channel`. A canceled context allowed `Unsubscribe` to return without removing the subscription, and an unsubscribe arriving after `Stop` marked the bus closed was acknowledged while the dispatcher could still hold an in-flight send reference. Callers could then close their delivery channel before the sole sender was fenced.

The hardening review also found a second ownership bug: `Subscribe` could enqueue a request, return `context.Canceled` without an ID, and then have the dispatcher install the unreachable subscription. Three direct cluster consumers could also stop reading while their live subscription remained backpressured, preventing the dispatcher from ever reaching their unsubscribe barrier.

## Design

- Define `Unsubscribe` as a non-cancelable ownership barrier.
- During bus draining, wait for dispatcher exit before acknowledging unsubscribe.
- Make repeated and concurrent `Stop` calls wait for the same terminal barrier.
- Once a subscribe request is queued, wait for the dispatcher's serialized ownership decision; reject a canceled request before installing it and return no ID on error.
- Give the Raft bootstrap watcher, Raft membership handler, and global name-registry listener owned subscription contexts. Cancel before they stop consuming or enter the unsubscribe barrier, including bootstrap watcher's natural-completion path.
- Document the actual send boundary: delivery is ordered/lossless while publisher and subscriber contexts stay active; cancellation may abort queued or in-progress delivery.

This uses the existing single-dispatcher model. It adds no recovery, panic suppression, queue, VM, or delivery machinery.

## Critical-delivery audit

- Registry transactions and entry application, Lua/WASM process/function registration, queue declarations, and store resource handover prepare correlated `AwaitService` waiters before publishing. Cancellation or missing replies fail the operation instead of reporting silent success.
- A 128-reply correlated burst test exceeds the shared subscriber channel buffer and proves every distinct reply is routed without loss.
- Cluster membership/bootstrap/global-name event consumers are advisory: reconciliation, polling, Raft state, and anti-entropy repair missed work. Their shutdown contexts are now owned explicitly so backlog cannot deadlock shutdown.
- `eventbus.NewSubscriber`, KV watcher, topology listener, and process event dispatcher already cancel their owned subscription contexts before waiting at `Unsubscribe`.

## Regression proofs

- queued canceled subscribe is rejected and retains neither ID nor channel
- unsubscribe preserves 256 preceding events exactly once and in order, then delivers none afterward
- stop preserves 128 preceding events for each of two subscribers exactly once and in order, then delivers none afterward
- critical `AwaitService` burst routes all 128 correlated replies
- Raft bootstrap (explicit stop and natural completion), membership handler, and global name registry cancel before the terminal barrier

Targeted barrier, critical-delivery, and consumer lifecycle tests passed 100 iterations under `-race`.

## Validation

- `go test -race ./...`
- targeted regression tests: `-race -count=100`
- rebased onto current `main` (`github.com/wippyai/go-lua v1.5.19`)
- `git diff --check`

## Performance

Five-run local comparison against the original PR head:

- `BenchmarkSend`: ~97 ns median vs ~102 ns baseline, 0 allocs/op
- `BenchmarkSendParallel`: within run-to-run noise, 0 allocs/op
- `BenchmarkSendMultipleSubscribers`: within run-to-run noise, 0 allocs/op
- `BenchmarkSubscribeUnsubscribe`: ~1.11 us median vs ~1.06 us baseline, unchanged 10 allocs/op

There is no measurable hot-path regression; the new context check is on subscribe processing, not send delivery.
