### PR TITLE
fix(cluster): harden naming consistency and Strong finalization

### DIFF
--- a/system/topology/namereg/kvbacked/expiry_race_test.go
+++ b/system/topology/namereg/kvbacked/expiry_race_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kvbacked
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/pid"
+	kvapi "github.com/wippyai/runtime/api/store/kv"
+)
+
+type beforeExpiryEngine struct {
+	kvapi.Engine
+	before func()
+}
+
+func (e *beforeExpiryEngine) Txn(ops []kvapi.TxnOp) (bool, error) {
+	expiry := false
+	for _, op := range ops {
+		if op.Kind == kvapi.TxnPut && op.Key == activeKey("claim") {
+			return e.Engine.Txn(ops)
+		}
+		if op.Kind == kvapi.TxnDelete && op.Key == pendingKey("claim") {
+			expiry = true
+		}
+	}
+	if expiry && e.before != nil {
+		before := e.before
+		e.before = nil
+		before()
+	}
+	return e.Engine.Txn(ops)
+}
+
+func TestExpiryValidatesVotesAtCommit(t *testing.T) {
+	for _, reject := range []bool{false, true} {
+		name := "ack"
+		if reject {
+			name = "reject"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := newStrongReg(t, []pid.NodeID{"node-1", "peer"}, time.Second, nil)
+			t.Cleanup(func() { r.strong.stopTimer("claim") })
+			owner := mkPID("node-1", "owner")
+			hdr := pendingHeader{PID: owner.String(), Name: "claim", RequiredNodes: []pid.NodeID{"node-1", "peer"}, DeadlineUnixNano: time.Now().Add(-time.Second).UnixNano()}
+			value, err := encode(hdr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := r.engine.Set(pendingKey("claim"), value); err != nil {
+				t.Fatal(err)
+			}
+			pe, err := r.engine.Get(pendingKey("claim"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			epoch := pe.Epoch
+			if _, err := r.engine.Set(ackKey("claim", epoch, "node-1"), []byte("node-1")); err != nil {
+				t.Fatal(err)
+			}
+			base := r.engine
+			r.engine = &beforeExpiryEngine{Engine: base, before: func() {
+				key := ackKey("claim", epoch, "peer")
+				if reject {
+					key = rejectKey("claim", epoch, "peer")
+				}
+				if _, err := base.Set(key, []byte("peer")); err != nil {
+					t.Fatal(err)
+				}
+			}}
+			r.strong.leaderExpire("claim", epoch, pe.Version, hdr, "deadline")
+			if _, err := base.Get(pendingKey("claim")); err != nil {
+				t.Fatalf("stale timeout decision removed claim: %v", err)
+			}
+
+			r.strong.reconcile("claim")
+			if reject {
+				reason, _, _ := r.strong.takeTerminal("claim")
+				if reason != strongRejectConflict {
+					t.Fatalf("committed rejection became timeout: %q", reason)
+				}
+			} else if _, err := base.Get(activeKey("claim")); err != nil {
+				t.Fatalf("committed ACK set did not promote: %v", err)
+			}
+		})
+	}
+}

--- a/system/topology/namereg/kvbacked/promotion_race_test.go
+++ b/system/topology/namereg/kvbacked/promotion_race_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kvbacked
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/pid"
+	kvapi "github.com/wippyai/runtime/api/store/kv"
+)
+
+type beforePromotionEngine struct {
+	kvapi.Engine
+	before func()
+}
+
+func (e *beforePromotionEngine) Txn(ops []kvapi.TxnOp) (bool, error) {
+	for _, op := range ops {
+		if op.Kind == kvapi.TxnPut && op.Key == activeKey("claim") && e.before != nil {
+			before := e.before
+			e.before = nil
+			before()
+			break
+		}
+	}
+	return e.Engine.Txn(ops)
+}
+
+func TestStrongRejectCommittedBeforePromotionWins(t *testing.T) {
+	testStrongChangedAdmission(t, true)
+}
+
+func TestStrongMissingAckPreventsPromotion(t *testing.T) {
+	testStrongChangedAdmission(t, false)
+}
+
+func testStrongChangedAdmission(t *testing.T, reject bool) {
+	t.Helper()
+	r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+	p := mkPID("node-1", "owner")
+	hdr := pendingHeader{PID: p.String(), Name: "claim", RequiredNodes: []pid.NodeID{"node-1"}}
+	encoded, err := encode(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.engine.Set(pendingKey("claim"), encoded); err != nil {
+		t.Fatal(err)
+	}
+	pe, err := r.engine.Get(pendingKey("claim"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.engine.Set(ackKey("claim", pe.Epoch, "node-1"), []byte("node-1")); err != nil {
+		t.Fatal(err)
+	}
+	base := r.engine
+	r.engine = &beforePromotionEngine{Engine: base, before: func() {
+		// A rejection wins the Raft order after the leader's ACK scan but
+		// before its promotion transaction. Header version remains unchanged.
+		if reject {
+			if _, err := base.Set(rejectKey("claim", pe.Epoch, "node-1"), []byte(strongRejectConflict)); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if err := base.Delete(ackKey("claim", pe.Epoch, "node-1")); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}}
+	r.strong.leaderPromote("claim", pe.Epoch, pe.Version, hdr)
+	got, err := r.Lookup(context.Background(), "claim")
+	if err != nil || got.Found {
+		t.Fatalf("rejected claim promoted: %+v err=%v", got, err)
+	}
+}

--- a/system/topology/namereg/kvbacked/readiness_lifecycle_test.go
+++ b/system/topology/namereg/kvbacked/readiness_lifecycle_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kvbacked
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/pid"
+	kvapi "github.com/wippyai/runtime/api/store/kv"
+)
+
+type readinessWatcher struct {
+	ctx    context.Context
+	events chan kvapi.WatchEvent
+	closed chan struct{}
+}
+
+func (w *readinessWatcher) Events() <-chan kvapi.WatchEvent { return w.events }
+func (w *readinessWatcher) Close() error                    { close(w.closed); return nil }
+
+type readinessEngine struct {
+	kvapi.Engine
+	watcher *readinessWatcher
+}
+
+func (e *readinessEngine) Watch(ctx context.Context, _ string) (kvapi.Watcher, error) {
+	e.watcher.ctx = ctx
+	return e.watcher, nil
+}
+
+func TestReadinessClearedWhenReconcilerStops(t *testing.T) {
+	for _, cancelContext := range []bool{false, true} {
+		name := "watch closed"
+		if cancelContext {
+			name = "context canceled"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+			watcher := &readinessWatcher{events: make(chan kvapi.WatchEvent), closed: make(chan struct{})}
+			r.engine = &readinessEngine{Engine: r.engine, watcher: watcher}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := r.StartReconciler(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if !r.NameReady() {
+				t.Fatal("reconciler did not become ready")
+			}
+			if cancelContext {
+				cancel()
+			} else {
+				close(watcher.events)
+			}
+			select {
+			case <-watcher.closed:
+			case <-time.After(time.Second):
+				t.Fatal("reconciler did not stop")
+			}
+			if r.NameReady() {
+				t.Fatal("node remains ready after naming synchronization stopped")
+			}
+			if watcher.ctx.Err() == nil {
+				t.Fatal("reconciliation worker context survived update-stream shutdown")
+			}
+		})
+	}
+}
+
+type failedSeedEngine struct {
+	*readinessEngine
+	failure error
+	prefix  string
+}
+
+func (e *failedSeedEngine) Scan(prefix string, fn func(kvapi.Entry) bool) error {
+	if prefix == e.prefix {
+		return e.failure
+	}
+	return e.Engine.Scan(prefix, fn)
+}
+
+func TestReadinessRequiresSuccessfulSeed(t *testing.T) {
+	for _, prefix := range []string{pendingPrefix, activePrefix} {
+		t.Run(prefix, func(t *testing.T) {
+			r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+			watcher := &readinessWatcher{events: make(chan kvapi.WatchEvent), closed: make(chan struct{})}
+			failure := errors.New("snapshot unavailable")
+			r.engine = &failedSeedEngine{readinessEngine: &readinessEngine{Engine: r.engine, watcher: watcher}, failure: failure, prefix: prefix}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := r.StartReconciler(ctx)
+			if !errors.Is(err, failure) {
+				t.Fatalf("failed seed reported successful startup: %v", err)
+			}
+			if r.NameReady() {
+				t.Fatal("failed seed permitted name admission")
+			}
+			select {
+			case <-watcher.closed:
+			default:
+				t.Fatal("failed startup leaked its watcher")
+			}
+		})
+	}
+}
+
+func TestReadinessRejectsMalformedNamingSeed(t *testing.T) {
+	for _, prefix := range []string{activePrefix, pendingPrefix} {
+		for _, defect := range []string{"encoding", "name", "owner"} {
+			t.Run(prefix+defect, func(t *testing.T) {
+				r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+				key := prefix + "broken"
+				var value []byte
+				if defect == "encoding" {
+					value = []byte{0xc1}
+				} else {
+					validPID := mkPID("node-1", "owner")
+					name, owner := "broken", validPID.String()
+					if defect == "name" {
+						name = "different"
+					} else {
+						owner = "invalid"
+					}
+					var err error
+					if prefix == activePrefix {
+						value, err = encode(activeValue{Name: name, PID: owner, Strong: true})
+					} else {
+						value, err = encode(pendingHeader{Name: name, PID: owner, RequiredNodes: []pid.NodeID{"node-1"}})
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if ok, err := r.engine.Txn([]kvapi.TxnOp{{Kind: kvapi.TxnPut, Key: key, Value: value}}); err != nil || !ok {
+					t.Fatalf("seed: %v %v", ok, err)
+				}
+				watcher := &readinessWatcher{events: make(chan kvapi.WatchEvent), closed: make(chan struct{})}
+				r.engine = &readinessEngine{Engine: r.engine, watcher: watcher}
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				err := r.StartReconciler(ctx)
+				if err == nil {
+					t.Fatal("malformed naming seed was accepted")
+				}
+				if !strings.Contains(err.Error(), key) {
+					t.Fatalf("error does not identify record: %v", err)
+				}
+				if r.NameReady() {
+					t.Fatal("malformed seed opened name admission")
+				}
+				select {
+				case <-watcher.closed:
+				default:
+					t.Fatal("failed startup retained its watcher")
+				}
+			})
+		}
+	}
+}
+
+func TestReadinessValidationPreservesAcceptedEmptyName(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+	if _, err := r.Register(t.Context(), "", mkPID("node-1", "owner")); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := r.StartReconciler(ctx); err != nil {
+		t.Fatalf("seed validation rejected a name accepted by the registry: %v", err)
+	}
+	if !r.NameReady() {
+		t.Fatal("valid stored record did not seed")
+	}
+}

--- a/system/topology/namereg/kvbacked/reconciler.go
+++ b/system/topology/namereg/kvbacked/reconciler.go
@@ -4,6 +4,7 @@ package kvbacked
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -13,19 +14,48 @@ import (
 	"go.uber.org/zap"
 )
 
+type reconcilerLifecycle struct{ ctx context.Context }
+
 // StartReconciler drives the registry off the kv watch stream: active-binding
 // changes feed the dissem cache (so non-members resolve names), and Strong
 // pending/ack/reject changes advance the Strong state machine. No-op when
 // neither dissem nor Strong is configured. The watcher stops when ctx ends.
-func (s *Service) StartReconciler(ctx context.Context) error {
+// Successful startup owns this Service for its lifetime: restarting requires a
+// new Service (including fresh dissemination state). Failed startup may retry.
+func (s *Service) StartReconciler(ctx context.Context) (err error) {
 	if s.strong == nil && s.dissem == nil {
 		return nil
 	}
-	w, err := s.engine.Watch(ctx, registryPrefix)
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-	s.seed()
+	ctx, cancel := context.WithCancel(ctx)
+	run := &reconcilerLifecycle{ctx: ctx}
+	if !s.reconciler.CompareAndSwap(nil, run) {
+		cancel()
+		return fmt.Errorf("registry reconciler already started; use a new service after shutdown")
+	}
+	defer func() {
+		if err != nil {
+			cancel()
+			s.reconciler.CompareAndSwap(run, nil)
+		}
+	}()
+	w, err := s.engine.Watch(ctx, registryPrefix)
+	if err != nil {
+		cancel()
+		return err
+	}
+	if err := s.seed(); err != nil {
+		cancel()
+		_ = w.Close()
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		cancel()
+		_ = w.Close()
+		return err
+	}
 	// The node has now learned and latched the cluster's in-flight/active Strong
 	// reservations; name-readiness can flip so cross-scope guards see them.
 	s.ready.Store(true)
@@ -36,7 +66,13 @@ func (s *Service) StartReconciler(ctx context.Context) error {
 		go s.leaderSweep(ctx)
 	}
 	go func() {
-		defer func() { _ = w.Close() }()
+		defer func() {
+			// A stopped update stream cannot justify further cross-scope
+			// admission. Stop the associated sweep even if the parent lives.
+			s.ready.Store(false)
+			cancel()
+			_ = w.Close()
+		}()
 		if s.dissem != nil {
 			defer s.dissem.Stop()
 		}
@@ -68,7 +104,9 @@ func (s *Service) leaderSweep(ctx context.Context) {
 			return
 		case <-t.C:
 			if s.leaderFn() {
-				s.strong.reconcileAllPending()
+				if err := s.strong.reconcileAllPending(); err != nil {
+					s.logger.Debug("registry pending scan failed", zap.Error(err))
+				}
 			}
 		}
 	}
@@ -76,27 +114,47 @@ func (s *Service) leaderSweep(ctx context.Context) {
 
 // seed primes local state from the current kv snapshot: dissem cache from active
 // bindings, and the Strong machine from in-flight pending reservations.
-func (s *Service) seed() {
-	if s.dissem != nil {
-		_ = s.engine.Scan(activePrefix, func(e kvapi.Entry) bool {
-			s.translateActive(strings.TrimPrefix(e.Key, activePrefix), e.Value, e.Epoch, false)
-			return true
-		})
-	}
+func (s *Service) seed() error {
 	if s.strong != nil {
-		s.strong.reconcileAllPending()
-		// Re-latch exclusions for ACTIVE Strong names recovered from the kv
-		// (snapshot restore / restart): in-memory strongState starts empty, and
-		// stable active names emit no watch event, so without this scan
-		// IsStrongReserved would wrongly report them free and a LOCAL/EVENTUAL
-		// register could shadow a live Strong name.
-		_ = s.engine.Scan(activePrefix, func(e kvapi.Entry) bool {
-			if av, derr := decodeActive(e.Value); derr == nil && av.Strong {
-				s.strong.reconcile(strings.TrimPrefix(e.Key, activePrefix))
-			}
-			return true
-		})
+		if err := s.strong.reconcileAllPending(); err != nil {
+			return err
+		}
 	}
+	// Scan active records once for both consumers. A skipped malformed
+	// record cannot justify opening cross-scope admission after startup.
+	var recordErr error
+	err := s.engine.Scan(activePrefix, func(e kvapi.Entry) bool {
+		active, err := decodeActive(e.Value)
+		if err != nil {
+			recordErr = fmt.Errorf("registry record %q: %w", e.Key, err)
+			return false
+		}
+		if recordErr = validateNamingRecord(e.Key, activePrefix, active.Name, active.PID); recordErr != nil {
+			return false
+		}
+		name := strings.TrimPrefix(e.Key, activePrefix)
+		if s.dissem != nil {
+			s.translateActive(name, e.Value, e.Epoch, false)
+		}
+		if s.strong != nil && active.Strong {
+			s.strong.reconcile(name)
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	return recordErr
+}
+
+func validateNamingRecord(key, prefix, name, owner string) error {
+	if key != prefix+name {
+		return fmt.Errorf("registry record %q: name mismatch", key)
+	}
+	if _, err := pid.ParsePID(owner); err != nil {
+		return fmt.Errorf("registry record %q: invalid owner: %w", key, err)
+	}
+	return nil
 }
 
 func (s *Service) handleWatchEvent(ev kvapi.WatchEvent) {
@@ -131,7 +189,9 @@ func (s *Service) handleWatchEvent(ev kvapi.WatchEvent) {
 		}
 	case strings.HasPrefix(key, ackPrefix), strings.HasPrefix(key, rejectPrefix):
 		if s.strong != nil {
-			s.strong.reconcileAllPending()
+			if err := s.strong.reconcileAllPending(); err != nil {
+				s.logger.Debug("registry pending scan failed", zap.Error(err))
+			}
 		}
 	}
 }
@@ -163,13 +223,28 @@ func (s *Service) translateActive(name string, value []byte, raftIndex uint64, d
 	}
 }
 
-func (st *strongState) reconcileAllPending() {
+func (st *strongState) reconcileAllPending() error {
 	var names []string
-	_ = st.svc.engine.Scan(pendingPrefix, func(e kvapi.Entry) bool {
+	var recordErr error
+	if err := st.svc.engine.Scan(pendingPrefix, func(e kvapi.Entry) bool {
+		header, err := decodePending(e.Value)
+		if err != nil {
+			recordErr = fmt.Errorf("registry record %q: %w", e.Key, err)
+			return false
+		}
+		if recordErr = validateNamingRecord(e.Key, pendingPrefix, header.Name, header.PID); recordErr != nil {
+			return false
+		}
 		names = append(names, strings.TrimPrefix(e.Key, pendingPrefix))
 		return true
-	})
+	}); err != nil {
+		return err
+	}
+	if recordErr != nil {
+		return recordErr
+	}
 	for _, n := range names {
 		st.reconcile(n)
 	}
+	return nil
 }

--- a/system/topology/namereg/kvbacked/reconciler_owner_test.go
+++ b/system/topology/namereg/kvbacked/reconciler_owner_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kvbacked
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	kvapi "github.com/wippyai/runtime/api/store/kv"
+)
+
+type countedReconcilerEngine struct {
+	kvapi.Engine
+	calls atomic.Int32
+}
+
+func (e *countedReconcilerEngine) Watch(context.Context, string) (kvapi.Watcher, error) {
+	e.calls.Add(1)
+	return &readinessWatcher{events: make(chan kvapi.WatchEvent), closed: make(chan struct{})}, nil
+}
+func TestReconcilerRejectsDuplicateStartBeforeCreatingWatcher(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+	engine := &countedReconcilerEngine{Engine: r.engine}
+	r.engine = engine
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	require.NoError(t, r.StartReconciler(ctx))
+	require.Error(t, r.StartReconciler(ctx))
+	require.Equal(t, int32(1), engine.calls.Load())
+	require.True(t, r.NameReady(), "rejected duplicate cannot close the current owner")
+}
+func TestCanceledReconcilerStartCreatesNoWatcher(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+	engine := &countedReconcilerEngine{Engine: r.engine}
+	r.engine = engine
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, r.StartReconciler(ctx), context.Canceled)
+	require.Zero(t, engine.calls.Load())
+	require.False(t, r.NameReady())
+}
+
+type blockedEventsWatcher struct {
+	*readinessWatcher
+	entered, release chan struct{}
+	once             sync.Once
+}
+
+func (w *blockedEventsWatcher) Events() <-chan kvapi.WatchEvent {
+	w.once.Do(func() { close(w.entered); <-w.release })
+	return w.events
+}
+
+type blockedEventsEngine struct {
+	kvapi.Engine
+	watcher *blockedEventsWatcher
+}
+
+func (e *blockedEventsEngine) Watch(context.Context, string) (kvapi.Watcher, error) {
+	return e.watcher, nil
+}
+func TestReconcilerCancellationClosesReadinessBeforeWorkerRuns(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+	w := &blockedEventsWatcher{readinessWatcher: &readinessWatcher{events: make(chan kvapi.WatchEvent), closed: make(chan struct{})}, entered: make(chan struct{}), release: make(chan struct{})}
+	r.engine = &blockedEventsEngine{Engine: r.engine, watcher: w}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	defer close(w.release)
+	require.NoError(t, r.StartReconciler(ctx))
+	select {
+	case <-w.entered:
+	case <-time.After(time.Second):
+		t.Fatal("watch worker did not start")
+	}
+	cancel()
+	require.False(t, r.NameReady(), "cancellation must close admission without waiting for worker scheduling")
+}
+
+func TestReconcilerFailedSeedReleasesStartupOwnership(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1"}, time.Second, nil)
+	engine := &countedReconcilerEngine{Engine: r.engine}
+	r.engine = engine
+	ok, err := r.engine.Txn([]kvapi.TxnOp{{Kind: kvapi.TxnPut, Key: activeKey("broken"), Value: []byte{0xc1}}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	require.Error(t, r.StartReconciler(ctx))
+	require.False(t, r.NameReady())
+	ok, err = r.engine.Txn([]kvapi.TxnOp{{Kind: kvapi.TxnDelete, Key: activeKey("broken")}})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, r.StartReconciler(ctx), "failed startup must release ownership after cleanup")
+	require.Equal(t, int32(2), engine.calls.Load())
+	require.True(t, r.NameReady())
+}

--- a/system/topology/namereg/kvbacked/registry.go
+++ b/system/topology/namereg/kvbacked/registry.go
@@ -103,6 +103,7 @@ type barrierEngine interface {
 
 // Service is the kv-backed name registry.
 type Service struct {
+	reconciler atomic.Pointer[reconcilerLifecycle]
 	engine     kvapi.Engine
 	leaderRead leaderReadEngine
 	topo       topology.Topology

--- a/system/topology/namereg/kvbacked/strong.go
+++ b/system/topology/namereg/kvbacked/strong.go
@@ -497,7 +497,14 @@ func (st *strongState) leaderPromote(name string, epoch, headerVer uint64, hdr p
 		{Kind: kvapi.TxnPut, Cond: kvapi.CondAny, Key: nodeIndexKey(p, name), Value: idx},
 	}
 	for _, n := range hdr.RequiredNodes {
-		ops = append(ops, kvapi.TxnOp{Kind: kvapi.TxnDelete, Cond: kvapi.CondAny, Key: ackKey(name, epoch, n)})
+		// The leader's preceding scan is only a hint. Validate the entire
+		// admission decision in the committed transaction so a rejection that
+		// precedes promotion in Raft order cannot be ignored.
+		ops = append(ops,
+			kvapi.TxnOp{Kind: kvapi.TxnCheck, Cond: kvapi.CondExists, Key: ackKey(name, epoch, n)},
+			kvapi.TxnOp{Kind: kvapi.TxnCheck, Cond: kvapi.CondAbsent, Key: rejectKey(name, epoch, n)},
+			kvapi.TxnOp{Kind: kvapi.TxnDelete, Cond: kvapi.CondAny, Key: ackKey(name, epoch, n)},
+		)
 	}
 	committed, terr := st.svc.engine.Txn(ops)
 	if terr != nil {

--- a/system/topology/namereg/kvbacked/strong.go
+++ b/system/topology/namereg/kvbacked/strong.go
@@ -535,13 +535,35 @@ func (st *strongState) leaderExpire(name string, epoch, headerVer uint64, hdr pe
 		{Kind: kvapi.TxnDelete, Cond: kvapi.CondAny, Key: pendingKey(name)},
 	}
 	for _, n := range hdr.RequiredNodes {
-		if _, err := st.svc.engine.Get(ackKey(name, epoch, n)); err != nil {
+		ack := ackKey(name, epoch, n)
+		_, err := st.svc.engine.Get(ack)
+		if err != nil && !errors.Is(err, kvapi.ErrKeyNotFound) {
+			return
+		}
+		absent := errors.Is(err, kvapi.ErrKeyNotFound)
+		if absent {
 			missing = append(missing, n)
 		}
+		if reason == "deadline" {
+			// Keep the reported missing set and rejection precedence true at
+			// commit, not merely at the leader's earlier read.
+			condition := kvapi.CondExists
+			if absent {
+				condition = kvapi.CondAbsent
+			}
+			ops = append(ops,
+				kvapi.TxnOp{Kind: kvapi.TxnCheck, Cond: condition, Key: ack},
+				kvapi.TxnOp{Kind: kvapi.TxnCheck, Cond: kvapi.CondAbsent, Key: rejectKey(name, epoch, n)},
+			)
+		}
 		ops = append(ops,
-			kvapi.TxnOp{Kind: kvapi.TxnDelete, Cond: kvapi.CondAny, Key: ackKey(name, epoch, n)},
+			kvapi.TxnOp{Kind: kvapi.TxnDelete, Cond: kvapi.CondAny, Key: ack},
 			kvapi.TxnOp{Kind: kvapi.TxnDelete, Cond: kvapi.CondAny, Key: rejectKey(name, epoch, n)},
 		)
+	}
+	if reason == "deadline" && len(missing) == 0 {
+		st.leaderPromote(name, epoch, headerVer, hdr)
+		return
 	}
 	if committed, terr := st.svc.engine.Txn(ops); terr != nil || !committed {
 		return

--- a/system/topology/namereg/kvbacked/strong.go
+++ b/system/topology/namereg/kvbacked/strong.go
@@ -173,6 +173,11 @@ func (s *Service) nameReady() bool {
 	// No Strong plane -> no join barrier needed. Otherwise the node is ready
 	// only once the reconciler has seeded (learned and latched the cluster's
 	// in-flight/active Strong reservations), so it cannot shadow one.
+	if s.strong != nil {
+		if run := s.reconciler.Load(); run != nil && run.ctx.Err() != nil {
+			return false
+		}
+	}
 	return s.strong == nil || s.ready.Load()
 }
 


### PR DESCRIPTION
Strong naming could promote or expire reservations from a stale vote scan, and the KV-backed registry could report readiness after failed seeding or after its update stream stopped.

This change validates promotion and deadline expiry predicates in the committed transaction. Reconciler startup now owns one lifecycle, validates the complete pending and active seed, fails closed on malformed records or scan errors, clears readiness when synchronization stops, rejects duplicate starts, and releases ownership after a failed start so it can be retried.

The replay is limited to the existing KV-backed naming implementation. Work already merged through #662 and #665 is omitted. It adds no exported API, protocol, boot configuration, timeout knob, relay ingress path, documentation, or fixture surface.

Validation:
- KV-backed naming race suite
- real-Raft cluster integration race suite
- full go vet and pinned lint
- Windows build, module verification, and diff check