### PR TITLE
fix(process): allow context composition with inherited security

### DIFF
--- a/runtime/lua/modules/process/context.go
+++ b/runtime/lua/modules/process/context.go
@@ -32,6 +32,9 @@ type Spawner struct {
 	hasActor bool
 	hasScope bool
 	hasOpts  bool
+	// Explicit overrides require authorization; inherited security does not.
+	customActor bool
+	customScope bool
 }
 
 func init() {
@@ -56,15 +59,17 @@ func cloneSpawner(spawner *Spawner) *Spawner {
 	}
 
 	return &Spawner{
-		values:   spawner.values,
-		options:  spawner.options,
-		actor:    spawner.actor,
-		hasActor: spawner.hasActor,
-		scope:    spawner.scope,
-		hasScope: spawner.hasScope,
-		hasOpts:  spawner.hasOpts,
-		name:     spawner.name,
-		messages: spawner.messages,
+		values:      spawner.values,
+		options:     spawner.options,
+		actor:       spawner.actor,
+		hasActor:    spawner.hasActor,
+		scope:       spawner.scope,
+		hasScope:    spawner.hasScope,
+		hasOpts:     spawner.hasOpts,
+		customActor: spawner.customActor,
+		customScope: spawner.customScope,
+		name:        spawner.name,
+		messages:    spawner.messages,
 	}
 }
 
@@ -286,7 +291,7 @@ func spawnerWithContext(l *lua.LState) int {
 
 	ctxTable := l.CheckTable(2)
 
-	if (spawner.hasScope || spawner.hasActor) && !security.IsAllowed(ctx, "process.security", "security", secAttrs) {
+	if (spawner.customScope || spawner.customActor) && !security.IsAllowed(ctx, "process.security", "security", secAttrs) {
 		l.RaiseError("not allowed to spawn processes with custom security context")
 		return 0
 	}
@@ -304,17 +309,8 @@ func spawnerWithContext(l *lua.LState) int {
 		}
 	})
 
-	newSpawner := &Spawner{
-		values:   newValues,
-		options:  spawner.options,
-		actor:    spawner.actor,
-		hasActor: spawner.hasActor,
-		scope:    spawner.scope,
-		hasScope: spawner.hasScope,
-		hasOpts:  spawner.hasOpts,
-		name:     spawner.name,
-		messages: spawner.messages,
-	}
+	newSpawner := cloneSpawner(spawner)
+	newSpawner.values = newValues
 
 	value.PushTypedUserData(l, newSpawner, spawnerTypeName)
 	return 1
@@ -398,6 +394,7 @@ func spawnerWithActor(l *lua.LState) int {
 	newSpawner := cloneSpawner(spawner)
 	newSpawner.actor = actor
 	newSpawner.hasActor = true
+	newSpawner.customActor = true
 
 	value.PushTypedUserData(l, newSpawner, spawnerTypeName)
 	return 1
@@ -442,6 +439,7 @@ func spawnerWithScope(l *lua.LState) int {
 	newSpawner := cloneSpawner(spawner)
 	newSpawner.scope = scope
 	newSpawner.hasScope = true
+	newSpawner.customScope = true
 
 	value.PushTypedUserData(l, newSpawner, spawnerTypeName)
 	return 1

--- a/runtime/lua/modules/process/spawner_security_test.go
+++ b/runtime/lua/modules/process/spawner_security_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package process
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/registry"
+	secapi "github.com/wippyai/runtime/api/security"
+	secsystem "github.com/wippyai/runtime/system/security"
+)
+
+type spawnerTestPolicy struct{ contextAllowed, securityAllowed bool }
+
+func (*spawnerTestPolicy) ID() registry.ID { return registry.NewID("test", "spawner") }
+func (p *spawnerTestPolicy) Evaluate(_ secapi.Actor, action, _ string, _ attrs.Bag) secapi.Result {
+	if action == "process.context" && p.contextAllowed || action == "process.security" && p.securityAllowed {
+		return secapi.Allow
+	}
+	return secapi.Deny
+}
+
+func spawnerSecurityLua(t *testing.T, policy *spawnerTestPolicy) (*lua.LState, secapi.Scope) {
+	t.Helper()
+	l, _ := newLuaWithPID(t)
+	scope := secsystem.NewScope([]secapi.Policy{policy})
+	require.NoError(t, secapi.SetActor(l.Context(), secapi.Actor{ID: "caller"}))
+	require.NoError(t, secapi.SetScope(l.Context(), scope))
+	actorUD, scopeUD := l.NewUserData(), l.NewUserData()
+	actorUD.Value = secapi.Actor{ID: "replacement"}
+	scopeUD.Value = secsystem.NewScope(nil)
+	l.SetGlobal("other_actor", actorUD)
+	l.SetGlobal("other_scope", scopeUD)
+	return l, scope
+}
+
+func TestSpawnerInheritedSecurityAllowsContextComposition(t *testing.T) {
+	for _, chain := range []string{
+		`process.with_options({marker = "option"}):with_context({greeting = "hello"})`,
+		`process.with_context({greeting = "hello"}):with_options({marker = "option"})`,
+		`process.with_context({greeting = "before"}):with_context({greeting = "hello"}):with_options({marker = "option"})`,
+	} {
+		t.Run(chain, func(t *testing.T) {
+			l, scope := spawnerSecurityLua(t, &spawnerTestPolicy{contextAllowed: true})
+			require.NoError(t, l.DoString("result = "+chain))
+			spawner := l.GetGlobal("result").(*lua.LUserData).Value.(*Spawner)
+			child, frame := ctxapi.OpenFrameContext(context.Background())
+			defer ctxapi.ReleaseFrameContext(frame)
+			require.NoError(t, frame.SetMultiple(buildSpawnerContext(spawner)...))
+			actor, ok := secapi.GetActor(child)
+			require.True(t, ok)
+			require.Equal(t, "caller", actor.ID)
+			childScope, ok := secapi.GetScope(child)
+			require.True(t, ok)
+			require.Same(t, scope, childScope)
+			greeting, ok := ctxapi.GetValues(child).Get("greeting")
+			require.True(t, ok)
+			require.Equal(t, "hello", greeting)
+			require.Equal(t, "option", spawner.options.GetString("marker", ""))
+		})
+	}
+}
+
+func TestSpawnerExplicitSecurityStillRequiresPermission(t *testing.T) {
+	for _, override := range []string{`:with_actor(other_actor)`, `:with_scope(other_scope)`} {
+		t.Run(override, func(t *testing.T) {
+			policy := &spawnerTestPolicy{contextAllowed: true}
+			l, _ := spawnerSecurityLua(t, policy)
+			require.ErrorContains(t, l.DoString("result = process.with_options({})"+override), "custom security context")
+			policy.securityAllowed = true
+			require.NoError(t, l.DoString("result = process.with_options({})"+override+`:with_options({}):with_name("child"):with_context({first = true})`))
+			// A second context edit must retain the existing reauthorization check
+			// after all cloning paths, including the first with_context call.
+			policy.securityAllowed = false
+			require.ErrorContains(t, l.DoString(`result:with_context({second = true})`), "custom security context")
+		})
+	}
+}
+
+func TestSpawnerContextPermissionStillRequired(t *testing.T) {
+	l, _ := spawnerSecurityLua(t, &spawnerTestPolicy{})
+	require.ErrorContains(t, l.DoString(`process.with_options({})`), "custom options")
+	require.ErrorContains(t, l.DoString(`process.with_context({})`), "custom context")
+}


### PR DESCRIPTION
With process.context allowed and process.security denied, `process.with_options({}):with_context({...})` rejects the caller's inherited security as a custom override. Repeated `with_context` calls have the same defect. Reversing the two different calls already works on this baseline.

Separate security presence from explicit override intent. Inherited actor/scope still reach the child; only with_actor/with_scope mark an override for the existing with_context reauthorization check. Use cloneSpawner for with_context too, so every cloning path preserves that intent.

Lua regressions reproduce the original failure and cover both call orders, repeated context edits, preservation of child identity/scope/options/values, denied explicit overrides, denied context edits, and retained override authorization checks after cloning and a prior with_context. Race tests pass for the process module and runtime security; scoped golangci-lint passes.

Reported in https://gist.github.com/butschster/0625fd672a9f170d375f326da83e2111 . General runtime fix; no application-specific behavior.
