### PR TITLE
feat(raft): add bounded cancellable proposal waiting

### DIFF
--- a/api/cluster/raft/config.go
+++ b/api/cluster/raft/config.go
@@ -4,6 +4,12 @@ package raft
 
 import "time"
 
+// DefaultMaxPendingApplies bounds context-aware future tracking per node.
+const DefaultMaxPendingApplies = 128
+
+// DefaultMaxPendingApplyBytes bounds retained command copies for unresolved work.
+const DefaultMaxPendingApplyBytes = 64 << 20
+
 // Config holds configuration for a Raft node.
 //
 // Raft defaults to a diskless control plane (in-memory stores): cluster state
@@ -26,16 +32,21 @@ import "time"
 // see existing peers as raft_status="in" and skip bootstrap; the leader's
 // reconciler adds them via AddVoter.
 type Config struct {
-	DataDir           string        `json:"data_dir,omitempty"`
-	CommitTimeout     time.Duration `json:"commit_timeout"`
-	SnapshotInterval  time.Duration `json:"snapshot_interval"`
-	ElectionTimeout   time.Duration `json:"election_timeout"`
-	HeartbeatTimeout  time.Duration `json:"heartbeat_timeout"`
-	SnapshotThreshold uint64        `json:"snapshot_threshold"`
-	TrailingLogs      uint64        `json:"trailing_logs"`
-	BootstrapExpect   int           `json:"bootstrap_expect,omitempty"`
-	SnapshotRetain    int           `json:"snapshot_retain"`
-	MaxPool           int           `json:"max_pool"`
+	DataDir string `json:"data_dir,omitempty"`
+	// MaxPendingApplies and MaxPendingApplyBytes bound unresolved context-aware
+	// proposal count and owned command bytes, including canceled callers.
+	// Zero selects the defaults. These do not bound log or FSM storage.
+	MaxPendingApplyBytes int           `json:"max_pending_apply_bytes"`
+	MaxPendingApplies    int           `json:"max_pending_applies"`
+	CommitTimeout        time.Duration `json:"commit_timeout"`
+	SnapshotInterval     time.Duration `json:"snapshot_interval"`
+	ElectionTimeout      time.Duration `json:"election_timeout"`
+	HeartbeatTimeout     time.Duration `json:"heartbeat_timeout"`
+	SnapshotThreshold    uint64        `json:"snapshot_threshold"`
+	TrailingLogs         uint64        `json:"trailing_logs"`
+	BootstrapExpect      int           `json:"bootstrap_expect,omitempty"`
+	SnapshotRetain       int           `json:"snapshot_retain"`
+	MaxPool              int           `json:"max_pool"`
 	// ShutdownTransferTimeout bounds the best-effort leadership transfer
 	// attempted by Stop() when this node is leader. Zero defaults to one
 	// election timeout. The transfer is an availability optimization, not a
@@ -54,6 +65,12 @@ type Config struct {
 
 // InitDefaults fills zero-valued fields with sensible defaults.
 func (c *Config) InitDefaults() {
+	if c.MaxPendingApplyBytes <= 0 {
+		c.MaxPendingApplyBytes = DefaultMaxPendingApplyBytes
+	}
+	if c.MaxPendingApplies <= 0 {
+		c.MaxPendingApplies = DefaultMaxPendingApplies
+	}
 	if c.SnapshotRetain == 0 {
 		c.SnapshotRetain = 3
 	}

--- a/api/cluster/raft/raft.go
+++ b/api/cluster/raft/raft.go
@@ -4,6 +4,7 @@
 package raft
 
 import (
+	"context"
 	"time"
 )
 
@@ -134,3 +135,9 @@ type (
 		IsVoter bool
 	}
 )
+
+// ContextApplier optionally supports cancellable proposal waiting. Cancellation
+// after admission means an unknown outcome, not proof that no commit occurred.
+type ContextApplier interface {
+	ApplyContext(context.Context, []byte, time.Duration) (*ApplyResponse, error)
+}

--- a/boot/components/system/cluster.example.yaml
+++ b/boot/components/system/cluster.example.yaml
@@ -83,3 +83,15 @@ cluster:
 #     # future compaction mode; do not treat a TTL as causal proof.
 #     global_dissem_tombstone_retention: 0
 #   kv_crdt_tombstone_retention: 0
+
+# Context-aware proposal admission (cluster.raft):
+#   raft:
+#     max_pending_applies: 128
+#     max_pending_apply_bytes: 67108864
+# Both budgets must be positive integers. They bound unresolved ApplyContext
+# futures and retained command payloads, including proposals whose callers have
+# canceled. Capacity returns when the underlying Apply actually finishes.
+# Cancellation does not roll back admitted work; do not automatically retry an
+# uncertain proposal. Budgets do not cover persistent Raft log/FSM storage.
+# Existing Apply callers retain their existing behavior; KV/naming adoption of
+# the optional ApplyContext interface is a separate integration change.

--- a/boot/components/system/proposal_policy.go
+++ b/boot/components/system/proposal_policy.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package system
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/wippyai/runtime/api/boot"
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+)
+
+func loadPendingApplyLimits(cfg boot.Config) (int, int, error) {
+	count, bytes := raftapi.DefaultMaxPendingApplies, raftapi.DefaultMaxPendingApplyBytes
+	for _, field := range []struct {
+		target *int
+		name   string
+	}{
+		{&count, "max_pending_applies"}, {&bytes, "max_pending_apply_bytes"},
+	} {
+		key := "raft." + field.name
+		if value, exists := cfg.Get(key); exists {
+			parsed, err := strconv.Atoi(fmt.Sprint(value))
+			if err != nil || parsed <= 0 {
+				return 0, 0, fmt.Errorf("cluster.%s must be a positive integer", key)
+			}
+			*field.target = parsed
+		}
+	}
+	return count, bytes, nil
+}

--- a/boot/components/system/proposal_policy_test.go
+++ b/boot/components/system/proposal_policy_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+)
+
+func TestPendingApplyBudgets(t *testing.T) {
+	cfg := boot.NewConfig(boot.WithSection(ClusterName, map[string]any{}))
+	count, bytes, err := loadPendingApplyLimits(cfg.Sub(ClusterName))
+	require.NoError(t, err)
+	require.Equal(t, raftapi.DefaultMaxPendingApplies, count)
+	require.Equal(t, raftapi.DefaultMaxPendingApplyBytes, bytes)
+	cfg = boot.NewConfig(boot.WithSection(ClusterName, map[string]any{"raft.max_pending_applies": 3, "raft.max_pending_apply_bytes": "4096"}))
+	count, bytes, err = loadPendingApplyLimits(cfg.Sub(ClusterName))
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+	require.Equal(t, 4096, bytes)
+	for _, key := range []string{"raft.max_pending_applies", "raft.max_pending_apply_bytes"} {
+		for _, value := range []any{0, -1, 1.5, true, "invalid"} {
+			cfg := boot.NewConfig(boot.WithSection(ClusterName, map[string]any{key: value}))
+			_, _, err := loadPendingApplyLimits(cfg.Sub(ClusterName))
+			require.ErrorContains(t, err, key)
+		}
+	}
+}

--- a/boot/components/system/raft.go
+++ b/boot/components/system/raft.go
@@ -220,16 +220,22 @@ func Raft() boot.Component {
 			// existing peers with raft_status=in and skip bootstrap; the
 			// leader's reconciler adds them via AddVoter.
 			bootstrapExpect = raftCfg.GetInt(ClusterRaftBootstrapExpect, 1)
+			maxPendingApplies, maxPendingApplyBytes, err := loadPendingApplyLimits(raftCfg)
+			if err != nil {
+				return ctx, err
+			}
 			rc := raftapi.Config{
-				BootstrapExpect:   bootstrapExpect,
-				SnapshotThreshold: uint64(raftCfg.GetInt(ClusterRaftSnapshotThreshold, 0)),
-				SnapshotInterval:  raftCfg.GetDuration(ClusterRaftSnapshotInterval, 0),
-				SnapshotRetain:    raftCfg.GetInt(ClusterRaftSnapshotRetain, 0),
-				TrailingLogs:      uint64(raftCfg.GetInt(ClusterRaftTrailingLogs, 0)),
-				MaxAppendEntries:  raftCfg.GetInt(ClusterRaftMaxAppendEntries, 0),
-				HeartbeatTimeout:  raftCfg.GetDuration(ClusterRaftHeartbeatTimeout, 0),
-				ElectionTimeout:   raftCfg.GetDuration(ClusterRaftElectionTimeout, 0),
-				CommitTimeout:     raftCfg.GetDuration(ClusterRaftCommitTimeout, 0),
+				MaxPendingApplies:    maxPendingApplies,
+				MaxPendingApplyBytes: maxPendingApplyBytes,
+				BootstrapExpect:      bootstrapExpect,
+				SnapshotThreshold:    uint64(raftCfg.GetInt(ClusterRaftSnapshotThreshold, 0)),
+				SnapshotInterval:     raftCfg.GetDuration(ClusterRaftSnapshotInterval, 0),
+				SnapshotRetain:       raftCfg.GetInt(ClusterRaftSnapshotRetain, 0),
+				TrailingLogs:         uint64(raftCfg.GetInt(ClusterRaftTrailingLogs, 0)),
+				MaxAppendEntries:     raftCfg.GetInt(ClusterRaftMaxAppendEntries, 0),
+				HeartbeatTimeout:     raftCfg.GetDuration(ClusterRaftHeartbeatTimeout, 0),
+				ElectionTimeout:      raftCfg.GetDuration(ClusterRaftElectionTimeout, 0),
+				CommitTimeout:        raftCfg.GetDuration(ClusterRaftCommitTimeout, 0),
 			}
 			// store.kv.raft requires a durable raft; default the node data_dir to
 			// ~/.wippy/store so raft is fs-durable out of the box (no toggle). The

--- a/cluster/raft/apply_context.go
+++ b/cluster/raft/apply_context.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+)
+
+type proposalResult struct {
+	response *raftapi.ApplyResponse
+	err      error
+}
+
+// proposalWaits bounds futures retained after callers cancel. Hashicorp futures
+// have no cancellation operation: capacity belongs to the outstanding work and
+// is released only when it actually finishes, never when its caller leaves.
+type proposalWaits struct {
+	slots           chan struct{}
+	changed         chan struct{}
+	mu              sync.Mutex
+	bytes, maxBytes int
+}
+
+// Revalidate lifecycle after admission waits and before handing work to Raft.
+// This is not rollback: once apply begins its outcome may remain unknown.
+func proposalAdmissionError(ctx context.Context, stop <-chan struct{}) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-stop:
+		return raftapi.ErrNotRunning
+	default:
+		return nil
+	}
+}
+
+func (w *proposalWaits) reserveBytes(ctx context.Context, stop <-chan struct{}, size int) error {
+	if w.maxBytes <= 0 || size > w.maxBytes {
+		return fmt.Errorf("raft: proposal exceeds max_pending_apply_bytes")
+	}
+	for {
+		if err := proposalAdmissionError(ctx, stop); err != nil {
+			return err
+		}
+		w.mu.Lock()
+		if err := proposalAdmissionError(ctx, stop); err != nil {
+			w.mu.Unlock()
+			return err
+		}
+		if size <= w.maxBytes-w.bytes {
+			w.bytes += size
+			w.mu.Unlock()
+			return nil
+		}
+		if w.changed == nil {
+			w.changed = make(chan struct{})
+		}
+		changed := w.changed
+		w.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-stop:
+			return raftapi.ErrNotRunning
+		case <-changed:
+		}
+	}
+}
+func (w *proposalWaits) releaseBytes(size int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.bytes -= size
+	if w.changed != nil {
+		close(w.changed)
+		w.changed = nil
+	}
+}
+
+func (w *proposalWaits) run(ctx context.Context, stop <-chan struct{}, cmd []byte, apply func([]byte) (*raftapi.ApplyResponse, error)) (*raftapi.ApplyResponse, error) {
+	if err := proposalAdmissionError(ctx, stop); err != nil {
+		return nil, err
+	}
+	if w.maxBytes <= 0 || len(cmd) > w.maxBytes {
+		return nil, fmt.Errorf("raft: proposal exceeds max_pending_apply_bytes")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-stop:
+		return nil, raftapi.ErrNotRunning
+	case w.slots <- struct{}{}:
+	}
+	if err := proposalAdmissionError(ctx, stop); err != nil {
+		<-w.slots
+		return nil, err
+	}
+	if err := w.reserveBytes(ctx, stop, len(cmd)); err != nil {
+		<-w.slots
+		return nil, err
+	}
+	if err := proposalAdmissionError(ctx, stop); err != nil {
+		w.releaseBytes(len(cmd))
+		<-w.slots
+		return nil, err
+	}
+	owned := append([]byte(nil), cmd...)
+	done := make(chan proposalResult, 1)
+	go func() {
+		defer func() { w.releaseBytes(len(owned)); <-w.slots }()
+		if err := proposalAdmissionError(ctx, stop); err != nil {
+			done <- proposalResult{err: err}
+			return
+		}
+		response, err := apply(owned)
+		done <- proposalResult{response: response, err: err}
+	}()
+	select {
+	case out := <-done:
+		return out.response, out.err
+	case <-ctx.Done():
+		select {
+		case out := <-done:
+			return out.response, out.err
+		default:
+		}
+		return nil, fmt.Errorf("raft: proposal outcome unknown: %w", ctx.Err())
+	case <-stop:
+		select {
+		case out := <-done:
+			return out.response, out.err
+		default:
+		}
+		return nil, fmt.Errorf("raft: proposal outcome unknown: %w", raftapi.ErrNotRunning)
+	}
+}
+
+// ApplyContext lets the caller stop waiting for a proposal. Cancellation after
+// submission does not roll it back and must not trigger an automatic retry.
+// The timeout retains Apply's queue-admission meaning; ctx controls caller wait.
+func (n *Node) ApplyContext(ctx context.Context, cmd []byte, timeout time.Duration) (*raftapi.ApplyResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	n.mu.Lock()
+	running := n.raft != nil && n.started
+	n.mu.Unlock()
+	if !running {
+		return nil, raftapi.ErrNotRunning
+	}
+	// The caller may reuse cmd when cancellation returns. Copy only after the
+	// bounded admission gate is acquired.
+	// Ownership must transfer before the waiting method can return.
+	return n.proposals.run(ctx, n.stopCh, cmd, func(owned []byte) (*raftapi.ApplyResponse, error) {
+		return n.Apply(owned, timeout)
+	})
+}
+
+var _ raftapi.ContextApplier = (*Node)(nil)

--- a/cluster/raft/apply_context_test.go
+++ b/cluster/raft/apply_context_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	hraft "github.com/hashicorp/raft"
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+	"go.uber.org/zap"
+)
+
+func TestCanceledProposalRetainsCapacityUntilFutureFinishes(t *testing.T) {
+	waits := &proposalWaits{slots: make(chan struct{}, 1), maxBytes: 64}
+	stop := make(chan struct{})
+	started, finish := make(chan struct{}), make(chan struct{})
+	var calls atomic.Int32
+	input := []byte("original")
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := waits.run(ctx, stop, input, func(owned []byte) (*raftapi.ApplyResponse, error) {
+			calls.Add(1)
+			close(started)
+			<-finish
+			if string(owned) != "original" {
+				t.Errorf("canceled caller corrupted in-flight proposal: %q", owned)
+			}
+			return &raftapi.ApplyResponse{Index: 1}, nil
+		})
+		result <- err
+	}()
+	<-started
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel: %v", err)
+	}
+	copy(input, "modified")
+	if len(waits.slots) != 1 {
+		t.Fatal("cancel prematurely freed unresolved proposal capacity")
+	}
+	next, stopNext := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer stopNext()
+	_, err := waits.run(next, stop, nil, func([]byte) (*raftapi.ApplyResponse, error) { calls.Add(1); return nil, nil })
+	if !errors.Is(err, context.DeadlineExceeded) || calls.Load() != 1 {
+		t.Fatalf("exceeded unresolved proposal limit: calls=%d err=%v", calls.Load(), err)
+	}
+	close(finish)
+	// Completion frees capacity; a later request must make progress.
+	recovery, stopRecovery := context.WithTimeout(context.Background(), time.Second)
+	defer stopRecovery()
+	out, err := waits.run(recovery, stop, nil, func([]byte) (*raftapi.ApplyResponse, error) { return &raftapi.ApplyResponse{Index: 2}, nil })
+	if err != nil || out.Index != 2 {
+		t.Fatalf("future completion did not restore capacity: %+v %v", out, err)
+	}
+}
+
+func TestStoppedProposalTrackerDoesNotSubmit(t *testing.T) {
+	waits := &proposalWaits{slots: make(chan struct{}, 1), maxBytes: 64}
+	stop := make(chan struct{})
+	close(stop)
+	_, err := waits.run(context.Background(), stop, nil, func([]byte) (*raftapi.ApplyResponse, error) { t.Fatal("submitted after shutdown"); return nil, nil })
+	if !errors.Is(err, raftapi.ErrNotRunning) {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+type pausedApplyFSM struct {
+	started chan struct{}
+	finish  chan struct{}
+	once    sync.Once
+}
+
+func (f *pausedApplyFSM) Apply(*hraft.Log) any {
+	f.once.Do(func() { close(f.started); <-f.finish })
+	return "committed"
+}
+func (*pausedApplyFSM) Snapshot() (hraft.FSMSnapshot, error) {
+	return nil, errors.New("snapshot unused in this test")
+}
+func (*pausedApplyFSM) Restore(reader io.ReadCloser) error { return reader.Close() }
+
+func TestApplyContextCancelsWaitForRealRaftFuture(t *testing.T) {
+	fsm := &pausedApplyFSM{started: make(chan struct{}), finish: make(chan struct{})}
+	release := sync.OnceFunc(func() { close(fsm.finish) })
+	cfg := hraft.DefaultConfig()
+	cfg.LocalID = "one"
+	cfg.LogOutput = io.Discard
+	store := hraft.NewInmemStore()
+	_, transport := hraft.NewInmemTransport("one")
+	instance, err := hraft.NewRaft(cfg, fsm, store, store, hraft.NewInmemSnapshotStore(), transport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { release(); _ = instance.Shutdown().Error(); _ = transport.Close() })
+	if err := instance.BootstrapCluster(hraft.Configuration{Servers: []hraft.Server{{ID: "one", Address: "one", Suffrage: hraft.Voter}}}).Error(); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.After(5 * time.Second)
+	leaderTick := time.NewTicker(10 * time.Millisecond)
+	defer leaderTick.Stop()
+	for instance.State() != hraft.Leader {
+		select {
+		case <-deadline:
+			t.Fatal("single-node leader did not start")
+		case <-leaderTick.C:
+		}
+	}
+	node := NewNode("one", fsm, raftapi.Config{MaxPendingApplies: 1}, nil, zap.NewNop(), nil, nil, nil)
+	node.raft, node.started = instance, true
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, err := node.ApplyContext(ctx, []byte("proposal"), time.Second); done <- err }()
+	select {
+	case <-fsm.started:
+	case <-time.After(time.Second):
+		t.Fatal("proposal never reached FSM")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiting did not honor cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("caller remained blocked on Raft future")
+	}
+	if len(node.proposals.slots) != 1 {
+		t.Fatal("unresolved future lost its tracking slot")
+	}
+	release()
+	recovery, stopRecovery := context.WithTimeout(context.Background(), time.Second)
+	defer stopRecovery()
+	out, err := node.ApplyContext(recovery, []byte("next"), time.Second)
+	if err != nil || out.Response != "committed" {
+		t.Fatalf("tracking did not recover: %+v %v", out, err)
+	}
+}

--- a/cluster/raft/proposal_bytes_test.go
+++ b/cluster/raft/proposal_bytes_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+)
+
+func TestCanceledProposalRetainsByteBudgetUntilCompletion(t *testing.T) {
+	waits := &proposalWaits{slots: make(chan struct{}, 2), maxBytes: 4}
+	stop := make(chan struct{})
+	started, finish := make(chan struct{}), make(chan struct{})
+	release := sync.OnceFunc(func() { close(finish) })
+	defer release()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := waits.run(ctx, stop, []byte("full"), func([]byte) (*raftapi.ApplyResponse, error) { close(started); <-finish; return nil, nil })
+		done <- err
+	}()
+	<-started
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	waits.mu.Lock()
+	require.Equal(t, 4, waits.bytes)
+	waits.mu.Unlock()
+	// A count slot is free, but the canceled proposal still owns all byte credit.
+	short, cancelShort := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancelShort()
+	_, err := waits.run(short, stop, []byte("x"), func([]byte) (*raftapi.ApplyResponse, error) { t.Error("byte budget exceeded"); return nil, nil })
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	release()
+	later, cancelLater := context.WithTimeout(t.Context(), time.Second)
+	defer cancelLater()
+	_, err = waits.run(later, stop, []byte("next"), func([]byte) (*raftapi.ApplyResponse, error) { return nil, nil })
+	require.NoError(t, err, "real completion must restore byte capacity")
+}
+
+func TestOversizedProposalDoesNotCopyOrSubmit(t *testing.T) {
+	waits := &proposalWaits{slots: make(chan struct{}, 1), maxBytes: 1}
+	_, err := waits.run(t.Context(), make(chan struct{}), []byte("too large"), func([]byte) (*raftapi.ApplyResponse, error) { t.Error("oversized proposal submitted"); return nil, nil })
+	require.ErrorContains(t, err, "max_pending_apply_bytes")
+	require.Empty(t, waits.slots)
+	require.Zero(t, waits.bytes)
+	waits.slots <- struct{}{}
+	defer func() { <-waits.slots }()
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	_, err = waits.run(ctx, make(chan struct{}), []byte("too large"), func([]byte) (*raftapi.ApplyResponse, error) { t.Error("oversized proposal submitted"); return nil, nil })
+	require.ErrorContains(t, err, "max_pending_apply_bytes", "oversized work must be rejected before waiting for a count slot")
+}
+
+func TestStoppedProposalByteWaitReturnsCapacity(t *testing.T) {
+	waits := &proposalWaits{slots: make(chan struct{}, 1), maxBytes: 1}
+	stop := make(chan struct{})
+	require.NoError(t, waits.reserveBytes(t.Context(), stop, 1))
+	defer waits.releaseBytes(1)
+	done := make(chan error, 1)
+	go func() {
+		_, err := waits.run(t.Context(), stop, []byte("x"), func([]byte) (*raftapi.ApplyResponse, error) { t.Error("submitted after stop"); return nil, nil })
+		done <- err
+	}()
+	require.Eventually(t, func() bool {
+		waits.mu.Lock()
+		defer waits.mu.Unlock()
+		return waits.changed != nil
+	}, time.Second, time.Millisecond, "proposal must be waiting for byte capacity before shutdown")
+	close(stop)
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, raftapi.ErrNotRunning)
+	case <-time.After(time.Second):
+		t.Fatal("byte admission ignored shutdown")
+	}
+	require.Empty(t, waits.slots)
+}
+
+type observedProposalContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *observedProposalContext) Err() error {
+	err := c.Context.Err()
+	c.once.Do(func() { close(c.observed) })
+	return err
+}
+
+func TestProposalByteAdmissionRechecksCancellationAfterContention(t *testing.T) {
+	waits := &proposalWaits{slots: make(chan struct{}, 1), maxBytes: 1}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	observed := &observedProposalContext{Context: ctx, observed: make(chan struct{})}
+	waits.mu.Lock()
+	done := make(chan error, 1)
+	go func() { done <- waits.reserveBytes(observed, make(chan struct{}), 1) }()
+	// The first cancellation check observed a live caller. Hold the ownership
+	// mutex until cancellation, so acquisition must revalidate that observation.
+	<-observed.observed
+	cancel()
+	waits.mu.Unlock()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.Zero(t, waits.bytes, "canceled admission must not consume byte credit")
+}

--- a/cluster/raft/raft.go
+++ b/cluster/raft/raft.go
@@ -31,6 +31,7 @@ import (
 // Node wraps a hashicorp/raft instance and integrates it with the wippy
 // event bus and cluster membership system.
 type Node struct {
+	proposals   proposalWaits
 	fsm         hraft.FSM
 	bus         event.Bus
 	logStore    hraft.LogStore
@@ -56,13 +57,14 @@ func NewNode(localID string, fsm hraft.FSM, cfg raftapi.Config, bus event.Bus, l
 	coll metrics.Collector, mp otelmetric.MeterProvider, tp trace.TracerProvider) *Node {
 	cfg.InitDefaults()
 	return &Node{
-		fsm:     fsm,
-		config:  cfg,
-		localID: localID,
-		bus:     bus,
-		logger:  logger,
-		stopCh:  make(chan struct{}),
-		tel:     newTelemetry(coll, mp, tp),
+		proposals: proposalWaits{slots: make(chan struct{}, cfg.MaxPendingApplies), maxBytes: cfg.MaxPendingApplyBytes},
+		fsm:       fsm,
+		config:    cfg,
+		localID:   localID,
+		bus:       bus,
+		logger:    logger,
+		stopCh:    make(chan struct{}),
+		tel:       newTelemetry(coll, mp, tp),
 	}
 }
 


### PR DESCRIPTION
Add optional `raft.ContextApplier` / `Node.ApplyContext` so consumers can stop waiting for a Raft proposal without pretending to cancel a commit. This is a prerequisite for the context-aware KV/naming integration tracked in #664.

The implementation reserves count and command-byte capacity before copying caller input. An admitted proposal retains both reservations until its underlying Apply finishes, including after caller cancellation. Capacity exhaustion waits on release notifications with cancellation/shutdown support; oversized commands are rejected before allocation or count-slot waiting. Lifecycle checks run after contention and immediately before invoking Apply. No retry or rollback is implied by an uncertain result.

Boot exposes positive integer budgets `cluster.raft.max_pending_applies` (128 by default) and `cluster.raft.max_pending_apply_bytes` (64 MiB). These cover only unresolved ApplyContext work and its owned command payloads. Persistent log/FSM storage and existing direct Apply calls are outside those limits. The existing Apply timeout argument retains its queue-admission meaning; the context bounds caller waiting.

Validation: real HashiCorp Raft future cancellation, caller-buffer ownership, retained count/byte capacity after cancellation, recovery after actual completion, oversized rejection, shutdown while waiting for bytes, and a reproduced cancellation-versus-admission-lock regression. Standalone race suites pass for Raft (3.714s), boot and real-Raft cluster integration (50.355s); final boot checks and scoped lint pass.

This PR provides the bounded primitive. KV/naming adoption is separate and is not claimed to be completed here. No merge requested.
