### PR TITLE
Identify dependencies missing a controlling version

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1285,6 +1285,16 @@ func foldRootDependencyComponents(deps []desiredDependency, fresh map[string]str
 		if !elected {
 			controller = group[0]
 		}
+		if strict && controller.definition.Version == "" {
+			return nil, nil, apierror.New(apierror.Invalid, fmt.Sprintf(
+				"dependency %s (%s) requires a version; specify a version constraint or explicit '*'",
+				controller.entry.ID.String(), component,
+			)).WithDetails(attrs.NewBagFrom(map[string]any{
+				"entry_id":  controller.entry.ID.String(),
+				"component": component,
+				"field":     "version",
+			}))
+		}
 
 		for _, dep := range group {
 			if idsEqual(dep.entry.ID, controller.entry.ID) {

--- a/boot/deps/hub/dependency_version_diagnostics_test.go
+++ b/boot/deps/hub/dependency_version_diagnostics_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	regapi "github.com/wippyai/runtime/api/registry"
+)
+
+func TestMissingControllingDependencyVersionNamesEntry(t *testing.T) {
+	root := desiredDependency{
+		entry:      regapi.Entry{ID: regapi.NewID("app", "core")},
+		definition: DependencyDefinition{Component: "acme/core"},
+	}
+	_, _, err := foldRootDependencyComponents([]desiredDependency{root}, nil, true)
+	require.ErrorContains(t, err, "app:core")
+	require.ErrorContains(t, err, "acme/core")
+	require.ErrorContains(t, err, "version")
+	root.definition.Version = "*"
+	roots, references, err := foldRootDependencyComponents([]desiredDependency{root}, nil, true)
+	require.NoError(t, err)
+	require.Len(t, roots, 1)
+	require.Empty(t, references)
+}
+
+func TestUnversionedFoldedReferenceStillAllowed(t *testing.T) {
+	root := desiredDependency{entry: regapi.Entry{ID: regapi.NewID("app", "a")}, definition: DependencyDefinition{Component: "acme/core", Version: "1.0.0"}}
+	reference := desiredDependency{entry: regapi.Entry{ID: regapi.NewID("app", "b")}, definition: DependencyDefinition{Component: "acme/core"}}
+	roots, references, err := foldRootDependencyComponents([]desiredDependency{reference, root}, nil, true)
+	require.NoError(t, err)
+	require.Len(t, roots, 1)
+	require.Equal(t, "1.0.0", roots[0].definition.Version)
+	require.Len(t, references, 1)
+	require.Equal(t, "*", references[0].definition.Version)
+}


### PR DESCRIPTION
A controlling `ns.dependency` without a version eventually failed with an unnamed invalid-resolution error. During new dependency expansion, report the controlling entry ID, component, and missing version, with guidance to supply a constraint or explicit `*`. Preserve reference wildcard normalization and existing-lock replay behavior.

Validation: Full dependency handler suite, including missing-version, wildcard, folded-reference, and lock-replay regressions; full `make lint`.
