### PR TITLE
Support process.send from function handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/tree-sitter/tree-sitter-php v0.24.2
 	github.com/tree-sitter/tree-sitter-python v0.25.0
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
-	github.com/wippyai/go-lua v1.5.18
+	github.com/wippyai/go-lua v1.5.20-0.20260903130651-4d15e597625b
 	github.com/wippyai/module-registry-proto-go v0.0.1
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-github.com/wippyai/go-lua v1.5.18 h1:EA8ee+Whq0zQiMjyBp0K/gg/TdCYdhNcZ3mVjKkb5yU=
-github.com/wippyai/go-lua v1.5.18/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
+github.com/wippyai/go-lua v1.5.20-0.20260903130651-4d15e597625b h1:pqvoCyNn67/ymmaAV2FbDmmm6qKx0GXB9NhlX2dODns=
+github.com/wippyai/go-lua v1.5.20-0.20260903130651-4d15e597625b/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/module-registry-proto-go v0.0.1 h1:EYnW8MTrI/gs7TJ0ilTVgJal3e0NWmXQigeamrXu0mk=
 github.com/wippyai/module-registry-proto-go v0.0.1/go.mod h1:p4ihYQKRQuqRVLxaH1YL0IEnkz4zKdyfVADOwvA5Tno=
 github.com/wippyai/tree-sitter-markdown v0.0.3 h1:u6e53+hzPSS848Xhm+I48SwtvWQHrC21wDrogdwCwuc=

--- a/runtime/lua/engine/process_factory.go
+++ b/runtime/lua/engine/process_factory.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 
 	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/logs"
 	"github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/registry"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	"github.com/wippyai/runtime/runtime/lua/code"
+	"go.uber.org/zap"
 )
 
 // CompiledFactory creates processes from compiled code.
@@ -31,6 +33,10 @@ func NewProcessFactory(code *code.Manager) *ProcessFactory {
 	return &ProcessFactory{
 		code: code,
 	}
+}
+
+func logRecoveredPanic(l *lua.LState, stack string) {
+	logs.GetLogger(l.Context()).Error("recovered Lua panic", zap.String("stack", stack))
 }
 
 // FactoryOption configures process creation via ProcessFactory.
@@ -441,6 +447,7 @@ func (f *Factory) CreateState() (*lua.LState, error) {
 		CallStackSize:       128,
 		MinimizeStackMemory: true,
 		IncludeGoStackTrace: true,
+		PanicHandler:        logRecoveredPanic,
 	}
 	if f.stateOpts != nil {
 		opts = *f.stateOpts

--- a/runtime/lua/engine/process_test.go
+++ b/runtime/lua/engine/process_test.go
@@ -14,6 +14,7 @@ import (
 	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/dispatcher"
 	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/api/logs"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/process"
@@ -21,6 +22,9 @@ import (
 	"github.com/wippyai/runtime/api/runtime/resource"
 	"github.com/wippyai/runtime/system/clock"
 	"github.com/wippyai/runtime/system/scheduler/pool/static"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // testYieldCmdID is a test command ID for simulating external yields
@@ -1268,6 +1272,81 @@ func TestProcessExternalYieldBasic(t *testing.T) {
 
 	if output.Status() != process.StepDone {
 		t.Fatalf("expected StepDone, got %d", output.Status())
+	}
+}
+
+func TestProcessTailCallExternalYield(t *testing.T) {
+	proc := mustNewProcess(t,
+		WithScript(`return test_yield(10)`, "test.lua"),
+		WithModuleBinder(bindTestYield),
+	)
+
+	ctx, _ := ctxapi.OpenFrameContext(context.Background())
+	if err := proc.Init(ctx, "", nil); err != nil {
+		t.Fatal(err)
+	}
+	defer proc.Close()
+
+	var output process.StepOutput
+	if err := proc.Step(nil, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Status() != process.StepYield {
+		t.Fatalf("step status = %d, want StepYield", output.Status())
+	}
+	if output.Count() != 1 {
+		t.Fatalf("yield count = %d, want 1", output.Count())
+	}
+
+	yield := output.Yields()[0]
+	output.Reset()
+	events := []process.Event{{Type: process.EventYieldComplete, Tag: yield.Tag, Data: "sent"}}
+	if err := proc.Step(events, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Status() != process.StepDone {
+		t.Fatalf("resume status = %d, want StepDone", output.Status())
+	}
+	if got := output.Result().Data(); got != lua.LString("sent") {
+		t.Fatalf("result = %v, want sent", got)
+	}
+}
+
+func TestProcessLogsRecoveredPanicStack(t *testing.T) {
+	core, observed := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(core)
+	ctx := logs.WithLogger(ctxapi.NewRootContext(), logger)
+	ctx, frame := ctxapi.OpenFrameContext(ctx)
+	defer ctxapi.ReleaseFrameContext(frame)
+
+	proc := mustNewProcess(t,
+		WithScript(`panic_now()`, "test.lua"),
+		WithModuleBinder(func(l *lua.LState) error {
+			l.SetGlobal("panic_now", l.NewFunction(func(*lua.LState) int {
+				panic("runtime panic sentinel")
+			}))
+			return nil
+		}),
+	)
+	if err := proc.Init(ctx, "", nil); err != nil {
+		t.Fatal(err)
+	}
+	defer proc.Close()
+
+	var output process.StepOutput
+	err := proc.Step(nil, &output)
+	if err == nil {
+		t.Fatal("step error is nil")
+	}
+	if !strings.Contains(err.Error(), "TestProcessLogsRecoveredPanicStack") {
+		t.Fatalf("step error = %q, want Go stack", err)
+	}
+	entries := observed.FilterMessage("recovered Lua panic").All()
+	if len(entries) != 1 {
+		t.Fatalf("panic log count = %d, want 1", len(entries))
+	}
+	if got := entries[0].ContextMap()["stack"]; got != err.Error() {
+		t.Fatal("logged stack does not match returned error")
 	}
 }
 

--- a/tests/app/src/test/funcs/_index.yaml
+++ b/tests/app/src/test/funcs/_index.yaml
@@ -35,6 +35,27 @@ entries:
     source: file://error_with_kind.lua
     method: main
 
+  - name: send_statement
+    kind: function.lua
+    source: file://send_handler.lua
+    method: send_statement
+    modules:
+      - process
+
+  - name: send_tail
+    kind: function.lua
+    source: file://send_handler.lua
+    method: send_tail
+    modules:
+      - process
+
+  - name: send_pressure
+    kind: function.lua
+    source: file://send_handler.lua
+    method: send_pressure
+    modules:
+      - process
+
   # Test cases
   - name: call
     kind: function.lua
@@ -168,6 +189,44 @@ entries:
     modules:
       - funcs
 
+  - name: process_send
+    kind: function.lua
+    meta:
+      type: test
+      suite: funcs
+      description: process.send through funcs.Executor
+    source: file://process_send.lua
+    method: main
+    imports:
+      assert2: app.lib:assert
+    modules:
+      - funcs
+      - process
+      - security
+      - time
+    security:
+      actor:
+        id: funcs_process_send
+      policies:
+        - app.test.security:allow_all
+
+  - name: process_send_runner
+    kind: process.lua
+    source: file://process_send.lua
+    method: main
+    imports:
+      assert2: app.lib:assert
+    modules:
+      - funcs
+      - process
+      - security
+      - time
+    security:
+      actor:
+        id: funcs_process_send_runner
+      policies:
+        - app.test.security:allow_all
+
   # Helper for module restriction test - intentionally has NO modules list
   - name: undeclared_module
     kind: function.lua
@@ -189,4 +248,3 @@ entries:
       assert2: app.lib:assert
     modules:
       - funcs
-

--- a/tests/app/src/test/funcs/process_send.lua
+++ b/tests/app/src/test/funcs/process_send.lua
@@ -1,0 +1,51 @@
+local assert = require("assert2")
+local funcs = require("funcs")
+local security = require("security")
+local time = require("time")
+
+local function receive(inbox, want)
+	local timeout = time.after("2s")
+	local result = channel.select {
+		inbox:case_receive(),
+		timeout:case_receive(),
+	}
+	assert.eq(result.channel, inbox, "message received")
+	local message = result.value
+	assert.eq(message:topic(), "mcp.command", "message topic")
+	assert.eq(message:payload():data().value, want, "message payload")
+end
+
+local function main()
+	local name = "funcs_send_" .. tostring(process.pid())
+	local registered, register_err = process.registry.register(name)
+	assert.is_nil(register_err, "registry registration has no error")
+	assert.ok(registered, "registry registration succeeds")
+
+	local inbox = process.inbox()
+	local policy, policy_err = security.policy("app.test.security:allow_all")
+	assert.is_nil(policy_err, "allow policy lookup has no error")
+	local scope = security.new_scope():with(policy)
+	local actor = security.new_actor("funcs_process_send")
+	local exec = funcs.new():with_actor(actor):with_scope(scope)
+
+	local sent, statement_err = exec:call("app.test.funcs:send_statement", name, "statement")
+	assert.is_nil(statement_err, "statement send has no error: " .. tostring(statement_err))
+	assert.ok(sent, "statement send succeeds")
+	receive(inbox, "statement")
+
+	sent, statement_err = exec:call("app.test.funcs:send_pressure", name, "pressure")
+	assert.is_nil(statement_err, "pressure send has no error: " .. tostring(statement_err))
+	assert.ok(sent, "pressure send succeeds")
+	receive(inbox, "pressure")
+
+	sent, statement_err = exec:call("app.test.funcs:send_tail", name, "tail")
+	assert.is_nil(statement_err, "tail send has no error: " .. tostring(statement_err))
+	assert.ok(sent, "tail send succeeds")
+	receive(inbox, "tail")
+
+	local unregistered = process.registry.unregister(name)
+	assert.ok(unregistered, "registry removal succeeds")
+	return true
+end
+
+return { main = main }

--- a/tests/app/src/test/funcs/send_handler.lua
+++ b/tests/app/src/test/funcs/send_handler.lua
@@ -1,0 +1,73 @@
+local function lookup(name)
+	local target, err = process.registry.lookup(name)
+	if err then
+		return nil, err
+	end
+	return target
+end
+
+local function send_statement(name, value)
+	local target, err = lookup(name)
+	if err then
+		return nil, err
+	end
+	local sent, send_err = process.send(target, "mcp.command", { value = value })
+	return sent, send_err
+end
+
+local function send_tail(name, value)
+	local target, err = lookup(name)
+	if err then
+		return nil, err
+	end
+	return process.send(target, "mcp.command", { value = value })
+end
+
+local function send_pressure(name, value)
+	local ok, result = pcall(function()
+		local title = "title"
+		local class = "class"
+		local user_id = "user"
+		local actor_id = "actor"
+		local actor_scope = "scope"
+		local schedule_type = "interval"
+		local schedule_expression = "1h"
+		local timeout_seconds = 300
+		local max_retries = 3
+		local enabled = true
+		local task_args = {
+			title = title,
+			class = class,
+			user_id = user_id,
+			actor_id = actor_id,
+			actor_scope = actor_scope,
+			schedule_type = schedule_type,
+			schedule_expression = schedule_expression,
+			timeout_seconds = timeout_seconds,
+			max_retries = max_retries,
+			enabled = enabled,
+		}
+		local target, lookup_err = lookup(name)
+		if lookup_err then
+			error(lookup_err)
+		end
+		local sent, send_err = process.send(target, "mcp.command", {
+			value = value,
+			task_args = task_args,
+		})
+		if send_err then
+			error(send_err)
+		end
+		return sent
+	end)
+	if not ok then
+		return nil, result
+	end
+	return result
+end
+
+return {
+	send_statement = send_statement,
+	send_tail = send_tail,
+	send_pressure = send_pressure,
+}


### PR DESCRIPTION
# Reason for This PR

A `function.lua` handler can call `process.send` through `funcs.call`. The runtime used a `go-lua` version that lost the sole resumable Go frame for a tail-position system yield. Recovered Go panics also returned no Go stack and wrote no diagnostic log. This change also adds regression coverage for https://github.com/wippyai/go-lua/issues/37.

This pull request depends on https://github.com/wippyai/go-lua/pull/41. It uses the exact public commit while that pull request waits for approval.

## Description of Changes

- update `go-lua` to the commit that contains the yield fix and recovered-panic diagnostics
- log the same recovered Go panic stack that the caller receives
- add runtime tests for a tail-position external yield and recovered panic logging
- add application tests for statement, protected-call register-pressure, and tail-position `process.send` calls through `funcs.call`

## Validation

- `make lint`: zero issues
- `make test` with race detection and documented external-service skips: passed
- `make build-wippy-local`: passed
- built runtime end-user smoke with `app.test.funcs:process_send_runner`: passed
- `go mod verify`: passed
- independent code review: no remaining findings

The full application harness stopped before test execution because Docker is not available on this host. The focused application smoke test uses the same application entries and passed.