### PR TITLE
Correct security SDK authorization argument names

### DIFF
--- a/runtime/lua/modules/security/types.go
+++ b/runtime/lua/modules/security/types.go
@@ -25,14 +25,14 @@ func init() {
 	// Policy type
 	policyType = typ.NewInterface("security.Policy", []typ.Method{
 		{Name: "id", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
-		{Name: "evaluate", Type: typ.Func().Param("self", typ.Self).Param("actor", actorType).Param("resource", typ.String).Param("action", typ.String).OptParam("context", typ.Any).Returns(typ.String).Build()},
+		{Name: "evaluate", Type: typ.Func().Param("self", typ.Self).Param("actor", actorType).Param("action", typ.String).Param("resource", typ.String).OptParam("context", typ.Any).Returns(typ.String).Build()},
 	})
 
 	// Scope type (self-referential and references policyType)
 	scopeType = typ.NewInterface("security.Scope", []typ.Method{
 		{Name: "with", Type: typ.Func().Param("self", typ.Self).Param("policy", policyType).Returns(typ.Self).Build()},
 		{Name: "without", Type: typ.Func().Param("self", typ.Self).Param("policy", typ.Any).Returns(typ.Self).Build()},
-		{Name: "evaluate", Type: typ.Func().Param("self", typ.Self).Param("actor", actorType).Param("resource", typ.String).Param("action", typ.String).OptParam("context", typ.Any).Returns(typ.String).Build()},
+		{Name: "evaluate", Type: typ.Func().Param("self", typ.Self).Param("actor", actorType).Param("action", typ.String).Param("resource", typ.String).OptParam("context", typ.Any).Returns(typ.String).Build()},
 		{Name: "contains", Type: typ.Func().Param("self", typ.Self).Param("policy", typ.Any).Returns(typ.Boolean).Build()},
 		{Name: "policies", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewArray(policyType)).Build()},
 	})
@@ -58,7 +58,7 @@ func ModuleTypes() *io.Manifest {
 	moduleType := typ.NewInterface("security", []typ.Method{
 		{Name: "actor", Type: typ.Func().Returns(typ.NewOptional(actorType)).Build()},
 		{Name: "scope", Type: typ.Func().Returns(typ.NewOptional(scopeType)).Build()},
-		{Name: "can", Type: typ.Func().Param("resource", typ.String).Param("action", typ.String).OptParam("context", typ.Any).Returns(typ.Boolean).Build()},
+		{Name: "can", Type: typ.Func().Param("action", typ.String).Param("resource", typ.String).OptParam("context", typ.Any).Returns(typ.Boolean).Build()},
 		{Name: "policy", Type: typ.Func().Param("name", typ.String).Returns(policyType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "named_scope", Type: typ.Func().Param("name", typ.String).Returns(scopeType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "new_scope", Type: typ.Func().OptParam("policies", typ.NewArray(policyType)).Returns(scopeType).Build()},


### PR DESCRIPTION
The Lua security manifest labels authorization arguments as resource, action, while the implementation and documented API accept action, resource. Correct the parameter names for `security.can`, `Policy:evaluate` and `Scope:evaluate` so SDK signatures describe the actual call order.

Validation: the security module race suite passed; pinned golangci-lint v2.13.2 reported zero issues for the package. Parameter types and runtime authorization behavior are unchanged.

Extracted from Bee's local runtime patch. GitHub CI is skipped on this preparation commit to conserve Actions quota; local checks are complete.
