### PR TITLE
fix(naming): bound Strong waits and back off failed deadline barriers

### DIFF
--- a/system/topology/namereg/kvbacked/strong.go
+++ b/system/topology/namereg/kvbacked/strong.go
@@ -185,16 +185,11 @@ func (st *strongState) register(ctx context.Context, name string, p pid.PID) (gl
 	if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) && time.Until(dl) >= 50*time.Millisecond {
 		deadline = dl
 	}
-	// Guarantee the wait is bounded: if the caller's context has no deadline, the
-	// waiter must still not block forever should a reconcile path skip delivery.
-	// The backstop fires a grace period AFTER the Strong deadline so the normal
-	// expiry path (leader timer -> leaderExpire -> deliver) wins the race and
-	// returns the typed StrongRegistrationTimeoutError rather than ctx.Err().
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithDeadline(ctx, deadline.Add(2*time.Second))
-		defer cancel()
-	}
+	// Bound result waiting even when the caller supplies a distant deadline.
+	// An earlier caller deadline is preserved by context.WithDeadline. The
+	// grace lets the normal expiry transaction win before reporting uncertainty.
+	ctx, cancel := context.WithDeadline(ctx, deadline.Add(2*time.Second))
+	defer cancel()
 
 	hdr, err := encode(pendingHeader{
 		PID:              p.String(),
@@ -459,11 +454,12 @@ func (st *strongState) leaderDrive(name string, epoch, headerVer uint64, hdr pen
 	}
 	// Deadline reached. Barrier so a committed-but-unapplied ack set is not
 	// falsely expired, then re-check completion before giving up. The barrier
-	// runs at most once per reservation (the deadline tick), never on the hot
-	// ack path.
+	// runs on deadline attempts; failures retry with a delay. It is not needed
+	// on the normal acknowledgement path.
 	if st.svc.barrier != nil {
 		if err := st.svc.barrier(); err != nil {
-			st.armTimer(name, hdr.DeadlineUnixNano)
+			// A past deadline would schedule an immediate callback loop.
+			st.armTimer(name, time.Now().Add(time.Second).UnixNano())
 			return
 		}
 	}

--- a/system/topology/namereg/kvbacked/wait_bounds_test.go
+++ b/system/topology/namereg/kvbacked/wait_bounds_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kvbacked
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/pid"
+	globalapi "github.com/wippyai/runtime/api/topology/namereg/global"
+)
+
+func TestStrongDistantCallerDeadlineStillHasRuntimeWaitBound(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1", "ghost"}, 20*time.Millisecond, nil)
+	r.strong.isLeader = func() bool { return false }
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.RegisterScope(ctx, "claim", mkPID("node-1", "owner"), globalapi.Strong)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+			t.Fatalf("unexpected wait outcome: %v, caller=%v", err, ctx.Err())
+		}
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("runtime wait inherited the caller's distant deadline")
+	}
+}
+
+func TestExpiredStrongBarrierFailureDoesNotSpin(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1", "ghost"}, time.Second, nil)
+	var leader atomic.Bool
+	leader.Store(true)
+	r.strong.isLeader = leader.Load
+	var probes atomic.Int32
+	r.barrier = func() error { probes.Add(1); return errors.New("barrier temporarily unavailable") }
+	t.Cleanup(func() { leader.Store(false); r.strong.stopTimer("claim") })
+	owner := mkPID("node-1", "owner")
+	hdr := pendingHeader{PID: owner.String(), Name: "claim", RequiredNodes: []pid.NodeID{"node-1", "ghost"}, DeadlineUnixNano: time.Now().Add(-time.Second).UnixNano()}
+	value, err := encode(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.engine.Set(pendingKey("claim"), value); err != nil {
+		t.Fatal(err)
+	}
+	pe, err := r.engine.Get(pendingKey("claim"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.strong.leaderDrive("claim", pe.Epoch, pe.Version, hdr)
+	time.Sleep(75 * time.Millisecond)
+	if got := probes.Load(); got > 1 {
+		t.Fatalf("expired deadline caused immediate retry loop: %d probes", got)
+	}
+}

--- a/system/topology/namereg/kvbacked/wait_bounds_test.go
+++ b/system/topology/namereg/kvbacked/wait_bounds_test.go
@@ -18,6 +18,7 @@ func TestStrongDistantCallerDeadlineStillHasRuntimeWaitBound(t *testing.T) {
 	r.strong.isLeader = func() bool { return false }
 	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()
+	started := time.Now()
 	done := make(chan error, 1)
 	go func() {
 		_, err := r.RegisterScope(ctx, "claim", mkPID("node-1", "owner"), globalapi.Strong)
@@ -28,10 +29,28 @@ func TestStrongDistantCallerDeadlineStillHasRuntimeWaitBound(t *testing.T) {
 		if !errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
 			t.Fatalf("unexpected wait outcome: %v, caller=%v", err, ctx.Err())
 		}
+		if elapsed := time.Since(started); elapsed < time.Second {
+			t.Fatalf("runtime wait ended before the Strong deadline grace: %v", elapsed)
+		}
 	case <-time.After(3 * time.Second):
 		cancel()
 		<-done
 		t.Fatal("runtime wait inherited the caller's distant deadline")
+	}
+}
+
+func TestStrongEarlierCallerDeadlineStillWins(t *testing.T) {
+	r := newStrongReg(t, []pid.NodeID{"node-1", "ghost"}, 5*time.Second, nil)
+	r.strong.isLeader = func() bool { return false }
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := r.RegisterScope(ctx, "claim", mkPID("node-1", "owner"), globalapi.Strong)
+	if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("earlier caller deadline outcome: %v, caller=%v", err, ctx.Err())
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("runtime deadline overrode earlier caller deadline: %v", elapsed)
 	}
 }
 
@@ -58,7 +77,19 @@ func TestExpiredStrongBarrierFailureDoesNotSpin(t *testing.T) {
 	}
 	r.strong.leaderDrive("claim", pe.Epoch, pe.Version, hdr)
 	time.Sleep(75 * time.Millisecond)
-	if got := probes.Load(); got > 1 {
+	if got := probes.Load(); got != 1 {
 		t.Fatalf("expired deadline caused immediate retry loop: %d probes", got)
+	}
+
+	deadline := time.After(1500 * time.Millisecond)
+	for probes.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatal("failed barrier was never retried")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if got := probes.Load(); got != 2 {
+		t.Fatalf("barrier retry was not bounded: %d probes", got)
 	}
 }


### PR DESCRIPTION
A distant caller deadline could bypass the runtime Strong deadline plus grace, leaving result waiting effectively unbounded. Separately, a failed deadline barrier rearmed the already-expired deadline and caused a hot retry loop.

Always cap result waiting at the Strong deadline plus the existing two-second grace while preserving earlier caller cancellation. Retry failed deadline barriers once per second instead of immediately.

Regression coverage proves the parent hangs or spins, the runtime cap does not fire prematurely, earlier caller deadlines still win, and barrier retries remain both bounded and live. The KV-backed naming package passes under race and repository-pinned scoped lint reports zero issues.

Submission and forwarding retain their existing operation timeouts. No public API, command/wire encoding, persisted field, scope guarantee, Lua/native binding, or configuration surface changes.