### PR TITLE
fix(kv): reject malformed forwarded write replies

### DIFF
--- a/system/kv/forward_write_shape_test.go
+++ b/system/kv/forward_write_shape_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package kv
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	raftapi "github.com/wippyai/runtime/api/cluster/raft"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/relay"
+	kvapi "github.com/wippyai/runtime/api/store/kv"
+)
+
+type damagedWriteReplyRouter struct {
+	*routerTo
+	damage func([]byte) []byte
+}
+
+func (r damagedWriteReplyRouter) Send(pkg *relay.Package) error {
+	if pkg.Messages[0].Topic == topicKVForwardResp {
+		p := pkg.Messages[0].Payloads[0]
+		original := p.Data().([]byte)
+		// Mutate only the response after the leader has actually applied the write.
+		altered := r.damage(bytes.Clone(original))
+		// A replacement payload also supports truncated/extended frames.
+		pkg.Messages[0].Payloads[0] = payload.New(altered)
+	}
+	return r.routerTo.Send(pkg)
+}
+func (r damagedWriteReplyRouter) SendContext(ctx context.Context, pkg *relay.Package) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return r.Send(pkg)
+}
+
+func TestMalformedWriteReplyNeverRetriesCommittedMutation(t *testing.T) {
+	for _, shape := range []string{"generic-lookalike", "success-notleader", "notleader-trailing", "invalid-ok", "short-header"} {
+		t.Run(shape, func(t *testing.T) {
+			router := damagedWriteReplyRouter{routerTo: &routerTo{}, damage: func(out []byte) []byte {
+				switch shape {
+				case "generic-lookalike":
+					clear(out[8:17])
+					out[17] = errOther
+					return append(out[:18], []byte(errForwardNotLeader.Error())...)
+				case "success-notleader":
+					out[17] = errNotLeaderCode
+				case "notleader-trailing":
+					clear(out[8:17])
+					out[17] = errNotLeaderCode
+					return append(out, 1)
+				case "invalid-ok":
+					out[16] = 2
+				case "short-header":
+					return out[:8]
+				}
+				return out
+			}}
+			router.engines = make(map[string]*RaftEngine)
+			for _, node := range []string{"leader", "client"} {
+				fsm := NewRaftFSM(nil)
+				e := NewRaftEngine(&fakeRaft{fsm: fsm, leader: node == "leader", leaderID: "leader"}, fsm, nil, node, router, nil)
+				e.forwardWait = 100 * time.Millisecond
+				router.engines[node] = e
+				require.NoError(t, e.Start(t.Context()))
+				t.Cleanup(func() { require.NoError(t, e.Stop()) })
+			}
+			_, err := router.engines["client"].Set("once", []byte("value"))
+			require.Error(t, err)
+			value, found := router.engines["leader"].fsm.get("once")
+			require.True(t, found)
+			require.Equal(t, uint64(1), value.Version, "an invalid reply must not replay a committed write")
+			require.NotErrorIs(t, err, errForwardNotLeader)
+			require.NotErrorIs(t, err, errForwardTimeout, "a correlatable malformed reply must wake its waiter")
+		})
+	}
+}
+
+type writeShapeCaptureReplies struct{ replies chan []byte }
+
+func (r writeShapeCaptureReplies) Send(pkg *relay.Package) error {
+	return r.SendContext(context.Background(), pkg)
+}
+func (r writeShapeCaptureReplies) SendContext(ctx context.Context, pkg *relay.Package) error {
+	data := bytes.Clone(pkg.Messages[0].Payloads[0].Data().([]byte))
+	select {
+	case r.replies <- data:
+		relay.ReleasePackage(pkg)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestForwardWriteReplyCanonicalRoundTrip(t *testing.T) {
+	cases := []applyResult{
+		{}, {OK: true}, {OK: true, Version: 7}, {Version: 9},
+		{Err: kvapi.ErrKeyNotFound}, {Err: kvapi.ErrLeaseNotFound},
+		{Err: kvapi.ErrVersionMismatch, Version: 11}, {Err: raftapi.ErrNotLeader},
+		{Err: raftapi.ErrLeadershipLost}, {Err: errors.New("")},
+		{Err: errors.New(errForwardNotLeader.Error())},
+	}
+	for _, result := range cases {
+		replies := make(chan []byte, 1)
+		fsm := NewRaftFSM(nil)
+		e := NewRaftEngine(&fakeRaft{fsm: fsm, leader: true}, fsm, nil, "leader", writeShapeCaptureReplies{replies: replies}, nil)
+		require.NoError(t, e.Start(t.Context()))
+		e.replyForward("client", 42, result)
+		var out []byte
+		select {
+		case out = <-replies:
+		case <-time.After(time.Second):
+			t.Fatal("write reply missing")
+		}
+		require.NoError(t, e.Stop())
+		require.Equal(t, uint64(42), binary.BigEndian.Uint64(out))
+		decoded := decodeForwardWriteResponse(out)
+		require.Equal(t, result.OK, decoded.OK)
+		require.Equal(t, result.Version, decoded.Version)
+		if errors.Is(result.Err, raftapi.ErrNotLeader) {
+			require.ErrorIs(t, decoded.Err, errForwardNotLeader)
+		} else if result.Err == nil {
+			require.NoError(t, decoded.Err)
+		} else {
+			require.EqualError(t, decoded.Err, result.Err.Error())
+			require.NotErrorIs(t, decoded.Err, errForwardNotLeader)
+		}
+	}
+}
+
+func FuzzForwardWriteReplyRetryClassification(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(make([]byte, 18))
+	rejection := make([]byte, 18)
+	rejection[17] = errNotLeaderCode
+	f.Add(rejection)
+	opaque := make([]byte, 18)
+	opaque[17] = errOther
+	f.Add(append(opaque, []byte(errForwardNotLeader.Error())...))
+	f.Fuzz(func(t *testing.T, out []byte) {
+		if len(out) > 4096 {
+			t.Skip()
+		}
+		result := decodeForwardWriteResponse(out)
+		if errors.Is(result.Err, errForwardNotLeader) {
+			require.Len(t, out, 18)
+			require.Equal(t, byte(0), out[16])
+			require.Equal(t, errNotLeaderCode, out[17])
+			require.Zero(t, binary.BigEndian.Uint64(out[8:16]))
+		}
+		if result.Err == nil {
+			require.Len(t, out, 18)
+			require.LessOrEqual(t, out[16], byte(1))
+			require.Equal(t, errNone, out[17])
+		}
+	})
+}
+
+type rejectFirstWriteRouter struct {
+	*routerTo
+	rejected atomic.Bool
+}
+
+func (r *rejectFirstWriteRouter) Send(pkg *relay.Package) error {
+	if pkg.Messages[0].Topic == topicKVForwardReq && r.rejected.CompareAndSwap(false, true) {
+		response := make([]byte, 18)
+		copy(response[:8], pkg.Messages[0].Payloads[0].Data().([]byte)[:8])
+		response[17] = errNotLeaderCode
+		reply := relay.NewServicePackage(pkg.Target.Node, KVRaftHostID, pkg.Source.Node, KVRaftHostID, topicKVForwardResp, payload.New(response))
+		relay.ReleasePackage(pkg)
+		return r.routerTo.Send(reply)
+	}
+	return r.routerTo.Send(pkg)
+}
+func (r *rejectFirstWriteRouter) SendContext(ctx context.Context, pkg *relay.Package) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return r.Send(pkg)
+}
+func TestExplicitWriteRejectionStillRetries(t *testing.T) {
+	router := &rejectFirstWriteRouter{routerTo: &routerTo{engines: make(map[string]*RaftEngine)}}
+	for _, node := range []string{"leader", "client"} {
+		fsm := NewRaftFSM(nil)
+		e := NewRaftEngine(&fakeRaft{fsm: fsm, leader: node == "leader", leaderID: "leader"}, fsm, nil, node, router, nil)
+		router.engines[node] = e
+		require.NoError(t, e.Start(t.Context()))
+		t.Cleanup(func() { require.NoError(t, e.Stop()) })
+	}
+	version, err := router.engines["client"].Set("once", []byte("value"))
+	require.NoError(t, err)
+	require.True(t, router.rejected.Load())
+	require.Equal(t, uint64(1), version)
+	value, found := router.engines["leader"].fsm.get("once")
+	require.True(t, found)
+	require.Equal(t, uint64(1), value.Version)
+}

--- a/system/kv/raft_forward.go
+++ b/system/kv/raft_forward.go
@@ -60,8 +60,8 @@ const forwardReplyGrace = 2 * time.Second
 const forwardWaitTimeout = raftApplyTimeout + forwardReplyGrace
 
 // errForwardNotLeader marks a forwarded write that reached a non-leader. The op
-// was provably NOT applied (a leader that loses leadership mid-Apply does not
-// commit), so the caller may safely re-resolve the leader and retry.
+// was rejected before acceptance, so the caller may safely re-resolve and retry.
+// Losing leadership after acceptance is a different, uncertain outcome.
 var errForwardNotLeader = staticErr("kv: forwarded write reached a non-leader")
 
 // errForwardTimeout marks a forwarded write whose reply never arrived. Unlike a
@@ -118,7 +118,8 @@ func kindToErr(kind byte, msg string) error {
 	case errNotLeaderCode:
 		return errForwardNotLeader
 	default:
-		return staticErr(msg)
+		// Remote text must never recreate a local control-flow sentinel.
+		return errors.New(msg)
 	}
 }
 
@@ -458,23 +459,46 @@ func (e *RaftEngine) handleForwardResp(msg *relay.Message) {
 		return
 	}
 	out, ok := msg.Payloads[0].Data().([]byte)
-	if !ok || len(out) < 18 {
+	if !ok || len(out) < 8 {
 		return
 	}
 	corr := binary.BigEndian.Uint64(out[:8])
-	res := applyResult{
-		Version: binary.BigEndian.Uint64(out[8:16]),
-		OK:      out[16] == 1,
-		Err:     kindToErr(out[17], string(out[18:])),
-	}
+
 	e.fwdMu.Lock()
 	ch, found := e.pending[corr]
 	e.fwdMu.Unlock()
 	if !found {
 		return
 	}
+	res := decodeForwardWriteResponse(out)
 	select {
 	case ch <- res:
 	default:
 	}
+}
+
+// Only a canonical explicit not-leader rejection permits a retry. Malformed
+// replies are uncertain outcomes even if some bytes resemble a rejection.
+func decodeForwardWriteResponse(out []byte) applyResult {
+	if len(out) < 18 {
+		return applyResult{Err: staticErr("kv: write response header truncated")}
+	}
+	if out[16] > 1 {
+		return applyResult{Err: staticErr("kv: write response invalid success flag")}
+	}
+	kind := out[17]
+	if kind > errOther {
+		return applyResult{Err: staticErr("kv: write response unknown error kind")}
+	}
+	if kind != errOther && len(out) != 18 {
+		return applyResult{Err: staticErr("kv: write response trailing data")}
+	}
+	if kind != errNone && out[16] != 0 {
+		return applyResult{Err: staticErr("kv: write response contradictory result")}
+	}
+	version := binary.BigEndian.Uint64(out[8:16])
+	if kind == errNotLeaderCode && version != 0 {
+		return applyResult{Err: staticErr("kv: write response rejection has a version")}
+	}
+	return applyResult{Version: version, OK: out[16] == 1, Err: kindToErr(kind, string(out[18:]))}
 }


### PR DESCRIPTION
## Summary

- Retry forwarded writes only for the exact canonical non-leader rejection.
- Wake correlated waiters with non-retryable errors for malformed, contradictory, truncated, or trailing-data replies.
- Keep remote error text opaque so it cannot reconstruct the local retry sentinel.

The wire format and valid conditional-write behavior are unchanged.

## Regression coverage

Tests prove misleading replies cannot apply a committed mutation twice, while a genuine pre-acceptance rejection still retries and applies once. Production reply shapes are covered for success, failed conditions, errors, truncation, and invalid flags.

## Validation

- go test -race -count=1 -timeout=10m ./system/kv ./cluster/clustertest
- go vet ./system/kv ./cluster/clustertest
- golangci-lint v2.13.2 ./system/kv
- git diff --check origin/main...HEAD