### PR TITLE
fix(scheduler): keep workers alive while shutdown drains

### DIFF
--- a/system/scheduler/actor/resize_test.go
+++ b/system/scheduler/actor/resize_test.go
@@ -142,7 +142,7 @@ func TestSchedulerResizeRejectsWhileStopping(t *testing.T) {
 		sched.Stop(ctx)
 		close(stopDone)
 	}()
-	waitFor(t, func() bool { return sched.stopping.Load() })
+	waitFor(t, func() bool { return sched.isStopping() })
 
 	started := time.Now()
 	if err := sched.ResizeWorkers(2); !errors.Is(err, process.ErrSchedulerStopping) {

--- a/system/scheduler/actor/scheduler.go
+++ b/system/scheduler/actor/scheduler.go
@@ -23,6 +23,15 @@ import (
 	"github.com/wippyai/runtime/system/scheduler/affinity"
 )
 
+// The scheduler phase is monotonic. Draining closes admission but keeps workers
+// alive for asynchronous cancellation/cleanup yields. Worker exit is permitted
+// only after the process set drains or its shutdown deadline expires.
+const (
+	phaseRunning uint32 = iota
+	phaseDraining
+	phaseStoppingWorkers
+)
+
 type Option func(*Scheduler)
 
 var errNilPackage = apierror.New(apierror.Invalid, "cannot send nil package").WithRetryable(apierror.False)
@@ -89,10 +98,12 @@ type Scheduler struct {
 	retiredStolen   atomic.Uint64
 	queueSize       int
 	nextID          atomic.Uint64
-	stopping        atomic.Bool
+	phase           atomic.Uint32
 	collectStats    atomic.Bool
 	started         bool
 }
+
+func (s *Scheduler) isStopping() bool { return s.phase.Load() != phaseRunning }
 
 func NewScheduler(registry dispatcher.Registry, opts ...Option) *Scheduler {
 	s := &Scheduler{
@@ -124,17 +135,17 @@ func (s *Scheduler) getHandler(cmd dispatcher.Command) dispatcher.Handler {
 // Stop gracefully shuts down the scheduler.
 // Sends cancel events and waits for processes to complete or context deadline.
 func (s *Scheduler) Stop(ctx context.Context) {
-	// Publish the terminal state while serialized with Start and Resize, then
+	// Begin draining while serialized with Start and Resize, then
 	// release the control lock before lifecycle callbacks and worker waits.
 	s.controlMu.Lock()
-	if s.stopping.Swap(true) {
+	if !s.phase.CompareAndSwap(phaseRunning, phaseDraining) {
 		s.controlMu.Unlock()
 		return
 	}
 	s.controlMu.Unlock()
 
 	// Push cancel event directly to each processor's queue.
-	// Safe because stopping=true prevents pool release.
+	// Safe because draining prevents pool release.
 	// Wake idle/blocked processors so they process the cancel.
 	s.byPID.Range(func(_, value any) bool {
 		proc := value.(*Processor)
@@ -185,6 +196,9 @@ func (s *Scheduler) Stop(ctx context.Context) {
 	}
 
 	// Wake and wait for workers to exit
+	// Admission closes before cancellation, but workers must remain available
+	// for asynchronous cleanup until processes drain or the deadline expires.
+	s.phase.CompareAndSwap(phaseDraining, phaseStoppingWorkers)
 	s.wakeAll()
 	s.wg.Wait()
 
@@ -248,7 +262,7 @@ func (s *Scheduler) WakeProcessor(q *process.EventQueue, gen uint64) {
 }
 
 func (s *Scheduler) Submit(ctx context.Context, pid pid.PID, p process.Process, method string, input payload.Payloads) (*Processor, error) {
-	if s.stopping.Load() {
+	if s.isStopping() {
 		return nil, process.ErrSchedulerStopping
 	}
 	if s.maxProcesses > 0 && s.processorCount.Load() >= s.maxProcesses {
@@ -347,7 +361,7 @@ func (s *Scheduler) finishProcessor(proc *Processor, result *process.StepOutput,
 	s.byPID.Delete(proc.pid.String())
 	s.byQueue.Delete(proc.queue)
 
-	stopping := s.stopping.Load()
+	stopping := s.isStopping()
 	if !proc.pooled {
 		if s.processorCount.Add(-1) == 0 && stopping {
 			select {
@@ -382,7 +396,7 @@ func (s *Scheduler) finishProcessor(proc *Processor, result *process.StepOutput,
 }
 
 func (s *Scheduler) CreateProcessor(ctx context.Context, pid pid.PID, p process.Process) (*Processor, error) {
-	if s.stopping.Load() {
+	if s.isStopping() {
 		return nil, process.ErrSchedulerStopping
 	}
 	if s.maxProcesses > 0 && s.processorCount.Load() >= s.maxProcesses {

--- a/system/scheduler/actor/scheduler_workers.go
+++ b/system/scheduler/actor/scheduler_workers.go
@@ -24,7 +24,7 @@ func (s *Scheduler) Start() {
 	s.controlMu.Lock()
 	defer s.controlMu.Unlock()
 
-	if s.started || s.stopping.Load() {
+	if s.started || s.isStopping() {
 		return
 	}
 	s.started = true
@@ -41,14 +41,14 @@ func (s *Scheduler) ResizeWorkers(target int) error {
 	if target <= 0 {
 		return ErrInvalidWorkerCount
 	}
-	if s.stopping.Load() {
+	if s.isStopping() {
 		return process.ErrSchedulerStopping
 	}
 
 	s.controlMu.Lock()
 	defer s.controlMu.Unlock()
 
-	if s.stopping.Load() {
+	if s.isStopping() {
 		return process.ErrSchedulerStopping
 	}
 

--- a/system/scheduler/actor/shutdown_yield_test.go
+++ b/system/scheduler/actor/shutdown_yield_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+package actor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/dispatcher"
+	pidapi "github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/system/scheduler"
+)
+
+type shutdownGateHandler struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (h *shutdownGateHandler) Handle(_ context.Context, _ dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	h.once.Do(func() { close(h.started) })
+	go func() { <-h.release; receiver.CompleteYield(tag, nil, nil) }()
+	return nil
+}
+
+func TestShutdownResumesAsyncCleanup(t *testing.T) {
+	handler := &shutdownGateHandler{started: make(chan struct{}), release: make(chan struct{})}
+	registry := scheduler.NewRegistry()
+	registry.Register(1, handler)
+	results := make(chan *runtime.Result, 1)
+	sched := NewScheduler(registry, WithWorkers(1), WithLifecycle(&testLifecycle{onComplete: func(_ context.Context, _ pidapi.PID, result *runtime.Result) { results <- result }}))
+	sched.Start()
+	_, err := sched.Submit(context.Background(), pidapi.PID{UniqID: "shutdown-yield"}, &slowProcess{}, "", nil)
+	require.NoError(t, err)
+	select {
+	case <-handler.started:
+	case <-time.After(time.Second):
+		t.Fatal("process did not yield")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stopped := make(chan struct{})
+	go func() { sched.Stop(ctx); close(stopped) }()
+	require.Eventually(t, func() bool { return sched.isStopping() }, time.Second, time.Millisecond)
+	// Give the worker time to run out of immediate work during shutdown.
+	time.Sleep(30 * time.Millisecond)
+	close(handler.release)
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		cancel()
+		<-stopped
+		t.Fatal("shutdown abandoned async cleanup until its timeout")
+	}
+	completed := <-results
+	require.NoError(t, completed.Error)
+}

--- a/system/scheduler/actor/worker.go
+++ b/system/scheduler/actor/worker.go
@@ -65,7 +65,7 @@ func (w *Worker) run() {
 			continue
 		}
 
-		if s.stopping.Load() {
+		if s.phase.Load() == phaseStoppingWorkers {
 			w.drain()
 			return
 		}
@@ -85,7 +85,7 @@ func (w *Worker) run() {
 			w.handoffQueuedWork()
 			return
 		}
-		if s.stopping.Load() {
+		if s.phase.Load() == phaseStoppingWorkers {
 			w.drain()
 			return
 		}
@@ -151,7 +151,7 @@ func (w *Worker) park() {
 			w.executed.Add(1)
 			return
 		}
-		if s.stopping.Load() {
+		if s.phase.Load() == phaseStoppingWorkers {
 			w.parkMu.Unlock()
 			return
 		}


### PR DESCRIPTION
# Reason for This PR

Shutdown can restore the terminal immediately yet leave the runtime alive until its graceful-stop deadline. Scheduler workers currently exit as soon as shutdown starts; an asynchronous cleanup yield can complete after the workers have exited, leaving no worker to resume the process.

In the Bee demo, quitting reproduced a 10.04-second process exit despite terminal restoration in 0.10 seconds.

## Description of Changes

Replace the stopping boolean with one monotonic atomic lifecycle: running → draining → stopping workers. CAS transitions close admission first, keep workers available for asynchronous cleanup, and permit worker exit after processes drain or the existing deadline expires. Start/resize serialization, timeout cancellation, and pool-release protections remain in place. Worker checks retain a single atomic load/comparison; no polling loop is added.

Add a regression that holds an asynchronous yield across shutdown, then releases it and requires successful completion before the timeout. Update the resize test to check the lifecycle predicate.

Validation:
- `GOWORK=off go test -race ./system/scheduler/actor -timeout=90s`
- Configured golangci-lint on `./system/scheduler/actor/...`.
- Regression reproduced the failure before the fix.
- Three live Bee exits with the fix: 33.45 ms, 32.80 ms, and 37.66 ms. These are local exit measurements, not throughput benchmarks.

This PR is independent of the viewport work in #653.
