### PR TITLE
Preserve Lua tostring semantics in print functions

### DIFF
--- a/runtime/lua/engine/core_modules.go
+++ b/runtime/lua/engine/core_modules.go
@@ -72,7 +72,7 @@ func printFunc(l *lua.LState) int {
 
 	parts := make([]string, l.GetTop())
 	for i := 1; i <= l.GetTop(); i++ {
-		parts[i-1] = l.ToString(i)
+		parts[i-1] = l.ToStringMeta(l.Get(i)).String()
 	}
 	msg := strings.Join(parts, " ")
 

--- a/runtime/lua/engine/print_values_test.go
+++ b/runtime/lua/engine/print_values_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/logs"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestPrintUsesLuaStringConversion(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	core, output := observer.New(zap.InfoLevel)
+	l.SetContext(logs.WithLogger(ctxapi.NewRootContext(), zap.New(core)))
+	LoadModuleDef(l, PrintModule)
+	require.NoError(t, l.DoString(`
+		local plain = {}
+		local custom = setmetatable({}, {__tostring = function() return "custom" end})
+		print(true, false, nil, 42, custom, "tail")
+		print(plain)
+		expected_plain = tostring(plain)
+	`))
+	require.Len(t, output.All(), 2)
+	require.Equal(t, "true false nil 42 custom tail", output.All()[0].Message)
+	require.Equal(t, l.GetGlobal("expected_plain").String(), output.All()[1].Message)
+	require.ErrorContains(t, l.DoString(`print(setmetatable({}, {__tostring = function() error("conversion failed") end}))`), "conversion failed")
+}

--- a/runtime/lua/modules/io/module.go
+++ b/runtime/lua/modules/io/module.go
@@ -48,7 +48,7 @@ func ioWrite(l *lua.LState) int {
 
 	n := l.GetTop()
 	for i := 1; i <= n; i++ {
-		s := l.ToString(i)
+		s := l.ToStringMeta(l.Get(i)).String()
 		_, err := tc.Stdout.Write([]byte(s))
 		if err != nil {
 			l.Push(lua.LNil)
@@ -79,7 +79,7 @@ func ioPrint(l *lua.LState) int {
 		if i > 1 {
 			_, _ = tc.Stdout.Write([]byte("\t"))
 		}
-		s := l.ToString(i)
+		s := l.ToStringMeta(l.Get(i)).String()
 		_, _ = tc.Stdout.Write([]byte(s))
 	}
 	_, _ = tc.Stdout.Write([]byte("\n"))
@@ -105,7 +105,7 @@ func ioEprint(l *lua.LState) int {
 		if i > 1 {
 			_, _ = tc.Stderr.Write([]byte("\t"))
 		}
-		s := l.ToString(i)
+		s := l.ToStringMeta(l.Get(i)).String()
 		_, _ = tc.Stderr.Write([]byte(s))
 	}
 	_, _ = tc.Stderr.Write([]byte("\n"))

--- a/runtime/lua/modules/io/module.go
+++ b/runtime/lua/modules/io/module.go
@@ -48,7 +48,7 @@ func ioWrite(l *lua.LState) int {
 
 	n := l.GetTop()
 	for i := 1; i <= n; i++ {
-		s := l.ToStringMeta(l.Get(i)).String()
+		s := l.ToString(i)
 		_, err := tc.Stdout.Write([]byte(s))
 		if err != nil {
 			l.Push(lua.LNil)

--- a/runtime/lua/modules/io/print_values_test.go
+++ b/runtime/lua/modules/io/print_values_test.go
@@ -28,3 +28,18 @@ func TestPrintValuesUseLuaConversion(t *testing.T) {
 	require.Equal(t, "true\tfalse\tnil\t42\tcustom\ttail\n", stdout.String())
 	require.Equal(t, stdout.String(), stderr.String())
 }
+
+func TestWriteRetainsExistingConversion(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindIO(l)
+	var stdout bytes.Buffer
+	ctx, _ := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+	require.NoError(t, terminal.WithTerminalContext(ctx, terminal.NewTerminalContext(nil, &stdout, nil)))
+	l.SetContext(ctx)
+	require.NoError(t, l.DoString(`
+		local custom = setmetatable({}, {__tostring = function() error("must not run") end})
+		assert(io.write("head", 42, true, nil, custom, "tail"))
+	`))
+	require.Equal(t, "head42tail", stdout.String())
+}

--- a/runtime/lua/modules/io/print_values_test.go
+++ b/runtime/lua/modules/io/print_values_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package io
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/service/terminal"
+)
+
+func TestPrintValuesUseLuaConversion(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindIO(l)
+	var stdout, stderr bytes.Buffer
+	ctx, _ := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+	require.NoError(t, terminal.WithTerminalContext(ctx, terminal.NewTerminalContext(nil, &stdout, &stderr)))
+	l.SetContext(ctx)
+	require.NoError(t, l.DoString(`
+		local custom = setmetatable({}, {__tostring = function() return "custom" end})
+		assert(io.print(true, false, nil, 42, custom, "tail"))
+		assert(io.eprint(true, false, nil, 42, custom, "tail"))
+	`))
+	require.Equal(t, "true\tfalse\tnil\t42\tcustom\ttail\n", stdout.String())
+	require.Equal(t, stdout.String(), stderr.String())
+}


### PR DESCRIPTION
Lua `print`, `io.print`, and `io.eprint` silently omitted booleans, nil, and tables. Convert their arguments using the same `ToStringMeta` path as native Lua `tostring`, preserving custom `__tostring`, existing separators, and logger/stdout/stderr routing.

`io.write` retains its existing conversion behavior, including not invoking `__tostring`. A regression guards that boundary.

Validation: targeted engine and IO regressions passed with the race detector, including print values, metamethod output/error propagation, and unchanged `io.write` conversion. The new head triggers CI and renewed review.
