### PR TITLE
feat(application): host standalone bundled applications with canonical deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,3 +194,7 @@ build-sign-wippy-windows: build-wippy-windows-amd64 sign-wippy-windows
 .PHONY: run-wippy
 run-wippy:
 	go run --tags "fts5 sqlite_vec treesitter sqlite_preupdate_hook" -ldflags="$(WIPPY_LDFLAGS)" ./cmd/wippy/ $(ARGS)
+
+.PHONY: test-application
+test-application:
+	go test -tags "fts5 sqlite_vec treesitter sqlite_preupdate_hook" ./application ./cmd/wippy/cmd ./cmd/internal/entries ./boot/deps/lock

--- a/application/README.md
+++ b/application/README.md
@@ -1,0 +1,45 @@
+# Native application host
+
+This package provides the boot boundary used by standalone Wippy applications.
+The application supplies a complete, versioned bundle of canonical Hub packs and
+an explicit list of native boot components. The generated executable imports
+`application.Run`; it does not copy CLI loaders or implement a Hub resolver.
+
+`Bundle.Seed` validates pack hashes and published identities before creating a
+canonical deployment lock and vendor directory. An existing lock selecting the
+same root is preserved, even when it selects a newer application version. A
+corrupt or unrelated deployment fails closed.
+
+`Run` accepts `--state-dir`, `--command`, and `--base`, followed by `run` and
+application arguments, `update`, or `runtime` and canonical Wippy CLI arguments.
+With no explicit operation it runs the application's configured command. Default
+state is under the OS user configuration directory and executable name. The
+caller's working directory remains unchanged. Applications can map environment
+variables to workspace data paths with `Options.DataEnv`; explicit environment
+values take precedence.
+
+`update` stages the selected deployment, calls the executable's canonical Wippy
+update and lint commands, verifies installed pack digests, and switches the
+activation record only after success. An exclusive process-lifetime state lock
+prevents a concurrent launch or update. Previous deployment files remain available.
+The advanced `runtime` command directly exposes Wippy operations; it does not
+apply the standalone staged-update wrapper.
+
+`base` mode exposes `--base` as an explicit recovery boot with an independent
+registry history. `bootstrap` mode only seeds the initial deployment. Neither
+mode deletes or rolls back application databases. An application's migration
+checks still decide whether older bundled code can open newer data. There is no
+claim of transparent rollback across incompatible data schemas.
+
+Native components are additional host selections. Duplicate component names are
+rejected, including attempts to replace built-ins. Their Lua declarations and
+normal runtime permissions remain in force. The update lint gate detects missing
+native module exports and type incompatibility; explicit semantic-version native
+requirements are not implemented yet.
+
+`cmd.ExecuteWithOptions` is the process-level adapter to the normal Wippy command
+paths. Call it once from main, not concurrently or from application actors.
+Host-selected registry paths override package settings so an application update
+cannot relocate its deployment lock or registry history.
+
+Run `make test-application` for the host, deployment and command regression tests.

--- a/application/README.md
+++ b/application/README.md
@@ -2,8 +2,8 @@
 
 This package provides the boot boundary used by standalone Wippy applications.
 The application supplies a complete, versioned bundle of canonical Hub packs and
-an explicit list of native boot components. The generated executable imports
-`application.Run`; it does not copy CLI loaders or implement a Hub resolver.
+an explicit list of native boot components. The generated executable calls
+`application.Run`, which uses Wippy's command paths and Hub resolver.
 
 `Bundle.Seed` validates pack hashes and published identities before creating a
 canonical deployment lock and vendor directory. An existing lock selecting the

--- a/application/README.md
+++ b/application/README.md
@@ -43,3 +43,9 @@ Host-selected registry paths override package settings so an application update
 cannot relocate its deployment lock or registry history.
 
 Run `make test-application` for the host, deployment and command regression tests.
+
+For an assembled-binary Hub protocol acceptance test, set
+`WIPPY_TEST_APPLICATION_BINARY` and `WIPPY_TEST_APPLICATION_PACK` to the builder's
+hello executable and pack, then run `make test-application`. The fixture serves
+canonical Hub manifest/download RPCs locally and verifies a root-plus-dependency
+update, cold restart, explicit base recovery and failed-update preservation.

--- a/application/bundle.go
+++ b/application/bundle.go
@@ -18,7 +18,7 @@ import (
 	"github.com/wippyai/wapp"
 )
 
-// Pack is an exact published artifact, including its canonical Hub identity.
+// Pack is an exact published artifact, including its Hub identity.
 // Digest is the SHA-256 of Data, with a sha256: prefix.
 type Pack struct {
 	Module  string
@@ -73,10 +73,10 @@ func (bundle Bundle) validate() error {
 	return nil
 }
 
-// Seed installs an initial canonical deployment in directory and returns its
+// Seed installs an initial Wippy deployment in directory and returns its
 // lock path. An existing deployment must select the same application and is
 // never replaced, including when its version differs from the embedded pack.
-// Directory is exclusively for deployment files, not application databases.
+// Directory contains deployment files. Store application databases separately.
 func (bundle Bundle) Seed(directory string) (string, error) {
 	if err := bundle.validate(); err != nil {
 		return "", err

--- a/application/bundle.go
+++ b/application/bundle.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package application hosts native applications built on the Wippy runtime.
+package application
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wippyai/runtime/api/semver"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/wapp"
+)
+
+// Pack is an exact published artifact, including its canonical Hub identity.
+// Digest is the SHA-256 of Data, with a sha256: prefix.
+type Pack struct {
+	Module  string
+	Version string
+	Digest  string
+	Data    []byte
+}
+
+// Bundle is the complete offline deployment shipped by an executable.
+// Root selects the application; other packs are its locked dependencies.
+type Bundle struct {
+	Root  string
+	Packs []Pack
+}
+
+func (bundle Bundle) validate() error {
+	if err := lock.ValidateModuleName(bundle.Root); err != nil {
+		return err
+	}
+	seen := make(map[string]bool)
+	for _, pack := range bundle.Packs {
+		if err := lock.ValidateModuleName(pack.Module); err != nil {
+			return err
+		}
+		if _, err := semver.ParseVersion(pack.Version); err != nil {
+			return fmt.Errorf("pack %s version: %w", pack.Module, err)
+		}
+		if seen[pack.Module] {
+			return fmt.Errorf("duplicate bundled module %s", pack.Module)
+		}
+		seen[pack.Module] = true
+		digest := sha256.Sum256(pack.Data)
+		if pack.Digest != "sha256:"+hex.EncodeToString(digest[:]) {
+			return fmt.Errorf("pack %s digest mismatch", pack.Module)
+		}
+		reader, err := wapp.NewReader(bytes.NewReader(pack.Data))
+		if err != nil {
+			return fmt.Errorf("pack %s: %w", pack.Module, err)
+		}
+		metadata, err := reader.GetMetadata()
+		if err != nil {
+			return fmt.Errorf("pack %s metadata: %w", pack.Module, err)
+		}
+		name, _ := graph.ParseName(pack.Module)
+		if metadata["namespace"] != name.Organization+"."+name.Module || metadata["name"] != name.Module || metadata["version"] != pack.Version {
+			return fmt.Errorf("pack %s metadata does not match bundled identity", pack.Module)
+		}
+	}
+	if !seen[bundle.Root] {
+		return fmt.Errorf("bundled application %s is missing", bundle.Root)
+	}
+	return nil
+}
+
+// Seed installs an initial canonical deployment in directory and returns its
+// lock path. An existing deployment must select the same application and is
+// never replaced, including when its version differs from the embedded pack.
+// Directory is exclusively for deployment files, not application databases.
+func (bundle Bundle) Seed(directory string) (string, error) {
+	if err := bundle.validate(); err != nil {
+		return "", err
+	}
+	directory, err := filepath.Abs(directory)
+	if err != nil {
+		return "", err
+	}
+	lockPath := filepath.Join(directory, lock.DefaultFilename)
+	if _, err := os.Stat(directory); err == nil {
+		return bundle.existing(lockPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	parent := filepath.Dir(directory)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", err
+	}
+	staging, err := os.MkdirTemp(parent, ".deployment-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(staging)
+	locked, err := lock.New(filepath.Join(staging, lock.DefaultFilename))
+	if err != nil {
+		return "", err
+	}
+	locked.SetDirectories(lock.Directories{Modules: ".wippy", Src: "src"})
+	for _, pack := range bundle.Packs {
+		name, _ := graph.ParseName(pack.Module)
+		path := filepath.Join(staging, locked.GetVendorPath(), lock.WappPath(name, pack.Version))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return "", err
+		}
+		if err := writeSynced(path, pack.Data); err != nil {
+			return "", err
+		}
+		locked.SetModule(lock.Module{Name: pack.Module, Version: pack.Version, Hash: pack.Digest, Root: pack.Module == bundle.Root})
+	}
+	if err := locked.Write(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(staging, directory); err != nil {
+		// A concurrent first launch may have installed the same application.
+		if _, statErr := os.Stat(directory); statErr == nil {
+			return bundle.existing(lockPath)
+		}
+		return "", err
+	}
+	return lockPath, nil
+}
+
+func (bundle Bundle) existing(path string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("existing deployment lock: %w", err)
+	}
+	locked, err := lock.New(path)
+	if err != nil {
+		return "", err
+	}
+	if err := lock.Validate(locked); err != nil {
+		return "", err
+	}
+	roots := locked.GetRootModules()
+	if len(roots) != 1 || roots[0] != bundle.Root {
+		return "", fmt.Errorf("deployment does not select %s", bundle.Root)
+	}
+	return path, nil
+}
+
+func writeSynced(path string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/application/bundle_test.go
+++ b/application/bundle_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package application
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/wapp"
+)
+
+func testBundle(t *testing.T) Bundle {
+	t.Helper()
+	var data bytes.Buffer
+	err := wapp.NewWriter().PackEntries(wapp.Metadata{"namespace": "acme.app", "name": "app", "version": "1.0.0"}, nil, &data)
+	require.NoError(t, err)
+	digest := sha256.Sum256(data.Bytes())
+	return Bundle{Root: "acme/app", Packs: []Pack{{Module: "acme/app", Version: "1.0.0", Digest: fmt.Sprintf("sha256:%x", digest), Data: data.Bytes()}}}
+}
+
+func TestBundleSeedsOfflineAndPreservesUpdatedVersion(t *testing.T) {
+	bundle := testBundle(t)
+	dir := filepath.Join(t.TempDir(), "deployment")
+	path, err := bundle.Seed(dir)
+	require.NoError(t, err)
+	locked, err := lock.New(path)
+	require.NoError(t, err)
+	require.Equal(t, []string{"acme/app"}, locked.GetRootModules())
+	paths := locked.GetModuleLoadPaths()
+	require.Len(t, paths, 2)
+	data, err := os.ReadFile(paths[1].Path)
+	require.NoError(t, err)
+	require.Equal(t, bundle.Packs[0].Data, data)
+	locked.SetModule(lock.Module{Name: "acme/app", Version: "2.0.0", Root: true})
+	require.NoError(t, locked.Write())
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+	_, err = bundle.Seed(dir)
+	require.NoError(t, err)
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}
+
+func TestBundleRejectsCorruptionAndIdentityMismatch(t *testing.T) {
+	for _, mutation := range []func(*Bundle){
+		func(b *Bundle) { b.Packs[0].Data = append(b.Packs[0].Data, 0) },
+		func(b *Bundle) { b.Packs[0].Version = "2.0.0" },
+		func(b *Bundle) { b.Packs = append(b.Packs, b.Packs[0]) },
+		func(b *Bundle) { b.Root = "acme/other" },
+	} {
+		bundle := testBundle(t)
+		mutation(&bundle)
+		dir := filepath.Join(t.TempDir(), "deployment")
+		_, err := bundle.Seed(dir)
+		require.Error(t, err)
+		_, err = os.Stat(dir)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func TestBundleFailsClosedOnExistingInvalidDeployment(t *testing.T) {
+	bundle := testBundle(t)
+	dir := t.TempDir()
+	_, err := bundle.Seed(dir)
+	require.Error(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wippy.lock"), []byte("not: [yaml"), 0o600))
+	_, err = bundle.Seed(dir)
+	require.Error(t, err)
+}
+
+func TestBundleConcurrentFirstLaunch(t *testing.T) {
+	bundle := testBundle(t)
+	dir := filepath.Join(t.TempDir(), "deployment")
+	var wait sync.WaitGroup
+	failures := make(chan error, 8)
+	for range 8 {
+		wait.Go(func() { _, err := bundle.Seed(dir); failures <- err })
+	}
+	wait.Wait()
+	close(failures)
+	for err := range failures {
+		require.NoError(t, err)
+	}
+}

--- a/application/deployment.go
+++ b/application/deployment.go
@@ -58,13 +58,13 @@ func runChild(ctx context.Context, state string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	// Reexecute this binary with argv, never an application-selected executable or shell.
+	// Reexecute the running binary with the supplied argument slice.
 	command := exec.CommandContext(ctx, executable, append([]string{"--state-dir", state, "runtime"}, args...)...) //nolint:gosec // executable comes only from os.Executable
 	command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return command.Run()
 }
 
-// updateDeployment runs canonical update and lint in a disposable deployment.
+// updateDeployment runs Wippy update and lint in a disposable deployment.
 // Activation changes only after both commands and artifact verification succeed.
 func updateDeployment(ctx context.Context, options Options, state, current string, args []string, run commandRunner) error {
 	revisions := filepath.Join(state, "revisions")

--- a/application/deployment.go
+++ b/application/deployment.go
@@ -58,7 +58,8 @@ func runChild(ctx context.Context, state string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	command := exec.CommandContext(ctx, executable, append([]string{"--state-dir", state, "runtime"}, args...)...)
+	// Reexecute this binary with argv, never an application-selected executable or shell.
+	command := exec.CommandContext(ctx, executable, append([]string{"--state-dir", state, "runtime"}, args...)...) //nolint:gosec // executable comes only from os.Executable
 	command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return command.Run()
 }

--- a/application/deployment.go
+++ b/application/deployment.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/wippyai/runtime/boot/deps/hub"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+type activation struct {
+	Directory string `json:"directory"`
+	Previous  string `json:"previous,omitempty"`
+}
+
+func selectedDeployment(state string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(state, "active.json"))
+	if os.IsNotExist(err) {
+		return filepath.Join(state, "deployment"), nil
+	}
+	if err != nil {
+		return "", err
+	}
+	var current activation
+	if err := json.Unmarshal(data, &current); err != nil {
+		return "", fmt.Errorf("read application activation: %w", err)
+	}
+	if !filepath.IsLocal(current.Directory) || !strings.HasPrefix(filepath.ToSlash(current.Directory), "revisions/") {
+		return "", fmt.Errorf("invalid application activation path")
+	}
+	return filepath.Join(state, current.Directory), nil
+}
+
+func lockApplication(state string) (func(), error) {
+	file, err := os.OpenFile(filepath.Join(state, ".application.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	unlock, err := tryLockFile(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("application is already running or being updated: %w", err)
+	}
+	return func() { _ = unlock(); _ = file.Close() }, nil
+}
+
+type commandRunner func(context.Context, string, ...string) error
+
+func runChild(ctx context.Context, state string, args ...string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	command := exec.CommandContext(ctx, executable, append([]string{"--state-dir", state, "runtime"}, args...)...)
+	command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return command.Run()
+}
+
+// updateDeployment runs canonical update and lint in a disposable deployment.
+// Activation changes only after both commands and artifact verification succeed.
+func updateDeployment(ctx context.Context, options Options, state, current string, args []string, run commandRunner) error {
+	revisions := filepath.Join(state, "revisions")
+	if err := os.MkdirAll(revisions, 0o700); err != nil {
+		return err
+	}
+	candidate, err := os.MkdirTemp(revisions, "revision-")
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(candidate)
+		}
+	}()
+	deployment := filepath.Join(candidate, "deployment")
+	if err := os.CopyFS(deployment, os.DirFS(current)); err != nil {
+		return fmt.Errorf("stage application update: %w", err)
+	}
+	// Keep the original config path so relative replacements retain their base.
+	prefix := []string{}
+	config := filepath.Join(state, ".wippy.yaml")
+	if _, err := os.Stat(config); err == nil {
+		prefix = []string{"--config", config}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	updateArgs := append(append([]string{}, prefix...), "update")
+	if err := run(ctx, candidate, append(updateArgs, args...)...); err != nil {
+		return fmt.Errorf("update failed; active deployment unchanged: %w", err)
+	}
+	if err := run(ctx, candidate, append(append([]string{}, prefix...), "lint")...); err != nil {
+		return fmt.Errorf("updated application is incompatible with this executable: %w", err)
+	}
+	path, err := options.Bundle.existing(filepath.Join(deployment, lock.DefaultFilename))
+	if err != nil {
+		return err
+	}
+	locked, err := lock.New(path)
+	if err != nil {
+		return err
+	}
+	for _, pack := range locked.GetModuleLoadPaths() {
+		if pack.Module == "" {
+			continue
+		}
+		if info, err := os.Stat(pack.Path); err != nil || !info.Mode().IsRegular() {
+			return fmt.Errorf("updated module %s must be a verified pack", pack.Module)
+		}
+		if pack.Digest == "" {
+			return fmt.Errorf("updated module %s has no digest", pack.Module)
+		}
+		if err := hub.VerifyDownloadedArtifact(pack.Path, pack.Digest, 0); err != nil {
+			return err
+		}
+	}
+	relative, err := filepath.Rel(state, deployment)
+	if err != nil {
+		return err
+	}
+	previous, err := filepath.Rel(state, current)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(activation{Directory: relative, Previous: previous})
+	if err != nil {
+		return err
+	}
+	pending, err := os.CreateTemp(state, ".activation-")
+	if err != nil {
+		return err
+	}
+	pendingPath := pending.Name()
+	defer os.Remove(pendingPath)
+	if _, err := pending.Write(data); err != nil {
+		_ = pending.Close()
+		return err
+	}
+	if err := pending.Sync(); err != nil {
+		_ = pending.Close()
+		return err
+	}
+	if err := pending.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(pendingPath, filepath.Join(state, "active.json")); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}

--- a/application/deployment_test.go
+++ b/application/deployment_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package application
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailedUpdateNeverChangesActiveDeployment(t *testing.T) {
+	for _, failing := range []string{"update", "lint"} {
+		t.Run(failing, func(t *testing.T) {
+			state := t.TempDir()
+			bundle := testBundle(t)
+			current := filepath.Join(state, "deployment")
+			path, err := bundle.Seed(current)
+			require.NoError(t, err)
+			before, err := os.ReadFile(path)
+			require.NoError(t, err)
+			run := func(_ context.Context, candidate string, args ...string) error {
+				require.NotEqual(t, state, candidate)
+				if args[0] == failing {
+					require.NoError(t, os.WriteFile(filepath.Join(candidate, "deployment", "wippy.lock"), []byte("broken lock"), 0600))
+					return errors.New("injected failure")
+				}
+				return nil
+			}
+			err = updateDeployment(context.Background(), Options{Bundle: bundle}, state, current, nil, run)
+			require.Error(t, err)
+			after, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+			selected, err := selectedDeployment(state)
+			require.NoError(t, err)
+			require.Equal(t, current, selected)
+		})
+	}
+}
+
+func TestSuccessfulUpdateSelectsVerifiedCandidate(t *testing.T) {
+	state := t.TempDir()
+	bundle := testBundle(t)
+	current := filepath.Join(state, "deployment")
+	_, err := bundle.Seed(current)
+	require.NoError(t, err)
+	var commands []string
+	run := func(_ context.Context, _ string, args ...string) error {
+		commands = append(commands, args[0])
+		return nil
+	}
+	require.NoError(t, updateDeployment(context.Background(), Options{Bundle: bundle}, state, current, nil, run))
+	require.Equal(t, []string{"update", "lint"}, commands)
+	selected, err := selectedDeployment(state)
+	require.NoError(t, err)
+	require.NotEqual(t, current, selected)
+	_, err = bundle.existing(filepath.Join(selected, "wippy.lock"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(current, "wippy.lock"))
+	require.NoError(t, err)
+}
+
+func TestApplicationLockIsReleasedAndRejectsConcurrentRun(t *testing.T) {
+	state := t.TempDir()
+	unlock, err := lockApplication(state)
+	require.NoError(t, err)
+	_, err = lockApplication(state)
+	require.Error(t, err)
+	unlock()
+	unlock, err = lockApplication(state)
+	require.NoError(t, err)
+	unlock()
+}
+
+func TestActivationCannotEscapeStateDirectory(t *testing.T) {
+	state := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(state, "active.json"), []byte(`{"directory":"../outside"}`), 0600))
+	_, err := selectedDeployment(state)
+	require.Error(t, err)
+}

--- a/application/filelock_unix.go
+++ b/application/filelock_unix.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package application
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+var errLockBusy = errors.New("application lock is busy")
+
+func tryLockFile(file *os.File) (func() error, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return nil, errLockBusy
+	}
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	}, nil
+}

--- a/application/filelock_windows.go
+++ b/application/filelock_windows.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package application
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+var errLockBusy = errors.New("application lock is busy")
+
+func tryLockFile(file *os.File) (func() error, error) {
+	overlapped := &windows.Overlapped{}
+	handle := windows.Handle(file.Fd())
+	err := windows.LockFileEx(
+		handle,
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return nil, errLockBusy
+	}
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		return windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+	}, nil
+}

--- a/application/hub_binary_test.go
+++ b/application/hub_binary_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package application
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	commonv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/common/v1"
+	downloadv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/download/v1"
+	"github.com/wippyai/runtime/api/hub/wippy/api/hub/download/v1/downloadv1connect"
+	manifestv1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/manifest/v1"
+	"github.com/wippyai/runtime/api/hub/wippy/api/hub/manifest/v1/manifestv1connect"
+	"github.com/wippyai/wapp"
+)
+
+// TestHubBinaryUpdate exercises the actual assembled hello executable against
+// the canonical Hub wire API. Supply the builder fixture binary and its pack.
+func TestHubBinaryUpdate(t *testing.T) {
+	binary, packPath := os.Getenv("WIPPY_TEST_APPLICATION_BINARY"), os.Getenv("WIPPY_TEST_APPLICATION_PACK")
+	if binary == "" || packPath == "" {
+		t.Skip("requires assembled builder hello fixture")
+	}
+	binary, err := filepath.Abs(binary)
+	require.NoError(t, err)
+	data, err := os.ReadFile(packPath)
+	require.NoError(t, err)
+	reader, err := wapp.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	entries, err := reader.GetEntries()
+	require.NoError(t, err)
+	for i := range entries {
+		if entries[i].ID.Name == "main" {
+			entryData := entries[i].Data.(map[string]any)
+			entryData["source"] = strings.ReplaceAll(entryData["source"].(string), "Hello,", "Updated,")
+		}
+	}
+	entries = append(entries, wapp.Entry{ID: wapp.NewID("example.hello", "definition"), Kind: "ns.definition"}, wapp.Entry{ID: wapp.NewID("example.hello", "dependency"), Kind: "ns.dependency", Data: map[string]any{"component": "example/helper", "version": "1.0.0"}})
+	makePack := func(name, version string, entries []wapp.Entry) []byte {
+		var output bytes.Buffer
+		require.NoError(t, wapp.NewWriter().PackEntries(wapp.Metadata{"namespace": "example." + name, "name": name, "version": version}, entries, &output))
+		return output.Bytes()
+	}
+	artifacts := map[string][]byte{"hello": makePack("hello", "2.0.0", entries), "helper": makePack("helper", "1.0.0", []wapp.Entry{{ID: wapp.NewID("example.helper", "definition"), Kind: "ns.definition"}})}
+	var reject atomic.Bool
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/packs/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(artifacts[strings.TrimPrefix(r.URL.Path, "/packs/")])
+	})
+	mux.Handle(manifestv1connect.ManifestServiceGetManifestProcedure, connect.NewUnaryHandler(manifestv1connect.ManifestServiceGetManifestProcedure, func(_ context.Context, req *connect.Request[manifestv1.GetManifestRequest]) (*connect.Response[manifestv1.GetManifestResponse], error) {
+		if reject.Load() {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("fixture version unavailable"))
+		}
+		name := req.Msg.GetModule().GetName().GetName()
+		artifact, ok := artifacts[name]
+		if !ok {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("unknown module"))
+		}
+		version := "1.0.0"
+		if name == "hello" {
+			version = "2.0.0"
+		}
+		manifest := &manifestv1.ModuleManifest{Org: "example", Name: name, Version: version, VersionId: version, Digest: fmt.Sprintf("%x", sha256.Sum256(artifact)), SizeBytes: uint64(len(artifact)), Download: &commonv1.DownloadInfo{Url: server.URL + "/packs/" + name}}
+		if name == "hello" {
+			manifest.Dependencies = []*manifestv1.ResolvedDependency{{Org: "example", Name: "helper", Version: "1.0.0", Constraint: "1.0.0"}}
+		}
+		return connect.NewResponse(&manifestv1.GetManifestResponse{Manifest: manifest}), nil
+	}))
+	mux.Handle(downloadv1connect.DownloadServiceGetDownloadURLProcedure, connect.NewUnaryHandler(downloadv1connect.DownloadServiceGetDownloadURLProcedure, func(_ context.Context, req *connect.Request[downloadv1.GetDownloadURLRequest]) (*connect.Response[downloadv1.GetDownloadURLResponse], error) {
+		name := req.Msg.GetModule().GetName().GetName()
+		artifact, ok := artifacts[name]
+		if !ok {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("unknown module"))
+		}
+		version := "1.0.0"
+		if name == "hello" {
+			version = "2.0.0"
+		}
+		return connect.NewResponse(&downloadv1.GetDownloadURLResponse{Version: version, Download: &commonv1.DownloadInfo{Url: server.URL + "/packs/" + name, Digest: fmt.Sprintf("%x", sha256.Sum256(artifact)), SizeBytes: uint64(len(artifact))}}), nil
+	}))
+
+	root := t.TempDir()
+	state := filepath.Join(root, "state")
+	cwd := filepath.Join(root, "empty")
+	require.NoError(t, os.Mkdir(cwd, 0700))
+	invoke := func(args ...string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		command := exec.CommandContext(ctx, binary, append([]string{"--state-dir", state}, args...)...)
+		command.Dir = cwd
+		command.Env = append(os.Environ(), "HOME="+root, "XDG_CONFIG_HOME="+filepath.Join(root, "config"), "PATH=/nonexistent")
+		output, err := command.CombinedOutput()
+		return string(output), err
+	}
+	output, err := invoke("run", "Before")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Hello, Before!")
+	output, err = invoke("update", "example/hello", "--registry", server.URL)
+	require.NoError(t, err, output)
+	t.Log(output)
+	output, err = invoke("run", "After")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Updated, After!")
+	active, err := os.ReadFile(filepath.Join(state, "active.json"))
+	require.NoError(t, err)
+	output, err = invoke("--base", "run", "Recovery")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Hello, Recovery!")
+	// A failed Hub resolution must preserve the installed selection on restart.
+	reject.Store(true)
+	output, err = invoke("update", "example/hello", "--registry", server.URL)
+	require.Error(t, err, output)
+	after, err := os.ReadFile(filepath.Join(state, "active.json"))
+	require.NoError(t, err)
+	require.Equal(t, active, after)
+	output, err = invoke("run", "Restart")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Updated, Restart!")
+	files, err := os.ReadDir(cwd)
+	require.NoError(t, err)
+	require.Empty(t, files)
+}

--- a/application/identity.go
+++ b/application/identity.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package application
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+)
+
+func bundleID(bundle Bundle) string {
+	keys := make([]string, 0, len(bundle.Packs))
+	for _, pack := range bundle.Packs {
+		keys = append(keys, pack.Module+"@"+pack.Version+"="+pack.Digest)
+	}
+	sort.Strings(keys)
+	sum := sha256.New()
+	_, _ = sum.Write([]byte(bundle.Root + "\n"))
+	for _, key := range keys {
+		_, _ = sum.Write([]byte(key + "\n"))
+	}
+	return hex.EncodeToString(sum.Sum(nil))
+}

--- a/application/run.go
+++ b/application/run.go
@@ -68,7 +68,16 @@ func Run(ctx context.Context, options Options, args []string) error {
 	if err := configureDataEnvironment(stateDir, options.DataEnv); err != nil {
 		return err
 	}
-	deployment := filepath.Join(stateDir, "deployment")
+	unlock, err := lockApplication(stateDir)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	deployment, err := selectedDeployment(stateDir)
+	if err != nil {
+		return err
+	}
+	historyPath := filepath.Join(stateDir, "registry.db")
 	if *base {
 		if options.Mode != "base" {
 			return fmt.Errorf("bootstrap applications do not expose a base deployment")
@@ -76,12 +85,19 @@ func Run(ctx context.Context, options Options, args []string) error {
 		// Each executable's embedded content selects an independent baseline.
 		// Application databases are intentionally not rolled back or removed.
 		deployment = filepath.Join(stateDir, "base", bundleID(options.Bundle))
+		historyPath = filepath.Join(deployment, "registry.db")
 	}
 	lockPath, err := options.Bundle.Seed(deployment)
 	if err != nil {
 		return err
 	}
 	remaining := flags.Args()
+	if len(remaining) > 0 && remaining[0] == "update" {
+		if *base {
+			return fmt.Errorf("base recovery cannot be updated")
+		}
+		return updateDeployment(ctx, options, stateDir, deployment, remaining[1:], runChild)
+	}
 	runtimeArgs := []string{"run", "--silent", "--", *command}
 	if len(remaining) > 0 && remaining[0] == "runtime" {
 		if *base {
@@ -106,10 +122,10 @@ func Run(ctx context.Context, options Options, args []string) error {
 		LockFile:    lockPath,
 		ConfigFiles: configFiles,
 		Components:  options.Components,
-		Defaults: boot.NewConfig(boot.WithSection("registry", map[string]any{
+		Overrides: boot.NewConfig(boot.WithSection("registry", map[string]any{
 			"enable_history": true,
 			"history_type":   "sqlite",
-			"history_path":   filepath.Join(stateDir, "registry.db"),
+			"history_path":   historyPath,
 		})),
 	})
 }

--- a/application/run.go
+++ b/application/run.go
@@ -19,12 +19,12 @@ import (
 // DataEnv maps application-owned environment variables to paths within StateDir.
 // Existing environment values remain explicit user overrides.
 type Options struct {
+	DataEnv    map[string]string
+	Components []boot.Component
 	Name       string
 	Command    string
 	Mode       string
 	Bundle     Bundle
-	Components []boot.Component
-	DataEnv    map[string]string
 }
 
 var applicationName = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)

--- a/application/run.go
+++ b/application/run.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package application
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/cmd/wippy/cmd"
+)
+
+// Options selects the embedded application and its native host components.
+// DataEnv maps application-owned environment variables to paths within StateDir.
+// Existing environment values remain explicit user overrides.
+type Options struct {
+	Name       string
+	Command    string
+	Mode       string
+	Bundle     Bundle
+	Components []boot.Component
+	DataEnv    map[string]string
+}
+
+var applicationName = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+var environmentName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// Run is the process entry point for a standalone application. Application
+// arguments follow `run`; `runtime` exposes the canonical Wippy CLI, including
+// Hub authentication, update and source inspection commands.
+func Run(ctx context.Context, options Options, args []string) error {
+	if !applicationName.MatchString(options.Name) {
+		return fmt.Errorf("invalid application name")
+	}
+	if options.Mode != "base" && options.Mode != "bootstrap" {
+		return fmt.Errorf("application mode must be base or bootstrap")
+	}
+	if options.Command == "" {
+		return fmt.Errorf("application command is required")
+	}
+	flags := flag.NewFlagSet(options.Name, flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	state := flags.String("state-dir", "", "application state directory")
+	base := flags.Bool("base", false, "run the embedded recovery baseline")
+	command := flags.String("command", options.Command, "application command")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *state == "" {
+		config, err := os.UserConfigDir()
+		if err != nil {
+			return err
+		}
+		*state = filepath.Join(config, options.Name)
+	}
+	stateDir, err := filepath.Abs(*state)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return err
+	}
+	if err := configureDataEnvironment(stateDir, options.DataEnv); err != nil {
+		return err
+	}
+	deployment := filepath.Join(stateDir, "deployment")
+	if *base {
+		if options.Mode != "base" {
+			return fmt.Errorf("bootstrap applications do not expose a base deployment")
+		}
+		// Each executable's embedded content selects an independent baseline.
+		// Application databases are intentionally not rolled back or removed.
+		deployment = filepath.Join(stateDir, "base", bundleID(options.Bundle))
+	}
+	lockPath, err := options.Bundle.Seed(deployment)
+	if err != nil {
+		return err
+	}
+	remaining := flags.Args()
+	runtimeArgs := []string{"run", "--silent", "--", *command}
+	if len(remaining) > 0 && remaining[0] == "runtime" {
+		if *base {
+			return fmt.Errorf("base recovery only runs the embedded application")
+		}
+		runtimeArgs = remaining[1:]
+	} else {
+		if len(remaining) > 0 && remaining[0] == "run" {
+			remaining = remaining[1:]
+		}
+		runtimeArgs = append(runtimeArgs, remaining...)
+	}
+	configFiles := []string{}
+	configPath := filepath.Join(stateDir, ".wippy.yaml")
+	if _, err := os.Stat(configPath); err == nil {
+		configFiles = append(configFiles, configPath)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return cmd.ExecuteWithOptions(ctx, cmd.ExecuteOptions{
+		Args:        runtimeArgs,
+		LockFile:    lockPath,
+		ConfigFiles: configFiles,
+		Components:  options.Components,
+		Defaults: boot.NewConfig(boot.WithSection("registry", map[string]any{
+			"enable_history": true,
+			"history_type":   "sqlite",
+			"history_path":   filepath.Join(stateDir, "registry.db"),
+		})),
+	})
+}
+
+func configureDataEnvironment(state string, variables map[string]string) error {
+	for name, relative := range variables {
+		if !environmentName.MatchString(name) || !filepath.IsLocal(relative) {
+			return fmt.Errorf("invalid application data environment binding %q", name)
+		}
+		if _, exists := os.LookupEnv(name); !exists {
+			if err := os.Setenv(name, filepath.Join(state, relative)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/application/run.go
+++ b/application/run.go
@@ -31,7 +31,7 @@ var applicationName = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 var environmentName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
 
 // Run is the process entry point for a standalone application. Application
-// arguments follow `run`; `runtime` exposes the canonical Wippy CLI, including
+// arguments follow `run`; `runtime` exposes the Wippy CLI, including
 // Hub authentication, update and source inspection commands.
 func Run(ctx context.Context, options Options, args []string) error {
 	if !applicationName.MatchString(options.Name) {

--- a/boot/deps/lock/lock.go
+++ b/boot/deps/lock/lock.go
@@ -543,7 +543,10 @@ func ResolveModuleDir(vendorDir string, name graph.Name, version string) Resolve
 // Find locates a lock file in the given directory.
 // Returns absolute path to the lock file.
 func Find(dir, filename string) (string, error) {
-	lockPath := filepath.Join(dir, filename)
+	lockPath := filename
+	if !filepath.IsAbs(lockPath) {
+		lockPath = filepath.Join(dir, filename)
+	}
 	absPath, err := filepath.Abs(lockPath)
 	if err != nil {
 		return "", err

--- a/boot/deps/lock/lock_test.go
+++ b/boot/deps/lock/lock_test.go
@@ -824,3 +824,18 @@ func TestModulePath(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, path)
 	}
 }
+
+func TestFindAbsolutePathIgnoresSearchDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "selected.lock")
+	if err := os.WriteFile(path, []byte("directories: {}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	found, err := Find(t.TempDir(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found != path {
+		t.Fatalf("Find = %s, want %s", found, path)
+	}
+}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -38,12 +38,20 @@ import (
 // If modules are missing, it auto-installs them before loading entries.
 func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 	lockFilePath := lock.DefaultFilename
+	explicitLock := false
 	if cfg := boot.GetConfig(ctx); cfg != nil {
-		lockFilePath = cfg.GetString("registry.dependency_lock_path", lockFilePath)
+		selected := cfg.GetString("registry.dependency_lock_path", "")
+		if selected != "" {
+			lockFilePath = selected
+			explicitLock = true
+		}
 	}
 
 	lockPath, err := lock.Find(".", lockFilePath)
 	if err != nil {
+		if explicitLock {
+			return NewLoadLockFileError(err)
+		}
 		if !os.IsNotExist(err) {
 			return NewLoadLockFileError(err)
 		}

--- a/cmd/internal/entries/loader.go
+++ b/cmd/internal/entries/loader.go
@@ -38,6 +38,9 @@ import (
 // If modules are missing, it auto-installs them before loading entries.
 func LoadFromLockFile(ctx context.Context, logger *zap.Logger) error {
 	lockFilePath := lock.DefaultFilename
+	if cfg := boot.GetConfig(ctx); cfg != nil {
+		lockFilePath = cfg.GetString("registry.dependency_lock_path", lockFilePath)
+	}
 
 	lockPath, err := lock.Find(".", lockFilePath)
 	if err != nil {

--- a/cmd/wippy/cmd/execute_options.go
+++ b/cmd/wippy/cmd/execute_options.go
@@ -18,13 +18,13 @@ import (
 // ConfigFiles are explicit required files; an empty list disables ambient config.
 // Defaults have lower precedence than packed application and file configuration.
 type ExecuteOptions struct {
+	Defaults boot.Config
+	// Overrides are host-selected settings applied after package and CLI settings.
+	Overrides   boot.Config
+	LockFile    string
 	Args        []string
 	Components  []boot.Component
-	LockFile    string
 	ConfigFiles []string
-	Defaults    boot.Config
-	// Overrides are host-selected settings applied after package and CLI settings.
-	Overrides boot.Config
 }
 
 var nativeExecution atomic.Bool

--- a/cmd/wippy/cmd/execute_options.go
+++ b/cmd/wippy/cmd/execute_options.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/spf13/cobra"
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/cmd/internal/bootconfig"
+)
+
+// ExecuteOptions configures a native application's use of the Wippy CLI.
+// Components are additional host-selected components, never package grants.
+// ConfigFiles are explicit required files; an empty list disables ambient config.
+// Defaults have lower precedence than packed application and file configuration.
+type ExecuteOptions struct {
+	Args        []string
+	Components  []boot.Component
+	LockFile    string
+	ConfigFiles []string
+	Defaults    boot.Config
+}
+
+var nativeExecution atomic.Bool
+var nativeOptions *ExecuteOptions
+
+// ExecuteWithOptions runs one command using the canonical Wippy command paths.
+// Like Execute, it owns the process command state and signal handlers. Call it
+// once from main, never concurrently or from an application actor.
+func ExecuteWithOptions(ctx context.Context, options ExecuteOptions) error {
+	if ctx == nil {
+		return fmt.Errorf("execution context is required")
+	}
+	if options.LockFile == "" {
+		return fmt.Errorf("deployment lock file is required")
+	}
+	absolute, err := filepath.Abs(options.LockFile)
+	if err != nil {
+		return err
+	}
+	if err := validateNativeComponents(options.Components); err != nil {
+		return err
+	}
+	if !nativeExecution.CompareAndSwap(false, true) {
+		return fmt.Errorf("native command execution may only be called once")
+	}
+	options.LockFile = absolute
+	options.Components = append([]boot.Component(nil), options.Components...)
+	options.ConfigFiles = append([]string(nil), options.ConfigFiles...)
+	nativeOptions = &options
+	defaultLockFile = absolute
+	configFiles = options.ConfigFiles
+	// Commands declare their flag defaults at package initialization time.
+	// Keep every lock-aware command on the same host-selected deployment.
+	var configure func(*cobra.Command) error
+	configure = func(command *cobra.Command) error {
+		if flag := command.Flags().Lookup("lock-file"); flag != nil {
+			if err := flag.Value.Set(absolute); err != nil {
+				return err
+			}
+			flag.DefValue = absolute
+		}
+		for _, child := range command.Commands() {
+			if err := configure(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := configure(rootCmd); err != nil {
+		return err
+	}
+	rootCmd.SetArgs(options.Args)
+	return rootCmd.ExecuteContext(ctx)
+}
+
+func validateNativeComponents(additional []boot.Component) error {
+	names := make(map[boot.Name]bool)
+	for _, component := range StandardComponents() {
+		names[component.Name()] = true
+	}
+	for _, component := range additional {
+		if component == nil || component.Name() == "" {
+			return fmt.Errorf("native component must have a name")
+		}
+		if names[component.Name()] {
+			return fmt.Errorf("duplicate native component %q", component.Name())
+		}
+		names[component.Name()] = true
+	}
+	return nil
+}
+
+func selectedComponents() []boot.Component {
+	components := StandardComponents()
+	if nativeOptions != nil {
+		components = append(components, nativeOptions.Components...)
+	}
+	return components
+}
+
+func nativeBootDefaults() boot.Config {
+	if nativeOptions == nil {
+		return nil
+	}
+	return nativeOptions.Defaults
+}
+
+func applyNativeDeploymentConfig(cfg boot.Config) boot.Config {
+	if nativeOptions == nil {
+		return cfg
+	}
+	return bootconfig.Merge(cfg, boot.NewConfig(boot.WithSection("registry", map[string]any{
+		"dependency_lock_path": nativeOptions.LockFile,
+	})))
+}

--- a/cmd/wippy/cmd/execute_options.go
+++ b/cmd/wippy/cmd/execute_options.go
@@ -23,6 +23,8 @@ type ExecuteOptions struct {
 	LockFile    string
 	ConfigFiles []string
 	Defaults    boot.Config
+	// Overrides are host-selected settings applied after package and CLI settings.
+	Overrides boot.Config
 }
 
 var nativeExecution atomic.Bool
@@ -114,6 +116,7 @@ func applyNativeDeploymentConfig(cfg boot.Config) boot.Config {
 	if nativeOptions == nil {
 		return cfg
 	}
+	cfg = bootconfig.Merge(cfg, nativeOptions.Overrides)
 	return bootconfig.Merge(cfg, boot.NewConfig(boot.WithSection("registry", map[string]any{
 		"dependency_lock_path": nativeOptions.LockFile,
 	})))

--- a/cmd/wippy/cmd/execute_options.go
+++ b/cmd/wippy/cmd/execute_options.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ExecuteOptions configures a native application's use of the Wippy CLI.
-// Components are additional host-selected components, never package grants.
+// Components are additional services selected by the host.
 // ConfigFiles are explicit required files; an empty list disables ambient config.
 // Defaults have lower precedence than packed application and file configuration.
 type ExecuteOptions struct {
@@ -30,9 +30,9 @@ type ExecuteOptions struct {
 var nativeExecution atomic.Bool
 var nativeOptions *ExecuteOptions
 
-// ExecuteWithOptions runs one command using the canonical Wippy command paths.
+// ExecuteWithOptions runs one command using the Wippy command paths.
 // Like Execute, it owns the process command state and signal handlers. Call it
-// once from main, never concurrently or from an application actor.
+// once from main; command state is process-global.
 func ExecuteWithOptions(ctx context.Context, options ExecuteOptions) error {
 	if ctx == nil {
 		return fmt.Errorf("execution context is required")

--- a/cmd/wippy/cmd/execute_options_test.go
+++ b/cmd/wippy/cmd/execute_options_test.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/boot"
-	"testing"
 )
 
 func TestNativeComponentsCannotReplaceBuiltins(t *testing.T) {

--- a/cmd/wippy/cmd/execute_options_test.go
+++ b/cmd/wippy/cmd/execute_options_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+	"testing"
+)
+
+func TestNativeComponentsCannotReplaceBuiltins(t *testing.T) {
+	require.Error(t, validateNativeComponents([]boot.Component{StandardComponents()[0]}))
+	component := boot.New(boot.P{Name: "example.native"})
+	require.NoError(t, validateNativeComponents([]boot.Component{component}))
+	require.Error(t, validateNativeComponents([]boot.Component{component, component}))
+	require.Error(t, validateNativeComponents([]boot.Component{nil}))
+}

--- a/cmd/wippy/cmd/lint.go
+++ b/cmd/wippy/cmd/lint.go
@@ -351,7 +351,7 @@ func bootstrapLintContext(cfg boot.Config) (ctx context.Context, loader *bootpkg
 		return nil, nil, NewInitializeBootstrapContextError(err)
 	}
 
-	components := StandardComponents()
+	components := selectedComponents()
 	reservedNames := make(map[string]struct{}, len(components))
 	for _, comp := range components {
 		if comp == nil {

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -347,7 +347,6 @@ func loadRuntimeConfigWithDefaults(cmd *cobra.Command, logger *zap.Logger, runti
 	}
 
 	cfg = bootconfig.Merge(nativeBootDefaults(), cfg)
-	cfg = applyNativeDeploymentConfig(cfg)
 	cfg, err = bootconfig.ApplyProfiles(cfg, selectedProfiles(cmd))
 	if err != nil {
 		return nil, err
@@ -356,7 +355,7 @@ func loadRuntimeConfigWithDefaults(cmd *cobra.Command, logger *zap.Logger, runti
 	cfg = applyCLIOverrides(cfg)
 
 	if cmd == nil {
-		return bootconfig.ResolveVariables(cfg)
+		return bootconfig.ResolveVariables(applyNativeDeploymentConfig(cfg))
 	}
 
 	if sets, _ := cmd.Flags().GetStringArray("set"); len(sets) > 0 {
@@ -369,14 +368,14 @@ func loadRuntimeConfigWithDefaults(cmd *cobra.Command, logger *zap.Logger, runti
 
 	overrides, _ := cmd.Flags().GetStringSlice("override")
 	if len(overrides) == 0 {
-		return bootconfig.ResolveVariables(cfg)
+		return bootconfig.ResolveVariables(applyNativeDeploymentConfig(cfg))
 	}
 
 	cfg, err = applyOverrideFlags(cfg, overrides, logger)
 	if err != nil {
 		return nil, err
 	}
-	return bootconfig.ResolveVariables(cfg)
+	return bootconfig.ResolveVariables(applyNativeDeploymentConfig(cfg))
 }
 
 func selectedProfiles(cmd *cobra.Command) []string {

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -235,7 +235,7 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 	ctx = embedapi.WithRegistry(ctx, embedReg)
 	defer embedReg.Close()
 
-	components := StandardComponents()
+	components := selectedComponents()
 	ctx, extensionComponents, err := loadExtensionComponents(ctx, logger, components)
 	if err != nil {
 		logger.Error("failed to load extensions", zap.Error(err))
@@ -346,6 +346,8 @@ func loadRuntimeConfigWithDefaults(cmd *cobra.Command, logger *zap.Logger, runti
 		cfg = bootconfig.Merge(runtimeDefaults, cfg)
 	}
 
+	cfg = bootconfig.Merge(nativeBootDefaults(), cfg)
+	cfg = applyNativeDeploymentConfig(cfg)
 	cfg, err = bootconfig.ApplyProfiles(cfg, selectedProfiles(cmd))
 	if err != nil {
 		return nil, err
@@ -597,6 +599,9 @@ func loadBootConfig() (boot.Config, error) {
 }
 
 func loadRuntimeConfigFiles() (boot.Config, error) {
+	if nativeOptions != nil && len(configFiles) == 0 {
+		return nil, nil
+	}
 	if len(configFiles) == 0 {
 		return bootconfig.Load(defaultConfigFile)
 	}

--- a/cmd/wippy/cmd/run_pack_bootstrap.go
+++ b/cmd/wippy/cmd/run_pack_bootstrap.go
@@ -42,7 +42,7 @@ func bootstrapPackRuntimeWithDefaults(cmd *cobra.Command, baseLogger *zap.Logger
 	embedReg := embedpkg.NewRegistry()
 	ctx = embedapi.WithRegistry(ctx, embedReg)
 
-	components := StandardComponents()
+	components := selectedComponents()
 	ctx, extensionComponents, err := loadExtensionComponents(ctx, logger, components)
 	if err != nil {
 		logger.Error("failed to load extensions", zap.Error(err))

--- a/cmd/wippy/cmd/update.go
+++ b/cmd/wippy/cmd/update.go
@@ -29,6 +29,8 @@ var updateCmd = &cobra.Command{
 
 Without arguments, scans source directory and re-resolves the entire dependency graph,
 updating all modules to their latest compatible versions.
+For a published deployment, resolves from the application root in wippy.lock;
+no source directory is required and unrelated local source is not consulted.
 
 With module arguments, updates only the specified modules to their highest version
 compatible with other locked dependencies. New transitive dependencies are auto-added.
@@ -122,7 +124,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Full update otherwise
-	logger.Info("re-resolving all dependencies from source")
+	logger.Info("re-resolving application dependencies")
 
 	// Load old lock file for comparison
 	var oldLockObj *lock.Lock
@@ -136,17 +138,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Scan only application roots. Selected replacement modules expose their
-	// transitive declarations lazily through the replacement-aware resolver.
+	// Resolve the selected deployment root or scan source application roots.
+	// Replacement modules expose transitive declarations through the resolver.
 	logger.Info("scanning dependency sources", zap.String("src_dir", srcDir))
 
-	entries, err := loadDependencyScanEntries(app.Ctx, app.Loader, srcDir, oldLockObj, logger)
+	rootDeps, err := loadUpdateRoots(app.Ctx, app.Loader, srcDir, oldLockObj, app.Transcoder, logger)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
 
-	// Extract root dependencies from entries
-	rootDeps := extractRootDependencies(entries, app.Transcoder)
 	logger.Info("found root dependencies", zap.Int("count", len(rootDeps)))
 
 	resolvedModules := make([]hub.ResolvedModule, 0)
@@ -342,14 +342,13 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 		return nil
 	}
 
-	// Scan app source plus local replacement sources to get constraints.
-	entries, err := loadDependencyScanEntries(app.Ctx, app.Loader, srcDir, lockObj, logger)
+	// Use the locked deployment root or source application constraints.
+	rootDeps, err := loadUpdateRoots(app.Ctx, app.Loader, srcDir, lockObj, app.Transcoder, logger)
 	if err != nil {
 		return NewLoadEntriesFromSourceError(err)
 	}
 
 	// Extract source constraints
-	rootDeps := extractRootDependencies(entries, app.Transcoder)
 	sourceConstraints := make(map[string]string)
 	for _, dep := range rootDeps {
 		key := fmt.Sprintf("%s/%s", dep.Org, dep.Module)
@@ -446,6 +445,31 @@ func runTargetedUpdate(cmd *cobra.Command, lockFilePath, srcDir, modulesDir stri
 
 	logger.Info("update completed successfully")
 	return nil
+}
+
+// loadUpdateRoots preserves the lock's application identity for published
+// deployments. Such deployments need no source directory; scanning the caller's
+// source would allow unrelated files to replace the selected application.
+func loadUpdateRoots(ctx context.Context, ldr boot.Loader, srcDir string, locked *lock.Lock, transcoder payload.Transcoder, logger *zap.Logger) ([]dependencyRequest, error) {
+	if locked != nil {
+		roots := locked.GetRootModules()
+		if len(roots) != 0 {
+			requests := make([]dependencyRequest, 0, len(roots))
+			for _, root := range roots {
+				org, name, ok := strings.Cut(root, "/")
+				if !ok || org == "" || name == "" {
+					return nil, fmt.Errorf("invalid deployment root %q", root)
+				}
+				requests = append(requests, dependencyRequest{Org: org, Module: name})
+			}
+			return requests, nil
+		}
+	}
+	loaded, err := loadDependencyScanEntries(ctx, ldr, srcDir, locked, logger)
+	if err != nil {
+		return nil, err
+	}
+	return extractRootDependencies(loaded, transcoder), nil
 }
 
 func loadDependencyScanEntries(ctx context.Context, ldr boot.Loader, srcDir string, lockObj *lock.Lock, logger *zap.Logger) ([]regapi.Entry, error) {

--- a/cmd/wippy/cmd/update_test.go
+++ b/cmd/wippy/cmd/update_test.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -489,4 +490,23 @@ func assertPathMissing(t *testing.T, path string) {
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("stat %s: %v", path, err)
 	}
+}
+
+func TestUpdateDeploymentUsesLockedRootWithoutSource(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wippy.lock")
+	locked, err := lock.New(path)
+	require.NoError(t, err)
+	locked.SetModule(lock.Module{Name: "acme/desktop", Version: "1.0.0", Root: true})
+	locked.SetModule(lock.Module{Name: "acme/library", Version: "1.0.0"})
+	roots, err := loadUpdateRoots(context.Background(), nil, filepath.Join(t.TempDir(), "missing"), locked, nil, zap.NewNop())
+	require.NoError(t, err)
+	require.Equal(t, []dependencyRequest{{Org: "acme", Module: "desktop"}}, roots)
+}
+
+func TestUpdateSourceWorkspaceStillRequiresLoader(t *testing.T) {
+	locked, err := lock.New(filepath.Join(t.TempDir(), "wippy.lock"))
+	require.NoError(t, err)
+	locked.SetModule(lock.Module{Name: "acme/library", Version: "1.0.0"})
+	_, err = loadUpdateRoots(context.Background(), nil, "missing", locked, nil, zap.NewNop())
+	require.ErrorContains(t, err, "loader not available")
 }


### PR DESCRIPTION
Standalone applications need a supported way to boot bundled Hub packs with native components and continue using an installed, updated deployment without a source checkout.

Add `application.Run`, exact bundle validation and atomic first-deployment seeding. The host preserves existing application locks, selects explicit state paths, keeps the caller working directory, and supports an embedded recovery baseline or bootstrap-only mode. Additional native components retain normal Wippy module registration and permissions; duplicate component names fail before boot.

The default `update` path stages the current deployment, invokes canonical Wippy update and lint through the same executable, verifies pack digests, and switches activation only after success. An exclusive state lock prevents concurrent run/update. Advanced `runtime` commands remain direct Wippy operations. Application databases are never reset or rolled back; migration compatibility remains application-owned.

`cmd.ExecuteWithOptions` supplies the reusable command boundary. Explicit absolute deployment locks are honored by loading and dependency handling. This PR is stacked on #667 for source-free Hub update roots.

Validation:
- `make test-application`: application, command, entry-loader and lock suites passed.
- Bundle race tests passed, including concurrent first launch and preserving an updated selection.
- `make lint`: 0 issues.
- A generated standalone hello executable booted from an empty directory with no developer tools in PATH, restarted its deployment, and ran its embedded base.

- The assembled-binary Hub wire fixture passes: a newer root plus dependency, cold restart, base recovery and failure preservation. Builder CI runs this test with its actual executable.
- Bee native-module typed Lua integration, denied access, race/vet checks and standalone Settings/Terminal/F12 acceptance passed on its pinned patched runtime.

Explicit semantic native-version requirements remain outside the implemented gate; lint checks module exports and types. Bee supplies a Linux draft-release workflow in wippyai/bee#1. Stable publication and additional native platforms remain pending.
