### PR TITLE
fix(kv): reject malformed forwarded read replies

### DIFF
--- a/system/kv/forward_read_error_test.go
+++ b/system/kv/forward_read_error_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kv
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/relay"
+)
+
+type truncatedReadRouter struct {
+	receiver *RaftEngine
+	fallback relay.Receiver
+}
+
+func (r *truncatedReadRouter) Send(pkg *relay.Package) error {
+	if pkg.Messages[0].Topic != topicKVReadReq && r.fallback != nil {
+		return r.fallback.Send(pkg)
+	}
+	defer relay.ReleasePackage(pkg)
+	for _, msg := range pkg.Messages {
+		if msg.Topic != topicKVReadReq {
+			continue
+		}
+		req := msg.Payloads[0].Data().([]byte)
+		reply := make([]byte, 29)
+		copy(reply[:8], req[:8])
+		reply[8] = 1 // Found, but the declared value is missing from the frame.
+		binary.BigEndian.PutUint32(reply[25:29], 10)
+		return r.receiver.Send(relay.NewServicePackage("leader", KVRaftHostID, "client", KVRaftHostID, topicKVReadResp, payload.New(reply)))
+	}
+	return nil
+}
+
+func TestForwardReadRejectsTruncatedFoundResponse(t *testing.T) {
+	fsm := NewRaftFSM(nil)
+	router := &truncatedReadRouter{}
+	eng := NewRaftEngine(&fakeRaft{fsm: fsm, leaderID: "leader"}, fsm, nil, "client", router, nil)
+	router.receiver = eng
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = eng.Stop() })
+	got, err := eng.GetViaLeader("present")
+	if err == nil {
+		t.Fatalf("truncated response accepted as a successful read: %+v", got)
+	}
+	if err.Error() != "kv: read response truncated" {
+		t.Fatalf("lost protocol error: %v", err)
+	}
+}
+
+func TestForwardReadRejectsTruncationThroughMember(t *testing.T) {
+	engines := startForwardCluster(t, map[string]string{"A": "A", "B": "A", "C": "B"})
+	member := engines["B"]
+	member.router = &truncatedReadRouter{receiver: member, fallback: member.router}
+	got, err := engines["C"].GetViaLeader("present")
+	// The existing wire can only express unavailable at the intermediary.
+	// It must never translate the corrupt value into success or not-found.
+	if !errors.Is(err, errNoForwardLeader) {
+		t.Fatalf("re-forwarded corrupt read = %+v, %v; want unavailable", got, err)
+	}
+}

--- a/system/kv/raft_forward.go
+++ b/system/kv/raft_forward.go
@@ -234,7 +234,9 @@ func (e *RaftEngine) forwardReadHop(key string, hop byte) (readResult, error) {
 			time.Sleep(50 * time.Millisecond)
 			continue
 		}
-		return res, nil
+		// Decoder failures must survive both a direct read and a re-forwarding
+		// hop; a found flag alone does not make a malformed value valid.
+		return res, res.err
 	}
 	return readResult{}, errNoForwardLeader
 }


### PR DESCRIPTION
A truncated forwarded KV read reply sets a decoder error, but `forwardReadHop` discarded it. A reply marked found could therefore return a successful read with an empty value. Through an intermediary, the same error could be re-encoded as valid data.

Propagate the decoded error from `forwardReadHop`. Direct callers receive the protocol error; intermediaries report unavailability through the existing wire format. Valid missing-key responses and successful reads keep their existing behavior. No wire or persisted-state changes.

Validation: the direct truncated-response regression failed before the fix. Direct and intermediary regressions pass after it; isolated KV and real-Raft integration race suites and scoped lint pass.

This is one current-runtime cluster hardening fix; it does not address gossip-only lookup latency, client Strong readiness, or the remaining naming lifecycle work.
