### PR TITLE
Propagate WebSocket send and ping errors

### DIFF
--- a/runtime/lua/modules/websocket/leak_test.go
+++ b/runtime/lua/modules/websocket/leak_test.go
@@ -355,6 +355,36 @@ func goroutinesSettle(baseline int, budget stdtime.Duration) int {
 
 // WS normal connect/use/close: the subscription returns to 0 and the read-loop
 // goroutine exits.
+func TestWsSendAndPingReturnDispatcherResults(t *testing.T) {
+	srv := echoServer(t)
+	defer srv.Close()
+	tc := setupWsTest(t, 2)
+	defer tc.Close()
+	script := fmt.Sprintf(`
+		local conn = assert(websocket.connect(%q))
+		local ch = assert(conn:channel())
+		local ok, err = conn:send("hello")
+		assert(ok == true and err == nil, "send must report success")
+		local msg = ch:receive()
+		assert(msg.data == "hello")
+		ok, err = conn:ping()
+		assert(ok == true and err == nil, "ping must report success")
+		conn:close()
+		ok, err = conn:send("closed")
+		assert(ok == false and err ~= nil, "send must preserve dispatcher error")
+		ok, err = conn:ping()
+		assert(ok == false and err ~= nil, "ping must preserve dispatcher error")
+		return "ok"
+	`, wsURLOf(srv))
+	frameCtx, runPID := tc.frameCtxPID(t)
+	result, err := tc.scheduler.Execute(frameCtx, runPID, newWsProcess(t, script), "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Error, "script error: %v", result.Error)
+	require.NotNil(t, result.Value)
+	require.Equal(t, "ok", resultString(result.Value.Data()))
+}
+
 func TestLeak_WsConnectUseCloseReclaims(t *testing.T) {
 	srv := echoServer(t)
 	defer srv.Close()

--- a/runtime/lua/modules/websocket/spec.md
+++ b/runtime/lua/modules/websocket/spec.md
@@ -107,10 +107,10 @@ Returned by `websocket.connect()`.
 
 | Method | Signature | Returns | Notes |
 |--------|-----------|---------|-------|
-| send | (data: string, type?: integer) | - | Yields until sent. type: websocket.TEXT (1) or websocket.BINARY (2) |
+| send | (data: string, type?: integer) | boolean, error? | Yields until sent. type: websocket.TEXT (1) or websocket.BINARY (2) |
 | channel | () | channel | First call yields to subscribe, subsequent calls return same channel |
 | receive | () | channel | Alias for channel() |
-| ping | () | - | Yields until ping sent |
+| ping | () | boolean, error? | Yields until ping sent |
 | close | (code?: integer, reason?: string) | - | Yields until close sent. code default 1000 |
 
 #### client:send(data: string, type?: integer)
@@ -123,6 +123,8 @@ Sends a message to the server.
 | type | integer | no | 1 | websocket.TEXT (1) or websocket.BINARY (2) |
 
 **Yields:** until message sent
+
+**Returns:** `true, nil` on success; `false, error` if sending fails.
 
 ```lua
 client:send("Hello")
@@ -164,6 +166,8 @@ Alias for `client:channel()`. Provided for v1 API compatibility.
 Sends a ping to the server.
 
 **Yields:** until ping sent
+
+**Returns:** `true, nil` on success; `false, error` if the ping fails.
 
 ```lua
 client:ping()

--- a/runtime/lua/modules/websocket/yields.go
+++ b/runtime/lua/modules/websocket/yields.go
@@ -139,6 +139,13 @@ func (y *WsSendYield) ToCommand() dispatcher.Command {
 
 func (y *WsSendYield) Release() { ReleaseWsSendYield(y) }
 
+func (y *WsSendYield) HandleResult(l *lua.LState, _ any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LFalse, lua.NewLuaError(l, err.Error()).WithKind(lua.Internal).WithRetryable(false)}
+	}
+	return []lua.LValue{lua.LTrue, lua.LNil}
+}
+
 // WsSubscribeYield is yielded to start receiving messages on a channel.
 // This subscribes the channel to the topic and starts the dispatcher read loop.
 type WsSubscribeYield struct {
@@ -349,3 +356,10 @@ func (y *WsPingYield) ToCommand() dispatcher.Command {
 }
 
 func (y *WsPingYield) Release() { ReleaseWsPingYield(y) }
+
+func (y *WsPingYield) HandleResult(l *lua.LState, _ any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LFalse, lua.NewLuaError(l, err.Error()).WithKind(lua.Internal).WithRetryable(false)}
+	}
+	return []lua.LValue{lua.LTrue, lua.LNil}
+}


### PR DESCRIPTION
WebSocket `client:send()` and `client:ping()` yielded without a result handler, discarding dispatcher failures. Return `true, nil` on success and `false, err` on failure, and document the results.

Validation: WebSocket package tests with the race detector, including a real-server failure regression; full `make lint`.

Split from #639.
