### PR TITLE
Defer HTTP status commit until response output

### DIFF
--- a/api/service/http/context.go
+++ b/api/service/http/context.go
@@ -56,6 +56,7 @@ type RequestContext struct {
 	r               *http.Request
 	w               http.ResponseWriter
 	responseHandled bool
+	responseStatus  int
 }
 
 // GetRequestContext retrieves HTTP request context from FrameContext
@@ -154,6 +155,22 @@ func (h *RequestContext) ResponseWriter() http.ResponseWriter {
 	return h.w
 }
 
+// SetResponseStatus selects the final status without committing headers.
+// CommitResponseStatus must run before the body is written or the handler exits.
+func (h *RequestContext) SetResponseStatus(status int) {
+	h.responseStatus = status
+	h.MarkHandled()
+}
+
+// CommitResponseStatus writes a selected status once, preserving status-only
+// responses while allowing headers to be changed until the first write/flush.
+func (h *RequestContext) CommitResponseStatus() {
+	if h.responseStatus != 0 {
+		h.w.WriteHeader(h.responseStatus)
+		h.responseStatus = 0
+	}
+}
+
 // MarkHandled indicates that a response has been sent for this request.
 func (h *RequestContext) MarkHandled() {
 	h.responseHandled = true
@@ -177,6 +194,7 @@ func (h *RequestContext) SetResponseWriter(w http.ResponseWriter) {
 // ResetHandled resets the response handled flag (for pooling)
 func (h *RequestContext) ResetHandled() {
 	h.responseHandled = false
+	h.responseStatus = 0
 }
 
 // MiddlewareCreator is a function that creates a middleware handler from options

--- a/runtime/lua/modules/http/module_test.go
+++ b/runtime/lua/modules/http/module_test.go
@@ -610,6 +610,8 @@ func TestResponse_Basic(t *testing.T) {
 			res:set_status(http.STATUS.CREATED)
 		`)
 		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, recorder.Code, "status selection must not commit headers")
+		reqCtx.CommitResponseStatus()
 		assert.Equal(t, http.StatusCreated, recorder.Code)
 	})
 

--- a/runtime/lua/modules/http/response.go
+++ b/runtime/lua/modules/http/response.go
@@ -82,9 +82,11 @@ func responseSetStatus(l *lua.LState) int {
 		return 1
 	}
 	code := l.CheckInt(2)
-	res.writer.WriteHeader(code)
-	res.headersSent = true
-	res.rCtx.MarkHandled()
+	if code < 100 || code > 999 {
+		l.Push(lua.NewLuaError(l, "invalid HTTP status code").WithKind(lua.Invalid).WithRetryable(false))
+		return 1
+	}
+	res.rCtx.SetResponseStatus(code)
 	l.Push(lua.LNil)
 	return 1
 }
@@ -115,6 +117,8 @@ func responseWrite(l *lua.LState) int {
 		return 0
 	}
 	data := l.CheckString(2)
+	res.rCtx.CommitResponseStatus()
+	res.headersSent = true
 	_, err := res.writer.Write([]byte(data))
 	if err != nil {
 		luaErr := lua.WrapErrorWithLua(l, err, "write failed").
@@ -134,6 +138,7 @@ func responseFlush(l *lua.LState) int {
 	if res == nil {
 		return 0
 	}
+	res.rCtx.CommitResponseStatus()
 	if flusher, ok := res.writer.(interface{ Flush() }); ok {
 		flusher.Flush()
 	}
@@ -160,6 +165,8 @@ func responseWriteJSON(l *lua.LState) int {
 	if !res.headersSent {
 		res.writer.Header().Set("Content-Type", "application/json")
 	}
+	res.rCtx.CommitResponseStatus()
+	res.headersSent = true
 	_, err = res.writer.Write(data)
 	if err != nil {
 		luaErr := lua.WrapErrorWithLua(l, err, "write failed").
@@ -240,6 +247,8 @@ func responseWriteEvent(l *lua.LState) int {
 		return 1
 	}
 
+	res.rCtx.CommitResponseStatus()
+	res.headersSent = true
 	_, writeErr := fmt.Fprintf(res.writer, "event: %s\ndata: %s\n\n", name, data)
 	if writeErr != nil {
 		luaErr := lua.WrapErrorWithLua(l, writeErr, "write event failed").

--- a/runtime/lua/modules/http/response_status_test.go
+++ b/runtime/lua/modules/http/response_status_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	httpservice "github.com/wippyai/runtime/api/service/http"
+)
+
+func TestStatusBeforeHeadersAndBody(t *testing.T) {
+	for _, test := range []struct{ name, script, contentType string }{
+		{"text", `assert(res:set_content_type("text/plain") == nil); assert(res:write("body") == nil)`, "text/plain"},
+		{"json", `assert(res:write_json({ok = true}) == nil)`, "application/json"},
+		{"event", `assert(res:write_event({name = "test", data = {ok = true}}) == nil)`, "text/event-stream"},
+		{"flush", `assert(res:set_content_type("text/plain") == nil); assert(res:flush() == nil)`, "text/plain"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			l := lua.NewState()
+			defer l.Close()
+			bind(l)
+			ctx, frame := newTestContext()
+			recorder := httptest.NewRecorder()
+			reqCtx := httpservice.NewRequestContext(httptest.NewRequestWithContext(ctx, "GET", "/", nil), recorder)
+			require.NoError(t, frame.Set(httpservice.RequestKey(), reqCtx))
+			l.SetContext(ctx)
+			require.NoError(t, l.DoString(`
+				local res = http.response()
+				assert(res:set_status(202) == nil)
+				assert(res:set_status(201) == nil)
+				assert(res:set_header("X-Test", "present") == nil)
+			`+test.script+`
+				assert(res:set_status(200) ~= nil, "status must be fixed after commit")
+				assert(res:set_header("X-Late", "absent") ~= nil)
+			`))
+			// Result snapshots the actual transmitted headers, not the mutable map.
+			result := recorder.Result()
+			defer result.Body.Close()
+			require.Equal(t, http.StatusCreated, result.StatusCode)
+			require.Equal(t, "present", result.Header.Get("X-Test"))
+			require.Equal(t, test.contentType, result.Header.Get("Content-Type"))
+			require.Empty(t, result.Header.Get("X-Late"))
+		})
+	}
+}

--- a/runtime/lua/modules/http/spec.md
+++ b/runtime/lua/modules/http/spec.md
@@ -386,7 +386,8 @@ Returned by `http.response()`. Provides methods to build and send HTTP responses
 
 #### response:set_status(code: integer) → error
 
-Sets HTTP response status code.
+Selects the HTTP response status without sending headers. Headers are committed
+on the first write or flush, or when the handler returns without a body.
 
 | Param | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
@@ -399,6 +400,7 @@ Sets HTTP response status code.
 | Condition | Kind | Retryable |
 |-----------|------|-----------|
 | headers already sent | errors.INVALID | no |
+| code outside 100–999 | errors.INVALID | no |
 
 **Notes:**
 - Must be called before any write operations

--- a/service/http/factory.go
+++ b/service/http/factory.go
@@ -79,6 +79,8 @@ func (f *EndpointFactory) CreateHandler(_ context.Context, cfg *config.EndpointC
 		}
 
 		result, err := f.funcs.Call(execCtx, task)
+		// A handler may select a status without writing a body (e.g. 204).
+		rCtx.CommitResponseStatus()
 		if err != nil {
 			if !rCtx.ResponseHandled() {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/service/http/factory_test.go
+++ b/service/http/factory_test.go
@@ -209,6 +209,26 @@ func TestEndpointFactory_CreateHandler(t *testing.T) {
 		Func:   apiregistry.NewID("test", "func1"),
 	}
 
+	t.Run("status-only response retains late headers", func(t *testing.T) {
+		registry.Register(cfg.Func, func(ctx context.Context, _ runtime.Task) (*runtime.Result, error) {
+			rctx, ok := config.GetRequestContext(ctx)
+			require.True(t, ok)
+			rctx.SetResponseStatus(http.StatusNoContent)
+			rctx.ResponseWriter().Header().Set("X-After-Status", "present")
+			return &runtime.Result{}, nil
+		})
+		handler, err := factory.CreateHandler(context.Background(), cfg)
+		require.NoError(t, err)
+		ctx, _ := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequestWithContext(ctx, "GET", "/test", nil))
+		result := recorder.Result()
+		defer result.Body.Close()
+		require.Equal(t, http.StatusNoContent, result.StatusCode)
+		require.Equal(t, "present", result.Header.Get("X-After-Status"))
+		require.Empty(t, recorder.Body.String())
+	})
+
 	t.Run("successful handler creation", func(t *testing.T) {
 		ctx := ctxapi.NewRootContext()
 


### PR DESCRIPTION
`res:set_status()` wrote headers immediately, so later header changes were ignored. Store the selected status until body output or flush, and commit it at endpoint completion for status-only responses. No body buffering is added.

Validation: Lua HTTP and HTTP service package tests with the race detector, including header-after-status and status-only regressions; full `make lint`.

Split from #639.
