### PR TITLE
fix(naming): ignore PID string cache in ownership checks

### DIFF
--- a/api/pid/equal_test.go
+++ b/api/pid/equal_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package pid
+
+import "testing"
+
+func TestEqualIgnoresCacheButChecksEveryIdentityField(t *testing.T) {
+	original := PID{Node: "node", Host: "host", UniqID: "instance"}
+	cached := original.Precomputed()
+	if !original.Equal(cached) || !cached.Equal(original) {
+		t.Fatal("cache changed identity")
+	}
+	for _, field := range []string{"node", "host", "instance"} {
+		changed := cached
+		switch field {
+		case "node":
+			changed.Node = "different"
+		case "host":
+			changed.Host = "different"
+		case "instance":
+			changed.UniqID = "different"
+		}
+		if original.Equal(changed) || changed.Equal(original) {
+			t.Fatalf("ignored changed %s", field)
+		}
+	}
+	if !(PID{}).Equal(PID{}) {
+		t.Fatal("zero identities differ")
+	}
+}

--- a/api/pid/pid.go
+++ b/api/pid/pid.go
@@ -146,3 +146,9 @@ func (p *PID) UnmarshalJSON(data []byte) error {
 	*p = parsed
 	return nil
 }
+
+// Equal reports whether both PIDs identify the same process. The optional
+// cached string representation is not part of process identity.
+func (p PID) Equal(other PID) bool {
+	return p.Node == other.Node && p.Host == other.Host && p.UniqID == other.UniqID
+}

--- a/system/topology/namereg/eventual/pid_identity_test.go
+++ b/system/topology/namereg/eventual/pid_identity_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package eventual
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+)
+
+func TestStateSameOwnerIgnoresStringCache(t *testing.T) {
+	p := pid.PID{Node: "node", Host: "process", UniqID: "owner"}
+	s := NewState(p.Node)
+	require.True(t, s.Register("name", p.Precomputed(), 100, 0).Won)
+	require.True(t, s.Register("name", p, 200, 0).Won)
+	other := pid.PID{Node: p.Node, Host: p.Host, UniqID: "other"}
+	require.False(t, s.Register("name", other, 300, 0).Won)
+}
+
+func TestServiceSameOwnerIgnoresStringCache(t *testing.T) {
+	p := pid.PID{Node: "node", Host: "process", UniqID: "owner"}
+	svc := NewService(Config{LocalNodeID: p.Node})
+	require.NoError(t, svc.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, svc.Stop()) })
+
+	_, err := svc.Register("name", p.Precomputed())
+	require.NoError(t, err)
+	before := svc.state.CVSnapshot()
+
+	svc.reassertOwned("name")
+	require.Equal(t, before, svc.state.CVSnapshot())
+	require.False(t, svc.RevokeForStrong("name", p))
+	resolved, found := svc.state.Lookup("name")
+	require.True(t, found)
+	require.True(t, resolved.Equal(p))
+}

--- a/system/topology/namereg/eventual/service.go
+++ b/system/topology/namereg/eventual/service.go
@@ -269,7 +269,7 @@ func (s *Service) register(name string, p pid.PID, opts ...RegisterOption) (pid.
 	// Cross-scope check first — refuse to shadow CONSISTENT or LOCAL.
 	if s.cfg.CrossScope != nil {
 		if existing, found := s.cfg.CrossScope.LookupOther(name); found {
-			if existing == p {
+			if existing.Equal(p) {
 				return p, nil
 			}
 			s.tel.recordRegister("conflict_other_scope")
@@ -279,7 +279,7 @@ func (s *Service) register(name string, p pid.PID, opts ...RegisterOption) (pid.
 		// unless this node already holds the name to the same pid (re-register is
 		// safe — no shadowing risk).
 		if !s.cfg.CrossScope.NameReady() {
-			if cur, ok := s.state.Lookup(name); ok && cur == p {
+			if cur, ok := s.state.Lookup(name); ok && cur.Equal(p) {
 				return p, nil
 			}
 			s.tel.recordRegister("not_ready")
@@ -346,7 +346,7 @@ func (s *Service) RevokeForStrong(name string, keep pid.PID) bool {
 		return false
 	}
 	cur, ok := s.state.Lookup(name)
-	if !ok || cur == keep {
+	if !ok || cur.Equal(keep) {
 		return false
 	}
 	e := s.state.Unregister(name, time.Now().UnixMilli())
@@ -775,7 +775,7 @@ func (s *Service) reassertOwned(name string) {
 	if !ok {
 		return
 	}
-	if cur, found := s.state.Lookup(name); found && cur == reg.pid {
+	if cur, found := s.state.Lookup(name); found && cur.Equal(reg.pid) {
 		return
 	}
 	res := s.state.Register(name, reg.pid, time.Now().UnixMilli(), reg.priority)

--- a/system/topology/namereg/eventual/state.go
+++ b/system/topology/namereg/eventual/state.go
@@ -303,7 +303,7 @@ func (s *State) Register(name string, p pid.PID, wallMs int64, priority uint32) 
 
 	rec, existed := sh.entries[name]
 	if existed {
-		if cur, ok := rec.dots[s.localNode]; ok && !cur.Deleted && cur.PID != p {
+		if cur, ok := rec.dots[s.localNode]; ok && !cur.Deleted && !cur.PID.Equal(p) {
 			return RegisterResult{Entry: cur, Winner: s.winnerOf(rec), Won: false}
 		}
 	} else {

--- a/system/topology/namereg/global/fsm.go
+++ b/system/topology/namereg/global/fsm.go
@@ -191,7 +191,7 @@ func (f *FSM) applyRegister(cmd *Command, index uint64) any {
 		return &RegisterResult{PID: existing, FenceToken: established}
 	case registerConflict:
 		winner := f.resolve(cmd.Name, existing, cmd.PID)
-		if winner == cmd.PID {
+		if winner.Equal(cmd.PID) {
 			f.state.unregister(cmd.Name)
 			_, _, _ = f.state.register(cmd.Name, cmd.PID, nodeID, index)
 			f.tel.recordFenceToken(f.pgLabel, nodeID, index)

--- a/system/topology/namereg/global/pid_identity_test.go
+++ b/system/topology/namereg/global/pid_identity_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package global
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+)
+
+func TestStateSameOwnerIgnoresStringCache(t *testing.T) {
+	p := pid.PID{Node: "node", Host: "process", UniqID: "owner"}
+	s := newShardedState()
+	_, _, out := s.register("active", p.Precomputed(), p.Node, 1)
+	require.Equal(t, registerInserted, out)
+	_, _, out = s.register("active", p, p.Node, 2)
+	require.Equal(t, registerDedupe, out)
+	_, pending := s.registerPending("pending", p.Precomputed(), p.Node, 3, nil, 100, 0)
+	require.Equal(t, pendingInserted, pending)
+	_, pending = s.registerPending("pending", p, p.Node, 3, nil, 100, 0)
+	require.Equal(t, pendingDedupe, pending)
+	_, removed := s.unreservePending("pending", p)
+	require.True(t, removed)
+	_, pending = s.registerPending("wildcard", p, p.Node, 4, nil, 100, 0)
+	require.Equal(t, pendingInserted, pending)
+	zero := pid.PID{}
+	zero = zero.Precomputed()
+	_, removed = s.unreservePending("wildcard", zero)
+	require.True(t, removed)
+}
+
+func TestServiceSameOwnerIgnoresStringCache(t *testing.T) {
+	p := pid.PID{Node: "node", Host: "process", UniqID: "owner"}
+	presence := newFakeLocalPresence()
+	presence.setLocal("local", p.Precomputed())
+	presence.setEventual("eventual", p.Precomputed())
+
+	svc := &Service{}
+	svc.SetLocalPresence(presence)
+	for _, name := range []string{"local", "eventual"} {
+		_, conflict := svc.localConflict(name, p)
+		require.False(t, conflict)
+	}
+}
+
+func TestFSMIncomingWinnerIgnoresStringCache(t *testing.T) {
+	existing := pid.PID{Node: "node", Host: "process", UniqID: "existing"}
+	incoming := pid.PID{Node: "node", Host: "process", UniqID: "incoming"}
+	fsm := NewFSM(func(_ string, _, _ pid.PID) pid.PID {
+		return incoming.Precomputed()
+	})
+
+	first := fsm.applyRegister(&Command{Type: CmdRegister, Name: "name", PID: existing}, 1)
+	require.NoError(t, first.(*RegisterResult).Err)
+	second := fsm.applyRegister(&Command{Type: CmdRegister, Name: "name", PID: incoming}, 2)
+	result := second.(*RegisterResult)
+	require.NoError(t, result.Err)
+	require.True(t, result.PID.Equal(incoming))
+	resolved, found := fsm.State().Lookup("name")
+	require.True(t, found)
+	require.True(t, resolved.Equal(incoming))
+}

--- a/system/topology/namereg/global/service.go
+++ b/system/topology/namereg/global/service.go
@@ -527,7 +527,7 @@ func (s *Service) registerConsistent(name string, p pid.PID) (global.RegisterOut
 		}, global.ErrNameAlreadyRegistered
 	}
 
-	if result.ResolvedPID != (pid.PID{}) {
+	if !result.ResolvedPID.Equal(pid.PID{}) {
 		s.tel.recordReregistration(s.localNode, "global")
 	}
 

--- a/system/topology/namereg/global/state.go
+++ b/system/topology/namereg/global/state.go
@@ -194,7 +194,7 @@ func (s *shardedState) register(name string, p pid.PID, nodeID pid.NodeID, index
 	if e, ok := s.pending[name]; ok {
 		existingPID, epoch := e.PID, e.Epoch
 		s.pendingMu.RUnlock()
-		if existingPID == p {
+		if existingPID.Equal(p) {
 			return p, epoch, registerDedupe
 		}
 		return existingPID, epoch, registerConflict
@@ -206,7 +206,7 @@ func (s *shardedState) register(name string, p pid.PID, nodeID pid.NodeID, index
 	defer sh.mu.Unlock()
 
 	if existing, ok := sh.names[name]; ok {
-		if existing.PID == p {
+		if existing.PID.Equal(p) {
 			return p, existing.AppliedAt, registerDedupe
 		}
 
@@ -248,7 +248,7 @@ func (s *shardedState) registerPending(name string, p pid.PID, nodeID pid.NodeID
 	existing, hasActive := sh.names[name]
 	sh.mu.RUnlock()
 	if hasActive {
-		if existing.PID == p {
+		if existing.PID.Equal(p) {
 			return p, pendingDedupe
 		}
 		return existing.PID, pendingConflictActive
@@ -257,7 +257,7 @@ func (s *shardedState) registerPending(name string, p pid.PID, nodeID pid.NodeID
 	s.pendingMu.Lock()
 	defer s.pendingMu.Unlock()
 	if e, ok := s.pending[name]; ok {
-		if e.PID == p && e.Epoch == epoch {
+		if e.PID.Equal(p) && e.Epoch == epoch {
 			return p, pendingDedupe
 		}
 		return e.PID, pendingConflictPending
@@ -452,7 +452,7 @@ func (s *shardedState) unreservePending(name string, p pid.PID) (*pendingEntry, 
 	if !ok {
 		return nil, false
 	}
-	if p != (pid.PID{}) && e.PID != p {
+	if !p.Equal(pid.PID{}) && !e.PID.Equal(p) {
 		return e, false
 	}
 	delete(s.pending, name)
@@ -639,7 +639,7 @@ func (s *shardedState) lookupPendingByPID(p pid.PID) []string {
 	defer s.pendingMu.RUnlock()
 	out := make([]string, 0, 4)
 	for name, e := range s.pending {
-		if e.PID == p {
+		if e.PID.Equal(p) {
 			out = append(out, name)
 		}
 	}

--- a/system/topology/namereg/global/strong.go
+++ b/system/topology/namereg/global/strong.go
@@ -359,10 +359,10 @@ func (s *Service) localConflict(name string, pendingPID pid.PID) (pid.PID, bool)
 	if lp == nil {
 		return pid.PID{}, false
 	}
-	if p, ok := lp.LookupLocal(name); ok && p != pendingPID {
+	if p, ok := lp.LookupLocal(name); ok && !p.Equal(pendingPID) {
 		return p, true
 	}
-	if p, ok := lp.LookupEventual(name); ok && p != pendingPID {
+	if p, ok := lp.LookupEventual(name); ok && !p.Equal(pendingPID) {
 		return p, true
 	}
 	return pid.PID{}, false

--- a/system/topology/pid_identity_test.go
+++ b/system/topology/pid_identity_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	topologyapi "github.com/wippyai/runtime/api/topology"
+)
+
+func TestPIDRegistrySameOwnerIgnoresStringCache(t *testing.T) {
+	owner := pid.PID{Node: "node", Host: "process", UniqID: "owner"}
+	for _, scope := range []string{"local", "global", "reservation", "eventual", "not-ready"} {
+		t.Run(scope, func(t *testing.T) {
+			cached := owner.Precomputed()
+			r := NewPIDRegistry()
+			switch scope {
+			case "global":
+				r = NewPIDRegistry(WithGlobalRegistry(&fakeGlobalRegistry{active: map[string]pid.PID{"name": cached}}))
+			case "reservation":
+				r = NewPIDRegistry(WithGlobalRegistry(&fakeGlobalRegistry{reserved: map[string]pid.PID{"name": cached}}))
+			case "eventual":
+				r = NewPIDRegistry(WithEventualRegistry(&fakeEventualRegistry{active: map[string]pid.PID{"name": cached}}))
+			default:
+				_, err := r.Register("name", cached)
+				require.NoError(t, err)
+				if scope == "not-ready" {
+					r.SetGlobalRegistry(&fakeGlobalRegistry{notReady: true})
+				}
+			}
+			_, err := r.Register("name", owner)
+			require.NoError(t, err, "string caching must not change owner identity")
+			for _, other := range []pid.PID{
+				{Node: "other", Host: owner.Host, UniqID: owner.UniqID},
+				{Node: owner.Node, Host: "other", UniqID: owner.UniqID},
+				{Node: owner.Node, Host: owner.Host, UniqID: "other"},
+			} {
+				_, err := r.Register("name", other)
+				if scope == "not-ready" {
+					require.ErrorIs(t, err, topologyapi.ErrNameServiceNotReady)
+				} else {
+					require.ErrorIs(t, err, topologyapi.ErrNameAlreadyRegistered)
+				}
+			}
+		})
+	}
+}

--- a/system/topology/pid_registry.go
+++ b/system/topology/pid_registry.go
@@ -119,13 +119,13 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 	// different pid during the promotion window.
 	if gr := r.loadGlobalReg(); gr != nil {
 		if res, err := gr.Lookup(context.Background(), name); err == nil && res.Found {
-			if sameProcessIdentity(res.PID, p) {
+			if res.PID.Equal(p) {
 				return p, nil // same PID registered globally — allow
 			}
 			return res.PID, topology.ErrNameAlreadyRegistered
 		}
 		if reserved, ok := gr.IsStrongReserved(name); ok {
-			if sameProcessIdentity(reserved, p) {
+			if reserved.Equal(p) {
 				return p, nil // same PID reserved — allow
 			}
 			return reserved, topology.ErrNameAlreadyRegistered
@@ -137,7 +137,7 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 		// existing-binding fast paths.
 		if !gr.NameReady() {
 			if existing, ok := r.nameToID.Load(name); ok {
-				if ep, ok2 := existing.(pid.PID); ok2 && sameProcessIdentity(ep, p) {
+				if ep, ok2 := existing.(pid.PID); ok2 && ep.Equal(p) {
 					return p, nil
 				}
 			}
@@ -148,7 +148,7 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 	// Check eventual registry second to prevent local shadowing of eventual names.
 	if er := r.loadEventualReg(); er != nil {
 		if res, err := er.Lookup(context.Background(), name); err == nil && res.Found {
-			if sameProcessIdentity(res.PID, p) {
+			if res.PID.Equal(p) {
 				return p, nil // same PID registered eventually — allow
 			}
 			return res.PID, topology.ErrNameAlreadyRegistered
@@ -162,7 +162,7 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 			return p, nil
 		}
 		// Name already exists - check if it's the same PID (re-registration is ok)
-		if sameProcessIdentity(existingPID, p) {
+		if existingPID.Equal(p) {
 			return p, nil
 		}
 		return existingPID, topology.ErrNameAlreadyRegistered
@@ -319,9 +319,3 @@ func (r *PIDRegistry) Remove(p pid.PID) {
 
 // Ensure Registry implements the operation.Registry interface
 var _ topology.PIDRegistry = (*PIDRegistry)(nil)
-
-// sameProcessIdentity excludes PID's optional string cache from ownership.
-// Compare fields directly to avoid formatting or allocations in admission.
-func sameProcessIdentity(a, b pid.PID) bool {
-	return a.Node == b.Node && a.Host == b.Host && a.UniqID == b.UniqID
-}

--- a/system/topology/pid_registry.go
+++ b/system/topology/pid_registry.go
@@ -119,13 +119,13 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 	// different pid during the promotion window.
 	if gr := r.loadGlobalReg(); gr != nil {
 		if res, err := gr.Lookup(context.Background(), name); err == nil && res.Found {
-			if res.PID == p {
+			if sameProcessIdentity(res.PID, p) {
 				return p, nil // same PID registered globally — allow
 			}
 			return res.PID, topology.ErrNameAlreadyRegistered
 		}
 		if reserved, ok := gr.IsStrongReserved(name); ok {
-			if reserved == p {
+			if sameProcessIdentity(reserved, p) {
 				return p, nil // same PID reserved — allow
 			}
 			return reserved, topology.ErrNameAlreadyRegistered
@@ -137,7 +137,7 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 		// existing-binding fast paths.
 		if !gr.NameReady() {
 			if existing, ok := r.nameToID.Load(name); ok {
-				if ep, ok2 := existing.(pid.PID); ok2 && ep == p {
+				if ep, ok2 := existing.(pid.PID); ok2 && sameProcessIdentity(ep, p) {
 					return p, nil
 				}
 			}
@@ -148,7 +148,7 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 	// Check eventual registry second to prevent local shadowing of eventual names.
 	if er := r.loadEventualReg(); er != nil {
 		if res, err := er.Lookup(context.Background(), name); err == nil && res.Found {
-			if res.PID == p {
+			if sameProcessIdentity(res.PID, p) {
 				return p, nil // same PID registered eventually — allow
 			}
 			return res.PID, topology.ErrNameAlreadyRegistered
@@ -162,7 +162,7 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 			return p, nil
 		}
 		// Name already exists - check if it's the same PID (re-registration is ok)
-		if existingPID == p {
+		if sameProcessIdentity(existingPID, p) {
 			return p, nil
 		}
 		return existingPID, topology.ErrNameAlreadyRegistered
@@ -319,3 +319,9 @@ func (r *PIDRegistry) Remove(p pid.PID) {
 
 // Ensure Registry implements the operation.Registry interface
 var _ topology.PIDRegistry = (*PIDRegistry)(nil)
+
+// sameProcessIdentity excludes PID's optional string cache from ownership.
+// Compare fields directly to avoid formatting or allocations in admission.
+func sameProcessIdentity(a, b pid.PID) bool {
+	return a.Node == b.Node && a.Host == b.Host && a.UniqID == b.UniqID
+}


### PR DESCRIPTION
Re-registering the same process could incorrectly return `name already registered` when one PID had a precomputed string and the other did not. Go struct equality included that private cache field even though node, host, and instance ID were identical.

Add `PID.Equal` as the canonical allocation-free identity comparison. Apply it across composed LOCAL, CONSISTENT, Strong, and EVENTUAL naming paths: same-owner registration, cross-scope checks, Strong conditional acknowledgements, conflict-resolver results, eventual revoke/reassert decisions, pending deduplication and lookup, and conditional unreserve including the cached zero-PID sentinel. Different owners and reservation epochs remain distinct.

Regression coverage proves:
- cached and uncached representations of the same PID are accepted in all five composed registration paths and both underlying state machines;
- Strong LOCAL/EVENTUAL presence checks do not reject the same owner;
- equivalent resolver winners are applied;
- eventual reassertion does not mint a redundant dot and Strong reconciliation does not revoke the same owner;
- pending dedupe/unreserve and the cached zero wildcard remain correct;
- changing node, host, or instance ID changes identity.

Validation:
- `go test -race ./api/pid ./system/topology/...`
- `go vet ./api/pid ./system/topology/...`
- Windows amd64 build of PID and topology packages
- `git diff --check`