### PR TITLE
fix(naming): preserve the establishing epoch on registration retry

### DIFF
--- a/system/topology/namereg/global/fsm.go
+++ b/system/topology/namereg/global/fsm.go
@@ -187,7 +187,9 @@ func (f *FSM) applyRegister(cmd *Command, index uint64) any {
 		return &RegisterResult{PID: existing, FenceToken: index}
 	case registerDedupe:
 		f.tel.recordGlobalregDedupe()
-		return &RegisterResult{PID: existing, FenceToken: index}
+		// Retrying the same claim does not establish a new ownership epoch.
+		_, established, _ := f.state.LookupWithIndex(cmd.Name)
+		return &RegisterResult{PID: existing, FenceToken: established}
 	case registerConflict:
 		winner := f.resolve(cmd.Name, existing, cmd.PID)
 		if winner == cmd.PID {

--- a/system/topology/namereg/global/fsm.go
+++ b/system/topology/namereg/global/fsm.go
@@ -178,7 +178,7 @@ func (f *FSM) applyRegister(cmd *Command, index uint64) any {
 	if nodeID == "" {
 		nodeID = cmd.PID.Node
 	}
-	existing, outcome := f.state.register(cmd.Name, cmd.PID, nodeID, index)
+	existing, established, outcome := f.state.register(cmd.Name, cmd.PID, nodeID, index)
 	switch outcome {
 	case registerInserted:
 		f.tel.recordFenceToken(f.pgLabel, nodeID, index)
@@ -188,13 +188,12 @@ func (f *FSM) applyRegister(cmd *Command, index uint64) any {
 	case registerDedupe:
 		f.tel.recordGlobalregDedupe()
 		// Retrying the same claim does not establish a new ownership epoch.
-		_, established, _ := f.state.LookupWithIndex(cmd.Name)
 		return &RegisterResult{PID: existing, FenceToken: established}
 	case registerConflict:
 		winner := f.resolve(cmd.Name, existing, cmd.PID)
 		if winner == cmd.PID {
 			f.state.unregister(cmd.Name)
-			f.state.register(cmd.Name, cmd.PID, nodeID, index)
+			_, _, _ = f.state.register(cmd.Name, cmd.PID, nodeID, index)
 			f.tel.recordFenceToken(f.pgLabel, nodeID, index)
 			f.tel.recordGlobalregSize(f.state.Len())
 			f.emitBinding(BindingEvent{Name: cmd.Name, PID: cmd.PID, RaftIndex: index})

--- a/system/topology/namereg/global/receipt_test.go
+++ b/system/topology/namereg/global/receipt_test.go
@@ -26,3 +26,21 @@ func TestConsistentRetryReturnsEstablishingIndex(t *testing.T) {
 		t.Fatalf("reclaimed retry: %+v", last)
 	}
 }
+
+func TestConsistentRetryOfPendingClaimReturnsReservationEpoch(t *testing.T) {
+	f := NewFSM()
+	p := makePID("node", "host", "owner")
+	pending := applyAt(t, f, &Command{
+		Type: CmdRegisterPending,
+		Name: "claim",
+		PID:  p,
+	}, 10).(*RegisterResult)
+	if pending.Err != nil || pending.FenceToken != 10 {
+		t.Fatalf("pending: %+v", pending)
+	}
+
+	retry := applyAt(t, f, &Command{Type: CmdRegister, Name: "claim", PID: p}, 20).(*RegisterResult)
+	if retry.Err != nil || retry.FenceToken != pending.FenceToken {
+		t.Fatalf("pending retry changed the reservation epoch: pending=%+v retry=%+v", pending, retry)
+	}
+}

--- a/system/topology/namereg/global/receipt_test.go
+++ b/system/topology/namereg/global/receipt_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package global
+
+import "testing"
+
+func TestConsistentRetryReturnsEstablishingIndex(t *testing.T) {
+	f := NewFSM()
+	p := makePID("node", "host", "owner")
+	cmd := &Command{Type: CmdRegister, Name: "claim", PID: p}
+	first := applyAt(t, f, cmd, 10).(*RegisterResult)
+	retry := applyAt(t, f, cmd, 20).(*RegisterResult)
+	if first.Err != nil || retry.Err != nil {
+		t.Fatalf("register: %v, %v", first.Err, retry.Err)
+	}
+	if first.FenceToken != 10 || retry.FenceToken != first.FenceToken {
+		t.Fatalf("retry invented a new claim receipt: first=%d retry=%d", first.FenceToken, retry.FenceToken)
+	}
+	applyAt(t, f, &Command{Type: CmdUnregister, Name: "claim"}, 30)
+	reclaimed := applyAt(t, f, cmd, 40).(*RegisterResult)
+	if reclaimed.Err != nil || reclaimed.FenceToken != 40 {
+		t.Fatalf("reclaim: %+v", reclaimed)
+	}
+	last := applyAt(t, f, cmd, 50).(*RegisterResult)
+	if last.Err != nil || last.FenceToken != 40 {
+		t.Fatalf("reclaimed retry: %+v", last)
+	}
+}

--- a/system/topology/namereg/global/state.go
+++ b/system/topology/namereg/global/state.go
@@ -184,17 +184,20 @@ const (
 )
 
 // register attempts to insert or verify a name → PID mapping.
-// On success it returns the supplied PID and either registerInserted (fresh)
-// or registerDedupe (already mapped to the same PID — idempotent no-op).
-// On collision it returns the existing owner PID and registerConflict.
-func (s *shardedState) register(name string, p pid.PID, nodeID pid.NodeID, index uint64) (pid.PID, registerOutcome) {
+// It also returns the stored establishment token: the insertion index for an
+// active entry or the reservation epoch for a pending entry. On success it
+// returns the supplied PID and either registerInserted (fresh) or
+// registerDedupe (already mapped to the same PID — idempotent no-op). On
+// collision it returns the existing owner PID and registerConflict.
+func (s *shardedState) register(name string, p pid.PID, nodeID pid.NodeID, index uint64) (pid.PID, uint64, registerOutcome) {
 	s.pendingMu.RLock()
 	if e, ok := s.pending[name]; ok {
+		existingPID, epoch := e.PID, e.Epoch
 		s.pendingMu.RUnlock()
-		if e.PID == p {
-			return p, registerDedupe
+		if existingPID == p {
+			return p, epoch, registerDedupe
 		}
-		return e.PID, registerConflict
+		return existingPID, epoch, registerConflict
 	}
 	s.pendingMu.RUnlock()
 
@@ -204,10 +207,10 @@ func (s *shardedState) register(name string, p pid.PID, nodeID pid.NodeID, index
 
 	if existing, ok := sh.names[name]; ok {
 		if existing.PID == p {
-			return p, registerDedupe
+			return p, existing.AppliedAt, registerDedupe
 		}
 
-		return existing.PID, registerConflict
+		return existing.PID, existing.AppliedAt, registerConflict
 	}
 
 	sh.names[name] = &nameEntry{PID: p, NodeID: nodeID, AppliedAt: index}
@@ -217,7 +220,7 @@ func (s *shardedState) register(name string, p pid.PID, nodeID pid.NodeID, index
 
 	s.addToNodeIndex(nodeID, pidKey)
 
-	return p, registerInserted
+	return p, index, registerInserted
 }
 
 // pendingOutcome captures the disposition of a registerPending attempt.


### PR DESCRIPTION
## Problem

A duplicate Consistent registration in the legacy global FSM returned the retry's Raft log index even though the claim did not change. The public API promises the first-write ownership index: a claim created at index 10 and retried at 20 must return 10 both times.

The dedupe outcome can also refer to a same-PID Strong reservation that is still pending. Looking only in active state made that path return epoch zero.

## Fix

The state insertion primitive now returns the stored establishment token together with its outcome:

- active dedupe returns the original insertion/activation index;
- pending dedupe returns the reservation epoch;
- a fresh insertion returns its new index.

This avoids a second state lookup and does not mutate replicated state, commands, or schemas. Release followed by reclaim still establishes a new token. The default KV-backed registry already preserves stored epochs on its equivalent paths.

## Verification

- The active retry regression fails before the original fix (`10`, then `20`).
- The pending retry regression fails on the approved PR head with epoch `0` and passes after hardening.
- Release, reclaim, and another retry preserve the new ownership epoch.
- Current-main `go test -race ./system/topology/... ./runtime/lua/modules/process/...` passes.
- Repository-pinned golangci-lint v2.13.2 reports `0 issues` for the affected package.
