### PR TITLE
fix(terminal): translate wheel to cursor keys under alternate scroll

### DIFF
--- a/service/terminal/proxy/input.go
+++ b/service/terminal/proxy/input.go
@@ -13,13 +13,27 @@ import (
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
 
+// modeAlternateScroll is xterm's alternate scroll mode; the vendored ansi
+// package defines no constant for it.
+const modeAlternateScroll = ansi.DECMode(1007)
+
+// xterm delivers three cursor key presses per wheel notch under alternate scroll.
+const alternateScrollLines = 3
+
 type inputState struct {
 	keyboard       keyboardState
 	appCursor      atomic.Bool
+	altScreen      atomic.Bool
+	altScroll      atomic.Bool
 	bracketedPaste atomic.Bool
 	focusEvents    atomic.Bool
 	mouseEnabled   atomic.Bool
 	mouseSGR       atomic.Bool
+}
+
+// init applies the power-on mode defaults that differ from the zero value.
+func (s *inputState) init() {
+	s.altScroll.Store(true)
 }
 
 func (p *Proxy) handle(event ttyapi.Event) error {
@@ -138,7 +152,7 @@ func modifier(event ttyapi.Event) int {
 
 func (s *inputState) mouse(event ttyapi.Event) string {
 	if !s.mouseEnabled.Load() {
-		return ""
+		return s.alternateScroll(event)
 	}
 	button, ok := mouseButtons[event.Button]
 	if !ok {
@@ -155,6 +169,30 @@ func (s *inputState) mouse(event ttyapi.Event) string {
 	return ansi.MouseX10(encoded, x, y)
 }
 
+// alternateScroll implements xterm's DECSET 1007: while the alternate screen
+// buffer is active and mouse tracking is off, a wheel notch reaches the child
+// as cursor key presses. On the main screen the wheel belongs to the host
+// terminal's own scrollback.
+func (s *inputState) alternateScroll(event ttyapi.Event) string {
+	if !s.altScreen.Load() || !s.altScroll.Load() {
+		return ""
+	}
+	var name string
+	switch event.Button {
+	case "wheel_up":
+		name = "up"
+	case "wheel_down":
+		name = "down"
+	default:
+		return ""
+	}
+	prefix := "\x1b["
+	if s.appCursor.Load() {
+		prefix = "\x1bO"
+	}
+	return strings.Repeat(prefix+cursorKeys[name], alternateScrollLines)
+}
+
 var mouseButtons = map[string]ansi.MouseButton{
 	"none": ansi.MouseNone, "left": ansi.MouseLeft, "middle": ansi.MouseMiddle,
 	"right": ansi.MouseRight, "wheel_up": ansi.MouseWheelUp, "wheel_down": ansi.MouseWheelDown,
@@ -166,6 +204,10 @@ func (s *inputState) set(mode ansi.Mode, enabled bool) {
 	switch mode {
 	case ansi.ModeCursorKeys:
 		s.appCursor.Store(enabled)
+	case ansi.ModeAltScreen, ansi.ModeAltScreenSaveCursor:
+		s.altScreen.Store(enabled)
+	case modeAlternateScroll:
+		s.altScroll.Store(enabled)
 	case ansi.ModeBracketedPaste:
 		s.bracketedPaste.Store(enabled)
 	case ansi.ModeFocusEvent:

--- a/service/terminal/proxy/input_test.go
+++ b/service/terminal/proxy/input_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package proxy
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func wheel(button string) ttyapi.Event {
+	return ttyapi.Event{Type: "mouse", Action: "wheel", Button: button, X: 3, Y: 4}
+}
+
+func newTestInputState() *inputState {
+	state := &inputState{}
+	state.init()
+	return state
+}
+
+func TestAlternateScrollSendsCursorKeysOnAltScreen(t *testing.T) {
+	for _, mode := range []ansi.Mode{ansi.ModeAltScreen, ansi.ModeAltScreenSaveCursor} {
+		state := newTestInputState()
+		state.enable(mode)
+		require.Equal(t, "\x1b[A\x1b[A\x1b[A", state.mouse(wheel("wheel_up")))
+		require.Equal(t, "\x1b[B\x1b[B\x1b[B", state.mouse(wheel("wheel_down")))
+	}
+}
+
+func TestAlternateScrollUsesApplicationCursorKeys(t *testing.T) {
+	state := newTestInputState()
+	state.enable(ansi.ModeAltScreenSaveCursor)
+	state.enable(ansi.ModeCursorKeys)
+	require.Equal(t, "\x1bOA\x1bOA\x1bOA", state.mouse(wheel("wheel_up")))
+	require.Equal(t, "\x1bOB\x1bOB\x1bOB", state.mouse(wheel("wheel_down")))
+}
+
+func TestAlternateScrollIgnoresWheelOnMainScreen(t *testing.T) {
+	state := newTestInputState()
+	require.Empty(t, state.mouse(wheel("wheel_up")))
+	require.Empty(t, state.mouse(wheel("wheel_down")))
+}
+
+func TestAlternateScrollDisabledIgnoresWheel(t *testing.T) {
+	state := newTestInputState()
+	state.enable(ansi.ModeAltScreenSaveCursor)
+	state.disable(modeAlternateScroll)
+	require.Empty(t, state.mouse(wheel("wheel_up")))
+	state.enable(modeAlternateScroll)
+	require.Equal(t, "\x1b[A\x1b[A\x1b[A", state.mouse(wheel("wheel_up")))
+}
+
+func TestAlternateScrollYieldsToMouseTracking(t *testing.T) {
+	state := newTestInputState()
+	state.enable(ansi.ModeAltScreenSaveCursor)
+	state.enable(ansi.ModeMouseNormal)
+	require.Equal(t, ansi.MouseX10(ansi.EncodeMouseButton(ansi.MouseWheelUp, false, false, false, false), 2, 3),
+		state.mouse(wheel("wheel_up")))
+	state.enable(ansi.ModeMouseExtSgr)
+	require.Equal(t, ansi.MouseSgr(ansi.EncodeMouseButton(ansi.MouseWheelDown, false, false, false, false), 2, 3, false),
+		state.mouse(wheel("wheel_down")))
+}
+
+func TestAlternateScrollStopsAfterLeavingAltScreen(t *testing.T) {
+	state := newTestInputState()
+	state.enable(ansi.ModeAltScreenSaveCursor)
+	require.Equal(t, "\x1b[A\x1b[A\x1b[A", state.mouse(wheel("wheel_up")))
+	state.disable(ansi.ModeAltScreenSaveCursor)
+	require.Empty(t, state.mouse(wheel("wheel_up")))
+}
+
+func TestProxyTranslatesWheelUnderAlternateScroll(t *testing.T) {
+	process := &testProcess{stdout: io.NopCloser(strings.NewReader("")), input: make(chan []byte, 1)}
+	proxy, err := New(process, &testSurface{}, 10, 2)
+	require.NoError(t, err)
+	_, err = proxy.screen.Write([]byte(ansi.SetModeAltScreenSaveCursor))
+	require.NoError(t, err)
+	require.NoError(t, proxy.handle(wheel("wheel_down")))
+	require.Equal(t, "\x1b[B\x1b[B\x1b[B", string(<-process.input))
+}

--- a/service/terminal/proxy/proxy.go
+++ b/service/terminal/proxy/proxy.go
@@ -101,6 +101,7 @@ func New(process execapi.PTYProcess, surface ttyapi.Surface, width, height int) 
 	p.screen.SetScrollbackSize(retainedScrollbackLines)
 	p.height.Store(int64(height))
 	p.cursorVisible.Store(true)
+	p.input.init()
 	p.screen.SetCallbacks(vt.Callbacks{
 		EnableMode: p.input.enable, DisableMode: p.input.disable,
 		CursorVisibility: p.cursorVisible.Store,


### PR DESCRIPTION
## Problem

`inputState.mouse()` in `service/terminal/proxy` returned nothing while the child program had no mouse tracking mode enabled, so mouse wheel events from the physical terminal were dropped. Scrolling with the wheel inside a PTY-hosted TUI running in the alternate screen (coding agent CLIs, pagers) did nothing, while every mainstream terminal emulator delivers those notches as cursor keys through xterm alternate scroll (DECSET 1007, enabled by default).

## Fix

- Track the alternate screen (DECSET/DECRST 1047 and 1049) and alternate scroll mode 1007 (default on) in `inputState`; `x/vt` already routes every mode change through the proxy's `EnableMode`/`DisableMode` callbacks.
- When the alternate screen is active, mouse tracking is off, and 1007 is set, a wheel notch becomes three `CSI A`/`CSI B` sequences (`SS3 A`/`SS3 B` under application cursor keys).
- Main screen, mouse tracking on, and 1007 reset keep the previous behaviour.

## Tests

`service/terminal/proxy/input_test.go`: alt screen via 1047 and 1049, application cursor keys, main screen ignored, 1007 reset ignored, mouse tracking precedence (X10 and SGR encodings unchanged), leaving the alt screen, and an end-to-end proxy test where a wheel event reaches the child's stdin after the emulator sees DECSET 1049.

```
ok  github.com/wippyai/runtime/service/terminal        10.0s
ok  github.com/wippyai/runtime/service/terminal/proxy  0.27s
```

https://claude.ai/code/session_01JmcTyjTTagQC6pnQ1WxEAw
