### PR TITLE
fix(tty): preserve navigation keys and bound canvas control output

### DIFF
--- a/runtime/lua/modules/tty/canvas.go
+++ b/runtime/lua/modules/tty/canvas.go
@@ -23,6 +23,7 @@ const (
 // multiply as independently rendered surfaces overlap.
 type canvasWrapper struct {
 	screen *canvasBuffer
+	region canvasRegion
 	width  int
 	height int
 }
@@ -100,7 +101,8 @@ func canvasClear(l *lua.LState) int {
 		// Decode one complete fill row, then copy its styled cells. StyledString
 		// uses the bounded shared ANSI parser pool and understands SGR and OSC 8.
 		row := &canvasBuffer{Buffer: uv.NewBuffer(c.width, 1)}
-		uv.NewStyledString(ansi.Cut(fill, 0, c.width)).Draw(row, row.Bounds())
+		region := &canvasRegion{canvasBuffer: row, area: row.Bounds()}
+		uv.NewStyledString(ansi.Cut(fill, 0, c.width)).Draw(region, region.Bounds())
 		for y := 0; y < c.height; y++ {
 			for x := 0; x < c.width; x++ {
 				c.screen.SetCell(x, y, row.CellAt(x, 0))
@@ -195,10 +197,13 @@ func (c *canvasWrapper) put(x, y int, text string, limit int) {
 		return
 	}
 	// ansi.Cut may retain discarded trailing control sequences by design. The
-	// styled-cell decoder consumes those controls, while Draw exposes only the
-	// bounded cell area to the destination.
+	// drawing target independently rejects control-only cells and writes outside
+	// the placement rectangle, including decoder tail writes.
 	clipped := ansi.Cut(text, sourceX, sourceX+covered)
-	uv.NewStyledString(clipped).Draw(c.screen, uv.Rect(x, y, covered, 1))
+	// Canvas is owned by one Lua state. Reuse its drawing target rather than
+	// allocating a region for every row in an animated frame.
+	c.region.canvasBuffer, c.region.area = c.screen, uv.Rect(x, y, covered, 1)
+	uv.NewStyledString(clipped).Draw(&c.region, c.region.Bounds())
 }
 
 func canvasRows(l *lua.LState) int {

--- a/runtime/lua/modules/tty/canvas_boundary_test.go
+++ b/runtime/lua/modules/tty/canvas_boundary_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+)
+
+func TestCanvasRowControlsCannotEscapePlacement(t *testing.T) {
+	for _, text := range []string{"abc\x1b[2K", "abc\x1b[2J", "abc\t", "abc\x1b[100C", "abc\nnext", "abc\rX"} {
+		t.Run(text, func(t *testing.T) {
+			c := &canvasWrapper{width: 12, height: 3, screen: &canvasBuffer{Buffer: uv.NewBuffer(12, 3)}}
+			for y := range 3 {
+				c.put(0, y, "............", 12)
+			}
+			c.put(3, 1, text, 3)
+			for y := range 3 {
+				for x := range 12 {
+					if y == 1 && x >= 3 && x < 6 {
+						continue
+					}
+					require.Equal(t, ".", c.screen.CellAt(x, y).Content, "cell (%d,%d)", x, y)
+				}
+			}
+			rendered := c.screen.Render()
+			require.Equal(t, ansi.Strip(rendered), rendered, "non-styling controls must not reach terminal output")
+		})
+	}
+}
+
+func TestCanvasRegionPreservesStylesAndLinks(t *testing.T) {
+	c := &canvasWrapper{width: 10, height: 1, screen: &canvasBuffer{Buffer: uv.NewBuffer(10, 1)}}
+	c.put(0, 0, "..........", 10)
+	c.put(2, 0, "\x1b[31m\x1b]8;;https://example.com\x1b\\Hi\x1b]8;;\x1b\\\x1b[0m", 2)
+	require.Equal(t, "..Hi......", ansi.Strip(c.screen.Render()))
+	require.Equal(t, "https://example.com", c.screen.CellAt(2, 0).Link.URL)
+	require.NotNil(t, c.screen.CellAt(2, 0).Style.Fg)
+	require.True(t, c.screen.CellAt(4, 0).Style.IsZero())
+	require.True(t, c.screen.CellAt(4, 0).Link.IsZero())
+}
+
+func TestCanvasLuaRowsAndFillDiscardTerminalCommands(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+	require.NoError(t, l.DoString(`
+  local c = tty.canvas(12, 3)
+  assert(c:clear(".\27[2J"))
+  assert(c:put_rows(4, 2, {"abc\27[2K", "xyz\27[100C"}, 3))
+  local rows = c:rows()
+  assert(rows[1] == "............")
+  assert(rows[2] == "...abc......")
+  assert(rows[3] == "...xyz......")
+ `))
+}
+
+func BenchmarkCanvasStyledRow(b *testing.B) {
+	c := &canvasWrapper{width: 120, height: 1, screen: &canvasBuffer{Buffer: uv.NewBuffer(120, 1)}}
+	const text = "\x1b[31magent status\x1b[0m running"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.put(2, 0, text, 80)
+	}
+}

--- a/runtime/lua/modules/tty/canvas_region.go
+++ b/runtime/lua/modules/tty/canvas_region.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import uv "github.com/charmbracelet/ultraviolet"
+
+// canvasRegion enforces placement bounds at the cell-write boundary, not just
+// at the styled-string decoder. A canvas accepts styled cells, not terminal
+// commands: control-only decoder output must never enter its rendered rows.
+type canvasRegion struct {
+	*canvasBuffer
+	area uv.Rectangle
+}
+
+func (r *canvasRegion) Bounds() uv.Rectangle { return r.area }
+
+func (r *canvasRegion) CellAt(x, y int) *uv.Cell {
+	if !uv.Pos(x, y).In(r.area) {
+		return nil
+	}
+	return r.canvasBuffer.CellAt(x, y)
+}
+
+func (r *canvasRegion) SetCell(x, y int, cell *uv.Cell) {
+	if !uv.Pos(x, y).In(r.area) || (cell != nil && cell.Width <= 0) {
+		return
+	}
+	if cell != nil && x+cell.Width > r.area.Max.X {
+		blank := *cell
+		blank.Empty()
+		for column := x; column < r.area.Max.X; column++ {
+			r.canvasBuffer.SetCell(column, y, &blank)
+		}
+		return
+	}
+	r.canvasBuffer.SetCell(x, y, cell)
+}

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -117,7 +117,7 @@ content.
 | `rows()` | Render the complete row array for a surface |
 
 Canvas coordinates are one-based but may be negative for clipping. Canvas area
-is capped at 1,048,576 cells.
+is capped at 262,144 cells.
 
 ## Viewport
 

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -103,6 +103,12 @@ calls.
 at cell boundaries, understands grapheme width and styles, and prevents clipped
 escape sequences from leaking into neighboring content.
 
+Drawing accepts styled text, not terminal commands. SGR colors and OSC 8 links
+are preserved; terminal erase, cursor-motion, and other control-only output is
+not emitted. Each placement is clipped independently. A newline ends a row;
+use `put_rows` for multiple rows and paint shell borders separately from child
+content.
+
 | Method | Purpose |
 |---|---|
 | `clear(fill?)` | Clear all cells, optionally repeating a styled fill |

--- a/service/terminal/proxy/keyboard.go
+++ b/service/terminal/proxy/keyboard.go
@@ -87,6 +87,8 @@ func (s *keyboardState) encode(event ttyapi.Event) (string, bool) {
 			name = event.Key
 		}
 		_, special := kittyKeyCodes[name]
+		_, functional := kittyFunctionalKeys[name]
+		special = special || functional
 		plainText := !special && !event.Shift && !event.Alt && !event.Ctrl &&
 			event.Action != "release" && flags&(ansi.KittyReportAllKeysAsEscapeCodes|ansi.KittyReportEventTypes) == 0
 		if plainText {
@@ -100,6 +102,9 @@ func (s *keyboardState) encode(event ttyapi.Event) (string, bool) {
 			name = event.Key
 		}
 		if _, special := kittyKeyCodes[name]; special {
+			return "", false
+		}
+		if _, functional := kittyFunctionalKeys[name]; functional {
 			return "", false
 		}
 		if code, ok := keyCode(event); ok {
@@ -118,18 +123,53 @@ func encodeKittyKey(event ttyapi.Event, flags int) string {
 		return ""
 	}
 	mods := modifier(event)
+	name := event.KeyType
+	if name == "" || name == "runes" {
+		name = event.Key
+	}
+	// These controls retain their legacy press encoding until report-all is
+	// requested, including when event-type reporting is enabled.
+	if flags&ansi.KittyReportAllKeysAsEscapeCodes == 0 && (name == "enter" || name == "tab" || name == "backspace") {
+		if event.Action == "release" {
+			return ""
+		}
+		if mods == 1 {
+			return fixedKeys[name]
+		}
+	}
 	eventType := 1
 	if event.Action == "release" {
 		eventType = 3
 	}
+	final := byte('u')
+	if key, ok := kittyFunctionalKeys[name]; ok {
+		code, final = key.code, key.final
+	}
 	params := strconv.Itoa(code)
+	if final != 'u' && final != '~' && mods == 1 && flags&ansi.KittyReportEventTypes == 0 {
+		params = ""
+	}
 	if mods != 1 || flags&ansi.KittyReportEventTypes != 0 {
 		params += ";" + strconv.Itoa(mods)
 		if flags&ansi.KittyReportEventTypes != 0 {
 			params += ":" + strconv.Itoa(eventType)
 		}
 	}
-	return "\x1b[" + params + "u"
+	return "\x1b[" + params + string(final)
+}
+
+// Functional keys retain their specified CSI final byte under Kitty
+// enhancements. Private-use CSI-u numbers are not their wire encoding.
+var kittyFunctionalKeys = map[string]struct {
+	code  int
+	final byte
+}{
+	"insert": {2, '~'}, "delete": {3, '~'},
+	"left": {1, 'D'}, "right": {1, 'C'}, "up": {1, 'A'}, "down": {1, 'B'},
+	"home": {1, 'H'}, "end": {1, 'F'}, "pgup": {5, '~'}, "pgdown": {6, '~'},
+	"f1": {1, 'P'}, "f2": {1, 'Q'}, "f3": {13, '~'}, "f4": {1, 'S'},
+	"f5": {15, '~'}, "f6": {17, '~'}, "f7": {18, '~'}, "f8": {19, '~'},
+	"f9": {20, '~'}, "f10": {21, '~'}, "f11": {23, '~'}, "f12": {24, '~'},
 }
 
 func keyCode(event ttyapi.Event) (int, bool) {
@@ -139,6 +179,9 @@ func keyCode(event ttyapi.Event) (int, bool) {
 	}
 	if code, ok := kittyKeyCodes[name]; ok {
 		return code, true
+	}
+	if key, ok := kittyFunctionalKeys[name]; ok {
+		return key.code, true
 	}
 	if event.Key == "" {
 		return 0, false
@@ -152,12 +195,6 @@ func keyCode(event ttyapi.Event) (int, bool) {
 
 var kittyKeyCodes = map[string]int{
 	"esc": 27, "enter": 13, "tab": 9, "backspace": 127, "space": 32,
-	"insert": 57348, "delete": 57349, "left": 57350, "right": 57351,
-	"up": 57352, "down": 57353, "pgup": 57354, "pgdown": 57355,
-	"home": 57356, "end": 57357,
-	"f1": 57364, "f2": 57365, "f3": 57366, "f4": 57367,
-	"f5": 57368, "f6": 57369, "f7": 57370, "f8": 57371,
-	"f9": 57372, "f10": 57373, "f11": 57374, "f12": 57375,
 }
 
 func (p *Proxy) installKeyboardHandlers() {

--- a/service/terminal/proxy/keyboard.go
+++ b/service/terminal/proxy/keyboard.go
@@ -82,10 +82,7 @@ func (s *keyboardState) encode(event ttyapi.Event) (string, bool) {
 	modifyOtherKeys := s.modifyOtherKeys
 	s.mu.RUnlock()
 	if flags != 0 {
-		name := event.KeyType
-		if name == "" || name == "runes" {
-			name = event.Key
-		}
+		name := keyName(event)
 		_, special := kittyKeyCodes[name]
 		_, functional := kittyFunctionalKeys[name]
 		special = special || functional
@@ -97,10 +94,7 @@ func (s *keyboardState) encode(event ttyapi.Event) (string, bool) {
 		return encodeKittyKey(event, flags), true
 	}
 	if modifyOtherKeys == 2 && event.Action != "release" && (event.Shift || event.Alt || event.Ctrl) {
-		name := event.KeyType
-		if name == "" || name == "runes" {
-			name = event.Key
-		}
+		name := keyName(event)
 		if _, special := kittyKeyCodes[name]; special {
 			return "", false
 		}
@@ -123,10 +117,7 @@ func encodeKittyKey(event ttyapi.Event, flags int) string {
 		return ""
 	}
 	mods := modifier(event)
-	name := event.KeyType
-	if name == "" || name == "runes" {
-		name = event.Key
-	}
+	name := keyName(event)
 	// These controls retain their legacy press encoding until report-all is
 	// requested, including when event-type reporting is enabled.
 	if flags&ansi.KittyReportAllKeysAsEscapeCodes == 0 && (name == "enter" || name == "tab" || name == "backspace") {
@@ -172,11 +163,15 @@ var kittyFunctionalKeys = map[string]struct {
 	"f9": {20, '~'}, "f10": {21, '~'}, "f11": {23, '~'}, "f12": {24, '~'},
 }
 
-func keyCode(event ttyapi.Event) (int, bool) {
-	name := event.KeyType
-	if name == "" || name == "runes" {
-		name = event.Key
+func keyName(event ttyapi.Event) string {
+	if event.KeyType == "" || event.KeyType == "runes" {
+		return event.Key
 	}
+	return event.KeyType
+}
+
+func keyCode(event ttyapi.Event) (int, bool) {
+	name := keyName(event)
 	if code, ok := kittyKeyCodes[name]; ok {
 		return code, true
 	}

--- a/service/terminal/proxy/keyboard_test.go
+++ b/service/terminal/proxy/keyboard_test.go
@@ -3,22 +3,88 @@
 package proxy
 
 import (
+	"fmt"
 	"testing"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
+
+func TestKittyFunctionalKeysRoundTrip(t *testing.T) {
+	keys := map[string]rune{
+		"left": uv.KeyLeft, "right": uv.KeyRight, "up": uv.KeyUp, "down": uv.KeyDown,
+		"home": uv.KeyHome, "end": uv.KeyEnd, "insert": uv.KeyInsert, "delete": uv.KeyDelete,
+		"pgup": uv.KeyPgUp, "pgdown": uv.KeyPgDown,
+		"f1": uv.KeyF1, "f2": uv.KeyF2, "f3": uv.KeyF3, "f4": uv.KeyF4,
+		"f5": uv.KeyF5, "f6": uv.KeyF6, "f7": uv.KeyF7, "f8": uv.KeyF8,
+		"f9": uv.KeyF9, "f10": uv.KeyF10, "f11": uv.KeyF11, "f12": uv.KeyF12,
+	}
+	for name, code := range keys {
+		for flags := 1; flags <= ansi.KittyAllFlags; flags++ {
+			for mods := 0; mods < 8; mods++ {
+				for _, action := range []string{"press", "release"} {
+					t.Run(fmt.Sprintf("%s/%d/%d/%s", name, flags, mods, action), func(t *testing.T) {
+						event := ttyapi.Event{Type: "key", KeyType: name, Key: name, Action: action,
+							Shift: mods&1 != 0, Alt: mods&2 != 0, Ctrl: mods&4 != 0}
+						seq := encodeKittyKey(event, flags)
+						if action == "release" && flags&ansi.KittyReportEventTypes == 0 {
+							require.Empty(t, seq)
+							return
+						}
+						var decoder uv.EventDecoder
+						n, decoded := decoder.Decode([]byte(seq))
+						require.Equal(t, len(seq), n)
+						key, ok := decoded.(uv.KeyEvent)
+						require.True(t, ok, "%q decoded as %T", seq, decoded)
+						require.Equal(t, code, key.Key().Code)
+						var expectedMod uv.KeyMod
+						if event.Shift {
+							expectedMod |= uv.ModShift
+						}
+						if event.Alt {
+							expectedMod |= uv.ModAlt
+						}
+						if event.Ctrl {
+							expectedMod |= uv.ModCtrl
+						}
+						require.Equal(t, expectedMod, key.Key().Mod)
+						// The pinned decoder drops release types for tilde keys;
+						// check their event-type parameter on the wire below.
+						if action == "release" && seq[len(seq)-1] != '~' {
+							require.IsType(t, uv.KeyReleaseEvent{}, decoded)
+						}
+						if action == "release" {
+							require.Contains(t, seq, ":3")
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestKittyControlCompatibility(t *testing.T) {
+	for _, name := range []string{"enter", "tab", "backspace"} {
+		for _, flags := range []int{1, 3, 7} {
+			event := ttyapi.Event{Type: "key", KeyType: name, Key: name, Action: "press"}
+			require.Equal(t, fixedKeys[name], encodeKittyKey(event, flags))
+			event.Action = "release"
+			require.Empty(t, encodeKittyKey(event, flags))
+		}
+	}
+}
 
 func TestKittyKeyboardNegotiationEncodesArrowsAndRelease(t *testing.T) {
 	var state keyboardState
 	state.push(ansi.KittyDisambiguateEscapeCodes | ansi.KittyReportEventTypes)
 	press, handled := state.encode(ttyapi.Event{Type: "key", KeyType: "down", Action: "press"})
 	require.True(t, handled)
-	require.Equal(t, "\x1b[57353;1:1u", press)
+	require.Equal(t, "\x1b[1;1:1B", press)
 	release, handled := state.encode(ttyapi.Event{Type: "key", KeyType: "down", Action: "release"})
 	require.True(t, handled)
-	require.Equal(t, "\x1b[57353;1:3u", release)
+	require.Equal(t, "\x1b[1;1:3B", release)
 	state.pop(1)
 	_, handled = state.encode(ttyapi.Event{Type: "key", KeyType: "down", Action: "press"})
 	require.False(t, handled)

--- a/service/terminal/proxy/proxy_test.go
+++ b/service/terminal/proxy/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -492,4 +493,73 @@ func TestProxyRunsNativeTerminal(t *testing.T) {
 	rendered := strings.Join(surface.rows, "\n")
 	surface.mu.Unlock()
 	require.Contains(t, rendered, "30 100")
+}
+
+func TestProxyRunsNativeInteractiveEditingKeys(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("native PTY integration requires Unix")
+	}
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("interactive PTY integration requires Bash")
+	}
+	executor := native.NewNativeExecutor(zap.NewNop(), &execapi.NativeExecutorConfig{})
+	process, err := executor.NewProcess(
+		"/bin/bash --noprofile --norc",
+		execapi.ProcessOptions{PTY: &execapi.PTYOptions{Width: 80, Height: 20, Term: "xterm-256color"}},
+	)
+	require.NoError(t, err)
+	ptyProcess, ok := process.(execapi.PTYProcess)
+	require.True(t, ok)
+	surface := &testSurface{}
+	proxy, err := New(ptyProcess, surface, 80, 20)
+	require.NoError(t, err)
+	events := make(chan ttyapi.Event, 32)
+	done := make(chan error, 1)
+	go func() { done <- proxy.Run(context.Background(), events) }()
+
+	sendText := func(value string) {
+		events <- ttyapi.Event{Type: "key", KeyType: "runes", Key: value, Action: "press"}
+	}
+	sendKey := func(name string) {
+		events <- ttyapi.Event{Type: "key", KeyType: name, Key: name, Action: "press"}
+	}
+	require.Eventually(t, func() bool {
+		surface.mu.Lock()
+		defer surface.mu.Unlock()
+		return strings.Contains(strings.Join(surface.rows, "\n"), "bash-")
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// Left inserts in the middle instead of echoing its escape sequence.
+	sendText("printf ac")
+	sendKey("left")
+	sendText("b")
+	sendKey("enter")
+
+	// Backspace edits the line according to the PTY's configured erase byte.
+	sendText("printf backX")
+	sendKey("backspace")
+	sendText("-ok")
+	sendKey("enter")
+
+	// Home followed by Ctrl+K replaces the whole current input line.
+	sendText("printf discarded")
+	sendKey("home")
+	events <- ttyapi.Event{Type: "key", KeyType: "runes", Key: "k", Ctrl: true, Action: "press"}
+	sendText("printf home-ok")
+	sendKey("enter")
+	sendText("exit")
+	sendKey("enter")
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("interactive terminal proxy did not finish")
+	}
+	surface.mu.Lock()
+	rendered := strings.Join(surface.rows, "\n")
+	surface.mu.Unlock()
+	require.Contains(t, rendered, "abc")
+	require.Contains(t, rendered, "back-ok")
+	require.Contains(t, rendered, "home-ok")
 }

--- a/tests/tty-surface-demo/README.md
+++ b/tests/tty-surface-demo/README.md
@@ -7,7 +7,10 @@ physical TTY → shell surface → virtual viewport → child process → PTY pr
 ```
 
 The shell owns placement and input routing. The child only sees its granted
-terminal and runs a real `/bin/sh` through the `terminal` adapter.
+terminal and runs Bash through the `terminal` adapter. Bash is used deliberately
+because minimal `/bin/sh` implementations such as Dash do not provide
+interactive line editing: arrow and Home keys would be echoed as escape
+sequences even when the terminal transport is correct.
 
 ```bash
 make build-wippy-linux-amd64

--- a/tests/tty-surface-demo/src/child.lua
+++ b/tests/tty-surface-demo/src/child.lua
@@ -9,7 +9,7 @@ local function main(command)
     assert(tty.start())
 
     local executor = assert(exec.get("tty_proof:exec"))
-    local process = assert(executor:exec(command or "/bin/sh", {
+    local process = assert(executor:exec(command or "/bin/bash --noprofile --norc", {
         pty = {term = "xterm-256color"},
     }))
     local session = assert(process:attach_terminal())

--- a/tests/tty-surface-demo/src/shell.lua
+++ b/tests/tty-surface-demo/src/shell.lua
@@ -21,7 +21,7 @@ local function main()
     local updates = assert(viewport:updates())
     local grant = assert(viewport:grant())
     local child = assert(process.with_options({terminal = grant})
-        :spawn_monitored("tty_proof:child", "tty_proof:workers", "/bin/sh"))
+        :spawn_monitored("tty_proof:child", "tty_proof:workers", "/bin/bash --noprofile --norc"))
 
     local revision = -1
     local snapshot: any = {rows = {}}
@@ -31,7 +31,7 @@ local function main()
 
     local function draw()
         local rows = {tty.text.truncate(
-            " Wippy TTY proof — real /bin/sh in a process-owned viewport (Ctrl+Q exits) ",
+            " Wippy TTY proof — real Bash in a process-owned viewport (Ctrl+Q exits) ",
             width)}
         for index = 1, height - 1 do
             rows[index + 1] = snapshot.rows[index] or ""


### PR DESCRIPTION
Fix navigation keys rendering as private-use Unicode in embedded terminal apps after Kitty negotiation, and prevent canvas tail controls from escaping their placement rectangle and erasing neighboring UI.

Functional keys use their specified CSI encodings, with modifiers and negotiated release events preserved. Key-name normalization is shared across encoders. Canvas writes enforce bounds at the cell boundary and discard control-only output while preserving SGR styles and OSC 8 links. The bounded target is reused for row drawing. The Lua SDK is unchanged.

Validation:

- 10,912 functional-key combinations, independent decoder checks, and native Bash PTY editing coverage.
- Canvas regressions cover erase/cursor controls, neighboring cells, styles, links, and Lua row/fill operations.
- Terminal, Lua TTY/exec, and virtual viewport race tests.
- Existing CI covers Linux, Windows, lint, and CodeQL.

The small runtime demo uses Bash for interactive editing. The desktop OS and Lineage applications are not included.

Protocol reference: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions
