### PR TITLE
Reduce Raft MessagePack allocations

### DIFF
--- a/cluster/raft/internode_codec_test.go
+++ b/cluster/raft/internode_codec_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package raft
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	hraft "github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+func legacyRaftEncode(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	err := codec.NewEncoder(&buf, &codec.MsgpackHandle{}).Encode(v)
+	return buf.Bytes(), err
+}
+func legacyRaftDecode(data []byte, v any) error {
+	return codec.NewDecoder(bytes.NewReader(data), &codec.MsgpackHandle{}).Decode(v)
+}
+
+func raftCodecSamples() []any {
+	header := hraft.RPCHeader{ProtocolVersion: 3, ID: []byte("node"), Addr: []byte("node-address")}
+	return []any{
+		&raftFrame{},
+		&raftFrame{ID: 42, Type: raftRPCAppendEntries, Request: true, Payload: []byte{0, 1, 255}, Snapshot: []byte("snapshot"), Error: "message", EOF: true},
+		&hraft.AppendEntriesRequest{RPCHeader: header, Term: 2, PrevLogEntry: 7, PrevLogTerm: 1, LeaderCommitIndex: 7, Entries: []*hraft.Log{{Index: 8, Term: 2, Type: hraft.LogCommand, Data: []byte("command"), Extensions: []byte("extension")}}},
+		&hraft.AppendEntriesResponse{RPCHeader: header, Term: 2, LastLog: 8, Success: true},
+		&hraft.RequestVoteRequest{RPCHeader: header, Term: 2, LastLogIndex: 8, LastLogTerm: 2},
+		&hraft.RequestVoteResponse{RPCHeader: header, Term: 2, Granted: true},
+		&hraft.RequestPreVoteRequest{RPCHeader: header, Term: 3, LastLogIndex: 8, LastLogTerm: 2},
+		&hraft.RequestPreVoteResponse{RPCHeader: header, Term: 3, Granted: true},
+		&hraft.InstallSnapshotRequest{RPCHeader: header, Term: 2, LastLogIndex: 8, LastLogTerm: 2, Configuration: []byte("configuration"), Peers: []byte("peers"), Size: 123},
+		&hraft.InstallSnapshotResponse{RPCHeader: header, Term: 2, Success: true},
+		&hraft.TimeoutNowRequest{RPCHeader: header},
+		&hraft.TimeoutNowResponse{RPCHeader: header},
+	}
+}
+
+func TestRaftCodecWireCompatibilityAndOwnership(t *testing.T) {
+	t.Parallel()
+	for i, sample := range raftCodecSamples() {
+		t.Run(fmt.Sprintf("%d-%T", i, sample), func(t *testing.T) {
+			t.Parallel()
+			for range 20 {
+				old, err := legacyRaftEncode(sample)
+				require.NoError(t, err)
+				wire, err := encodeMsgpack(sample)
+				require.NoError(t, err)
+				require.Equal(t, old, wire, "existing peers must receive the same MessagePack fields and representation")
+
+				typ := reflect.TypeOf(sample).Elem()
+				fromOld := reflect.New(typ).Interface()
+				fromNew := reflect.New(typ).Interface()
+				require.NoError(t, decodeMsgpack(old, fromOld))
+				require.NoError(t, legacyRaftDecode(wire, fromNew))
+				require.Equal(t, sample, fromOld)
+				require.Equal(t, sample, fromNew)
+				clear(old)
+				clear(wire)
+				require.Equal(t, sample, fromOld, "decoded data must not borrow the received frame")
+				require.Equal(t, sample, fromNew)
+
+				retained, err := encodeMsgpack(sample)
+				require.NoError(t, err)
+				expected := bytes.Clone(retained)
+				for range 3 {
+					_, err = encodeMsgpack(&raftFrame{Payload: bytes.Repeat([]byte{7}, 4096)})
+					require.NoError(t, err)
+				}
+				require.Equal(t, expected, retained, "another encode must not overwrite an earlier frame")
+			}
+		})
+	}
+}
+
+func BenchmarkRaftMessageCodec(b *testing.B) {
+	frame := &raftFrame{ID: 42, Type: raftRPCAppendEntries, Request: true, Payload: bytes.Repeat([]byte{1}, 1024)}
+	wire, err := encodeMsgpack(frame)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run("encode", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			if _, err := encodeMsgpack(frame); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("decode", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			var result raftFrame
+			if err := decodeMsgpack(wire, &result); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func FuzzRaftFrameCodecCompatibility(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0xc1})
+	for _, frame := range []*raftFrame{{}, {ID: 42, Type: raftRPCAppendEntries, Request: true, Payload: []byte("payload"), Error: "error", EOF: true}} {
+		wire, err := legacyRaftEncode(frame)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(wire)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+		var old, current raftFrame
+		oldErr := legacyRaftDecode(data, &old)
+		currentErr := decodeMsgpack(data, &current)
+		require.Equal(t, oldErr == nil, currentErr == nil, "decoder acceptance changed")
+		if oldErr == nil {
+			require.Equal(t, old, current)
+			clear(data)
+			require.Equal(t, old, current, "decoded payload must survive reuse of receive buffer")
+		}
+	})
+}

--- a/cluster/raft/internode_transport.go
+++ b/cluster/raft/internode_transport.go
@@ -3,7 +3,6 @@
 package raft
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -464,16 +463,21 @@ func (t *raftMessageTransport) sendReply(peer cluster.NodeID, id uint64, typ uin
 	}
 }
 
+// MsgpackHandle caches type metadata and supports concurrent encoders/decoders
+// once configured. Never mutate it after first use. Each operation still owns
+// its codec and output; no pooled payload buffer can escape to the transport.
+var raftMsgpackHandle codec.MsgpackHandle
+
 func encodeMsgpack(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := codec.NewEncoder(&buf, &codec.MsgpackHandle{}).Encode(v); err != nil {
+	var data []byte
+	if err := codec.NewEncoderBytes(&data, &raftMsgpackHandle).Encode(v); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	return data, nil
 }
 
 func decodeMsgpack(data []byte, v any) error {
-	return codec.NewDecoder(bytes.NewReader(data), &codec.MsgpackHandle{}).Decode(v)
+	return codec.NewDecoderBytes(data, &raftMsgpackHandle).Decode(v)
 }
 
 type raftMessagePipeline struct {


### PR DESCRIPTION
Raft RPC encoding created a fresh MessagePack handle and temporary I/O wrappers for every frame, repeatedly allocating type metadata and buffers. Reuse the codec's concurrency-safe, immutable handle and encode/decode byte frames directly. Each operation retains its own codec and owned payload buffers.

Compatibility tests compare exact wire bytes against the previous encoder, decode in both directions, and verify that subsequent encoding or receive-buffer reuse cannot overwrite retained payloads. They run concurrently across every Raft request/response type and the transport envelope. A differential decoder fuzz target covers malformed frames.

For a 1 KiB transport frame on Linux/AMD64:

| Operation | Allocations before → after | Bytes/op before → after |
| --- | --- | --- |
| Encode | 25 → 5 | 4,504 → 2,808 |
| Decode | 25 → 4 | 2,688 → 1,456 |

Validation on this branch:
- `GOWORK=off go test -race ./cluster/raft ./cluster/clustertest -count=1`
- Focused concurrent compatibility and fuzz-seed race tests; scoped golangci-lint.
- `BenchmarkRaftMessageCodec`, three samples after the change.

The same codec helpers also passed 175,298 differential fuzz executions and a three-process leader-kill/restart test with delay, jitter and actual packet loss in the separate hardening checkout. That checkout contains other pending fixes; its fault test is supplemental evidence, not an isolated proof of this PR. Microbenchmarks do not establish end-to-end cluster throughput.
