### PR TITLE
fix(internode): preserve peer state across concurrent joins

### DIFF
--- a/cluster/internode/managed_join_race_test.go
+++ b/cluster/internode/managed_join_race_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"go.uber.org/zap"
+)
+
+// Pause inbound authorization after its initial missing-state check. A formal
+// membership join then creates the state and admits a message before inbound
+// auto-management resumes. The duplicate join must not reset that queue.
+func TestInboundAutoManagementPreservesConcurrentMembershipJoin(t *testing.T) {
+	observed := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	resume := func() { once.Do(func() { close(release) }) }
+	defer resume()
+	cfg := insecureManagerConfig()
+	cfg.LocalNodeID = "a-local" // Tie-break drops the inbound connection after admission.
+	cfg.Logger = zap.NewNop()
+	cfg.AuthorizePeer = func(cluster.NodeID, net.Addr) bool { close(observed); <-release; return true }
+	m := NewConnectionManager(cfg, nil).(*manager)
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+	finished := make(chan struct{})
+	go func() { defer close(finished); m.handleInboundConnection(server) }()
+	peer, err := PerformClientHandshake(client, cfg.NodeConnectionConfig(), zap.NewNop(), "z-peer", "a-local")
+	require.NoError(t, err)
+	defer peer.Close()
+	select {
+	case <-observed:
+	case <-time.After(time.Second):
+		t.Fatal("inbound admission not reached")
+	}
+	m.AddManagedNode("z-peer")
+	original := m.nodeStates.GetNodeState("z-peer")
+	require.NotNil(t, original)
+	require.NoError(t, m.nodeStates.QueueMessageClass("z-peer", []byte("already-admitted"), ClassRaftRPC))
+	resume()
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("inbound handler did not finish")
+	}
+	require.Same(t, original, m.nodeStates.GetNodeState("z-peer"))
+	require.Equal(t, [][]byte{[]byte("already-admitted")}, drainAllData(m.nodeStates, "z-peer"))
+	m.RemoveManagedNode("z-peer")
+}
+
+func TestConcurrentManagedJoinsPreserveAdmittedMessages(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	failures := make(chan error, 32)
+	for i := range 32 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			m.AddManagedNode("peer")
+			failures <- m.nodeStates.QueueMessageClass("peer", []byte{byte(i)}, ClassRaftRPC)
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(failures)
+	for err := range failures {
+		require.NoError(t, err)
+	}
+	queued := drainAllData(m.nodeStates, "peer")
+	require.Len(t, queued, 32)
+	seen := make(map[byte]bool)
+	for _, data := range queued {
+		require.Len(t, data, 1)
+		require.False(t, seen[data[0]])
+		seen[data[0]] = true
+	}
+	m.RemoveManagedNode("peer")
+}
+
+func TestDetachedPeerCleanupDoesNotRemoveReplacement(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	m.AddManagedNode("peer")
+	old := m.nodeStates.GetNodeState("peer")
+	old.stateMu.Lock()
+	var once sync.Once
+	release := func() { once.Do(old.stateMu.Unlock) }
+	defer release()
+	removed := make(chan struct{})
+	go func() { m.RemoveManagedNode("peer"); close(removed) }()
+	require.Eventually(t, func() bool { return m.nodeStates.GetNodeState("peer") == nil }, time.Second, time.Millisecond)
+	joined := make(chan struct{})
+	go func() { m.AddManagedNode("peer"); close(joined) }()
+	select {
+	case <-joined:
+	case <-time.After(time.Second):
+		t.Fatal("old resource cleanup blocked new admission")
+	}
+	replacement := m.nodeStates.GetNodeState("peer")
+	require.NotSame(t, old, replacement)
+	require.NoError(t, m.nodeStates.QueueMessageClass("peer", []byte("new-generation"), ClassRaftRPC))
+	release()
+	select {
+	case <-removed:
+	case <-time.After(time.Second):
+		t.Fatal("old cleanup did not finish")
+	}
+	require.Same(t, replacement, m.nodeStates.GetNodeState("peer"))
+	require.Equal(t, [][]byte{[]byte("new-generation")}, drainAllData(m.nodeStates, "peer"))
+	m.RemoveManagedNode("peer")
+}
+
+// A cancelled loop can run its deferred cleanup after membership removal has
+// detached its state and a new incarnation has been admitted. That cleanup
+// must remain scoped to the generation the loop originally owned.
+func TestDetachedLoopCleanupDoesNotMutateReplacementGeneration(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	m.AddManagedNode("peer")
+	old := m.nodeStates.GetNodeState("peer")
+	require.NotNil(t, old)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	oldLoop := &nodeControlLoop{
+		ctx:       ctx,
+		cancel:    cancel,
+		manager:   m,
+		nodeID:    "peer",
+		nodeState: old,
+		commands:  make(chan nodeCommand),
+	}
+	m.controlLoopsMu.Lock()
+	m.controlLoops["peer"] = oldLoop
+	m.controlLoopsMu.Unlock()
+
+	m.RemoveManagedNode("peer")
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("remove did not cancel the old control loop")
+	}
+	m.AddManagedNode("peer")
+	replacement := m.nodeStates.GetNodeState("peer")
+	require.NotNil(t, replacement)
+	require.NotSame(t, old, replacement)
+	m.nodeStates.SetNodeState("peer", StateRetrying)
+
+	// This is the deferred cleanup the cancelled old loop runs after Remove.
+	oldLoop.cleanup()
+	_, got := m.nodeStates.GetNodeConnection("peer")
+	require.Equal(t, StateRetrying, got, "old-loop cleanup changed replacement state")
+	m.RemoveManagedNode("peer")
+}
+
+func TestDetachedLoopDrainDoesNotTouchReplacementGeneration(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	m.AddManagedNode("peer")
+	old := m.nodeStates.GetNodeState("peer")
+	require.NotNil(t, old)
+
+	conn := &NodeConnection{}
+	oldLoop := &nodeControlLoop{manager: m, nodeID: "peer", nodeState: old, connection: conn}
+	oldLoop.bindConnectionDrain()
+	require.NotNil(t, conn.drainFn)
+	require.NotNil(t, conn.requeueFn)
+
+	m.RemoveManagedNode("peer")
+	m.AddManagedNode("peer")
+	replacement := m.nodeStates.GetNodeState("peer")
+	require.NotNil(t, replacement)
+	require.NotSame(t, old, replacement)
+	require.NoError(t, m.nodeStates.QueueMessageClass("peer", []byte("replacement"), ClassRaftRPC))
+
+	require.Empty(t, conn.drainFn(1), "stale drain consumed replacement data")
+	conn.requeueFn([]Outbound{{Data: []byte("stale"), Class: ClassRaftRPC}})
+	require.Equal(t, [][]byte{[]byte("replacement")}, drainAllData(m.nodeStates, "peer"))
+	m.RemoveManagedNode("peer")
+}

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -156,6 +156,7 @@ type nodeControlLoop struct {
 	logger     *zap.Logger
 	cancel     context.CancelFunc
 	nodeID     cluster.NodeID
+	nodeState  *NodeState
 	addr       string
 	state      ConnectionState
 	retryDelay time.Duration
@@ -349,6 +350,9 @@ func (m *manager) ConnectedNodes() []cluster.NodeID {
 }
 
 func (m *manager) AddManagedNode(nodeID cluster.NodeID) {
+	// Serialize membership and inbound admission with state detachment.
+	m.controlLoopsMu.Lock()
+	defer m.controlLoopsMu.Unlock()
 	m.logger.Info("Adding new managed node", zap.String("node", nodeID))
 
 	// If the node already has state, it was either:
@@ -369,13 +373,11 @@ func (m *manager) AddManagedNode(nodeID cluster.NodeID) {
 	// If there's an old control loop for this node (e.g. from a previous
 	// incarnation that left and is now rejoining), tear it down first to
 	// prevent the old loop from interfering with the new state.
-	m.controlLoopsMu.Lock()
 	if oldLoop, exists := m.controlLoops[nodeID]; exists {
 		m.logger.Info("Tearing down stale control loop for rejoining node", zap.String("node", nodeID))
 		oldLoop.cancel()
 		delete(m.controlLoops, nodeID)
 	}
-	m.controlLoopsMu.Unlock()
 
 	m.nodeStates.CreateNodeState(nodeID)
 }
@@ -392,9 +394,11 @@ func (m *manager) RemoveManagedNode(nodeID cluster.NodeID) {
 		loop.cancel()
 		delete(m.controlLoops, nodeID)
 	}
+	state := m.nodeStates.detachNodeState(nodeID)
 	m.controlLoopsMu.Unlock()
 
-	m.nodeStates.RemoveNodeState(nodeID)
+	// Close connections and drain old queues without holding the lifecycle lock.
+	m.nodeStates.closeDetachedNodeState(nodeID, state)
 }
 
 func (m *manager) GetListenPort() int {
@@ -500,7 +504,8 @@ func (m *manager) sendCommand(nodeID cluster.NodeID, cmd nodeCommand) {
 	loop, exists := m.controlLoops[nodeID]
 	if !exists {
 		// Before creating a loop, verify the underlying state exists.
-		if m.nodeStates.GetNodeState(nodeID) == nil {
+		state := m.nodeStates.GetNodeState(nodeID)
+		if state == nil {
 			m.controlLoopsMu.Unlock()
 			m.logger.Error("Attempted to create control loop for unmanaged node", zap.String("node", nodeID))
 			return
@@ -509,6 +514,7 @@ func (m *manager) sendCommand(nodeID cluster.NodeID, cmd nodeCommand) {
 		ctx, cancel := context.WithCancel(m.ctx)
 		loop = &nodeControlLoop{
 			nodeID:     nodeID,
+			nodeState:  state,
 			manager:    m,
 			commands:   make(chan nodeCommand, m.config.CommandQueueSize),
 			state:      StateNone,
@@ -595,7 +601,9 @@ func (loop *nodeControlLoop) handleConnect(data connectData) {
 	}
 	loop.state = StateConnecting
 	loop.isOutbound = true
-	loop.manager.nodeStates.SetNodeState(loop.nodeID, loop.state)
+	if !loop.manager.nodeStates.setNodeStateForState(loop.nodeID, loop.nodeState, loop.state) {
+		return
+	}
 
 	addr, port := loop.addr, loop.port
 	loop.manager.wg.Add(1)
@@ -627,7 +635,14 @@ func (loop *nodeControlLoop) handleConnected(data connectedData) {
 	loop.state = StateConnected
 	loop.retryCount = 0
 	loop.retryDelay = loop.manager.config.InitialRetryDelay
-	loop.manager.nodeStates.SetNodeConnection(loop.nodeID, loop.connection, loop.state)
+	if !loop.manager.nodeStates.setNodeConnectionForState(loop.nodeID, loop.nodeState, loop.connection, loop.state) {
+		if loop.connection != nil {
+			loop.connection.Close()
+		}
+		loop.connection = nil
+		loop.state = StateNone
+		return
+	}
 	loop.logger.Info("Connection established successfully", zap.Bool("is_outbound", loop.isOutbound))
 
 	// Wire the connection's writeLoop to drain this node's per-class queues
@@ -651,15 +666,16 @@ func (loop *nodeControlLoop) handleConnected(data connectedData) {
 func (loop *nodeControlLoop) bindConnectionDrain() {
 	nodeID := loop.nodeID
 	nsm := loop.manager.nodeStates
-	notify := nsm.GetMessageNotifier(nodeID)
+	state := loop.nodeState
+	notify := state.messageNotify
 	if notify == nil {
 		loop.logger.Error("no message notifier for managed node", zap.String("node", nodeID))
 		notify = make(chan struct{})
 	}
 	loop.connection.bindDrain(
 		notify,
-		func(n int) []Outbound { return nsm.DrainMessages(nodeID, n) },
-		func(b []Outbound) { nsm.RequeueMessages(nodeID, b) },
+		func(n int) []Outbound { return nsm.drainMessagesForState(nodeID, state, n) },
+		func(b []Outbound) { nsm.requeueMessagesForState(nodeID, state, b) },
 		loop.manager.config.DrainBatchSize,
 	)
 }
@@ -681,7 +697,7 @@ func (loop *nodeControlLoop) handleDisconnected(data disconnectedData) {
 		loop.connection.Close()
 		loop.connection = nil
 	}
-	loop.manager.nodeStates.SetNodeConnection(loop.nodeID, nil, StateNone)
+	loop.manager.nodeStates.setNodeConnectionForState(loop.nodeID, loop.nodeState, nil, StateNone)
 
 	if data.ShouldRetry && loop.isOutbound && loop.retryCount < loop.manager.config.MaxRetryAttempts {
 		loop.state = StateRetrying
@@ -691,7 +707,7 @@ func (loop *nodeControlLoop) handleDisconnected(data disconnectedData) {
 		}
 		fallbackAddr, fallbackPort := loop.addr, loop.port
 		time.AfterFunc(loop.retryDelay, func() {
-			addr, port, hasAddr := loop.manager.nodeStates.GetNodeAddress(loop.nodeID)
+			addr, port, hasAddr := loop.manager.nodeStates.getNodeAddressForState(loop.nodeID, loop.nodeState)
 			if !hasAddr {
 				addr, port = fallbackAddr, fallbackPort
 			}
@@ -711,7 +727,7 @@ func (loop *nodeControlLoop) cleanup() {
 		loop.connection.Close()
 		loop.connection = nil
 	}
-	loop.manager.nodeStates.SetNodeConnection(loop.nodeID, nil, StateNone)
+	loop.manager.nodeStates.setNodeConnectionForState(loop.nodeID, loop.nodeState, nil, StateNone)
 }
 
 func (loop *nodeControlLoop) sendCommandToSelf(cmd nodeCommand) {
@@ -859,7 +875,7 @@ func (m *manager) handleInboundConnection(conn net.Conn) {
 			return
 		}
 		m.logger.Info("Auto-managing authorized inbound node", zap.String("node", remoteNodeID))
-		m.nodeStates.CreateNodeState(remoteNodeID)
+		m.AddManagedNode(remoteNodeID)
 	}
 
 	_, currentState := m.nodeStates.GetNodeConnection(remoteNodeID)

--- a/cluster/internode/state_manager.go
+++ b/cluster/internode/state_manager.go
@@ -300,11 +300,21 @@ func (nsm *NodeStateManager) SetNodeConnection(nodeID cluster.NodeID, conn *Node
 		nsm.logger.Warn("Attempted to set connection for an unmanaged node", zap.String("node_id", nodeID))
 		return
 	}
+	nsm.setNodeConnectionForState(nodeID, state, conn, newState)
+}
 
+// setNodeConnectionForState updates only the supplied generation. A control
+// loop retains this pointer so cleanup from an old incarnation cannot modify
+// a replacement that has reused the same node ID.
+func (nsm *NodeStateManager) setNodeConnectionForState(nodeID cluster.NodeID, state *NodeState, conn *NodeConnection, newState ConnectionState) bool {
+	if state == nil || nsm.GetNodeState(nodeID) != state {
+		return false
+	}
 	state.stateMu.Lock()
 	state.connection = conn
 	state.state = newState
 	state.stateMu.Unlock()
+	return true
 }
 
 func (nsm *NodeStateManager) GetNodeConnection(nodeID cluster.NodeID) (*NodeConnection, ConnectionState) {
@@ -327,10 +337,17 @@ func (nsm *NodeStateManager) SetNodeState(nodeID cluster.NodeID, newState Connec
 		nsm.logger.Warn("Attempted to set state for an unmanaged node", zap.String("node_id", nodeID))
 		return
 	}
+	nsm.setNodeStateForState(nodeID, state, newState)
+}
 
+func (nsm *NodeStateManager) setNodeStateForState(nodeID cluster.NodeID, state *NodeState, newState ConnectionState) bool {
+	if state == nil || nsm.GetNodeState(nodeID) != state {
+		return false
+	}
 	state.stateMu.Lock()
 	state.state = newState
 	state.stateMu.Unlock()
+	return true
 }
 
 func (nsm *NodeStateManager) UpdateNodeAddress(nodeID cluster.NodeID, addr string, port int) {
@@ -350,7 +367,13 @@ func (nsm *NodeStateManager) GetNodeAddress(nodeID cluster.NodeID) (string, int,
 	if state == nil {
 		return "", 0, false
 	}
+	return nsm.getNodeAddressForState(nodeID, state)
+}
 
+func (nsm *NodeStateManager) getNodeAddressForState(nodeID cluster.NodeID, state *NodeState) (string, int, bool) {
+	if state == nil || nsm.GetNodeState(nodeID) != state {
+		return "", 0, false
+	}
 	state.stateMu.RLock()
 	addr := state.address
 	state.stateMu.RUnlock()
@@ -365,7 +388,14 @@ var drainClasses = [...]Class{ClassRaftControl, ClassRaftRPC, ClassGossip}
 
 func (nsm *NodeStateManager) DrainMessages(nodeID cluster.NodeID, maxCount int) []Outbound {
 	state := nsm.GetNodeState(nodeID)
-	if state == nil || maxCount <= 0 {
+	return nsm.drainMessagesForState(nodeID, state, maxCount)
+}
+
+// drainMessagesForState drains only the supplied generation. Connection drain
+// callbacks retain their loop's state pointer, preventing a detached
+// connection from consuming a replacement's queue.
+func (nsm *NodeStateManager) drainMessagesForState(nodeID cluster.NodeID, state *NodeState, maxCount int) []Outbound {
+	if state == nil || nsm.GetNodeState(nodeID) != state || maxCount <= 0 {
 		return nil
 	}
 
@@ -442,6 +472,16 @@ func (nsm *NodeStateManager) GetMessageNotifier(nodeID cluster.NodeID) <-chan st
 // without losing QoS context. Internally splits the input by class and
 // delegates to RequeueMessagesClass for the per-class cap arithmetic.
 func (nsm *NodeStateManager) RequeueMessages(nodeID cluster.NodeID, messages []Outbound) {
+	state := nsm.GetNodeState(nodeID)
+	nsm.requeueMessagesForState(nodeID, state, messages)
+}
+
+// requeueMessagesForState returns frames only to the supplied generation.
+// A stale connection must never repopulate a newer peer incarnation's queue.
+func (nsm *NodeStateManager) requeueMessagesForState(nodeID cluster.NodeID, state *NodeState, messages []Outbound) {
+	if state == nil || nsm.GetNodeState(nodeID) != state {
+		return
+	}
 	if len(messages) == 0 {
 		return
 	}
@@ -459,7 +499,7 @@ func (nsm *NodeStateManager) RequeueMessages(nodeID cluster.NodeID, messages []O
 		if len(perClass[c]) == 0 {
 			continue
 		}
-		nsm.RequeueMessagesClass(nodeID, perClass[c], Class(c))
+		nsm.requeueMessagesClassForState(nodeID, state, perClass[c], Class(c))
 	}
 }
 
@@ -467,11 +507,15 @@ func (nsm *NodeStateManager) RequeueMessages(nodeID cluster.NodeID, messages []O
 // of the per-class queue. Reliable classes are preserved while the peer
 // remains managed. Gossip keeps its lossy cap.
 func (nsm *NodeStateManager) RequeueMessagesClass(nodeID cluster.NodeID, messages [][]byte, class Class) {
+	state := nsm.GetNodeState(nodeID)
+	nsm.requeueMessagesClassForState(nodeID, state, messages, class)
+}
+
+func (nsm *NodeStateManager) requeueMessagesClassForState(nodeID cluster.NodeID, state *NodeState, messages [][]byte, class Class) {
 	if len(messages) == 0 {
 		return
 	}
-	state := nsm.GetNodeState(nodeID)
-	if state == nil {
+	if state == nil || nsm.GetNodeState(nodeID) != state {
 		nsm.logger.Warn("Dropping messages to requeue for unmanaged node",
 			zap.String("node_id", nodeID),
 			zap.Int("message_count", len(messages)),
@@ -531,14 +575,24 @@ func (nsm *NodeStateManager) RequeueMessagesClass(nodeID cluster.NodeID, message
 // RemoveNodeState completely removes a node's state from memory.
 // This should only be called by the manager when a node leaves the cluster.
 func (nsm *NodeStateManager) RemoveNodeState(nodeID cluster.NodeID) {
+	nsm.closeDetachedNodeState(nodeID, nsm.detachNodeState(nodeID))
+}
+
+// Separate identity removal from resource cleanup so a manager can serialize
+// join/leave decisions without holding its lifecycle lock during Close.
+func (nsm *NodeStateManager) detachNodeState(nodeID cluster.NodeID) *NodeState {
 	state, ok := nsm.nodeStates.LoadAndDelete(nodeID)
 	if !ok {
+		return nil
+	}
+	return state.(*NodeState)
+}
+
+func (nsm *NodeStateManager) closeDetachedNodeState(nodeID cluster.NodeID, nodeState *NodeState) {
+	if nodeState == nil {
 		return
 	}
-
 	nsm.logger.Info("Removing managed state for node", zap.String("node", nodeID))
-	nodeState := state.(*NodeState)
-
 	nodeState.stateMu.Lock()
 	if nodeState.connection != nil {
 		nodeState.connection.Close()


### PR DESCRIPTION
Concurrent membership discovery and inbound auto-management could reset the same peer state, dropping queued messages. A canceled loop or stale connection could also mutate or drain a replacement peer generation that reused the same node ID.

This change serializes join and detach decisions under the manager lifecycle lock, closes detached resources outside that lock, and binds control-loop state and queue callbacks to the exact peer generation they own.

Coverage includes concurrent duplicate joins, inbound admission racing membership discovery, replacement during blocked cleanup, stale loop cleanup, and stale drain/requeue callbacks.

Validation:
- Internode race suite, count 3
- Cluster integration race suite
- Go vet
- golangci-lint 2.13.2: 0 issues
- Windows compile

Scope is limited to three cluster/internode files. No public API, configuration, protocol, ingress, transport, or documentation changes.