### PR TITLE
fix(topology): preserve monitor relationships across lifecycle cleanup

### DIFF
--- a/system/topology/monitor_caller_lifetime_test.go
+++ b/system/topology/monitor_caller_lifetime_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+	topapi "github.com/wippyai/runtime/api/topology"
+)
+
+// A reused PID string does not make a replacement process the issuer of a
+// request that was still being admitted when the previous process completed.
+func TestRemoteMonitorCannotAdoptReplacementCaller(t *testing.T) {
+	for _, replace := range []bool{false, true} {
+		name := "departed"
+		if replace {
+			name = "replacement"
+		}
+		t.Run(name, func(t *testing.T) {
+			caller := pid.PID{Node: "local", Host: "app", UniqID: "caller"}
+			target := pid.PID{Node: "remote", Host: "app", UniqID: "target"}
+			var topo *Topology
+			topo = NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+				defer relay.ReleasePackage(pkg)
+				for _, msg := range pkg.Messages {
+					for _, pl := range msg.Payloads {
+						if _, ok := pl.Data().(*topapi.MonitorRequestEvent); ok {
+							topo.Complete(caller, &runtime.Result{})
+							if replace {
+								require.NoError(t, topo.Register(caller))
+							}
+						}
+					}
+				}
+				return nil
+			}), "local")
+			require.NoError(t, topo.Register(caller))
+			err := topo.Monitor(caller, target)
+			require.Error(t, err, "a departed caller cannot own successful monitor admission")
+			sh := topo.getShard(caller.String())
+			sh.mu.RLock()
+			state, exists := sh.processes[caller.String()]
+			watching := false
+			if exists {
+				_, watching = state.watching[target.String()]
+			}
+			sh.mu.RUnlock()
+			require.Equal(t, replace, exists)
+			require.False(t, watching, "late admission cannot attach to a replacement lifetime")
+		})
+	}
+}

--- a/system/topology/monitor_release_identity_test.go
+++ b/system/topology/monitor_release_identity_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	topapi "github.com/wippyai/runtime/api/topology"
+)
+
+// Admission order is request/release/request. A returning older release must
+// not remove the sender record of that last request.
+func TestRemoteDemonitorPreservesNewerObservation(t *testing.T) {
+	caller := pid.PID{Node: "local", Host: "app", UniqID: "caller"}
+	target := pid.PID{Node: "remote", Host: "app", UniqID: "target"}
+	for _, mode := range []string{"existing", "absent", "replaced-caller"} {
+		t.Run(mode, func(t *testing.T) {
+			var topo *Topology
+			var admitted []topapi.Kind
+			topo = NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+				defer relay.ReleasePackage(pkg)
+				for _, msg := range pkg.Messages {
+					for _, pl := range msg.Payloads {
+						switch pl.Data().(type) {
+						case *topapi.MonitorRequestEvent:
+							admitted = append(admitted, topapi.MonitorRequest)
+						case *topapi.MonitorReleaseEvent:
+							admitted = append(admitted, topapi.MonitorRelease)
+							// The release is admitted before the newer monitor.
+							if mode == "replaced-caller" {
+								topo.Remove(caller)
+								require.NoError(t, topo.Register(caller))
+							}
+							require.NoError(t, topo.Monitor(caller, target))
+						}
+					}
+				}
+				return nil
+			}), "local")
+			require.NoError(t, topo.Register(caller))
+			if mode != "absent" {
+				require.NoError(t, topo.Monitor(caller, target))
+			}
+			require.NoError(t, topo.Demonitor(caller, target))
+			want := []topapi.Kind{topapi.MonitorRelease, topapi.MonitorRequest}
+			if mode != "absent" {
+				want = append([]topapi.Kind{topapi.MonitorRequest}, want...)
+			}
+			require.Equal(t, want, admitted)
+			sh := topo.getShard(caller.String())
+			sh.mu.RLock()
+			_, watching := sh.processes[caller.String()].watching[target.String()]
+			sh.mu.RUnlock()
+			require.True(t, watching, "older release must retain the newer sender observation")
+		})
+	}
+}
+
+func BenchmarkMonitorObservationLifecycle(b *testing.B) {
+	for _, node := range []string{"local", "remote"} {
+		b.Run(node, func(b *testing.B) {
+			topo := NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+				relay.ReleasePackage(pkg)
+				return nil
+			}), "local")
+			caller := pid.PID{Node: "local", Host: "app", UniqID: "caller"}
+			target := pid.PID{Node: node, Host: "app", UniqID: "target"}
+			caller, target = caller.Precomputed(), target.Precomputed()
+			if err := topo.Register(caller); err != nil {
+				b.Fatal(err)
+			}
+			if node == "local" {
+				if err := topo.Register(target); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := topo.Monitor(caller, target); err != nil {
+					b.Fatal(err)
+				}
+				if err := topo.Demonitor(caller, target); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/system/topology/node_exit_boundary_test.go
+++ b/system/topology/node_exit_boundary_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/pid"
@@ -105,6 +106,67 @@ func TestNodeIndexLastRemovalRacesRegistration(t *testing.T) {
 		require.Equal(t, []string{fresh.String()}, keys)
 		topo.Remove(fresh)
 	}
+}
+
+func TestNodeExitConcurrentRegistrationAfterDetachSurvives(t *testing.T) {
+	topo := NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+		relay.ReleasePackage(pkg)
+		return nil
+	}), "local")
+	old := pid.PID{Node: "remote", Host: "app", UniqID: "old"}
+	require.NoError(t, topo.Register(old))
+
+	var fresh pid.PID
+	for i := 0; ; i++ {
+		candidate := pid.PID{Node: "remote", Host: "app", UniqID: fmt.Sprintf("fresh-%d", i)}
+		if shardIndex(candidate.String()) == numShards-1 {
+			fresh = candidate
+			break
+		}
+	}
+
+	// Hold the first shard so retirement is paused after its index detach and
+	// allow a new registration to publish in a later shard.
+	gate := &topo.shards[0]
+	gate.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		topo.HandleNodeExit("remote", nil)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, exists := topo.nodeIndex.Load("remote"); !exists {
+			break
+		}
+		if time.Now().After(deadline) {
+			gate.mu.Unlock()
+			t.Fatal("node index was not detached")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.NoError(t, topo.Register(fresh))
+	gate.mu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("node exit did not finish")
+	}
+
+	sh := topo.getShard(fresh.String())
+	sh.mu.RLock()
+	_, exists := sh.processes[fresh.String()]
+	sh.mu.RUnlock()
+	require.True(t, exists, "registration after the retirement boundary must survive")
+	index, indexed := topo.nodeIndex.Load("remote")
+	require.True(t, indexed)
+	nk := index.(*nodeKeys)
+	nk.mu.Lock()
+	keys := append([]string(nil), nk.keys...)
+	nk.mu.Unlock()
+	require.Equal(t, []string{fresh.String()}, keys)
 }
 
 // Isolate the unrelated-process scan. There are no notifications or failed-node

--- a/system/topology/node_exit_boundary_test.go
+++ b/system/topology/node_exit_boundary_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	topapi "github.com/wippyai/runtime/api/topology"
+)
+
+type nodeExitBoundaryRouter func(*relay.Package) error
+
+func (r nodeExitBoundaryRouter) Send(pkg *relay.Package) error { return r(pkg) }
+
+func TestNodeExitNotificationCannotEraseLaterRegistration(t *testing.T) {
+	old := pid.PID{Node: "remote", Host: "app", UniqID: "old"}
+	fresh := pid.PID{Node: "remote", Host: "app", UniqID: "fresh"}
+	observer := pid.PID{Node: "local", Host: "app", UniqID: "observer"}
+	var topo *Topology
+	called := false
+	topo = NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+		defer relay.ReleasePackage(pkg)
+		isExit := false
+		for _, msg := range pkg.Messages {
+			for _, pl := range msg.Payloads {
+				if event, ok := pl.Data().(*topapi.ExitEvent); ok && event.Kind == topapi.LinkDown {
+					isExit = true
+				}
+			}
+		}
+		if called || !isExit {
+			return nil
+		}
+		called = true
+		// A consumer reacts synchronously to LinkDown. No sleeps or scheduler
+		// assumptions: this is the exact notification-to-cleanup boundary.
+		require.NoError(t, topo.Register(fresh))
+		require.NoError(t, topo.Monitor(observer, fresh))
+		return nil
+	}), "local")
+	for _, p := range []pid.PID{old, observer} {
+		require.NoError(t, topo.Register(p))
+	}
+	require.NoError(t, topo.Monitor(observer, old))
+	topo.HandleNodeExit("remote", nil)
+	require.True(t, called)
+	key := fresh.String()
+	sh := topo.getShard(key)
+	sh.mu.RLock()
+	_, exists := sh.processes[key]
+	sh.mu.RUnlock()
+	require.True(t, exists)
+	index, indexed := topo.nodeIndex.Load("remote")
+	require.True(t, indexed, "node exit must not drop the newer process's index")
+	nk := index.(*nodeKeys)
+	nk.mu.Lock()
+	keys := append([]string(nil), nk.keys...)
+	nk.mu.Unlock()
+	require.Contains(t, keys, key)
+	observerKey := observer.String()
+	sh = topo.getShard(observerKey)
+	sh.mu.RLock()
+	_, watching := sh.processes[observerKey].watching[key]
+	sh.mu.RUnlock()
+	require.True(t, watching, "a monitor installed after notification must survive")
+}
+
+func TestNodeIndexLastRemovalRacesRegistration(t *testing.T) {
+	topo := NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+		relay.ReleasePackage(pkg)
+		return nil
+	}), "local")
+	for i := range 1000 {
+		old := pid.PID{Node: "local", Host: "app", UniqID: fmt.Sprintf("old-%d", i)}
+		fresh := pid.PID{Node: "local", Host: "app", UniqID: fmt.Sprintf("new-%d", i)}
+		require.NoError(t, topo.Register(old))
+		start := make(chan struct{})
+		registered := make(chan error, 1)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			topo.Remove(old)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			registered <- topo.Register(fresh)
+		}()
+		close(start)
+		wg.Wait()
+		require.NoError(t, <-registered)
+		index, exists := topo.nodeIndex.Load("local")
+		require.True(t, exists)
+		nk := index.(*nodeKeys)
+		nk.mu.Lock()
+		keys := append([]string(nil), nk.keys...)
+		nk.mu.Unlock()
+		require.Equal(t, []string{fresh.String()}, keys)
+		topo.Remove(fresh)
+	}
+}
+
+// Isolate the unrelated-process scan. There are no notifications or failed-node
+// entries, so this measures the per-shard sweep without routing overhead.
+func BenchmarkNodeExitUnrelatedTopology(b *testing.B) {
+	for _, count := range []int{0, 1000, 100000} {
+		b.Run(fmt.Sprintf("processes=%d", count), func(b *testing.B) {
+			topo := NewTopology(nodeExitBoundaryRouter(func(pkg *relay.Package) error {
+				relay.ReleasePackage(pkg)
+				return nil
+			}), "local")
+			for i := range count {
+				p := pid.PID{Node: "local", Host: "app", UniqID: fmt.Sprint(i)}
+				if err := topo.Register(p); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				topo.HandleNodeExit("absent", nil)
+			}
+		})
+	}
+}

--- a/system/topology/topology.go
+++ b/system/topology/topology.go
@@ -183,6 +183,31 @@ func (t *Topology) removeFromNodeIndex(node pid.NodeID, key string) {
 	}
 }
 
+// detachNodeIndex removes and snapshots one node's current registration
+// bucket. The bucket lock makes the snapshot and detach one boundary with
+// respect to addToNodeIndex: a registration that races the retirement either
+// lands in this returned snapshot or publishes to a fresh bucket.
+func (t *Topology) detachNodeIndex(node pid.NodeID) []string {
+	for {
+		val, ok := t.nodeIndex.Load(node)
+		if !ok {
+			return nil
+		}
+		nk := val.(*nodeKeys)
+		nk.mu.Lock()
+		current, live := t.nodeIndex.Load(node)
+		if !live || current != nk {
+			nk.mu.Unlock()
+			continue
+		}
+
+		keys := append([]string(nil), nk.keys...)
+		t.nodeIndex.CompareAndDelete(node, nk)
+		nk.mu.Unlock()
+		return keys
+	}
+}
+
 // Monitor attaches a caller to monitor a target pid.
 func (t *Topology) Monitor(caller, target pid.PID) error {
 	callerKey := caller.String()
@@ -763,8 +788,12 @@ func (t *Topology) Remove(p pid.PID) {
 func (t *Topology) HandleNodeExit(nodeID pid.NodeID, exitErr error) {
 	// Detach the old index before sweeping. Concurrent registrations publish in
 	// a fresh bucket; addToNodeIndex revalidates any bucket captured before this
-	// detach. Do not delete the new bucket at the end of retirement.
-	t.nodeIndex.LoadAndDelete(nodeID)
+	// detach. Sweep only the registrations that belonged to the detached bucket.
+	deadPIDKeys := t.detachNodeIndex(nodeID)
+	deadKeySet := make(map[string]struct{}, len(deadPIDKeys))
+	for _, key := range deadPIDKeys {
+		deadKeySet[key] = struct{}{}
+	}
 	type notification struct {
 		caller pid.PID
 		target pid.PID
@@ -791,11 +820,8 @@ func (t *Topology) HandleNodeExit(nodeID pid.NodeID, exitErr error) {
 					delete(state.watchers, watcherKey)
 				}
 			}
-			if nodeID != "" && state.pid.Node == nodeID {
+			if _, dead := deadKeySet[key]; dead {
 				delete(sh.processes, key)
-				// A registration concurrent with index detachment may already
-				// have published here. Remove only this retired process's key.
-				t.removeFromNodeIndex(nodeID, key)
 				t.recycleState(state)
 			}
 		}

--- a/system/topology/topology.go
+++ b/system/topology/topology.go
@@ -16,11 +16,21 @@ import (
 
 const numShards = 32
 
+// monitorAttempt is a non-zero-sized identity for one local remote-monitor
+// observation. A retained pointer cannot alias a later attempt, including after
+// processState pool reuse. It is not a wire token or remote installation proof.
+type monitorAttempt byte
+
+type watchedProcess struct {
+	attempt *monitorAttempt
+	pid.PID
+}
+
 // processState holds all state for a single registered process.
 type processState struct {
 	watchers map[string]pid.PID
 	links    map[string]pid.PID
-	watching map[string]pid.PID
+	watching map[string]watchedProcess
 	pid      pid.PID
 }
 
@@ -131,11 +141,20 @@ func (t *Topology) Register(p pid.PID) error {
 
 // addToNodeIndex adds a PID key to the node index.
 func (t *Topology) addToNodeIndex(node pid.NodeID, key string) {
-	val, _ := t.nodeIndex.LoadOrStore(node, &nodeKeys{})
-	nk := val.(*nodeKeys)
-	nk.mu.Lock()
-	defer nk.mu.Unlock()
-	nk.keys = append(nk.keys, key)
+	for {
+		val, _ := t.nodeIndex.LoadOrStore(node, &nodeKeys{})
+		nk := val.(*nodeKeys)
+		nk.mu.Lock()
+		// The last removal or node retirement may detach this bucket while
+		// we wait for it. Never append to an index that is no longer live.
+		current, ok := t.nodeIndex.Load(node)
+		if ok && current == nk {
+			nk.keys = append(nk.keys, key)
+			nk.mu.Unlock()
+			return
+		}
+		nk.mu.Unlock()
+	}
 }
 
 // removeFromNodeIndex removes a PID key from the node index.
@@ -154,7 +173,7 @@ func (t *Topology) removeFromNodeIndex(node pid.NodeID, key string) {
 		}
 	}
 	if len(nk.keys) == 0 {
-		t.nodeIndex.Delete(node)
+		t.nodeIndex.CompareAndDelete(node, nk)
 	}
 }
 
@@ -185,9 +204,9 @@ func (t *Topology) Monitor(caller, target pid.PID) error {
 		callerSh.mu.Lock()
 		if callerState, exists := callerSh.processes[callerKey]; exists && callerState.pid == caller {
 			if callerState.watching == nil {
-				callerState.watching = make(map[string]pid.PID)
+				callerState.watching = make(map[string]watchedProcess)
 			}
-			callerState.watching[targetKey] = target
+			callerState.watching[targetKey] = watchedProcess{PID: target, attempt: new(monitorAttempt)}
 		}
 		callerSh.mu.Unlock()
 		return nil
@@ -229,9 +248,9 @@ func (t *Topology) monitorSameShard(callerKey, targetKey string, caller, target 
 
 	if callerState, ok := sh.processes[callerKey]; ok {
 		if callerState.watching == nil {
-			callerState.watching = make(map[string]pid.PID)
+			callerState.watching = make(map[string]watchedProcess)
 		}
-		callerState.watching[targetKey] = target
+		callerState.watching[targetKey] = watchedProcess{PID: target}
 	}
 
 	return nil
@@ -272,9 +291,9 @@ func (t *Topology) monitorDifferentShards(callerKey, targetKey string, caller, t
 	callerSh := &t.shards[callerIdx]
 	if callerState, ok := callerSh.processes[callerKey]; ok {
 		if callerState.watching == nil {
-			callerState.watching = make(map[string]pid.PID)
+			callerState.watching = make(map[string]watchedProcess)
 		}
-		callerState.watching[targetKey] = target
+		callerState.watching[targetKey] = watchedProcess{PID: target}
 	}
 
 	return nil
@@ -287,14 +306,22 @@ func (t *Topology) Demonitor(caller, target pid.PID) error {
 
 	// Remote demonitoring
 	if target.Node != "" && target.Node != t.localNodeID {
+		callerSh := t.getShard(callerKey)
+		callerSh.mu.RLock()
+		var observed *monitorAttempt
+		if state, exists := callerSh.processes[callerKey]; exists {
+			observed = state.watching[targetKey].attempt
+		}
+		callerSh.mu.RUnlock()
+
 		pkg := topology.MonitorReleasePackage(caller, target)
 		if err := t.router.Send(pkg); err != nil {
 			return err
 		}
 
-		callerSh := t.getShard(callerKey)
 		callerSh.mu.Lock()
-		if callerState, exists := callerSh.processes[callerKey]; exists {
+		if callerState, exists := callerSh.processes[callerKey]; exists && observed != nil &&
+			callerState.watching[targetKey].attempt == observed {
 			delete(callerState.watching, targetKey)
 		}
 		callerSh.mu.Unlock()
@@ -601,7 +628,7 @@ func (t *Topology) Complete(p pid.PID, result *runtime.Result) {
 	var remoteWatching []pid.PID
 	for _, targetPID := range state.watching {
 		if targetPID.Node != "" && targetPID.Node != t.localNodeID {
-			remoteWatching = append(remoteWatching, targetPID)
+			remoteWatching = append(remoteWatching, targetPID.PID)
 		}
 	}
 
@@ -653,7 +680,7 @@ func (t *Topology) Complete(p pid.PID, result *runtime.Result) {
 	}
 }
 
-// cleanupReferences removes this PID from other processes' links/watching maps.
+// cleanupReferences removes both directions of this PID's relationships.
 func (t *Topology) cleanupReferences(key string, state *processState) {
 	// Remove from linked processes
 	for linkedKey := range state.links {
@@ -673,6 +700,18 @@ func (t *Topology) cleanupReferences(key string, state *processState) {
 			delete(watcherState.watching, key)
 		}
 		watcherSh.mu.Unlock()
+	}
+
+	// A departing observer must also leave the targets it was watching. Without
+	// this direction, long-lived targets retain every completed local observer
+	// and later send exit notifications to those dead processes.
+	for targetKey := range state.watching {
+		targetSh := t.getShard(targetKey)
+		targetSh.mu.Lock()
+		if targetState, ok := targetSh.processes[targetKey]; ok {
+			delete(targetState.watchers, key)
+		}
+		targetSh.mu.Unlock()
 	}
 }
 
@@ -703,48 +742,51 @@ func (t *Topology) Remove(p pid.PID) {
 // HandleNodeExit handles node failure by notifying all local processes
 // that were watching or linked to PIDs on the failed node.
 func (t *Topology) HandleNodeExit(nodeID pid.NodeID, exitErr error) {
-	// Get PIDs on the failed node (may be empty if we only had watchers)
-	var deadPIDKeys []string
-	deadKeySet := make(map[string]bool)
-
-	if val, ok := t.nodeIndex.Load(nodeID); ok {
-		nk := val.(*nodeKeys)
-		nk.mu.Lock()
-		deadPIDKeys = make([]string, len(nk.keys))
-		copy(deadPIDKeys, nk.keys)
-		nk.mu.Unlock()
-
-		for _, key := range deadPIDKeys {
-			deadKeySet[key] = true
-		}
-	}
-
+	// Detach the old index before sweeping. Concurrent registrations publish in
+	// a fresh bucket; addToNodeIndex revalidates any bucket captured before this
+	// detach. Do not delete the new bucket at the end of retirement.
+	t.nodeIndex.LoadAndDelete(nodeID)
 	type notification struct {
 		caller pid.PID
 		target pid.PID
 	}
 	var toNotify []notification
-
-	// Scan all shards for processes watching/linked to dead node
 	for i := range t.shards {
 		sh := &t.shards[i]
-		sh.mu.RLock()
-		for _, state := range sh.processes {
+		sh.mu.Lock()
+		for key, state := range sh.processes {
 			for targetKey, targetPID := range state.watching {
-				if deadKeySet[targetKey] || targetPID.Node == nodeID {
-					toNotify = append(toNotify, notification{state.pid, targetPID})
+				if targetPID.Node == nodeID {
+					toNotify = append(toNotify, notification{state.pid, targetPID.PID})
+					delete(state.watching, targetKey)
 				}
 			}
 			for linkedKey, linkedPID := range state.links {
-				if deadKeySet[linkedKey] || linkedPID.Node == nodeID {
+				if linkedPID.Node == nodeID {
 					toNotify = append(toNotify, notification{state.pid, linkedPID})
+					delete(state.links, linkedKey)
 				}
 			}
+			for watcherKey, watcherPID := range state.watchers {
+				if watcherPID.Node == nodeID {
+					delete(state.watchers, watcherKey)
+				}
+			}
+			if nodeID != "" && state.pid.Node == nodeID {
+				delete(sh.processes, key)
+				// A registration concurrent with index detachment may already
+				// have published here. Remove only this retired process's key.
+				t.removeFromNodeIndex(nodeID, key)
+				t.recycleState(state)
+			}
 		}
-		sh.mu.RUnlock()
+		sh.mu.Unlock()
 	}
 
-	// Send notifications
+	// All cleanup precedes notifications: a consumer can synchronously register
+	// a replacement without a trailing cleanup phase erasing it. Each shard has
+	// its own sweep boundary; this is not a distributed incarnation fence.
+	// Routing and user callbacks must never execute while topology is locked.
 	for _, n := range toNotify {
 		linkDownPayload := payload.New(&topology.ExitEvent{
 			At:   time.Now(),
@@ -756,42 +798,6 @@ func (t *Topology) HandleNodeExit(nodeID pid.NodeID, exitErr error) {
 		})
 		pkg := relay.NewPackage(topology.SystemPID, n.caller, topology.TopicEvents, linkDownPayload)
 		_ = t.router.Send(pkg)
-	}
-
-	// Cleanup: remove dead node PIDs from all shards
-	for _, pidKey := range deadPIDKeys {
-		sh := t.getShard(pidKey)
-		sh.mu.Lock()
-		if state, exists := sh.processes[pidKey]; exists {
-			delete(sh.processes, pidKey)
-			t.recycleState(state)
-		}
-		sh.mu.Unlock()
-	}
-	t.nodeIndex.Delete(nodeID)
-
-	// Clean up references in remaining processes
-	for i := range t.shards {
-		sh := &t.shards[i]
-		sh.mu.Lock()
-		for _, state := range sh.processes {
-			for targetKey, targetPID := range state.watching {
-				if deadKeySet[targetKey] || targetPID.Node == nodeID {
-					delete(state.watching, targetKey)
-				}
-			}
-			for linkedKey, linkedPID := range state.links {
-				if deadKeySet[linkedKey] || linkedPID.Node == nodeID {
-					delete(state.links, linkedKey)
-				}
-			}
-			for watcherKey, watcherPID := range state.watchers {
-				if deadKeySet[watcherKey] || watcherPID.Node == nodeID {
-					delete(state.watchers, watcherKey)
-				}
-			}
-		}
-		sh.mu.Unlock()
 	}
 }
 

--- a/system/topology/topology.go
+++ b/system/topology/topology.go
@@ -21,6 +21,10 @@ const numShards = 32
 // processState pool reuse. It is not a wire token or remote installation proof.
 type monitorAttempt byte
 
+// callerLifetime fences sends against processState pooling and same-PID reuse.
+// Allocated lazily only for processes that issue remote monitor requests.
+type callerLifetime byte
+
 type watchedProcess struct {
 	attempt *monitorAttempt
 	pid.PID
@@ -28,10 +32,11 @@ type watchedProcess struct {
 
 // processState holds all state for a single registered process.
 type processState struct {
-	watchers map[string]pid.PID
-	links    map[string]pid.PID
-	watching map[string]watchedProcess
-	pid      pid.PID
+	remoteLifetime *callerLifetime
+	watchers       map[string]pid.PID
+	links          map[string]pid.PID
+	watching       map[string]watchedProcess
+	pid            pid.PID
 }
 
 // shard holds a subset of processes with its own lock.
@@ -112,6 +117,7 @@ func (t *Topology) recycleState(s *processState) {
 			clear(s.watching)
 		}
 	}
+	s.remoteLifetime = nil
 	t.statePool.Put(s)
 }
 
@@ -186,7 +192,8 @@ func (t *Topology) Monitor(caller, target pid.PID) error {
 	if target.Node != "" && target.Node != t.localNodeID {
 		callerSh := t.getShard(callerKey)
 		callerSh.mu.Lock()
-		if _, exists := callerSh.processes[callerKey]; !exists {
+		callerState, exists := callerSh.processes[callerKey]
+		if !exists {
 			callerSh.mu.Unlock()
 			return topology.ErrPIDNotRegistered.WithDetails(attrs.Bag{
 				"pid":       callerKey,
@@ -194,6 +201,10 @@ func (t *Topology) Monitor(caller, target pid.PID) error {
 				"role":      "caller",
 			})
 		}
+		if callerState.remoteLifetime == nil {
+			callerState.remoteLifetime = new(callerLifetime)
+		}
+		lifetime := callerState.remoteLifetime
 		callerSh.mu.Unlock()
 
 		pkg := topology.MonitorRequestPackage(caller, target)
@@ -202,12 +213,20 @@ func (t *Topology) Monitor(caller, target pid.PID) error {
 		}
 
 		callerSh.mu.Lock()
-		if callerState, exists := callerSh.processes[callerKey]; exists && callerState.pid == caller {
-			if callerState.watching == nil {
-				callerState.watching = make(map[string]watchedProcess)
-			}
-			callerState.watching[targetKey] = watchedProcess{PID: target, attempt: new(monitorAttempt)}
+		callerState, exists = callerSh.processes[callerKey]
+		if !exists || callerState.remoteLifetime != lifetime {
+			callerSh.mu.Unlock()
+			// Sending succeeded, but its issuer no longer exists. Do not adopt
+			// the request into a replacement lifetime. An unversioned release
+			// here could erase that replacement's own remote monitor.
+			return topology.ErrPIDNotRegistered.WithDetails(attrs.Bag{
+				"pid": callerKey, "operation": "monitor", "role": "caller",
+			})
 		}
+		if callerState.watching == nil {
+			callerState.watching = make(map[string]watchedProcess)
+		}
+		callerState.watching[targetKey] = watchedProcess{PID: target, attempt: new(monitorAttempt)}
 		callerSh.mu.Unlock()
 		return nil
 	}

--- a/system/topology/watcher_cleanup_test.go
+++ b/system/topology/watcher_cleanup_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/runtime"
+)
+
+func TestDepartedObserverReleasesLocalWatcher(t *testing.T) {
+	for _, complete := range []bool{false, true} {
+		name := "remove"
+		if complete {
+			name = "complete"
+		}
+		t.Run(name, func(t *testing.T) {
+			router := newMockUpstream()
+			topo := NewTopology(router, "local")
+			caller := pid.PID{Node: "local", Host: "process", UniqID: "observer"}
+			target := pid.PID{Node: "local", Host: "process", UniqID: "service"}
+			other := pid.PID{Node: "local", Host: "process", UniqID: "other-observer"}
+			for _, p := range []pid.PID{caller, target, other} {
+				require.NoError(t, topo.Register(p))
+			}
+			require.NoError(t, topo.Monitor(caller, target))
+			require.NoError(t, topo.Monitor(other, target))
+			if complete {
+				topo.Complete(caller, &runtime.Result{})
+			} else {
+				topo.Remove(caller)
+			}
+			key := target.String()
+			sh := topo.getShard(key)
+			sh.mu.RLock()
+			_, stale := sh.processes[key].watchers[caller.String()]
+			_, retained := sh.processes[key].watchers[other.String()]
+			sh.mu.RUnlock()
+			require.False(t, stale, "a live service must not retain a departed observer")
+			require.True(t, retained, "unrelated observers remain installed")
+			topo.Complete(target, &runtime.Result{})
+			require.Empty(t, router.getSends(caller), "do not send a later service exit to a dead observer")
+			require.Len(t, router.getSends(other), 1)
+		})
+	}
+}


### PR DESCRIPTION
Topology cleanup could retain departed observers, erase relationships installed by a newer operation, or delete a process registered after node retirement began.

This change fixes the reproduced lifecycle boundaries:
- removing or completing an observer removes its watcher entry from live local targets without affecting unrelated observers;
- node retirement detaches and snapshots the current node-index bucket, sweeps only those registered PIDs, and completes relationship cleanup before notifications; registrations published after detachment use a fresh bucket and survive;
- node-index insertion revalidates a bucket after locking, while last removal deletes only the matching bucket;
- a returning remote Demonitor removes only the observation attempt it captured before sending;
- a remote Monitor returning after caller completion reports `ErrPIDNotRegistered` and cannot attach state to a replacement with the same PID; a lazy lifetime identity fences pooled state reuse.

Validation:
- deterministic regression for post-detach registration survival, repeated 20× under race;
- deterministic monitor, demonitor, watcher-cleanup, notification/re-registration, and node-index race regressions;
- full `go test -race ./system/topology`;
- `go vet ./system/topology`;
- Windows amd64 topology build;
- `git diff --check`.

No idle timers, background work, public API, configuration, or wire format are added. This fixes local lifecycle bookkeeping; acknowledged remote installation, distributed node-incarnation fencing, and attempt-bound remote cancellation remain separate protocol work.