### PR TITLE
Resolve HTTP overlay registry after boot installation

### DIFF
--- a/service/http/client/handler.go
+++ b/service/http/client/handler.go
@@ -98,9 +98,19 @@ func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispat
 	register(httpapi.RequestBatch, dispatcher.HandlerFunc(d.handleRequestBatch))
 }
 
+// An embedded dispatcher can supply its own registry. Otherwise resolve from
+// the completed application context: the network component may load after the
+// HTTP dispatcher is constructed. Do not cache a missing registry at boot.
+func (d *Dispatcher) requestNetworkRegistry(ctx context.Context) netapi.NetworkRegistry {
+	if d.networkReg != nil {
+		return d.networkReg
+	}
+	return netapi.GetNetworkRegistry(ctx)
+}
+
 func (d *Dispatcher) handleRequest(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
 	req := cmd.(*httpapi.RequestCmd)
-	networkReg := d.networkReg
+	networkReg := d.requestNetworkRegistry(ctx)
 
 	go func() {
 		result := executeRequest(ctx, d.pool, networkReg, req, true)
@@ -114,7 +124,7 @@ func (d *Dispatcher) handleRequest(ctx context.Context, cmd dispatcher.Command, 
 
 func (d *Dispatcher) handleRequestBatch(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
 	batch := cmd.(*httpapi.RequestBatchCmd)
-	networkReg := d.networkReg
+	networkReg := d.requestNetworkRegistry(ctx)
 
 	if len(batch.Requests) == 0 {
 		receiver.CompleteYield(tag, httpapi.BatchResponse{Responses: []httpapi.Response{}}, nil)

--- a/service/http/client/handler_overlay_test.go
+++ b/service/http/client/handler_overlay_test.go
@@ -845,3 +845,51 @@ func TestHandler_OverlayHostnamePassesThrough(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+// The HTTP dispatcher is constructed before the network boot component installs
+// its registry. Requests must observe that later installation.
+func TestHandler_LateNetworkRegistry(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("batch=%t", batch), func(t *testing.T) {
+			ctx := overlayTestCtx()
+			d := NewDispatcher(WithNetworkRegistry(netapi.GetNetworkRegistry(ctx)))
+			defer d.pool.Close()
+			ts := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+				_, _ = w.Write([]byte("late-overlay"))
+			}))
+			defer ts.Close()
+			svc := &recordingService{}
+			reg := newMockNetworkRegistry()
+			reg.register("network:late", svc, netapi.KindSOCKS5)
+			netapi.WithNetworkRegistry(ctx, reg)
+			request := &httpapi.RequestCmd{Method: "GET", URL: ts.URL, OverlayNetwork: "network:late"}
+			done := make(chan httpapi.Response, 1)
+			if batch {
+				require.NoError(t, d.handleRequestBatch(ctx, &httpapi.RequestBatchCmd{Requests: []*httpapi.RequestCmd{request}}, 0, &testReceiver{fn: func(data any) {
+					done <- data.(httpapi.BatchResponse).Responses[0]
+				}}))
+			} else {
+				require.NoError(t, d.handleRequest(ctx, request, 0, &testReceiver{fn: func(data any) {
+					done <- data.(httpapi.Response)
+				}}))
+			}
+			select {
+			case response := <-done:
+				require.Empty(t, response.Error)
+				require.Equal(t, "late-overlay", string(response.Body))
+				require.Positive(t, svc.dialCount())
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for overlay response")
+			}
+		})
+	}
+}
+
+func TestHandler_ExplicitNetworkRegistryTakesPrecedence(t *testing.T) {
+	ctx := overlayTestCtx()
+	explicit := newMockNetworkRegistry()
+	netapi.WithNetworkRegistry(ctx, newMockNetworkRegistry())
+	d := NewDispatcher(WithNetworkRegistry(explicit))
+	defer d.pool.Close()
+	require.Same(t, explicit, d.requestNetworkRegistry(ctx))
+}


### PR DESCRIPTION
The HTTP dispatcher captured the network registry before the network component installed it, leaving configured overlay requests unable to find a registry. When no registry was explicitly injected, resolve it from the request context for both single and batch requests. Explicit injection retains precedence; missing overlays still fail without clearnet fallback.

Validation: Full HTTP client suite with the race detector, including registry installation after dispatcher construction for single and batch requests; full `make lint`. No new mandatory boot dependency or mutable dispatcher registry is introduced.
