### PR TITLE
Preserve terminal frame edges and bottom rows after shrink

### DIFF
--- a/service/terminal/surface.go
+++ b/service/terminal/surface.go
@@ -54,7 +54,14 @@ func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 	if len(s.rows) > limit {
 		limit = len(s.rows)
 	}
-	for index := 0; index < limit; index++ {
+	// Clear removed rows first. After a terminal shrink, cursor moves to
+	// those old rows clamp to the new bottom row; painting must follow cleanup.
+	removed := limit - len(rows)
+	for step := 0; step < limit; step++ {
+		index := step - removed
+		if step < removed {
+			index = len(rows) + step
+		}
 		current, previous := "", ""
 		if index < len(rows) {
 			current = rows[index]
@@ -62,15 +69,18 @@ func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 		if index < len(s.rows) {
 			previous = s.rows[index]
 		}
-		if !s.invalid && current == previous && index < len(rows) && index < len(s.rows) {
+		if !s.invalid && removed == 0 && current == previous && index < len(rows) && index < len(s.rows) {
 			continue
 		}
 		changed++
 		output = append(output, '\x1b', '[')
 		output = strconv.AppendInt(output, int64(index+1), 10)
 		output = append(output, ';', '1', 'H')
-		output = append(output, current...)
+		// Clear the old extent before painting. EL after a full-width row
+		// erases its last cell while the terminal is in delayed autowrap.
 		output = append(output, "\x1b[0m\x1b[K"...)
+		output = append(output, current...)
+		output = append(output, "\x1b[0m"...)
 	}
 	if s.invalid && limit == 0 {
 		output = append(output, "\x1b[H\x1b[0m\x1b[J"...)

--- a/service/terminal/surface_test.go
+++ b/service/terminal/surface_test.go
@@ -7,9 +7,41 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/charmbracelet/x/vt"
 	"github.com/stretchr/testify/require"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
+
+func TestSurfaceShrinkPreservesBottomRow(t *testing.T) {
+	for _, invalidate := range []bool{false, true} {
+		screen := vt.NewEmulator(8, 4)
+		surface := NewSurface(screen, ttyapi.SurfaceOptions{})
+		_, err := surface.Present(ttyapi.Frame{Rows: []string{"content", "taskbar", "old", "tail"}})
+		require.NoError(t, err)
+		screen.Resize(8, 2)
+		if invalidate {
+			surface.Invalidate()
+		}
+		_, err = surface.Present(ttyapi.Frame{Rows: []string{"content", "taskbar"}})
+		require.NoError(t, err)
+		require.Contains(t, screen.Render(), "taskbar")
+	}
+}
+
+func TestSurfacePreservesFullWidthRows(t *testing.T) {
+	screen := vt.NewEmulator(8, 2)
+	surface := NewSurface(screen, ttyapi.SurfaceOptions{})
+	for _, rows := range [][]string{
+		{"12345678", "abcdefgh"},
+		{"87654321", "hgfedcba"},
+	} {
+		_, err := surface.Present(ttyapi.Frame{Rows: rows})
+		require.NoError(t, err)
+		for _, row := range rows {
+			require.Contains(t, screen.Render(), row)
+		}
+	}
+}
 
 type failingWriter struct {
 	err     error


### PR DESCRIPTION
A frame filling the terminal width loses its last cell because erase-to-end runs after painting, while the terminal is in delayed autowrap. Shrinking the terminal can also erase the new bottom row when cleanup cursor positions clamp to it.

Clear the old row before painting and clean removed rows before repainting the retained frame. Repaint retained rows after a shrink, including unchanged content.

Validation: both the full-width and shrink regressions fail against current main and pass with this change. The terminal service race suite passed; pinned golangci-lint v2.13.2 reported zero issues for the package.

Extracted from Bee's local runtime patch. GitHub CI is skipped on this preparation commit to conserve Actions quota; local checks are complete.
