### PR TITLE
Forward arguments to explicit run -x entries

### DIFF
--- a/cmd/wippy/cmd/exec_args_test.go
+++ b/cmd/wippy/cmd/exec_args_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExplicitExecForwardsPositionalArguments(t *testing.T) {
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.Mkdir("src", 0o755))
+	require.NoError(t, os.WriteFile("wippy.lock", []byte("directories:\n  src: ./src\n  modules: .wippy\n"), 0o600))
+	require.NoError(t, os.WriteFile("src/_index.yaml", []byte(`version: "1.0"
+namespace: app
+entries:
+  - name: terminal
+    kind: terminal.host
+    lifecycle:
+      auto_start: true
+  - name: explicit
+    kind: process.lua
+    method: main
+    source: |
+      return {main = function(a, b, c)
+        assert(a == "hello", "first argument lost")
+        assert(b == "file.wapp", "pack-like argument lost")
+        assert(c == "--flag", "flag argument lost")
+      end}
+`), 0o600))
+	setTestConfigFiles(t)
+	oldSilent := silentLogs
+	t.Cleanup(func() { silentLogs = oldSilent })
+	cmd := &cobra.Command{}
+	cmd.Flags().String("exec", "", "")
+	cmd.Flags().String("host", "", "")
+	cmd.Flags().String("registry", "", "")
+	require.NoError(t, cmd.ParseFlags([]string{"--exec", "app:explicit", "--", "hello", "file.wapp", "--flag"}))
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd.SetContext(ctx)
+	require.NoError(t, runWithUseCase(cmd, cmd.Flags().Args(), defaultUseCase))
+}

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -140,13 +140,6 @@ func runTest(cmd *cobra.Command, args []string) error {
 func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 	memLimit := initMemoryLimit()
 
-	var commandName string
-	var commandArgs []string
-	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
-		commandName = args[0]
-		commandArgs = args[1:]
-	}
-
 	execSpec := ""
 	execHost := ""
 	registryURL := ""
@@ -154,6 +147,14 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 		execSpec, _ = cmd.Flags().GetString("exec")
 		execHost, _ = cmd.Flags().GetString("host")
 		registryURL, _ = cmd.Flags().GetString("registry")
+	}
+
+	// With an explicit entry, every positional token belongs to that process.
+	var commandName string
+	var commandArgs []string
+	if execSpec == "" && len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		commandName = args[0]
+		commandArgs = args[1:]
 	}
 
 	if commandName != "" {


### PR DESCRIPTION
With `wippy run -x app:entry hello`, `hello` was interpreted as a command name. Explicit `-x` now takes precedence and all positional arguments go to the selected process, including `.wapp` tokens and arguments following `--`. Named-command behavior is unchanged.

Validation: Full CLI package tests, including a real process that asserts forwarded arguments; full `make lint`.
