### PR TITLE
Allow publication dry runs without Hub credentials

### DIFF
--- a/cmd/wippy/cmd/publish.go
+++ b/cmd/wippy/cmd/publish.go
@@ -121,16 +121,20 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 		registryURL = store.DefaultRegistry()
 	}
 
-	cred, err := store.Get(registryURL)
-	if err != nil {
-		return NewPublishNotAuthenticatedError(registryURL, err)
+	var token string
+	if !dryRun {
+		cred, err := store.Get(registryURL)
+		if err != nil {
+			return NewPublishNotAuthenticatedError(registryURL, err)
+		}
+		token = cred.Token
 	}
 
 	// Resolve version interactively when not provided and not publishing a label
-	if label == "" && cfg.Version == "" {
+	if !dryRun && label == "" && cfg.Version == "" {
 		hubClient, clientErr := hub.NewClient(hub.Options{
 			BaseURL: registryURL,
-			Token:   cred.Token,
+			Token:   token,
 		})
 		if clientErr != nil {
 			return NewPublishClientError(registryURL, clientErr)
@@ -183,7 +187,7 @@ func runPublish(cmd *cobra.Command, _ []string) error {
 
 	client, err := hub.NewClient(hub.Options{
 		BaseURL: registryURL,
-		Token:   cred.Token,
+		Token:   token,
 	})
 	if err != nil {
 		return NewPublishClientError(registryURL, err)

--- a/cmd/wippy/cmd/publish_dry_run_test.go
+++ b/cmd/wippy/cmd/publish_dry_run_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPublishCredentialRequirements(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dryRun  bool
+		version string
+		want    string
+	}{
+		{"dry run requires explicit version", true, "", "version is required"},
+		{"upload requires credentials", false, "1.2.3", "not authenticated"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			t.Setenv("HOME", dir)
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			t.Setenv("WIPPY_TOKEN", "")
+			t.Setenv("WIPPY_REGISTRY", "https://hub.wippy.ai")
+			if err := os.WriteFile(filepath.Join(dir, "wippy.yaml"), []byte("organization: test\nmodule: example\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			command := &cobra.Command{}
+			command.Flags().String("config", dir, "")
+			command.Flags().Bool("dry-run", tc.dryRun, "")
+			command.Flags().String("version", tc.version, "")
+			previousSilent := silentLogs
+			t.Cleanup(func() { silentLogs = previousSilent })
+			err := runPublish(command, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runPublish error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`wippy publish --dry-run --version 1.2.3` currently fails without Hub credentials before it reaches packing. This prevents CI from validating publication packs without access to a publication secret.

Skip credential lookup and interactive Hub version selection for dry runs. A versioned dry run requires a version in the manifest or `--version`; labeled dry runs retain their existing local validation. Actual uploads still require credentials before packing.

Validation: publisher race tests passed, including regressions for a credential-free dry run with no version and an unauthenticated real upload. Rebuilt Bee's pinned native runtime with this patch and ran `make hub-check BEE_VERSION=0.1.0-dev` with an empty HOME/XDG_CONFIG_HOME and WIPPY_TOKEN/WIPPY_REGISTRY removed: strict lint and publication packing passed. Runtime CI skipped under the requested quota limit; Bee's Linux PR validation includes the patched runtime.
