### PR TITLE
fix: preserve WebSocket results, defer HTTP status, and correct TTY startup

### DIFF
--- a/api/service/http/context.go
+++ b/api/service/http/context.go
@@ -56,6 +56,7 @@ type RequestContext struct {
 	r               *http.Request
 	w               http.ResponseWriter
 	responseHandled bool
+	responseStatus  int
 }
 
 // GetRequestContext retrieves HTTP request context from FrameContext
@@ -154,6 +155,22 @@ func (h *RequestContext) ResponseWriter() http.ResponseWriter {
 	return h.w
 }
 
+// SetResponseStatus selects the final status without committing headers.
+// CommitResponseStatus must run before the body is written or the handler exits.
+func (h *RequestContext) SetResponseStatus(status int) {
+	h.responseStatus = status
+	h.MarkHandled()
+}
+
+// CommitResponseStatus writes a selected status once, preserving status-only
+// responses while allowing headers to be changed until the first write/flush.
+func (h *RequestContext) CommitResponseStatus() {
+	if h.responseStatus != 0 {
+		h.w.WriteHeader(h.responseStatus)
+		h.responseStatus = 0
+	}
+}
+
 // MarkHandled indicates that a response has been sent for this request.
 func (h *RequestContext) MarkHandled() {
 	h.responseHandled = true
@@ -177,6 +194,7 @@ func (h *RequestContext) SetResponseWriter(w http.ResponseWriter) {
 // ResetHandled resets the response handled flag (for pooling)
 func (h *RequestContext) ResetHandled() {
 	h.responseHandled = false
+	h.responseStatus = 0
 }
 
 // MiddlewareCreator is a function that creates a middleware handler from options

--- a/runtime/lua/modules/http/module_test.go
+++ b/runtime/lua/modules/http/module_test.go
@@ -610,6 +610,8 @@ func TestResponse_Basic(t *testing.T) {
 			res:set_status(http.STATUS.CREATED)
 		`)
 		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, recorder.Code, "status selection must not commit headers")
+		reqCtx.CommitResponseStatus()
 		assert.Equal(t, http.StatusCreated, recorder.Code)
 	})
 

--- a/runtime/lua/modules/http/response.go
+++ b/runtime/lua/modules/http/response.go
@@ -82,9 +82,11 @@ func responseSetStatus(l *lua.LState) int {
 		return 1
 	}
 	code := l.CheckInt(2)
-	res.writer.WriteHeader(code)
-	res.headersSent = true
-	res.rCtx.MarkHandled()
+	if code < 100 || code > 999 {
+		l.Push(lua.NewLuaError(l, "invalid HTTP status code").WithKind(lua.Invalid).WithRetryable(false))
+		return 1
+	}
+	res.rCtx.SetResponseStatus(code)
 	l.Push(lua.LNil)
 	return 1
 }
@@ -115,6 +117,8 @@ func responseWrite(l *lua.LState) int {
 		return 0
 	}
 	data := l.CheckString(2)
+	res.rCtx.CommitResponseStatus()
+	res.headersSent = true
 	_, err := res.writer.Write([]byte(data))
 	if err != nil {
 		luaErr := lua.WrapErrorWithLua(l, err, "write failed").
@@ -134,6 +138,7 @@ func responseFlush(l *lua.LState) int {
 	if res == nil {
 		return 0
 	}
+	res.rCtx.CommitResponseStatus()
 	if flusher, ok := res.writer.(interface{ Flush() }); ok {
 		flusher.Flush()
 	}
@@ -160,6 +165,8 @@ func responseWriteJSON(l *lua.LState) int {
 	if !res.headersSent {
 		res.writer.Header().Set("Content-Type", "application/json")
 	}
+	res.rCtx.CommitResponseStatus()
+	res.headersSent = true
 	_, err = res.writer.Write(data)
 	if err != nil {
 		luaErr := lua.WrapErrorWithLua(l, err, "write failed").
@@ -240,6 +247,8 @@ func responseWriteEvent(l *lua.LState) int {
 		return 1
 	}
 
+	res.rCtx.CommitResponseStatus()
+	res.headersSent = true
 	_, writeErr := fmt.Fprintf(res.writer, "event: %s\ndata: %s\n\n", name, data)
 	if writeErr != nil {
 		luaErr := lua.WrapErrorWithLua(l, writeErr, "write event failed").

--- a/runtime/lua/modules/http/response_status_test.go
+++ b/runtime/lua/modules/http/response_status_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	httpservice "github.com/wippyai/runtime/api/service/http"
+)
+
+func TestStatusBeforeHeadersAndBody(t *testing.T) {
+	for _, test := range []struct{ name, script, contentType string }{
+		{"text", `assert(res:set_content_type("text/plain") == nil); assert(res:write("body") == nil)`, "text/plain"},
+		{"json", `assert(res:write_json({ok = true}) == nil)`, "application/json"},
+		{"event", `assert(res:write_event({name = "test", data = {ok = true}}) == nil)`, "text/event-stream"},
+		{"flush", `assert(res:set_content_type("text/plain") == nil); assert(res:flush() == nil)`, "text/plain"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			l := lua.NewState()
+			defer l.Close()
+			bind(l)
+			ctx, frame := newTestContext()
+			recorder := httptest.NewRecorder()
+			reqCtx := httpservice.NewRequestContext(httptest.NewRequest("GET", "/", nil), recorder)
+			require.NoError(t, frame.Set(httpservice.RequestKey(), reqCtx))
+			l.SetContext(ctx)
+			require.NoError(t, l.DoString(`
+				local res = http.response()
+				assert(res:set_status(202) == nil)
+				assert(res:set_status(201) == nil)
+				assert(res:set_header("X-Test", "present") == nil)
+			`+test.script+`
+				assert(res:set_status(200) ~= nil, "status must be fixed after commit")
+				assert(res:set_header("X-Late", "absent") ~= nil)
+			`))
+			// Result snapshots the actual transmitted headers, not the mutable map.
+			result := recorder.Result()
+			defer result.Body.Close()
+			require.Equal(t, http.StatusCreated, result.StatusCode)
+			require.Equal(t, "present", result.Header.Get("X-Test"))
+			require.Equal(t, test.contentType, result.Header.Get("Content-Type"))
+			require.Empty(t, result.Header.Get("X-Late"))
+		})
+	}
+}

--- a/runtime/lua/modules/http/response_status_test.go
+++ b/runtime/lua/modules/http/response_status_test.go
@@ -25,7 +25,7 @@ func TestStatusBeforeHeadersAndBody(t *testing.T) {
 			bind(l)
 			ctx, frame := newTestContext()
 			recorder := httptest.NewRecorder()
-			reqCtx := httpservice.NewRequestContext(httptest.NewRequest("GET", "/", nil), recorder)
+			reqCtx := httpservice.NewRequestContext(httptest.NewRequestWithContext(ctx, "GET", "/", nil), recorder)
 			require.NoError(t, frame.Set(httpservice.RequestKey(), reqCtx))
 			l.SetContext(ctx)
 			require.NoError(t, l.DoString(`

--- a/runtime/lua/modules/http/spec.md
+++ b/runtime/lua/modules/http/spec.md
@@ -386,7 +386,8 @@ Returned by `http.response()`. Provides methods to build and send HTTP responses
 
 #### response:set_status(code: integer) → error
 
-Sets HTTP response status code.
+Selects the HTTP response status without sending headers. Headers are committed
+on the first write or flush, or when the handler returns without a body.
 
 | Param | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
@@ -399,6 +400,7 @@ Sets HTTP response status code.
 | Condition | Kind | Retryable |
 |-----------|------|-----------|
 | headers already sent | errors.INVALID | no |
+| code outside 100–999 | errors.INVALID | no |
 
 **Notes:**
 - Must be called before any write operations

--- a/runtime/lua/modules/httpclient/types.go
+++ b/runtime/lua/modules/httpclient/types.go
@@ -39,6 +39,7 @@ var requestOptionsType = typ.NewRecord().
 	OptField("body", typ.String).
 	OptField("timeout", typ.NewUnion(typ.Number, typ.String)).
 	OptField("unix_socket", typ.String).
+	OptField("overlay_network", typ.String).
 	OptField("query", typ.NewMap(typ.String, typ.String)).
 	OptField("cookies", typ.NewMap(typ.String, typ.String)).
 	OptField("form", typ.NewMap(typ.String, typ.String)).

--- a/runtime/lua/modules/httpclient/types_test.go
+++ b/runtime/lua/modules/httpclient/types_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package httpclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/go-lua/types/io"
+	"github.com/wippyai/runtime/runtime/lua/code"
+)
+
+func TestOverlayNetworkRequestOptionsTypecheck(t *testing.T) {
+	tc := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+	_, diagnostics, err := tc.Check(`
+local client = require("http_client")
+local function network(opts: client.RequestOptions): string?
+    return opts.overlay_network
+end
+local response, err = client.get("http://peer/", {overlay_network = "app:network"})
+local response2, err2 = client.request("POST", "http://peer/", {overlay_network = "app:network", body = "test"})
+`, "overlay_request.lua", map[string]*io.Manifest{"http_client": ModuleTypes()})
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "unexpected diagnostics: %v", diagnostics)
+}

--- a/runtime/lua/modules/websocket/leak_test.go
+++ b/runtime/lua/modules/websocket/leak_test.go
@@ -355,6 +355,36 @@ func goroutinesSettle(baseline int, budget stdtime.Duration) int {
 
 // WS normal connect/use/close: the subscription returns to 0 and the read-loop
 // goroutine exits.
+func TestWsSendAndPingReturnDispatcherResults(t *testing.T) {
+	srv := echoServer(t)
+	defer srv.Close()
+	tc := setupWsTest(t, 2)
+	defer tc.Close()
+	script := fmt.Sprintf(`
+		local conn = assert(websocket.connect(%q))
+		local ch = assert(conn:channel())
+		local ok, err = conn:send("hello")
+		assert(ok == true and err == nil, "send must report success")
+		local msg = ch:receive()
+		assert(msg.data == "hello")
+		ok, err = conn:ping()
+		assert(ok == true and err == nil, "ping must report success")
+		conn:close()
+		ok, err = conn:send("closed")
+		assert(ok == false and err ~= nil, "send must preserve dispatcher error")
+		ok, err = conn:ping()
+		assert(ok == false and err ~= nil, "ping must preserve dispatcher error")
+		return "ok"
+	`, wsURLOf(srv))
+	frameCtx, runPID := tc.frameCtxPID(t)
+	result, err := tc.scheduler.Execute(frameCtx, runPID, newWsProcess(t, script), "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Error, "script error: %v", result.Error)
+	require.NotNil(t, result.Value)
+	require.Equal(t, "ok", resultString(result.Value.Data()))
+}
+
 func TestLeak_WsConnectUseCloseReclaims(t *testing.T) {
 	srv := echoServer(t)
 	defer srv.Close()

--- a/runtime/lua/modules/websocket/spec.md
+++ b/runtime/lua/modules/websocket/spec.md
@@ -107,10 +107,10 @@ Returned by `websocket.connect()`.
 
 | Method | Signature | Returns | Notes |
 |--------|-----------|---------|-------|
-| send | (data: string, type?: integer) | - | Yields until sent. type: websocket.TEXT (1) or websocket.BINARY (2) |
+| send | (data: string, type?: integer) | boolean, error? | Yields until sent. type: websocket.TEXT (1) or websocket.BINARY (2) |
 | channel | () | channel | First call yields to subscribe, subsequent calls return same channel |
 | receive | () | channel | Alias for channel() |
-| ping | () | - | Yields until ping sent |
+| ping | () | boolean, error? | Yields until ping sent |
 | close | (code?: integer, reason?: string) | - | Yields until close sent. code default 1000 |
 
 #### client:send(data: string, type?: integer)
@@ -123,6 +123,8 @@ Sends a message to the server.
 | type | integer | no | 1 | websocket.TEXT (1) or websocket.BINARY (2) |
 
 **Yields:** until message sent
+
+**Returns:** `true, nil` on success; `false, error` if sending fails.
 
 ```lua
 client:send("Hello")
@@ -164,6 +166,8 @@ Alias for `client:channel()`. Provided for v1 API compatibility.
 Sends a ping to the server.
 
 **Yields:** until ping sent
+
+**Returns:** `true, nil` on success; `false, error` if the ping fails.
 
 ```lua
 client:ping()

--- a/runtime/lua/modules/websocket/yields.go
+++ b/runtime/lua/modules/websocket/yields.go
@@ -139,6 +139,13 @@ func (y *WsSendYield) ToCommand() dispatcher.Command {
 
 func (y *WsSendYield) Release() { ReleaseWsSendYield(y) }
 
+func (y *WsSendYield) HandleResult(l *lua.LState, _ any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LFalse, lua.NewLuaError(l, err.Error()).WithKind(lua.Internal).WithRetryable(false)}
+	}
+	return []lua.LValue{lua.LTrue, lua.LNil}
+}
+
 // WsSubscribeYield is yielded to start receiving messages on a channel.
 // This subscribes the channel to the topic and starts the dispatcher read loop.
 type WsSubscribeYield struct {
@@ -349,3 +356,10 @@ func (y *WsPingYield) ToCommand() dispatcher.Command {
 }
 
 func (y *WsPingYield) Release() { ReleaseWsPingYield(y) }
+
+func (y *WsPingYield) HandleResult(l *lua.LState, _ any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LFalse, lua.NewLuaError(l, err.Error()).WithKind(lua.Internal).WithRetryable(false)}
+	}
+	return []lua.LValue{lua.LTrue, lua.LNil}
+}

--- a/service/http/factory.go
+++ b/service/http/factory.go
@@ -79,6 +79,8 @@ func (f *EndpointFactory) CreateHandler(_ context.Context, cfg *config.EndpointC
 		}
 
 		result, err := f.funcs.Call(execCtx, task)
+		// A handler may select a status without writing a body (e.g. 204).
+		rCtx.CommitResponseStatus()
 		if err != nil {
 			if !rCtx.ResponseHandled() {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/service/http/factory_test.go
+++ b/service/http/factory_test.go
@@ -209,6 +209,26 @@ func TestEndpointFactory_CreateHandler(t *testing.T) {
 		Func:   apiregistry.NewID("test", "func1"),
 	}
 
+	t.Run("status-only response retains late headers", func(t *testing.T) {
+		registry.Register(cfg.Func, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+			rctx, ok := config.GetRequestContext(ctx)
+			require.True(t, ok)
+			rctx.SetResponseStatus(http.StatusNoContent)
+			rctx.ResponseWriter().Header().Set("X-After-Status", "present")
+			return &runtime.Result{}, nil
+		})
+		handler, err := factory.CreateHandler(context.Background(), cfg)
+		require.NoError(t, err)
+		ctx, _ := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequestWithContext(ctx, "GET", "/test", nil))
+		result := recorder.Result()
+		defer result.Body.Close()
+		require.Equal(t, http.StatusNoContent, result.StatusCode)
+		require.Equal(t, "present", result.Header.Get("X-After-Status"))
+		require.Empty(t, recorder.Body.String())
+	})
+
 	t.Run("successful handler creation", func(t *testing.T) {
 		ctx := ctxapi.NewRootContext()
 

--- a/tests/tty-demo/src/norton.lua
+++ b/tests/tty-demo/src/norton.lua
@@ -417,6 +417,13 @@ end
 
 -- Main
 local function main()
+    -- Subscribe before starting input delivery so the initial event is retained.
+    local ch = tty.events()
+    if not ch then
+        io.print("tty.events failed")
+        return
+    end
+
     local ok, err = tty.start()
     if not ok then
         io.print("tty.start failed: " .. tostring(err))
@@ -428,13 +435,6 @@ local function main()
     if cols then
         width = cols
         height = rows
-    end
-
-    local ch = tty.events()
-    if not ch then
-        tty.stop()
-        io.print("tty.events failed")
-        return
     end
 
     io.write(ALT_SCREEN_ON .. CURSOR_HIDE)

--- a/tests/tty-demo/src/tty_demo.lua
+++ b/tests/tty-demo/src/tty_demo.lua
@@ -207,7 +207,7 @@ local function render_layout_tab(w: integer, h: integer): string
     local vert = tty.text.join_vertical(CENTER, box_a, box_b)
     local joined = tty.text.join_horizontal(TOP, horiz, "   ", vert)
 
-    local pw = math.min(30, w - 4)
+    local pw = math.floor(math.min(30, w - 4))
     local placed = tty.text.place(pw, 3, CENTER, CENTER, "centered")
     local placed_box = tty.style():border(ROUNDED):border_foreground("#444444"):render(placed)
 
@@ -261,11 +261,11 @@ local function render_bindings_tab(w: integer, h: integer): string
 
     lines[#lines + 1] = "  " .. sec:render("Match tests:")
     local tests = {
-        {name = "q",          ev = {type = "key", key = "q",   key_type = "runes", ctrl = false, alt = false, shift = false}},
-        {name = "ctrl+c",     ev = {type = "key", key = "c",   key_type = "runes", ctrl = true,  alt = false, shift = false}},
-        {name = "esc",        ev = {type = "key", key = "esc", key_type = "esc",   ctrl = false, alt = false, shift = false}},
-        {name = "x (no)",     ev = {type = "key", key = "x",   key_type = "runes", ctrl = false, alt = false, shift = false}},
-        {name = "mouse (no)", ev = {type = "mouse", action = "press", button = "left"}},
+        {name = "q",          ev = {type = "key", action = "press", key = "q",   key_type = "runes", ctrl = false, alt = false, shift = false}},
+        {name = "ctrl+c",     ev = {type = "key", action = "press", key = "c",   key_type = "runes", ctrl = true,  alt = false, shift = false}},
+        {name = "esc",        ev = {type = "key", action = "press", key = "esc", key_type = "esc",   ctrl = false, alt = false, shift = false}},
+        {name = "x (no)",     ev = {type = "key", action = "press", key = "x",   key_type = "runes", ctrl = false, alt = false, shift = false}},
+        {name = "mouse (no)", ev = {type = "mouse", action = "press", button = "left", x = 0, y = 0, ctrl = false, alt = false, shift = false}},
     }
     for _, t in ipairs(tests) do
         local m = bindings.quit:matches(t.ev)
@@ -392,6 +392,13 @@ end
 -- Main
 
 local function main()
+    -- Subscribe before starting input delivery so the initial event is retained.
+    local ch = tty.events()
+    if not ch then
+        io.print("tty.events failed")
+        return
+    end
+
     local ok, err = tty.start()
     if not ok then
         io.print("tty.start failed: " .. tostring(err))
@@ -403,13 +410,6 @@ local function main()
     if cols then
         width = cols
         height = rows
-    end
-
-    local ch = tty.events()
-    if not ch then
-        tty.stop()
-        io.print("tty.events failed")
-        return
     end
 
     tty.mouse(true)

--- a/tests/tty-surface-demo/src/shell.lua
+++ b/tests/tty-surface-demo/src/shell.lua
@@ -6,8 +6,8 @@ local time = require("time")
 local tty = require("tty")
 
 local function main()
-    assert(tty.start())
     local events = assert(tty.events())
+    assert(tty.start())
     local lifecycle = assert(process.events())
     local output = assert(tty.surface({
         alternate_screen = true,


### PR DESCRIPTION
The documentation sweep in wippyai/docs#35 exposed dropped WebSocket operation results, premature HTTP header commitment, an omitted HTTP client option type, and TTY startup ordering that could lose initial events.

- Return `true, nil` or `false, error` from WebSocket send/ping through the yield result handler.
- Defer the selected HTTP status until the first body write/flush or handler completion. `set_status(201); set_header(...); write_json(...)` now sends the chosen status and headers together; status-only responses such as 204 remain supported.
- Include `overlay_network` in the exported HTTP client request options type.
- Subscribe to events before starting input in the TTY demos. Align the toolkit's sample events and layout width with the current types so both demo apps lint cleanly.

Validation: affected HTTP, HTTP client, WebSocket and TTY Go suites pass, including race checks. Regression checks fail against the previous implementations. Built the runtime, linted both TTY demo apps, and verified rendering and normal exit of tty-demo, norton and tty-proof through pseudo-terminals.

The HTTP change stores one pending status integer per request and keeps streaming writes. No performance benchmark was run.
