### PR TITLE
Restore SQLite transaction serialization with separate CDC snapshot readers

### DIFF
--- a/service/sql/engine/sqlite/concurrency_test.go
+++ b/service/sql/engine/sqlite/concurrency_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	config "github.com/wippyai/runtime/api/service/sql"
+)
+
+func TestApplicationReadWriteTransactionSerializesCompetingWriter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cfg := &config.SQLiteConfig{File: filepath.Join(t.TempDir(), "app.db"), Pool: config.PoolConfig{MaxOpen: 8, MaxIdle: 8, MaxLifetime: time.Hour}}
+	opened, err := (engine{}).Open(ctx, cfg)
+	require.NoError(t, err)
+	defer opened.DB.Close()
+	if opened.Observer != nil {
+		defer opened.Observer.Close()
+	}
+	(engine{}).Tune(opened.DB, cfg)
+	require.NoError(t, (engine{}).Prepare(ctx, opened.DB, cfg))
+	_, err = opened.DB.ExecContext(ctx, "CREATE TABLE counts(id INTEGER PRIMARY KEY, n INTEGER); INSERT INTO counts VALUES(1,0)")
+	require.NoError(t, err)
+	tx, err := opened.DB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	var n int
+	require.NoError(t, tx.QueryRowContext(ctx, "SELECT n FROM counts WHERE id=1").Scan(&n))
+	done := make(chan error, 1)
+	go func() { _, err := opened.DB.ExecContext(ctx, "UPDATE counts SET n=n+1 WHERE id=1"); done <- err }()
+	// The competing operation must enter database/sql's connection wait queue,
+	// rather than commit against the first transaction's established read view.
+	require.Eventually(t, func() bool { return opened.DB.Stats().WaitCount > 0 }, time.Second, time.Millisecond, "competing writer escaped application transaction serialization")
+	_, err = tx.ExecContext(ctx, "UPDATE counts SET n=? WHERE id=1", n+1)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.NoError(t, <-done)
+	require.NoError(t, opened.DB.QueryRowContext(ctx, "SELECT n FROM counts WHERE id=1").Scan(&n))
+	require.Equal(t, 2, n)
+}

--- a/service/sql/engine/sqlite/observer.go
+++ b/service/sql/engine/sqlite/observer.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,6 +49,11 @@ func (c *sqliteConnector) Connect(context.Context) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Snapshot connections share driver configuration but do not participate
+	// in mutation observation: their DSN enforces read-only access.
+	if c.backend == nil {
+		return raw, nil
+	}
 	sqliteConn, ok := raw.(*sqlite3.SQLiteConn)
 	if !ok {
 		_ = raw.Close()
@@ -83,6 +89,26 @@ func openSQLite(_ context.Context, dsn string, limits ...int) (*sql.DB, sqlapi.C
 	}
 	db := sql.OpenDB(connector)
 	backend.db = db
+	if dsn != ":memory:" {
+		readDSN, err := url.Parse(dsn)
+		if err != nil {
+			_ = backend.Close()
+			_ = db.Close()
+			return nil, nil, err
+		}
+		params := readDSN.Query()
+		if params.Get("mode") != "memory" {
+			params.Set("mode", "ro")
+			readDSN.RawQuery = params.Encode()
+			readDB := sql.OpenDB(&sqliteConnector{driver: connector.driver, dsn: readDSN.String()})
+			// One scan at a time bounds snapshot connections independently of
+			// the application's single writer. Opening remains lazy until CDC
+			// requests a snapshot; ordinary SQL adds no physical connection.
+			readDB.SetMaxOpenConns(1)
+			readDB.SetMaxIdleConns(1)
+			backend.snapshotDB = readDB
+		}
+	}
 	return db, backend, nil
 }
 
@@ -91,6 +117,7 @@ type sqliteBackend struct {
 	streams      map[*mutationStream]struct{}
 	fence        chan struct{}
 	db           *sql.DB
+	snapshotDB   *sql.DB
 	relayDone    chan struct{}
 	relayQueue   []*backendBatch
 	maxChanges   int
@@ -349,6 +376,9 @@ func (b *sqliteBackend) Close() error {
 	b.mu.Unlock()
 
 	b.closeStreams(streams, errObserverClosed)
+	if b.snapshotDB != nil {
+		_ = b.snapshotDB.Close()
+	}
 	b.signalRelay()
 	<-b.relayDone
 	return nil

--- a/service/sql/engine/sqlite/observer_test.go
+++ b/service/sql/engine/sqlite/observer_test.go
@@ -6,6 +6,7 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -156,6 +157,9 @@ func TestPerPoolSnapshotLiveIsolation(t *testing.T) {
 
 	_, err = first.opened.DB.ExecContext(context.Background(), `INSERT INTO items (id, value) VALUES (4, 'first-overflow')`)
 	require.NoError(t, err)
+	// Publication is asynchronous. Wait for overflow before consuming, or the
+	// receive itself can free capacity before the queued second batch arrives.
+	require.Eventually(t, func() bool { return errors.Is(firstBackpressured.Err(), errObserverOverflow) }, time.Second, time.Millisecond)
 	select {
 	case _, ok := <-firstBackpressured.Changes():
 		require.False(t, ok)
@@ -390,7 +394,7 @@ func TestObserverSnapshotHandoffIncludesInFlightWriterAsLive(t *testing.T) {
 	observed, err := openObservedDB(t, filepath.Join(t.TempDir(), "snapshot-inflight.db"))
 	require.NoError(t, err)
 	defer observed.Close()
-	assert.Equal(t, 0, observed.opened.DB.Stats().MaxOpenConnections, "file-backed SQLite should retain the default unlimited pool")
+	assert.Equal(t, 1, observed.opened.DB.Stats().MaxOpenConnections, "snapshots must leave the single application writer available")
 	_, err = observed.opened.DB.ExecContext(context.Background(), `CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)`)
 	require.NoError(t, err)
 	tx, err := observed.opened.DB.BeginTx(context.Background(), nil)

--- a/service/sql/engine/sqlite/snapshot.go
+++ b/service/sql/engine/sqlite/snapshot.go
@@ -24,7 +24,10 @@ func (b *sqliteBackend) Snapshot(ctx context.Context, opts sqlapi.SnapshotOption
 	}
 	b.mu.Lock()
 	closed := b.closed
-	db := b.db
+	db := b.snapshotDB
+	if db == nil {
+		db = b.db
+	}
 	b.mu.Unlock()
 	if closed {
 		return nil, errObserverClosed
@@ -32,7 +35,8 @@ func (b *sqliteBackend) Snapshot(ctx context.Context, opts sqlapi.SnapshotOption
 	if db == nil {
 		return nil, errors.New("sqlite snapshot has no database")
 	}
-	// Reserve the physical connection before taking the fence. SQL pools may
+	// File snapshots use a separate read-only pool to leave the application
+	// writer available. Reserve its connection before taking the fence. SQL pools may
 	// have a single connection; taking the fence first would let a writer hold
 	// that connection while waiting for the snapshot and deadlock both paths.
 	conn, err := db.Conn(ctx)

--- a/service/sql/engine/sqlite/snapshot_pool_test.go
+++ b/service/sql/engine/sqlite/snapshot_pool_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+//go:build sqlite_preupdate_hook
+
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sqlapi "github.com/wippyai/runtime/api/service/sql"
+)
+
+func TestSnapshotPoolIsReadOnlyAndLazy(t *testing.T) {
+	o, err := openObservedDB(t, filepath.Join(t.TempDir(), "app.db"))
+	require.NoError(t, err)
+	defer o.Close()
+	b := o.opened.Observer.(*sqliteBackend)
+	require.NotNil(t, b.snapshotDB)
+	require.Zero(t, b.snapshotDB.Stats().OpenConnections)
+	ctx := context.Background()
+	_, err = o.opened.DB.ExecContext(ctx, "CREATE TABLE items(id INTEGER)")
+	require.NoError(t, err)
+	require.Zero(t, b.snapshotDB.Stats().OpenConnections, "ordinary SQL must not open snapshot connections")
+	_, err = b.snapshotDB.ExecContext(ctx, "INSERT INTO items VALUES(1)")
+	require.ErrorContains(t, err, "readonly")
+	require.NoError(t, b.Close())
+	require.Error(t, b.snapshotDB.PingContext(ctx))
+}
+
+func TestSnapshotConnectionWaitDoesNotBlockWriterAndCancels(t *testing.T) {
+	o, err := openObservedDB(t, filepath.Join(t.TempDir(), "app.db"))
+	require.NoError(t, err)
+	defer o.Close()
+	b := o.opened.Observer.(*sqliteBackend)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err = o.opened.DB.ExecContext(ctx, "CREATE TABLE items(id INTEGER)")
+	require.NoError(t, err)
+	held, err := b.snapshotDB.Conn(ctx)
+	require.NoError(t, err)
+	defer held.Close()
+	waitCtx, stop := context.WithCancel(ctx)
+	defer stop()
+	done := make(chan error, 1)
+	go func() {
+		s, err := b.Snapshot(waitCtx, sqlapi.SnapshotOptions{})
+		if s != nil {
+			_ = s.Close()
+		}
+		done <- err
+	}()
+	require.Eventually(t, func() bool { return b.snapshotDB.Stats().WaitCount > 0 }, time.Second, time.Millisecond)
+	_, err = o.opened.DB.ExecContext(ctx, "INSERT INTO items VALUES(1)")
+	require.NoError(t, err, "snapshot admission must not hold the commit fence")
+	stop()
+	require.ErrorIs(t, <-done, context.Canceled)
+}

--- a/service/sql/engine/sqlite/sqlite.go
+++ b/service/sql/engine/sqlite/sqlite.go
@@ -96,17 +96,12 @@ func (engine) Tune(db *sql.DB, ec config.EngineConfig) {
 		return
 	}
 
-	// A private in-memory database is scoped to one physical connection, so
-	// sharing it across a pool would create multiple unrelated databases. File
-	// databases, however, need the configured pool width so a snapshot read
-	// transaction does not consume the only writer connection.
-	if cfg.File == ":memory:" {
-		db.SetMaxOpenConns(1)
-		db.SetMaxIdleConns(1)
-	} else {
-		db.SetMaxOpenConns(cfg.Pool.MaxOpen)
-		db.SetMaxIdleConns(cfg.Pool.MaxIdle)
-	}
+	// Serialize application operations for the full lifetime of a transaction.
+	// Multiple deferred read/write transactions can otherwise fail to upgrade
+	// their WAL snapshot even with a busy timeout. CDC snapshots own a separate
+	// read-only pool and must not widen this application pool.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	db.SetConnMaxLifetime(cfg.Pool.MaxLifetime)
 }
 

--- a/service/sql/engine/sqlite/sqlite_test.go
+++ b/service/sql/engine/sqlite/sqlite_test.go
@@ -70,7 +70,7 @@ func TestTuneSingleWriter(t *testing.T) {
 	assert.Equal(t, 1, db.Stats().MaxOpenConnections)
 }
 
-func TestTuneHonorsFilePoolWidth(t *testing.T) {
+func TestTunePreservesSingleApplicationConnection(t *testing.T) {
 	db, err := sql.Open("sqlite3", "file:test-tune-pool?mode=memory&cache=shared")
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
@@ -79,7 +79,7 @@ func TestTuneHonorsFilePoolWidth(t *testing.T) {
 		File: filepath.Join(t.TempDir(), "tune.db"),
 		Pool: config.PoolConfig{MaxOpen: 4, MaxIdle: 3, MaxLifetime: time.Hour},
 	})
-	assert.Equal(t, 4, db.Stats().MaxOpenConnections)
+	assert.Equal(t, 1, db.Stats().MaxOpenConnections)
 }
 
 func TestValidateConfigType(t *testing.T) {


### PR DESCRIPTION
PR #351 widened file-backed SQLite application pools from one connection to the configured width (unlimited by default). This changed transaction semantics even without CDC: deferred transactions could read a WAL snapshot, race another writer, and fail when upgrading to a write. The rqlite driver already has a five-second busy timeout; that does not resolve `SQLITE_BUSY_SNAPSHOT`.

Restore one application connection, held for the whole transaction, as before #351. Give file-backed CDC snapshots a separate, lazily opened read-only pool with one connection. Its connector belongs to the same pool generation, carries no mutation hooks, and closes with the observer. Snapshot admission acquires the reader before the commit fence, preserving snapshot-to-live ordering without consuming the application writer. Private in-memory databases retain their existing single-connection path.

Validation:
- Added a no-CDC transaction regression: a competing writer must wait until the read/write transaction commits; both updates remain visible. It fails on the previous implementation.
- Added read-only/lazy snapshot-pool, cancellation, and writer-progress checks. Existing concurrent snapshot-to-live and in-flight-writer coverage passes with the restored application limit.
- SQL suites pass both without hooks and with `sqlite_preupdate_hook` under the race detector; SQLite CDC suite and full lint pass.
- Booted Hub `kickside/kickside@0.1.131` with fresh databases. The baseline failed in Keeper reconciliation with `Edge insert failed: database is locked`. The fix completes all 8 bootloaders and 96 reconciliation batches (9,515 commands, 2,956 entries, zero failures); the homepage responds HTTP 200.

The existing overflow test now waits for asynchronous overflow processing before receiving from its stream; receiving immediately could itself free capacity and invalidate the test's expectation.
