### PR TITLE
fix(raft): unblock shutdown during stalled peer RPCs

### DIFF
--- a/cluster/raft/raft.go
+++ b/cluster/raft/raft.go
@@ -266,16 +266,19 @@ func (n *Node) Stop(_ context.Context) error {
 	}
 
 	f := n.raft.Shutdown()
-	if err := f.Error(); err != nil {
-		return fmt.Errorf("raft shutdown: %w", err)
-	}
-
+	// Shutdown signals Raft workers, but its future joins them before closing
+	// transport. Wake outstanding RPCs now so a silent peer cannot hold that
+	// join until its normal request deadline. Leadership transfer has finished.
 	if n.transport != nil {
 		if closer, ok := n.transport.(hraft.WithClose); ok {
 			if err := closer.Close(); err != nil {
 				n.logger.Warn("raft transport close failed", zap.Error(err))
 			}
 		}
+	}
+
+	if err := f.Error(); err != nil {
+		return fmt.Errorf("raft shutdown: %w", err)
 	}
 
 	if n.closeStores != nil {

--- a/cluster/raft/shutdown_rpc_test.go
+++ b/cluster/raft/shutdown_rpc_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	hraft "github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+	"github.com/wippyai/runtime/cluster/internode"
+	"go.uber.org/zap"
+)
+
+// Admission succeeds but the peer never answers: equivalent to an established
+// connection whose remote process has stopped consuming Raft requests.
+type unansweredRaftConn struct {
+	*raftTransportConn
+	sent chan struct{}
+}
+
+func (c *unansweredRaftConn) SendToNode(cluster.NodeID, []byte, internode.Class) error {
+	select {
+	case c.sent <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func TestNodeStopUnblocksOutstandingReplication(t *testing.T) {
+	conn := &unansweredRaftConn{raftTransportConn: newRaftTransportFabric().conn("one"), sent: make(chan struct{}, 1)}
+	transport, err := newRaftMessageTransport("one", conn, time.Minute, zap.NewNop())
+	require.NoError(t, err)
+	cfg := hraft.DefaultConfig()
+	cfg.LocalID, cfg.LogOutput = "one", io.Discard
+	cfg.HeartbeatTimeout, cfg.ElectionTimeout, cfg.LeaderLeaseTimeout = 50*time.Millisecond, 50*time.Millisecond, 50*time.Millisecond
+	store := hraft.NewInmemStore()
+	fsm := &shutdownTestFSM{}
+	instance, err := hraft.NewRaft(cfg, fsm, store, store, hraft.NewInmemSnapshotStore(), transport)
+	require.NoError(t, err)
+	node := NewNode("one", fsm, raftapi.Config{ShutdownTransferTimeout: time.Millisecond}, nil, zap.NewNop(), nil, nil, nil)
+	node.raft, node.transport, node.started = instance, transport, true
+	t.Cleanup(func() { _ = transport.Close(); _ = instance.Shutdown().Error() })
+	require.NoError(t, instance.BootstrapCluster(hraft.Configuration{Servers: []hraft.Server{{ID: "one", Address: "one", Suffrage: hraft.Voter}}}).Error())
+	require.Eventually(t, func() bool { return instance.State() == hraft.Leader }, 5*time.Second, time.Millisecond)
+	require.NoError(t, instance.AddNonvoter("unanswered", "unanswered", 0, time.Second).Error())
+	select {
+	case <-conn.sent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replication never started")
+	}
+	stopped := make(chan error, 1)
+	go func() { stopped <- node.Stop(context.Background()) }()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		// Release transport first so failure does not strand the shutdown worker.
+		_ = transport.Close()
+		require.NoError(t, <-stopped)
+		t.Fatal("shutdown waited on the remote RPC deadline instead of closing transport")
+	}
+}
+
+func TestTransportCloseUnblocksIncompleteSnapshot(t *testing.T) {
+	conn := newRaftTransportFabric().conn("receiver")
+	transport, err := newRaftMessageTransport("receiver", conn, time.Minute, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = transport.Close() })
+	payload, err := encodeMsgpack(&hraft.InstallSnapshotRequest{Term: 3, Size: int64(raftSnapshotChunkSize)})
+	require.NoError(t, err)
+	wire, err := encodeMsgpack(&raftFrame{ID: 42, Type: raftRPCInstallSnapshot, Request: true, Payload: payload})
+	require.NoError(t, err)
+	transport.onFrame("sender", wire)
+	rpc := <-transport.Consumer()
+	read := make(chan error, 1)
+	go func() { _, err := io.ReadAll(rpc.Reader); read <- err }()
+	require.NoError(t, transport.Close())
+	select {
+	case err := <-read:
+		require.ErrorIs(t, err, hraft.ErrTransportShutdown)
+	case <-time.After(time.Second):
+		t.Fatal("snapshot reader remained blocked after transport close")
+	}
+	transport.mu.Lock()
+	require.Empty(t, transport.snapshots)
+	transport.mu.Unlock()
+	require.NoError(t, transport.Close(), "shutdown and Raft future may both close transport")
+}
+
+// This fixture exercises transport shutdown, with immediate FSM application.
+type shutdownTestFSM struct{}
+
+func (*shutdownTestFSM) Apply(*hraft.Log) any { return nil }
+func (*shutdownTestFSM) Snapshot() (hraft.FSMSnapshot, error) {
+	return nil, errors.New("snapshot unused in shutdown test")
+}
+func (*shutdownTestFSM) Restore(reader io.ReadCloser) error { return reader.Close() }


### PR DESCRIPTION
Raft shutdown can wait for an unanswered peer RPC to reach its normal request deadline. The HashiCorp Raft shutdown future joins workers before closing the transport, so waiting on that future first leaves replication workers blocked during network stalls.\n\nAfter the existing leadership-transfer attempt, initiate Raft shutdown and close the transport before joining the shutdown future. Stores still close only after workers finish. This adds no exported API, runtime binding, config or protocol field, timeout, retry, wire-format change, or naming-semantics change.\n\nValidation:\n- The outstanding-replication regression fails on the parent and passes with this change.\n- Regression coverage also checks that transport closure releases an incomplete snapshot reader and tolerates repeated closure.\n- GOWORK=off go test -race ./cluster/raft ./cluster/clustertest\n- Scoped golangci-lint run ./cluster/raft/...\n\nThis is an independently reviewable shutdown fix from the cluster hardening work tracked in #664. Broader admission/reconnect work remains separate. Concurrent Stop callers and caller-context cancellation are outside this change.