### PR TITLE
Declare HTTP client overlay_network option

### DIFF
--- a/runtime/lua/modules/httpclient/types.go
+++ b/runtime/lua/modules/httpclient/types.go
@@ -39,6 +39,7 @@ var requestOptionsType = typ.NewRecord().
 	OptField("body", typ.String).
 	OptField("timeout", typ.NewUnion(typ.Number, typ.String)).
 	OptField("unix_socket", typ.String).
+	OptField("overlay_network", typ.String).
 	OptField("query", typ.NewMap(typ.String, typ.String)).
 	OptField("cookies", typ.NewMap(typ.String, typ.String)).
 	OptField("form", typ.NewMap(typ.String, typ.String)).

--- a/runtime/lua/modules/httpclient/types_test.go
+++ b/runtime/lua/modules/httpclient/types_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package httpclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/go-lua/types/io"
+	"github.com/wippyai/runtime/runtime/lua/code"
+)
+
+func TestOverlayNetworkRequestOptionsTypecheck(t *testing.T) {
+	tc := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+	_, diagnostics, err := tc.Check(`
+local client = require("http_client")
+local function network(opts: client.RequestOptions): string?
+    return opts.overlay_network
+end
+local response, err = client.get("http://peer/", {overlay_network = "app:network"})
+local response2, err2 = client.request("POST", "http://peer/", {overlay_network = "app:network", body = "test"})
+`, "overlay_request.lua", map[string]*io.Manifest{"http_client": ModuleTypes()})
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "unexpected diagnostics: %v", diagnostics)
+}


### PR DESCRIPTION
Add the implemented `overlay_network` option to the HTTP client type manifest so typed Lua callers can select an overlay network.

Validation: HTTP module tests including a compiler regression; full `make lint`.

Split from #639. Runtime boot wiring is handled separately.
