### PR TITLE
fix(internode): prevent shutdown hang when a closed connection starts

### DIFF
--- a/cluster/internode/connection.go
+++ b/cluster/internode/connection.go
@@ -197,6 +197,12 @@ func (c *NodeConnection) bindDrain(notify <-chan struct{}, drain func(int) []Out
 // ExitCleanShutdown and Run returns the writer's error.
 func (c *NodeConnection) Run(handler func(class Class, msg []byte)) *ConnectionError {
 	c.lifecycleMu.Lock()
+	// Close may win before the monitor goroutine starts. Do not publish a
+	// fresh writer context after the one-shot Close has already completed.
+	if c.closed.Load() {
+		c.lifecycleMu.Unlock()
+		return &ConnectionError{Reason: ExitCleanShutdown, Err: ErrCleanShutdown}
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
 	c.lifecycleMu.Unlock()

--- a/cluster/internode/connection_start_test.go
+++ b/cluster/internode/connection_start_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestConnectionRunAfterCloseReturns(t *testing.T) {
+	a, b := newMockConnPair()
+	defer b.Close()
+	connection := newNodeConnection(a, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
+	connection.Close()
+	done := make(chan *ConnectionError, 1)
+	go func() { done <- connection.Run(func(Class, []byte) {}) }()
+	select {
+	case err := <-done:
+		require.Equal(t, ExitCleanShutdown, err.Reason)
+	case <-time.After(time.Second):
+		// Release the leaked writer on the unfixed implementation so the
+		// regression itself does not leave a background goroutine behind.
+		connection.lifecycleMu.Lock()
+		if connection.cancel != nil {
+			connection.cancel()
+		}
+		connection.lifecycleMu.Unlock()
+		<-done
+		t.Fatal("Run created an uncanceled writer after Close")
+	}
+}


### PR DESCRIPTION
Closing a peer connection before its monitor starts can hang connection-manager shutdown forever. `Run` created a new writer context after the one-shot `Close` had completed; the reader exited on the closed socket, but the writer remained parked and `Run` waited indefinitely.

Check the closed state under the existing lifecycle mutex before creating the writer context. A closed connection returns clean shutdown immediately. The opposite ordering still lets `Close` cancel the published context. This adds no timers, goroutines, or per-message work.

Validation:
- Deterministic regression fails before the fix and returns cleanly afterward.
- Isolated `GOWORK=off go test -race ./cluster/internode -count=1` passes.
- Scoped golangci-lint passes.
- Found during the broader three-voter Raft/TLS enrollment harness with 20ms ±10ms delay and 5% loss. Timeout stacks showed manager shutdown waiting on the leaked writer. After the fix that harness completed, with 20 actual packet drops and zero final backlog. The harness includes other unpublished hardening changes; it is supporting evidence, not a standalone test in this PR.
