### PR TITLE
fix(naming): stop cross-scope fallback after lookup failures

### DIFF
--- a/api/topology/lookup.go
+++ b/api/topology/lookup.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/pid"
+)
+
+// ContextPIDRegistry preserves lookup cancellation and errors across name scopes.
+// An error must stop resolution rather than select an owner in a weaker scope.
+// PIDRegistry remains supported for existing local registry implementations.
+type ContextPIDRegistry interface {
+	PIDRegistry
+	LookupContext(context.Context, string) (pid.PID, bool, error)
+}
+
+// LookupPID uses context-aware lookup when available. The legacy fallback cannot
+// interrupt a blocking implementation or recover errors hidden by its bool API;
+// implementations that perform remote I/O must implement ContextPIDRegistry.
+func LookupPID(ctx context.Context, registry PIDRegistry, name string) (pid.PID, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return pid.PID{}, false, err
+	}
+	if registry == nil {
+		return pid.PID{}, false, nil
+	}
+	if contextual, ok := registry.(ContextPIDRegistry); ok {
+		return contextual.LookupContext(ctx, name)
+	}
+	p, found := registry.Lookup(name)
+	if err := ctx.Err(); err != nil {
+		return pid.PID{}, false, err
+	}
+	return p, found, nil
+}

--- a/api/topology/topology.go
+++ b/api/topology/topology.go
@@ -100,7 +100,8 @@ type (
 
 		// Lookup finds the Target registered with a given name.
 		// Checks the global registry first (if available), then local.
-		// Returns the Target and true if found, empty Target and false if not found
+		// Returns the Target and true if found. False cannot distinguish absence
+		// from lookup failure; use ContextPIDRegistry for error-aware resolution.
 		Lookup(name string) (pid.PID, bool)
 
 		// Remove completely removes a pid from a registry

--- a/runtime/lua/modules/process/module.go
+++ b/runtime/lua/modules/process/module.go
@@ -795,7 +795,11 @@ func registryLookup(l *lua.LState) int {
 
 	if reg := topology.GetRegistry(ctx); reg != nil {
 		checked = true
-		if p, found := reg.Lookup(name); found {
+		p, found, err := topology.LookupPID(ctx, reg, name)
+		if err != nil {
+			return pushProcessError(l, lua.LNil, wrapProcessError(l, err, "", lua.Internal))
+		}
+		if found {
 			l.Push(lua.LString(p.String()))
 			return 1
 		}

--- a/runtime/lua/modules/process/process_edge_test.go
+++ b/runtime/lua/modules/process/process_edge_test.go
@@ -65,6 +65,15 @@ type fakePIDRegistry struct {
 	entries map[string]pid.PID
 }
 
+type failingContextPIDRegistry struct {
+	*fakePIDRegistry
+	err error
+}
+
+func (r *failingContextPIDRegistry) LookupContext(context.Context, string) (pid.PID, bool, error) {
+	return pid.PID{}, false, r.err
+}
+
 func (r *fakePIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 	if r.entries == nil {
 		r.entries = make(map[string]pid.PID)
@@ -701,6 +710,26 @@ func TestRegistryLookup_NotFound(t *testing.T) {
 		end
 	`)
 	assert.NoError(t, err)
+}
+
+func TestRegistryLookup_ContextFailure(t *testing.T) {
+	reg := &failingContextPIDRegistry{
+		fakePIDRegistry: &fakePIDRegistry{},
+		err:             errors.New("registry unavailable"),
+	}
+	l, _ := newLuaWithPIDAndRegistry(t, reg)
+
+	err := l.DoString(`
+		local pid, lookup_err = process.registry.lookup("service")
+		if pid ~= nil then error("expected nil") end
+		if lookup_err:kind() ~= "Internal" then
+			error("expected Internal kind, got: " .. tostring(lookup_err:kind()))
+		end
+		if tostring(lookup_err) ~= "registry unavailable" then
+			error("unexpected error: " .. tostring(lookup_err))
+		end
+	`)
+	require.NoError(t, err)
 }
 
 func TestRegistryRegister_AndLookup(t *testing.T) {

--- a/service/queue/consumer/consumer_test.go
+++ b/service/queue/consumer/consumer_test.go
@@ -700,13 +700,11 @@ func TestConsumer_DeadWorkerTimeout(t *testing.T) {
 
 	startedProcessing := make(chan struct{})
 	blockForever := make(chan struct{})
+	t.Cleanup(func() { close(blockForever) })
 
 	funcReg := &mockFuncRegistry{
 		onCall: func() {
-			select {
-			case startedProcessing <- struct{}{}:
-			default:
-			}
+			close(startedProcessing)
 			<-blockForever
 		},
 	}
@@ -830,6 +828,7 @@ func TestConsumer_StopWithAllWorkersBlocked(t *testing.T) {
 
 	allWorkersStarted := make(chan struct{})
 	blockAllWorkers := make(chan struct{})
+	t.Cleanup(func() { close(blockAllWorkers) })
 	workersStarted := atomic.Int32{}
 
 	funcReg := &mockFuncRegistry{

--- a/system/process/resolve.go
+++ b/system/process/resolve.go
@@ -32,28 +32,45 @@ type ResolvedDestination struct {
 // Registries are read from ctx via global.GetRegistry,
 // topology.GetEventualRegistry and topology.GetRegistry. A nil registry at
 // any layer is skipped silently — callers that need a layer to be present
-// must enforce that themselves.
+// must enforce that themselves. A lookup error stops resolution: an unavailable
+// stronger scope is not evidence that its name is absent.
 func ResolveDestination(ctx context.Context, dest string) (ResolvedDestination, error) {
+	if err := ctx.Err(); err != nil {
+		return ResolvedDestination{}, err
+	}
 	if p, err := pidapi.ParsePID(dest); err == nil {
 		return ResolvedDestination{PID: p}, nil
 	}
 
 	if gr := global.GetRegistry(ctx); gr != nil {
 		result, err := gr.Lookup(ctx, dest)
-		if err == nil && result.Found {
+		if err != nil {
+			return ResolvedDestination{}, err
+		}
+		if result.Found {
 			return ResolvedDestination{PID: result.PID}, nil
 		}
 	}
 
 	if er := topology.GetEventualRegistry(ctx); er != nil {
 		result, err := er.Lookup(ctx, dest)
-		if err == nil && result.Found {
+		if err != nil {
+			return ResolvedDestination{}, err
+		}
+		if result.Found {
 			return ResolvedDestination{PID: result.PID}, nil
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return ResolvedDestination{}, err
+	}
 	if pr := topology.GetRegistry(ctx); pr != nil {
-		if p, ok := pr.Lookup(dest); ok {
+		p, found, err := topology.LookupPID(ctx, pr, dest)
+		if err != nil {
+			return ResolvedDestination{}, err
+		}
+		if found {
 			return ResolvedDestination{PID: p}, nil
 		}
 	}

--- a/system/process/resolve_test.go
+++ b/system/process/resolve_test.go
@@ -18,7 +18,8 @@ import (
 // fakeGlobalReg is an in-memory global.Registry used to drive the
 // global-name branch of ResolveDestination.
 type fakeGlobalReg struct {
-	entries map[string]pidapi.PID
+	lookupErr error
+	entries   map[string]pidapi.PID
 }
 
 func newFakeGlobalReg() *fakeGlobalReg {
@@ -48,6 +49,9 @@ func (r *fakeGlobalReg) Unregister(_ context.Context, name string) (bool, error)
 }
 
 func (r *fakeGlobalReg) Lookup(_ context.Context, name string, opts ...global.LookupOption) (global.LookupResult, error) {
+	if r.lookupErr != nil {
+		return global.LookupResult{}, r.lookupErr
+	}
 	var o global.LookupOptions
 	for _, opt := range opts {
 		opt(&o)
@@ -69,7 +73,8 @@ func (r *fakeGlobalReg) RemoveNode(_ context.Context, _ pidapi.NodeID) error { r
 
 // fakeEventualReg implements topology.EventualRegistry with no fencing.
 type fakeEventualReg struct {
-	entries map[string]pidapi.PID
+	lookupErr error
+	entries   map[string]pidapi.PID
 }
 
 func newFakeEventualReg() *fakeEventualReg {
@@ -94,6 +99,9 @@ func (r *fakeEventualReg) Unregister(name string) bool {
 }
 
 func (r *fakeEventualReg) Lookup(_ context.Context, name string, _ ...global.LookupOption) (global.LookupResult, error) {
+	if r.lookupErr != nil {
+		return global.LookupResult{}, r.lookupErr
+	}
 	p, ok := r.entries[name]
 	if !ok {
 		return global.LookupResult{}, nil
@@ -206,4 +214,69 @@ func TestResolveDestination_GlobalShadowsEventualAndLocal(t *testing.T) {
 	resolved, err := ResolveDestination(ctx, "svc")
 	require.NoError(t, err)
 	assert.Equal(t, globalPID, resolved.PID, "global registration must win")
+}
+
+func TestResolveDestinationDoesNotRouteAroundRegistryFailure(t *testing.T) {
+	for _, layer := range []string{"global", "eventual"} {
+		t.Run(layer, func(t *testing.T) {
+			gr, er, lr := newFakeGlobalReg(), newFakeEventualReg(), newFakeLocalReg()
+			failure := errors.New("registry unavailable")
+			shadow := pidapi.PID{Host: "h", UniqID: "shadow"}
+			_, err := lr.Register("svc", shadow)
+			require.NoError(t, err)
+			if layer == "global" {
+				gr.lookupErr = failure
+				er.put("svc", shadow)
+			} else {
+				er.lookupErr = failure
+			}
+			result, err := ResolveDestination(buildCtx(gr, er, lr), "svc")
+			require.ErrorIs(t, err, failure)
+			require.Empty(t, result.PID.Host, "failed authoritative lookup must not select a weaker-scope process")
+		})
+	}
+}
+
+func TestResolveDestinationCanceledNameDoesNotSelectLocal(t *testing.T) {
+	lr := newFakeLocalReg()
+	_, err := lr.Register("svc", pidapi.PID{Host: "h", UniqID: "shadow"})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(buildCtx(nil, nil, lr))
+	cancel()
+	result, err := ResolveDestination(ctx, "svc")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, result.PID.Host)
+}
+
+func TestResolveDestinationConfirmedAbsenceStillFallsThrough(t *testing.T) {
+	gr, er, lr := newFakeGlobalReg(), newFakeEventualReg(), newFakeLocalReg()
+	target := pidapi.PID{Host: "h", UniqID: "eventual"}
+	er.put("svc", target)
+	result, err := ResolveDestination(buildCtx(gr, er, lr), "svc")
+	require.NoError(t, err)
+	require.Equal(t, target, result.PID)
+	er.Unregister("svc")
+	_, err = lr.Register("svc", target)
+	require.NoError(t, err)
+	result, err = ResolveDestination(buildCtx(gr, er, lr), "svc")
+	require.NoError(t, err)
+	require.Equal(t, target, result.PID)
+}
+
+type contextualLocalRegistry struct {
+	*fakeLocalReg
+	failure error
+}
+
+func (*contextualLocalRegistry) Lookup(string) (pidapi.PID, bool) { panic("legacy lookup used") }
+func (r *contextualLocalRegistry) LookupContext(context.Context, string) (pidapi.PID, bool, error) {
+	return pidapi.PID{}, false, r.failure
+}
+
+func TestResolveDestinationUsesContextualAggregateRegistry(t *testing.T) {
+	failure := errors.New("aggregate unavailable")
+	ctx := ctxapi.NewRootContext()
+	topology.WithRegistry(ctx, &contextualLocalRegistry{fakeLocalReg: newFakeLocalReg(), failure: failure})
+	_, err := ResolveDestination(ctx, "svc")
+	require.ErrorIs(t, err, failure)
 }

--- a/system/topology/pid_lookup_context_test.go
+++ b/system/topology/pid_lookup_context_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	globalapi "github.com/wippyai/runtime/api/topology/namereg/global"
+)
+
+type unavailableGlobalLookup struct {
+	*fakeGlobalRegistry
+	failure error
+}
+
+func (r *unavailableGlobalLookup) Lookup(context.Context, string, ...globalapi.LookupOption) (globalapi.LookupResult, error) {
+	return globalapi.LookupResult{}, r.failure
+}
+
+func TestPIDRegistryLegacyLookupDoesNotShadowUnavailableGlobal(t *testing.T) {
+	reg := NewPIDRegistry()
+	shadow := pid.PID{Host: "h", UniqID: "shadow"}
+	_, err := reg.Register("svc", shadow)
+	require.NoError(t, err)
+	reg.SetGlobalRegistry(&unavailableGlobalLookup{fakeGlobalRegistry: &fakeGlobalRegistry{}, failure: errors.New("unavailable")})
+	_, found := reg.Lookup("svc")
+	require.False(t, found, "legacy facade cannot expose an error but must not choose a weaker-scope owner")
+}
+
+type waitingGlobalLookup struct {
+	*fakeGlobalRegistry
+	entered chan struct{}
+}
+
+func (r *waitingGlobalLookup) Lookup(ctx context.Context, _ string, _ ...globalapi.LookupOption) (globalapi.LookupResult, error) {
+	close(r.entered)
+	<-ctx.Done()
+	return globalapi.LookupResult{}, ctx.Err()
+}
+
+func TestPIDRegistryParentLookupPreservesCancellation(t *testing.T) {
+	global := &waitingGlobalLookup{fakeGlobalRegistry: &fakeGlobalRegistry{}, entered: make(chan struct{})}
+	parent := NewPIDRegistry(WithGlobalRegistry(global))
+	child := NewPIDRegistry(WithParent(parent))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, _, err := child.LookupContext(ctx, "svc"); done <- err }()
+	select {
+	case <-global.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parent read not reached")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("parent read ignored cancellation")
+	}
+}
+
+func TestPIDRegistryContextPreservesParentFailure(t *testing.T) {
+	failure := errors.New("parent unavailable")
+	parent := NewPIDRegistry(WithGlobalRegistry(&unavailableGlobalLookup{fakeGlobalRegistry: &fakeGlobalRegistry{}, failure: failure}))
+	child := NewPIDRegistry(WithParent(parent))
+	_, found, err := child.LookupContext(context.Background(), "svc")
+	require.ErrorIs(t, err, failure)
+	require.False(t, found)
+}
+
+type unavailableEventualLookup struct {
+	*fakeEventualRegistry
+	failure error
+}
+
+func (r *unavailableEventualLookup) Lookup(context.Context, string, ...globalapi.LookupOption) (globalapi.LookupResult, error) {
+	return globalapi.LookupResult{}, r.failure
+}
+
+func TestPIDRegistryRegistrationRejectsUnknownCrossScopeOwnership(t *testing.T) {
+	for _, scope := range []string{"global", "eventual"} {
+		t.Run(scope, func(t *testing.T) {
+			reg := NewPIDRegistry()
+			owner := pid.PID{Host: "h", UniqID: "owner"}
+			_, err := reg.Register("existing", owner)
+			require.NoError(t, err)
+			failure := errors.New("ownership lookup unavailable")
+			if scope == "global" {
+				reg.SetGlobalRegistry(&unavailableGlobalLookup{fakeGlobalRegistry: &fakeGlobalRegistry{}, failure: failure})
+			} else {
+				reg.SetEventualRegistry(&unavailableEventualLookup{fakeEventualRegistry: &fakeEventualRegistry{}, failure: failure})
+			}
+			_, err = reg.Register("svc", owner)
+			require.ErrorIs(t, err, failure)
+			_, found := reg.LookupLocal("svc")
+			require.False(t, found, "failed ownership check must not create a local binding")
+			_, err = reg.Register("existing", owner)
+			require.ErrorIs(t, err, failure)
+			current, found := reg.LookupLocal("existing")
+			require.True(t, found)
+			require.True(t, current.Equal(owner), "lookup failure must preserve existing bindings")
+		})
+	}
+}

--- a/system/topology/pid_registry.go
+++ b/system/topology/pid_registry.go
@@ -118,7 +118,11 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 	// also blocks a conflicting local bind so the name cannot be granted to a
 	// different pid during the promotion window.
 	if gr := r.loadGlobalReg(); gr != nil {
-		if res, err := gr.Lookup(context.Background(), name); err == nil && res.Found {
+		res, err := gr.Lookup(context.Background(), name)
+		if err != nil {
+			return pid.PID{}, err
+		}
+		if res.Found {
 			if res.PID.Equal(p) {
 				return p, nil // same PID registered globally — allow
 			}
@@ -147,7 +151,11 @@ func (r *PIDRegistry) Register(name string, p pid.PID) (pid.PID, error) {
 
 	// Check eventual registry second to prevent local shadowing of eventual names.
 	if er := r.loadEventualReg(); er != nil {
-		if res, err := er.Lookup(context.Background(), name); err == nil && res.Found {
+		res, err := er.Lookup(context.Background(), name)
+		if err != nil {
+			return pid.PID{}, err
+		}
+		if res.Found {
 			if res.PID.Equal(p) {
 				return p, nil // same PID registered eventually — allow
 			}
@@ -243,32 +251,49 @@ func (r *PIDRegistry) Unregister(name string) bool {
 	return true
 }
 
+// Lookup is the legacy facade. An error is unrepresentable here, but must
+// never authorize fallback to a different owner in a weaker scope.
 func (r *PIDRegistry) Lookup(name string) (pid.PID, bool) {
-	// Check global registry first — global names take priority (strongest consistency).
+	p, found, err := r.LookupContext(context.Background(), name)
+	if err != nil {
+		return pid.PID{}, false
+	}
+	return p, found
+}
+
+var _ topology.ContextPIDRegistry = (*PIDRegistry)(nil)
+
+// LookupContext preserves precedence and caller lifetime through all scopes and
+// parent registries. Only successful absence permits fallback.
+func (r *PIDRegistry) LookupContext(ctx context.Context, name string) (pid.PID, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return pid.PID{}, false, err
+	}
 	if gr := r.loadGlobalReg(); gr != nil {
-		if res, err := gr.Lookup(context.Background(), name); err == nil && res.Found {
-			return res.PID, true
+		res, err := gr.Lookup(ctx, name)
+		if err != nil {
+			return pid.PID{}, false, err
+		}
+		if res.Found {
+			return res.PID, true, nil
 		}
 	}
-
-	// Check eventual registry second — gossip-replicated names.
 	if er := r.loadEventualReg(); er != nil {
-		if res, err := er.Lookup(context.Background(), name); err == nil && res.Found {
-			return res.PID, true
+		res, err := er.Lookup(ctx, name)
+		if err != nil {
+			return pid.PID{}, false, err
+		}
+		if res.Found {
+			return res.PID, true, nil
 		}
 	}
-
-	if pidVal, exists := r.nameToID.Load(name); exists {
-		if p, ok := pidVal.(pid.PID); ok {
-			return p, true
-		}
+	if err := ctx.Err(); err != nil {
+		return pid.PID{}, false, err
 	}
-
-	if r.parent != nil {
-		return r.parent.Lookup(name)
+	if p, found := r.LookupLocal(name); found {
+		return p, true, nil
 	}
-
-	return pid.PID{}, false
+	return topology.LookupPID(ctx, r.parent, name)
 }
 
 // LookupLocal reads only this registry's own name table, bypassing the global


### PR DESCRIPTION
A global or eventual lookup failure could be treated as absence, allowing destination resolution to select a different process with the same name in a weaker scope. Local registration could likewise create a binding after its cross-scope ownership check failed. This affects send, terminate, cancel, monitor, link, and Lua registry lookup.

Lookup errors now stop resolution and local registration. Only a successful not-found result permits global → eventual → local → parent fallback. Existing bindings are preserved, and same-owner checks retain the cache-independent PID identity semantics from #674.

Add the optional `ContextPIDRegistry` compatibility interface and `LookupPID` helper so callers can preserve errors and cancellation without breaking legacy local implementations. Remote-I/O registries can adopt the context-aware interface; the original boolean interface remains supported. No worker, timer, retry, persisted-record change, or additional lookup is introduced.

Regression coverage includes failed global/eventual/aggregate/parent lookups, confirmed-absence fallback, canceled resolution, parent cancellation, legacy shadow prevention, refusal of new local bindings, preservation of existing bindings, and Lua propagation as a clear `Internal` error.

Hosted Windows validation also exposed an unrelated dropped startup signal in `TestConsumer_DeadWorkerTimeout`: a nonblocking send on an unbuffered channel could leave the test waiting until the package timeout. The test now uses a deterministic close handshake and releases intentionally blocked workers during cleanup; both blocked-worker tests pass 20× under race.

Validation:
- `go test -race ./api/topology ./system/process ./system/topology/... ./runtime/lua/modules/process`
- `go test -race ./service/queue/consumer`
- blocked-worker queue regressions repeated 20× under race
- `go vet` on the changed production packages
- Windows amd64 build of the changed production packages
- `git diff --check`