### PR TITLE
fix(kv): isolate snapshot values and publish only changed shards

### DIFF
--- a/api/store/kv/kv.go
+++ b/api/store/kv/kv.go
@@ -63,6 +63,12 @@ type TxnOp struct {
 	Cond   TxnCond
 }
 
+// SnapshotReader reads selected keys from one local immutable view. Missing keys
+// are omitted. Values belong to the caller. This does not imply quorum freshness.
+type SnapshotReader interface {
+	GetMany(keys []string) (map[string]Entry, error)
+}
+
 // Engine is the low-level coordination key-value store. Reads are always local
 // (served from an in-memory replica); writes may replicate depending on the
 // backend (raft for store.kv.raft, gossip CRDT for store.kv.crdt).

--- a/api/store/kv/kv.go
+++ b/api/store/kv/kv.go
@@ -63,12 +63,6 @@ type TxnOp struct {
 	Cond   TxnCond
 }
 
-// SnapshotReader reads selected keys from one local immutable view. Missing keys
-// are omitted. Values belong to the caller. This does not imply quorum freshness.
-type SnapshotReader interface {
-	GetMany(keys []string) (map[string]Entry, error)
-}
-
 // Engine is the low-level coordination key-value store. Reads are always local
 // (served from an in-memory replica); writes may replicate depending on the
 // backend (raft for store.kv.raft, gossip CRDT for store.kv.crdt).

--- a/system/kv/raft_engine.go
+++ b/system/kv/raft_engine.go
@@ -135,6 +135,10 @@ func (e *RaftEngine) proposeRaw(cmd []byte) (applyResult, error) {
 
 // --- kvapi.Engine reads (local) ---
 
+func (e *RaftEngine) GetMany(keys []string) (map[string]kvapi.Entry, error) {
+	return e.fsm.snap.Load().getMany(keys)
+}
+
 func (e *RaftEngine) Get(key string) (kvapi.Entry, error) {
 	ent, ok := e.fsm.get(key)
 	if !ok {
@@ -167,15 +171,15 @@ func (e *RaftEngine) GetLinearizable(key string) (kvapi.Entry, error) {
 	return e.Get(key)
 }
 
-// ScanAtIndex captures the cluster commit index, then scans the published
-// snapshot under prefix, returning the index as the consistent "as-of" point.
+// ScanAtIndex barriers on the leader, then reads entries and their applied KV
+// index from one immutable snapshot. Other Raft domains may have newer indexes.
 func (e *RaftEngine) ScanAtIndex(prefix string, fn func(kvapi.Entry) bool) (uint64, error) {
 	if err := e.raft.Barrier(raftApplyTimeout); err != nil {
 		return 0, err
 	}
-	idx := e.raft.CommitIndex()
-	e.fsm.scan(prefix, fn)
-	return idx, nil
+	snap := e.fsm.snap.Load()
+	snap.scan(prefix, fn)
+	return snap.index, nil
 }
 
 func (e *RaftEngine) Watch(ctx context.Context, prefix string) (kvapi.Watcher, error) {

--- a/system/kv/raft_engine.go
+++ b/system/kv/raft_engine.go
@@ -135,10 +135,6 @@ func (e *RaftEngine) proposeRaw(cmd []byte) (applyResult, error) {
 
 // --- kvapi.Engine reads (local) ---
 
-func (e *RaftEngine) GetMany(keys []string) (map[string]kvapi.Entry, error) {
-	return e.fsm.snap.Load().getMany(keys)
-}
-
 func (e *RaftEngine) Get(key string) (kvapi.Entry, error) {
 	ent, ok := e.fsm.get(key)
 	if !ok {

--- a/system/kv/raft_fsm.go
+++ b/system/kv/raft_fsm.go
@@ -237,9 +237,10 @@ type snapLease struct {
 }
 
 type fsmState struct {
-	Entries []snapEntry
-	Leases  []snapLease
-	Version uint64
+	Entries    []snapEntry
+	Leases     []snapLease
+	ApplyIndex uint64
+	Version    uint64
 }
 
 // Snapshot captures a consistent copy of the kv state. raft serializes this
@@ -248,7 +249,7 @@ func (f *RaftFSM) Snapshot() (hraft.FSMSnapshot, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	st := fsmState{Version: f.state.version}
+	st := fsmState{Version: f.state.version, ApplyIndex: f.state.applyIndex}
 	for _, e := range f.state.entries {
 		st.Entries = append(st.Entries, snapEntry{
 			Key: e.key, Value: e.value, Version: e.version, LeaseID: string(e.leaseID), Epoch: e.epoch,
@@ -291,12 +292,16 @@ func (f *RaftFSM) Restore(rc io.ReadCloser) error {
 
 	fresh := newState()
 	fresh.version = st.Version
+	fresh.applyIndex = st.ApplyIndex
 	freshLeases := newLeaseManager()
 	for _, l := range st.Leases {
 		fresh.addLease(kvapi.LeaseID(l.ID), l.TTLms, l.ExpiresAtMs)
 		freshLeases.grant(kvapi.LeaseID(l.ID), msToDuration(l.TTLms), time.Now())
 	}
 	for _, e := range st.Entries {
+		if e.Epoch > fresh.applyIndex {
+			fresh.applyIndex = e.Epoch
+		}
 		fresh.entries[e.Key] = &entry{
 			key: e.Key, value: e.Value, version: e.Version, leaseID: kvapi.LeaseID(e.LeaseID), epoch: e.Epoch,
 		}

--- a/system/kv/service.go
+++ b/system/kv/service.go
@@ -181,10 +181,6 @@ func (s *Service) publishSnapshot() {
 
 // --- kvapi.Engine read operations (lock-free, from snapshot) ---
 
-func (s *Service) GetMany(keys []string) (map[string]kvapi.Entry, error) {
-	return s.snap.Load().getMany(keys)
-}
-
 func (s *Service) Get(key string) (kvapi.Entry, error) {
 	snap := s.snap.Load()
 	if snap == nil {

--- a/system/kv/service.go
+++ b/system/kv/service.go
@@ -181,6 +181,10 @@ func (s *Service) publishSnapshot() {
 
 // --- kvapi.Engine read operations (lock-free, from snapshot) ---
 
+func (s *Service) GetMany(keys []string) (map[string]kvapi.Entry, error) {
+	return s.snap.Load().getMany(keys)
+}
+
 func (s *Service) Get(key string) (kvapi.Entry, error) {
 	snap := s.snap.Load()
 	if snap == nil {
@@ -208,12 +212,12 @@ func (s *Service) GetLinearizable(key string) (kvapi.Entry, error) { return s.Ge
 
 // ScanAtIndex scans and returns the current global version as the as-of index.
 func (s *Service) ScanAtIndex(prefix string, fn func(kvapi.Entry) bool) (uint64, error) {
-	if err := s.Scan(prefix, fn); err != nil {
-		return 0, err
+	snap := s.snap.Load()
+	if snap == nil {
+		return 0, kvapi.ErrKVClosed
 	}
-	var idx uint64
-	err := s.submitAndWait(func() error { idx = s.state.version; return nil })
-	return idx, err
+	snap.scan(prefix, fn)
+	return snap.version, nil
 }
 
 // --- kvapi.Engine write operations (serialized through event loop) ---

--- a/system/kv/snapshot_integrity_test.go
+++ b/system/kv/snapshot_integrity_test.go
@@ -30,7 +30,7 @@ func TestGetManyNeverTearsAtomicTransaction(t *testing.T) {
 	}()
 	defer writer.Wait()
 	for i := 0; i < 1000; i++ {
-		entries, err := e.GetMany([]string{"a", "b", "missing"})
+		entries, err := e.fsm.snap.Load().getMany([]string{"a", "b", "missing"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -47,7 +47,7 @@ func TestGetManyNeverTearsAtomicTransaction(t *testing.T) {
 		}
 	}
 	writer.Wait()
-	entries, err := e.GetMany([]string{"a", "b"})
+	entries, err := e.fsm.snap.Load().getMany([]string{"a", "b"})
 	if err != nil || string(entries["a"].Value) != "999" || string(entries["b"].Value) != "999" {
 		t.Fatalf("returned values mutated replica: %v, %v", entries, err)
 	}

--- a/system/kv/snapshot_integrity_test.go
+++ b/system/kv/snapshot_integrity_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kv
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	hraft "github.com/hashicorp/raft"
+	kvapi "github.com/wippyai/runtime/api/store/kv"
+)
+
+func TestGetManyNeverTearsAtomicTransaction(t *testing.T) {
+	e, _ := newEngine(t)
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := 0; i < 1000; i++ {
+			value := []byte(fmt.Sprint(i))
+			if ok, err := e.Txn([]kvapi.TxnOp{
+				{Kind: kvapi.TxnPut, Key: "a", Value: value},
+				{Kind: kvapi.TxnPut, Key: "b", Value: value},
+			}); err != nil || !ok {
+				t.Errorf("transaction: %v %v", ok, err)
+				return
+			}
+		}
+	}()
+	defer writer.Wait()
+	for i := 0; i < 1000; i++ {
+		entries, err := e.GetMany([]string{"a", "b", "missing"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		a, aok := entries["a"]
+		b, bok := entries["b"]
+		if aok != bok || string(a.Value) != string(b.Value) {
+			t.Fatalf("torn transaction: a=%+v b=%+v", a, b)
+		}
+		if _, found := entries["missing"]; found {
+			t.Fatal("missing key included")
+		}
+		if len(a.Value) > 0 {
+			a.Value[0] = 'X'
+		}
+	}
+	writer.Wait()
+	entries, err := e.GetMany([]string{"a", "b"})
+	if err != nil || string(entries["a"].Value) != "999" || string(entries["b"].Value) != "999" {
+		t.Fatalf("returned values mutated replica: %v, %v", entries, err)
+	}
+}
+
+func TestRaftReadValuesCannotMutateReplica(t *testing.T) {
+	f := NewRaftFSM(nil)
+	f.state.set("key", []byte("original"), "")
+	f.snap.Store(f.state.snapshot())
+	e, _ := f.get("key")
+	e.Value[0] = 'X'
+	e, _ = f.get("key")
+	if string(e.Value) != "original" {
+		t.Fatalf("Get exposed mutable replica bytes: %q", e.Value)
+	}
+	f.scan("key", func(e kvapi.Entry) bool { e.Value[0] = 'Y'; return true })
+	e, _ = f.get("key")
+	if string(e.Value) != "original" {
+		t.Fatalf("Scan exposed mutable replica bytes: %q", e.Value)
+	}
+}
+
+func TestServiceScanIndexMatchesCapturedValues(t *testing.T) {
+	s := startTestService(t)
+	version, err := s.Set("key", []byte("before"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value string
+	index, err := s.ScanAtIndex("key", func(e kvapi.Entry) bool {
+		value = string(e.Value)
+		if _, err := s.Set("key", []byte("after")); err != nil {
+			t.Fatal(err)
+		}
+		return true
+	})
+	if err != nil || index != version || value != "before" {
+		t.Fatalf("inconsistent scan: index=%d want=%d value=%q err=%v", index, version, value, err)
+	}
+}
+
+func TestReadSnapshotRetainsEntriesAndAppliedIndex(t *testing.T) {
+	eng, f := newEngine(t)
+	_, err := eng.Set("a", []byte("before"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := f.snap.Load()
+	oldIndex := old.index
+	_, err = eng.Set("a", []byte("after"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := old.get("a"); string(got.Value) != "before" || old.index != oldIndex {
+		t.Fatal("old view changed")
+	}
+	// Model other commands committed in the shared Raft log, beyond this KV view.
+	eng.raft.(*fakeRaft).index += 50
+	var seen []string
+	idx, err := eng.ScanAtIndex("", func(e kvapi.Entry) bool {
+		seen = append(seen, string(e.Value))
+		// Publication during a scan cannot replace the view being traversed.
+		_, setErr := eng.Set("a", []byte("concurrent"))
+		if setErr != nil {
+			t.Fatal(setErr)
+		}
+		return true
+	})
+	if err != nil || idx != oldIndex+1 || len(seen) != 1 || seen[0] != "after" {
+		t.Fatalf("torn scan: index=%d values=%v err=%v", idx, seen, err)
+	}
+}
+
+func BenchmarkRaftApplyPopulated(b *testing.B) {
+	for _, size := range []int{1000, 10000, 100000} {
+		b.Run(fmt.Sprint(size), func(b *testing.B) {
+			f := NewRaftFSM(nil)
+			for i := 0; i < size; i++ {
+				f.state.set(fmt.Sprintf("key/%d", i), []byte("value"), "")
+			}
+			f.snap.Store(f.state.snapshot())
+			data := encodeCommand(command{Op: opSet, Key: "key/0", Value: []byte("updated")})
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				f.Apply(&hraft.Log{Data: data, Index: uint64(i + 1)})
+			}
+		})
+	}
+}

--- a/system/kv/state.go
+++ b/system/kv/state.go
@@ -3,13 +3,17 @@
 package kv
 
 import (
+	"maps"
 	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	kvapi "github.com/wippyai/runtime/api/store/kv"
 )
 
 // state holds the mutable KV data, accessed only from the event loop goroutine.
 type state struct {
+	published  *stateSnapshot
+	dirty      map[string]struct{}
 	entries    map[string]*entry
 	leases     map[kvapi.LeaseID]*leaseState
 	version    kvapi.Version // global monotonic revision counter
@@ -72,6 +76,7 @@ func (s *state) set(key string, value []byte, leaseID kvapi.LeaseID) (*entry, kv
 		epoch:   s.applyIndex,
 	}
 	s.entries[key] = e
+	s.markDirty(key)
 
 	// Attach to lease
 	if leaseID != "" {
@@ -91,6 +96,7 @@ func (s *state) del(key string) *entry {
 	}
 
 	delete(s.entries, key)
+	s.markDirty(key)
 
 	// Detach from lease
 	if e.leaseID != "" {
@@ -192,45 +198,97 @@ func (s *state) removeLease(id kvapi.LeaseID) []string {
 	return keys
 }
 
-// snapshot builds an immutable copy of all entries for lock-free reads.
-func (s *state) snapshot() *stateSnapshot {
-	snap := &stateSnapshot{
-		entries: make(map[string]*kvapi.Entry, len(s.entries)),
+// Snapshot publication copies only shards containing changed keys. Unchanged
+// maps and entries remain immutable and are shared with older readers.
+const snapshotShards = 256
+
+func snapshotShard(key string) uint64 { return xxhash.Sum64String(key) % snapshotShards }
+
+func (s *state) markDirty(key string) {
+	if s.dirty == nil {
+		s.dirty = make(map[string]struct{})
 	}
-	for k, e := range s.entries {
-		snap.entries[k] = &kvapi.Entry{
-			Key:     e.key,
-			Value:   copyBytes(e.value),
-			Version: e.version,
-			LeaseID: e.leaseID,
-			Epoch:   e.epoch,
+	s.dirty[key] = struct{}{}
+}
+
+func (s *state) snapshot() *stateSnapshot {
+	snap := &stateSnapshot{index: s.applyIndex, version: s.version}
+	if s.published != nil {
+		snap.shards = s.published.shards
+	} else {
+		for key := range s.entries {
+			s.markDirty(key)
 		}
 	}
+	var cloned [snapshotShards]bool
+	for key := range s.dirty {
+		shard := snapshotShard(key)
+		if !cloned[shard] {
+			snap.shards[shard] = maps.Clone(snap.shards[shard])
+			if snap.shards[shard] == nil {
+				snap.shards[shard] = make(map[string]*kvapi.Entry)
+			}
+			cloned[shard] = true
+		}
+		if e := s.entries[key]; e != nil {
+			snap.shards[shard][key] = &kvapi.Entry{Key: e.key, Value: copyBytes(e.value), Version: e.version, LeaseID: e.leaseID, Epoch: e.epoch}
+		} else {
+			delete(snap.shards[shard], key)
+		}
+	}
+	clear(s.dirty)
+	s.published = snap
 	return snap
 }
 
-// stateSnapshot is an immutable point-in-time view for lock-free reads.
+// stateSnapshot carries the applied KV index with precisely the entries that
+// were published at that index. It never samples Raft's possibly newer commit.
 type stateSnapshot struct {
-	entries map[string]*kvapi.Entry
+	shards  [snapshotShards]map[string]*kvapi.Entry
+	version uint64
+	index   uint64
+}
+
+func (s *stateSnapshot) getMany(keys []string) (map[string]kvapi.Entry, error) {
+	if s == nil {
+		return nil, kvapi.ErrKVClosed
+	}
+	out := make(map[string]kvapi.Entry, len(keys))
+	for _, key := range keys {
+		if e := s.get(key); e != nil {
+			out[key] = *e
+		}
+	}
+	return out, nil
 }
 
 func (s *stateSnapshot) get(key string) *kvapi.Entry {
 	if s == nil {
 		return nil
 	}
-	return s.entries[key]
+	e := s.shards[snapshotShard(key)][key]
+	if e == nil {
+		return nil
+	}
+	out := *e
+	out.Value = copyBytes(e.Value)
+	return &out
 }
 
 func (s *stateSnapshot) scan(prefix string, fn func(kvapi.Entry) bool) {
 	if s == nil {
 		return
 	}
-	for k, e := range s.entries {
-		if prefix != "" && !strings.HasPrefix(k, prefix) {
-			continue
-		}
-		if !fn(*e) {
-			return
+	for _, shard := range s.shards {
+		for k, e := range shard {
+			if prefix != "" && !strings.HasPrefix(k, prefix) {
+				continue
+			}
+			out := *e
+			out.Value = copyBytes(e.Value)
+			if !fn(out) {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- publish immutable KV snapshots using 256 hash shards, copying only shards that changed
- return caller-owned value buffers from `Get` and `Scan`
- make scan values and their reported revision come from the same immutable view
- persist the applied KV index in Raft snapshots while retaining compatibility with older snapshots

No Raft command encoding, public API, or runtime configuration is added. Batched snapshot reads remain an internal regression-test helper.

## Regression coverage

Go tests cover caller mutation, retained old views, atomic multi-key transaction visibility, matching scan revisions during concurrent writes, and applied-index restoration.

## Verification

- uncached `system/kv` race suite
- topology and cluster integration/race coverage
- `go vet`
- golangci-lint v2.13.2: 0 issues
- `git diff --check`
