### PR TITLE
Make viewport revocation tolerate recipient cleanup

### DIFF
--- a/api/tty/command.go
+++ b/api/tty/command.go
@@ -9,13 +9,14 @@ func init() {
 	dispatcher.MustRegisterCommands("tty",
 		Read, ReadLine, RawEnable, RawDisable,
 		StartInput, StopInput, ScreenSize,
-		EnableMouse, DisableMouse,
+		EnableMouse, DisableMouse, ViewportIO,
 	)
 }
 
 // Command IDs for terminal I/O.
 // Range 70-79 is reserved for terminal operations.
 const (
+	ViewportIO   dispatcher.CommandID = 79 // Cancellable remote viewport operations
 	Read         dispatcher.CommandID = 70 // Read bytes from stdin
 	ReadLine     dispatcher.CommandID = 71 // Read a line from stdin
 	RawEnable    dispatcher.CommandID = 72 // Enable raw terminal mode
@@ -103,3 +104,16 @@ type DisableMouseCmd struct{}
 func (c DisableMouseCmd) CmdID() dispatcher.CommandID {
 	return DisableMouse
 }
+
+// ViewportIOCmd runs only through the asynchronous terminal dispatcher.
+// Caller identity comes from its process context, never from command fields.
+type ViewportIOCmd struct {
+	View      RemoteViewport
+	Handle    string
+	Operation string
+	Event     Event
+	Width     int
+	Height    int
+}
+
+func (ViewportIOCmd) CmdID() dispatcher.CommandID { return ViewportIO }

--- a/api/tty/errors.go
+++ b/api/tty/errors.go
@@ -5,6 +5,10 @@ package tty
 import "errors"
 
 var (
+	ErrPermissionDenied    = errors.New("terminal mount permission denied")
+	ErrMountExpired        = errors.New("terminal mount expired or revoked")
+	ErrMeshBusy            = errors.New("terminal mesh capacity exceeded")
+	ErrMeshProtocol        = errors.New("invalid terminal mesh frame")
 	ErrServiceUnavailable  = errors.New("tty service unavailable")
 	ErrInvalidGrant        = errors.New("invalid terminal grant")
 	ErrInvalidPort         = errors.New("invalid terminal port")

--- a/api/tty/mount.go
+++ b/api/tty/mount.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/pid"
+)
+
+// MountRights are independent capabilities. No rights are implied by an
+// address, by mesh membership, or by another right.
+type MountRights struct {
+	Observe bool
+	Input   bool
+	Resize  bool
+}
+
+const (
+	RightObserve = "tty.observe"
+	RightInput   = "tty.input"
+	RightResize  = "tty.resize"
+)
+
+// MountableViewport delegates access to one exact process. Only the original
+// viewport owner can issue or revoke mounts; mounted views cannot re-delegate.
+type MountableViewport interface {
+	Mount(context.Context, pid.PID, MountRights) (string, error)
+	Revoke(context.Context, string) error
+}
+
+// CheckedViewport validates process ownership and rights before Lua accesses
+// a view, including snapshots already cached on the local node.
+type CheckedViewport interface {
+	Check(context.Context, string) error
+}
+
+// RemoteViewport exposes cancellable operations to the yielding dispatcher.
+// Snapshot and Updates always read the local cache and never wait for a peer.
+type RemoteViewport interface {
+	Viewport
+	SendContext(context.Context, Event) error
+	ResizeContext(context.Context, int, int) error
+}
+
+type RemoteService interface {
+	IsRemote(string) bool
+}
+
+// MeshTransport is a dedicated, authenticated peer protocol. Send must enqueue
+// without waiting for network I/O and must return an error at its queue limit.
+// Receive callbacks must never be invoked with a peer identity from payloads.
+type MeshTransport interface {
+	Send(peer string, data []byte) error
+	Receive(func(peer string, data []byte)) error
+}
+
+// MeshPeerChecker optionally rejects peers lacking surface protocol support
+// before sending a new class byte on a shared mesh connection.
+type MeshPeerChecker interface{ CheckPeer(string) error }

--- a/api/tty/page.go
+++ b/api/tty/page.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+	"fmt"
+	"image/color"
+	"strconv"
+	"strings"
+)
+
+// Page supplies the two terminal-default colors for a virtual viewport.
+// Both colors must be opaque #RRGGBB values; nil means no page.
+type Page struct {
+	Foreground string
+	Background string
+}
+
+func (p Page) Canonical() (Page, error) {
+	for _, value := range []string{p.Foreground, p.Background} {
+		if len(value) != 7 || value[0] != '#' {
+			return Page{}, fmt.Errorf("viewport page requires foreground and background in #RRGGBB form")
+		}
+		if _, err := strconv.ParseUint(value[1:], 16, 24); err != nil {
+			return Page{}, fmt.Errorf("viewport page color must be #RRGGBB: %w", err)
+		}
+	}
+	return Page{Foreground: strings.ToLower(p.Foreground), Background: strings.ToLower(p.Background)}, nil
+}
+
+// Colors returns opaque RGB colors from a previously validated page.
+func (p Page) Colors() (color.Color, color.Color) {
+	parse := func(value string) color.Color {
+		n, _ := strconv.ParseUint(strings.TrimPrefix(value, "#"), 16, 24)
+		return color.RGBA{R: uint8(n >> 16), G: uint8(n >> 8), B: uint8(n), A: 255}
+	}
+	return parse(p.Foreground), parse(p.Background)
+}
+
+// PageViewport is an optional owner-side capability. Page policy cannot be
+// changed by a delegated mount or by the program painting into the viewport.
+type PageViewport interface {
+	SetPage(context.Context, *Page) error
+}
+
+// PageProvider lets a PTY proxy answer program color queries from its owning
+// surface. The value is a copy; false retains the legacy terminal behavior.
+type PageProvider interface {
+	Page() (Page, bool)
+}

--- a/boot/components/system/all.go
+++ b/boot/components/system/all.go
@@ -19,6 +19,7 @@ func All() []boot.Component {
 		Environment(),
 		FrameResolvers(),
 		TTY(),
+		TTYMesh(),
 		Network(),
 		SocketDispatcher(),
 		Resources(),

--- a/boot/components/system/cluster.go
+++ b/boot/components/system/cluster.go
@@ -277,13 +277,14 @@ func Cluster() boot.Component {
 			// leader thrashes on the failing operation.
 			raftEligible := clusterRaftEnabled(clusterCfg) && clusterCfg.GetBool(ClusterRaftEligible, true)
 			nodeMeta := clusterapi.NodeMeta{
-				"version":                   "1.0.0",
-				"role":                      "wippy",
-				internode.MetadataPort:      strconv.Itoa(actualPort),
-				internode.MetadataPublicKey: base64.RawStdEncoding.EncodeToString(publicKey),
-				"raft_eligible":             strconv.FormatBool(raftEligible),
-				"raft_priority":             strconv.Itoa(clusterCfg.GetInt(ClusterRaftPriority, 100)),
-				"failure_domain":            clusterCfg.GetString(ClusterFailureDomain, ""),
+				"version":                         "1.0.0",
+				internode.MetadataSurfaceProtocol: "1",
+				"role":                            "wippy",
+				internode.MetadataPort:            strconv.Itoa(actualPort),
+				internode.MetadataPublicKey:       base64.RawStdEncoding.EncodeToString(publicKey),
+				"raft_eligible":                   strconv.FormatBool(raftEligible),
+				"raft_priority":                   strconv.Itoa(clusterCfg.GetInt(ClusterRaftPriority, 100)),
+				"failure_domain":                  clusterCfg.GetString(ClusterFailureDomain, ""),
 			}
 			if advertiseAddr != "" {
 				// v2 metadata is additive: old peers ignore it and keep using

--- a/boot/components/system/tty_mesh.go
+++ b/boot/components/system/tty_mesh.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package system
+
+import (
+	"context"
+	"errors"
+
+	"github.com/wippyai/runtime/api/boot"
+	clusterapi "github.com/wippyai/runtime/api/cluster"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/relay"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/cluster/internode"
+	ttysystem "github.com/wippyai/runtime/system/tty"
+)
+
+// TTYMesh adds the dedicated protocol only when clustering is configured.
+// TTY itself remains usable in local and embedded runtimes without a mesh.
+func TTYMesh() boot.Component {
+	return boot.New(boot.P{
+		Name:      "tty.mesh",
+		DependsOn: []boot.Name{TTYName, ClusterName},
+		Load: func(ctx context.Context) (context.Context, error) {
+			ac := ctxapi.AppFromContext(ctx)
+			if ac == nil {
+				return ctx, nil
+			}
+			cm, _ := ac.Get(connMgrKey).(internode.ConnectionManager)
+			if cm == nil {
+				return ctx, nil
+			}
+			service, ok := ttyapi.GetService(ctx).(*ttysystem.Service)
+			node := relay.GetNode(ctx)
+			if !ok || node == nil {
+				return nil, ttyapi.ErrServiceUnavailable
+			}
+			return ctx, service.SetMesh(node.ID(), surfaceMesh{cm: cm, membership: clusterapi.GetMembership(ctx)})
+		},
+	})
+}
+
+type surfaceMesh struct {
+	cm         internode.ConnectionManager
+	membership clusterapi.Membership
+}
+
+func (t surfaceMesh) Send(peer string, data []byte) error {
+	return t.cm.SendToNode(peer, data, internode.ClassSurface)
+}
+func (t surfaceMesh) Receive(fn func(string, []byte)) error {
+	if !t.cm.RegisterClassReceiver(internode.ClassSurface, fn) {
+		return errors.New("terminal mesh receiver already registered")
+	}
+	return nil
+}
+
+func (t surfaceMesh) CheckPeer(peer string) error {
+	if t.membership != nil {
+		for _, node := range t.membership.Nodes() {
+			if node.ID == peer && node.Meta[internode.MetadataSurfaceProtocol] == "1" {
+				return nil
+			}
+		}
+	}
+	return ttyapi.ErrServiceUnavailable
+}

--- a/boot/components/system/tty_mesh_test.go
+++ b/boot/components/system/tty_mesh_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	clusterapi "github.com/wippyai/runtime/api/cluster"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/cluster/internode"
+)
+
+type surfaceMembership []clusterapi.NodeInfo
+
+func (m surfaceMembership) Nodes() []clusterapi.NodeInfo { return m }
+func (surfaceMembership) LocalNode() clusterapi.NodeInfo { return clusterapi.NodeInfo{ID: "local"} }
+func (surfaceMembership) UpdateMeta(map[string]string)   {}
+
+func TestSurfaceMeshChecksPeerProtocolBeforeAttach(t *testing.T) {
+	transport := surfaceMesh{membership: surfaceMembership{
+		{ID: "old"},
+		{ID: "new", Meta: clusterapi.NodeMeta{internode.MetadataSurfaceProtocol: "1"}},
+	}}
+	require.NoError(t, transport.CheckPeer("new"))
+	require.ErrorIs(t, transport.CheckPeer("old"), ttyapi.ErrServiceUnavailable)
+	require.ErrorIs(t, transport.CheckPeer("absent"), ttyapi.ErrServiceUnavailable)
+	require.ErrorIs(t, (surfaceMesh{}).CheckPeer("new"), ttyapi.ErrServiceUnavailable)
+}

--- a/cluster/internode/class.go
+++ b/cluster/internode/class.go
@@ -13,6 +13,7 @@ package internode
 //   - ClassRaftRPC: raft RPC request/reply frames over internode. The name
 //     is kept for wire compatibility with the prior raft class byte; it no
 //     longer carries a byte stream.
+//   - ClassSurface: bounded admission; accepted frames survive write retries.
 type Class uint8
 
 const (
@@ -20,11 +21,23 @@ const (
 	ClassGossip
 	ClassPGBroadcast
 	ClassRaftRPC
+	// ClassSurface carries bounded terminal mount traffic. Both peers must
+	// support this protocol before a surface mount is used.
+	ClassSurface
 )
 
 // numClasses is the count of Class values. If a new Class is added, this
 // MUST be updated; the per-state ring slice is sized from it.
-const numClasses = 4
+const numClasses = 5
+
+// MetadataSurfaceProtocol advertises support before a peer emits the new
+// surface class on an existing connection to a potentially older node.
+const MetadataSurfaceProtocol = "tty_surface_protocol"
+
+// MaxSurfaceFrameSize bounds queued and in-flight surface payloads to 32 MiB
+// per managed peer (32 admission slots plus a reserved retry batch of 32),
+// independent of the larger Raft snapshot frame limit.
+const MaxSurfaceFrameSize = 512 << 10
 
 // String renders Class for log/metric labels.
 func (c Class) String() string {
@@ -37,6 +50,8 @@ func (c Class) String() string {
 		return "pg"
 	case ClassRaftRPC:
 		return "raft-rpc"
+	case ClassSurface:
+		return "surface"
 	default:
 		return "unknown"
 	}

--- a/cluster/internode/connection.go
+++ b/cluster/internode/connection.go
@@ -410,6 +410,9 @@ func readFrame(r io.Reader, maxMessageSize uint32) (Class, []byte, error) {
 		return 0, nil, protocolError(fmt.Sprintf("unknown sub-protocol class %d", header[1]))
 	}
 	size := binary.LittleEndian.Uint32(header[2:])
+	if class == ClassSurface && size > MaxSurfaceFrameSize {
+		return 0, nil, NewMessageSizeExceedsMaxError(int(size), MaxSurfaceFrameSize)
+	}
 	if size > maxMessageSize {
 		return 0, nil, NewMessageSizeExceedsMaxError(int(size), int(maxMessageSize))
 	}

--- a/cluster/internode/mux_test.go
+++ b/cluster/internode/mux_test.go
@@ -3,6 +3,9 @@
 package internode
 
 import (
+	"bytes"
+	"encoding/binary"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -36,7 +39,7 @@ func TestMux_ClassRoundTripPerClass(t *testing.T) {
 		})
 	}()
 
-	classes := []Class{ClassRaftControl, ClassGossip, ClassPGBroadcast, ClassRaftRPC}
+	classes := []Class{ClassRaftControl, ClassGossip, ClassPGBroadcast, ClassRaftRPC, ClassSurface}
 	for _, c := range classes {
 		payload := []byte("payload-" + c.String())
 		srcA.push(payload, c)
@@ -70,7 +73,7 @@ func TestMux_ConcurrentSendersDoNotInterleave(t *testing.T) {
 	a, b, srcA := p.a, p.b, p.srcA
 
 	const perClass = 500
-	classes := []Class{ClassRaftControl, ClassGossip, ClassPGBroadcast, ClassRaftRPC}
+	classes := []Class{ClassRaftControl, ClassGossip, ClassPGBroadcast, ClassRaftRPC, ClassSurface}
 
 	var perClassCount [numClasses]atomic.Int64
 	done := make(chan struct{})
@@ -245,4 +248,15 @@ func isConnected(mgr ConnectionManager, peer string) bool {
 		}
 	}
 	return false
+}
+
+func TestSurfaceRejectsOversizedHeaderBeforeReadingBody(t *testing.T) {
+	// A surface frame has a much smaller limit than a Raft snapshot. The peer
+	// must reject the header without allocating or waiting for the claimed body.
+	var header [frameHeaderSize]byte
+	header[0], header[1] = protocolVersion, byte(ClassSurface)
+	binary.LittleEndian.PutUint32(header[2:], MaxSurfaceFrameSize+1)
+	_, _, err := readFrame(bytes.NewReader(header[:]), 512<<20)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, io.EOF)
 }

--- a/cluster/internode/state_manager.go
+++ b/cluster/internode/state_manager.go
@@ -33,6 +33,7 @@ type NodeState struct {
 	connection    *NodeConnection
 	address       nodeAddress
 	lastDepth     [numClasses]int // last queue depth emitted to telemetry; guarded by queueMu
+	surfaceTurn   bool            // guarded by queueMu; fair turns between application classes
 	state         ConnectionState
 	stateMu       sync.RWMutex
 	queueMu       sync.Mutex
@@ -202,6 +203,9 @@ func (nsm *NodeStateManager) CreateNodeState(nodeID cluster.NodeID) {
 		ClassGossip:      nsm.config.GossipQueueCap,
 		ClassPGBroadcast: 0,
 		ClassRaftRPC:     0,
+		// Admission and drain each allow 32 surface frames. Reserve another
+		// batch so a failed write can requeue every accepted frame.
+		ClassSurface: 64,
 	}
 	queues := [numClasses]*classQueue{}
 	for i := range queues {
@@ -228,13 +232,13 @@ func (nsm *NodeStateManager) GetNodeState(nodeID cluster.NodeID) *NodeState {
 // Delivery policy is class-specific:
 //   - ClassRaftControl, ClassPGBroadcast, and ClassRaftRPC are reliable
 //     while the peer remains managed.
-//   - ClassGossip drops the new entry and returns ErrQueueFull when full.
+//   - ClassGossip and ClassSurface reject the new entry and returns ErrQueueFull when full.
 //
 // In all drop cases, internode_dropped_total{class,reason="queue_full"}
 // is incremented.
 //
 // Returns ErrNodeNotManaged if no state exists for nodeID.
-// Returns ErrQueueFull for gossip when full.
+// Returns ErrQueueFull for gossip or surface traffic when full.
 func (nsm *NodeStateManager) QueueMessageClass(nodeID cluster.NodeID, data []byte, class Class) error {
 	state := nsm.GetNodeState(nodeID)
 	if state == nil {
@@ -247,12 +251,21 @@ func (nsm *NodeStateManager) QueueMessageClass(nodeID cluster.NodeID, data []byt
 		return ErrUnknownClass
 	}
 
+	if class == ClassSurface && len(data) > MaxSurfaceFrameSize {
+		return NewMessageSizeExceedsMaxError(len(data), MaxSurfaceFrameSize)
+	}
 	state.queueMu.Lock()
 	q := state.queues[class]
 	var rejected bool
 	switch class {
 	case ClassRaftControl, ClassPGBroadcast, ClassRaftRPC:
 		q.pushNewest(data)
+	case ClassSurface:
+		if q.len() >= 32 {
+			rejected = true
+		} else {
+			q.pushNewest(data)
+		}
 	case ClassGossip:
 		if !q.pushNewest(data) {
 			rejected = true
@@ -345,17 +358,10 @@ func (nsm *NodeStateManager) GetNodeAddress(nodeID cluster.NodeID) (string, int,
 	return addr.addr, addr.port, addr.addr != "" && addr.port != 0
 }
 
-// drainClasses defines the QoS draining order. ClassRaftControl drains
-// first (smallest latency budget); ClassRaftRPC second so raft RPC
-// frames stay responsive; gossip and PG broadcast last. The order
-// matters under per-batch caps: a saturated control plane should not
-// starve raft RPC traffic forever.
-var drainClasses = [numClasses]Class{
-	ClassRaftControl,
-	ClassRaftRPC,
-	ClassGossip,
-	ClassPGBroadcast,
-}
+// Control traffic retains its existing priority. Surface and PG application
+// frames then take alternating turns so adding interactive traffic cannot
+// starve ordinary process messages (including when maxCount is one).
+var drainClasses = [...]Class{ClassRaftControl, ClassRaftRPC, ClassGossip}
 
 func (nsm *NodeStateManager) DrainMessages(nodeID cluster.NodeID, maxCount int) []Outbound {
 	state := nsm.GetNodeState(nodeID)
@@ -377,6 +383,28 @@ func (nsm *NodeStateManager) DrainMessages(nodeID cluster.NodeID, maxCount int) 
 			break
 		}
 	}
+	surfaceCount := 0
+	for len(out) < maxCount {
+		first, second := ClassPGBroadcast, ClassSurface
+		if state.surfaceTurn {
+			first, second = second, first
+		}
+		class := first
+		if state.queues[class].len() == 0 || (class == ClassSurface && surfaceCount == 32) {
+			class = second
+		}
+		if state.queues[class].len() == 0 || (class == ClassSurface && surfaceCount == 32) {
+			break
+		}
+		data, _ := state.queues[class].pop()
+		if data != nil {
+			out = append(out, Outbound{Data: data, Class: class})
+		}
+		if class == ClassSurface {
+			surfaceCount++
+		}
+		state.surfaceTurn = class != ClassSurface
+	}
 	// Snapshot post-drain depths. internode_queue_depth is a gauge — emit
 	// only the classes whose depth changed so an idle drain does not write
 	// numClasses no-op metric events.
@@ -389,9 +417,9 @@ func (nsm *NodeStateManager) DrainMessages(nodeID cluster.NodeID, maxCount int) 
 	}
 	state.queueMu.Unlock()
 
-	for _, class := range drainClasses {
+	for class := range numClasses {
 		if depthChanged[class] {
-			nsm.tel.recordQueueDepth(class, nodeID, depths[class])
+			nsm.tel.recordQueueDepth(Class(class), nodeID, depths[class])
 		}
 	}
 	return out
@@ -465,7 +493,7 @@ func (nsm *NodeStateManager) RequeueMessagesClass(nodeID cluster.NodeID, message
 			}
 			q.pushFront(messages[i])
 		}
-	case ClassGossip:
+	case ClassGossip, ClassSurface:
 		for i := len(messages) - 1; i >= 0; i-- {
 			if messages[i] == nil {
 				continue

--- a/cluster/internode/state_manager_test.go
+++ b/cluster/internode/state_manager_test.go
@@ -668,3 +668,54 @@ func TestNodeStateManager_Concurrent_AddressUpdates(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestSurfaceRequeuePreservesAcceptedFramesAtCapacity(t *testing.T) {
+	nsm := setupStateManager()
+	nsm.CreateNodeState("peer")
+	for i := range 32 {
+		require.NoError(t, nsm.QueueMessageClass("peer", []byte{byte(i)}, ClassSurface))
+	}
+	batch := nsm.DrainMessages("peer", 128)
+	require.Len(t, batch, 32)
+	for i := range 32 {
+		require.NoError(t, nsm.QueueMessageClass("peer", []byte{byte(i + 32)}, ClassSurface))
+	}
+	nsm.RequeueMessages("peer", batch)
+	// Repeated failed writes neither lose accepted frames nor reopen admission
+	// while the reserved retry batch occupies the queue.
+	for range 10 {
+		batch = nsm.DrainMessages("peer", 128)
+		require.Len(t, batch, 32)
+		require.ErrorIs(t, nsm.QueueMessageClass("peer", []byte("overflow"), ClassSurface), ErrQueueFull)
+		nsm.RequeueMessages("peer", batch)
+	}
+	got := nsm.DrainMessages("peer", 128)
+	got = append(got, nsm.DrainMessages("peer", 128)...)
+	require.Len(t, got, 64)
+	for i, frame := range got {
+		require.Equal(t, []byte{byte(i)}, frame.Data)
+	}
+	require.Empty(t, nsm.DrainMessages("peer", 128))
+}
+
+func TestSurfaceQueueBoundAndApplicationFairness(t *testing.T) {
+	nsm := setupStateManager()
+	nsm.CreateNodeState("peer")
+	for range 32 {
+		require.NoError(t, nsm.QueueMessageClass("peer", []byte("surface"), ClassSurface))
+	}
+	require.ErrorIs(t, nsm.QueueMessageClass("peer", []byte("overflow"), ClassSurface), ErrQueueFull)
+	require.Error(t, nsm.QueueMessageClass("peer", make([]byte, MaxSurfaceFrameSize+1), ClassSurface))
+	for range 32 {
+		require.NoError(t, nsm.QueueMessageClass("peer", []byte("process"), ClassPGBroadcast))
+	}
+	// Even a one-message drain must give both application classes a turn.
+	for range 32 {
+		a := nsm.DrainMessages("peer", 1)
+		b := nsm.DrainMessages("peer", 1)
+		require.Len(t, a, 1)
+		require.Len(t, b, 1)
+		require.NotEqual(t, a[0].Class, b[0].Class)
+	}
+	require.Empty(t, nsm.DrainMessages("peer", 32))
+}

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -34,7 +34,7 @@ func init() {
 	})
 	terminalSessionType = typ.NewInterface("exec.TerminalSession", []typ.Method{
 		{Name: "send", Type: typ.Func().Param("self", typ.Self).
-			Param("event", luatty.EventType()).
+			Param("event", luatty.InputEventType()).
 			Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "close", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},

--- a/runtime/lua/modules/tty/module_test.go
+++ b/runtime/lua/modules/tty/module_test.go
@@ -32,7 +32,7 @@ func TestModuleInfo(t *testing.T) {
 func TestModuleBuild(t *testing.T) {
 	tbl, yields := Module.Build()
 	require.NotNil(t, tbl)
-	assert.Equal(t, 5, len(yields))
+	assert.Equal(t, 6, len(yields))
 }
 
 func TestYieldTypes(t *testing.T) {

--- a/runtime/lua/modules/tty/mount_test.go
+++ b/runtime/lua/modules/tty/mount_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/security"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	securitysys "github.com/wippyai/runtime/system/security"
+	ttysys "github.com/wippyai/runtime/system/tty"
+)
+
+type luaMountPolicy struct{}
+
+func (luaMountPolicy) ID() registry.ID { return registry.ParseID("test:mount") }
+func (luaMountPolicy) Evaluate(_ security.Actor, action, _ string, _ attrs.Bag) security.Result {
+	if action == "tty.mount" || action == ttyapi.RightObserve {
+		return security.Allow
+	}
+	return security.Deny
+}
+
+func TestLuaMountRequiresPermissionsAndChecksEveryAccess(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	root := ttyapi.WithService(ctxapi.NewRootContext(), service)
+	owner, ownerFrame := ctxapi.OpenFrameContext(root)
+	defer ownerFrame.Close()
+	agent, agentFrame := ctxapi.OpenFrameContext(root)
+	defer agentFrame.Close()
+	require.NoError(t, runtime.SetFramePID(owner, pid.PID{Node: "n", Host: "h", UniqID: "owner"}))
+	require.NoError(t, runtime.SetFramePID(agent, pid.PID{Node: "n", Host: "h", UniqID: "agent"}))
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+	l.SetContext(owner)
+	require.NoError(t, l.DoString(`
+  own=assert(tty.viewport({width=80,height=24}))
+  local ref,err=own:mount("{n@h|agent}",{observe=true})
+  assert(ref==nil and err,"missing scope must deny observation grants")
+ `))
+	require.NoError(t, security.SetActor(owner, security.Actor{ID: "owner"}))
+	require.NoError(t, security.SetScope(owner, securitysys.NewScope([]security.Policy{luaMountPolicy{}})))
+	require.NoError(t, l.DoString(`
+  local ref,err=own:mount("{n@h|agent}",{observe=true,input=true})
+  assert(ref==nil and err,"observe permission must not grant input")
+  mount_ref=assert(own:mount("{n@h|agent}",{observe=true}))
+ `))
+	l.SetContext(agent)
+	require.NoError(t, l.DoString(`
+  -- Even if a userdata reaches another process, caller identity is checked.
+  local result,err=own:snapshot(); assert(result==nil and err)
+  result,err=own:grant(); assert(result==nil and err)
+  result,err=own:handle(); assert(result==nil and err)
+  result,err=own:close(); assert(result==nil and err)
+  observer=assert(tty.attach(mount_ref))
+  assert(observer:snapshot().width==80)
+  result,err=observer:send({type="key",key="x",key_type="runes",action="press"})
+  assert(result==nil and err)
+  result,err=observer:resize(90,30); assert(result==nil and err)
+  result,err=observer:mount("{n@h|other}",{observe=true}); assert(result==nil and err)
+ `))
+	l.SetContext(owner)
+	require.NoError(t, l.DoString(`assert(own:revoke(mount_ref))`))
+	l.SetContext(agent)
+	require.NoError(t, l.DoString(`
+  local snapshot,err=observer:snapshot(); assert(snapshot==nil and err)
+  assert(observer:close()); assert(observer:close())
+ `))
+}

--- a/runtime/lua/modules/tty/page.go
+++ b/runtime/lua/modules/tty/page.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"fmt"
+
+	lua "github.com/wippyai/go-lua"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func pageFromLua(value lua.LValue) (*ttyapi.Page, error) {
+	if value == lua.LNil {
+		return nil, nil
+	}
+	table, ok := value.(*lua.LTable)
+	if !ok {
+		return nil, fmt.Errorf("page must be a table with foreground and background #RRGGBB colors")
+	}
+	fg, fgOK := table.RawGetString("foreground").(lua.LString)
+	bg, bgOK := table.RawGetString("background").(lua.LString)
+	if !fgOK || !bgOK {
+		return nil, fmt.Errorf("page requires both foreground and background #RRGGBB colors")
+	}
+	page, err := (ttyapi.Page{Foreground: string(fg), Background: string(bg)}).Canonical()
+	if err != nil {
+		return nil, err
+	}
+	return &page, nil
+}
+
+func viewportSetPage(l *lua.LState) int {
+	v := checkViewport(l)
+	page, err := pageFromLua(l.Get(2))
+	if err != nil {
+		return invalidArgument(l, err.Error())
+	}
+	setter, ok := v.view.(ttyapi.PageViewport)
+	if !ok {
+		return invalidArgument(l, "viewport does not grant page configuration")
+	}
+	if err := setter.SetPage(l.Context(), page); err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "set viewport page"))
+		return 2
+	}
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}

--- a/runtime/lua/modules/tty/snapshot_bench_test.go
+++ b/runtime/lua/modules/tty/snapshot_bench_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	relaysys "github.com/wippyai/runtime/system/relay"
+	ttysys "github.com/wippyai/runtime/system/tty"
+)
+
+// The Lua materialization path is shared by local and remote cached snapshots.
+// Run the loop in Lua so per-iteration Go-to-Lua call overhead is not included.
+func BenchmarkLuaViewportSnapshot(b *testing.B) {
+	for _, mode := range []string{"full_frame", "unchanged_revision"} {
+		b.Run(mode, func(b *testing.B) {
+			service := ttysys.NewService()
+			defer service.Close()
+			ctx, frame := ctxapi.OpenFrameContext(ttyapi.WithService(ctxapi.NewRootContext(), service))
+			defer frame.Close()
+			ctx = relay.WithNode(ctx, relaysys.NewNode("n"))
+			require.NoError(b, runtime.SetFramePID(ctx, pid.PID{Node: "n", Host: "h", UniqID: "owner"}))
+			view, err := service.Create(ctx, 120, 40)
+			require.NoError(b, err)
+			binding, err := service.Binding(view.Grant())
+			require.NoError(b, err)
+			port, err := binding.Resolve(ctx)
+			require.NoError(b, err)
+			surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+			require.NoError(b, err)
+			rows := make([]string, 40)
+			for i := range rows {
+				rows[i] = strings.Repeat("x", 120)
+			}
+			_, err = surface.Present(ttyapi.Frame{Rows: rows})
+			require.NoError(b, err)
+			l := lua.NewState()
+			defer l.Close()
+			bindTTY(l)
+			l.SetContext(ctx)
+			pushViewport(l, view)
+			l.Pop(1) // nil error result
+			l.SetGlobal("view", l.Get(-1))
+			l.Pop(1)
+			l.SetGlobal("revision", lua.LInteger(view.Snapshot().Revision))
+			body := "view:snapshot()"
+			if mode == "unchanged_revision" {
+				body = "view:snapshot(revision)"
+			}
+			require.NoError(b, l.DoString("function sample(n) for i=1,n do "+body+" end end"))
+			fn := l.GetGlobal("sample")
+			b.ReportAllocs()
+			b.ResetTimer()
+			err = l.CallByParam(lua.P{Fn: fn, NRet: 0, Protect: true}, lua.LInteger(b.N))
+			b.StopTimer()
+			require.NoError(b, err)
+		})
+	}
+}

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -132,8 +132,10 @@ transactionally: a rejected process start restores an unresolved grant, while
 a process that has resolved the port consumes it permanently. Unsupported
 hosts reject terminal attachments rather than dropping them.
 
-`handle()` returns a viewer capability. `tty.attach(handle)` adds another local
-viewer. Handles do not grant presentation ownership and do not cross nodes.
+`handle()` returns a local viewport identifier. `tty.attach(handle)` adds a local
+viewer; a non-owner requires `tty.observe`, with input and resize granted only
+when permitted by its scope. Handles do not grant authority by themselves and
+do not cross nodes; use recipient-bound mounts for delegation.
 
 | Method | Purpose |
 |---|---|

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -173,3 +173,76 @@ For a byte-oriented PTY such as a shell, Codex, or Claude Code, allocate it with
 resize, input encoding, graceful termination, forced termination, and reaping;
 the enclosing surface/viewport model stays the same for native and Docker
 executors.
+
+## Process-bound mounts over the mesh
+
+A viewport owner can delegate independent observation, input, and resize rights
+using a mount reference. The reference is bound to an exact process PID,
+including its node. It is not a reusable bearer credential: another process,
+a different authenticated peer, or an already redeemed reference is rejected.
+
+```lua
+-- Owner, on the node hosting the viewport and producer.
+local view = assert(tty.viewport({width = 100, height = 30}))
+local observation = assert(view:mount(agent_pid, {observe = true}))
+local control = assert(view:mount(agent_pid, {input = true, resize = true}))
+
+-- Start the producer on this node with the existing terminal option.
+local child = assert(process.with_options({terminal = view:grant()})
+    :spawn("app:terminal_child", "app:workers"))
+-- Pass observation/control to that exact agent through the application's
+-- existing process messaging or orchestration. The child needs no mesh code.
+```
+
+```lua
+-- Agent, potentially on another mesh node.
+local observer = assert(tty.attach(observation))
+local control = assert(tty.attach(control))
+local changes = assert(observer:updates())
+local snapshot = assert(observer:snapshot())
+
+assert(control:send({type = "paste", text = "echo hello"}))
+assert(control:send({
+    type = "key", key = "enter", key_type = "enter", action = "press",
+}))
+assert(control:resize(120, 40))
+
+-- Updates are coalesced revision hints. Read the current snapshot for state.
+local revision, open = changes:receive()
+if open then snapshot = observer:snapshot() end
+```
+
+`viewport:mount(recipient_pid, {observe?, input?, resize?}) -> reference, error`
+requires `tty.mount` and each requested right (`tty.observe`, `tty.input`,
+`tty.resize`) on the owner's viewport handle. Every right defaults to false;
+an empty grant is rejected. Only the original owner can delegate, and mounted
+views cannot issue producer grants or further mounts. Input does not imply
+observation, and sending a resize event cannot bypass the resize right.
+
+`viewport:revoke(reference) -> true, error` revokes an issued mount. Closing
+its owner viewport or completing the owner process revokes its mounts too.
+Snapshots and updates require observation rights; snapshots return `nil, error`
+when access is denied or the mounted view has ended. Already delivered content
+cannot be recalled by revocation.
+
+A viewport's plain `handle()` is an address, not observation authority.
+Attaching another process to that handle locally now requires `tty.observe`.
+Input and resize are separately selected from the attaching process's scope.
+The creator retains access to its own viewport. This intentionally tightens
+older code that shared handles without assigning any observation permission.
+
+Remote `tty.attach`, `send`, and `resize` yield through the dispatcher. Snapshot
+reads use a local cache; update subscriptions retain the existing channel API.
+Remote ports are not synthesized from OS file descriptors: producers keep
+using their node-local terminal grant, `tty.surface`, or `exec:attach_terminal`.
+This also preserves the existing VT interpretation of PTY output and cursor
+state. Arbitrary process spawning across nodes remains the responsibility of
+application orchestration; a surface mount does not grant process or exec
+permissions.
+
+Remote mounts use a 30-second lease, renewed every 10 seconds while attached.
+Unused grants expire after 30 seconds; local redeemed mounts are process-owned.
+Remote operations time out after 5 seconds. Re-attachment requires a fresh
+mount; transport reconnection does not permit replaying terminal input.
+Both nodes must advertise surface protocol version 1. Peers without that
+capability are rejected before writing a new protocol class to their connection.

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -146,11 +146,51 @@ do not cross nodes; use recipient-bound mounts for delegation.
 | `send(event)` | Forward validated input to a started producer |
 | `resize(width, height)` | Update geometry and notify producer/viewers when changed |
 | `close()` | Detach only this viewer |
+| `set_page(page?)` | Creator process only: replace opaque page defaults, or clear them with `nil` |
 
 Updates are bounded hints, not an event log. A slow viewer receives the newest
 available watermark and must call `snapshot()`. Presentation and resize never
 block on slow viewers. Closing the last viewer does not kill a live producer;
 closing the producer port does not destroy state while viewers remain.
+
+## Opaque viewport pages
+
+A compositing shell can supply its page defaults once, without rewriting child
+ANSI output or filling behind every child row:
+
+```lua
+local view = assert(tty.viewport({width = 80, height = 24,
+    page = {foreground = "#102030", background = "#f0e0d0"}}))
+-- When the shell changes palette; the producer need not repaint default cells.
+assert(view:set_page({foreground = "#e0def4", background = "#191724"}))
+```
+
+Both colours must be opaque `#RRGGBB` strings. Only the creator process can change the page, including through a local handle
+it reattaches after an in-process upgrade. Other viewers and delegated mounts
+cannot change it, even with resize rights. `set_page(nil)` restores the
+producer's original rows. Without a page, viewport output keeps its previous
+terminal-default behaviour; ordinary PTY sessions keep emulator defaults.
+
+A page resolves default foreground/background cells, SGR resets, unstyled spaces,
+and omitted rows to explicit colours across the viewport width and height.
+Explicit ANSI colours, attributes, hyperlinks, and painted blanks survive.
+Wide glyphs clipped at the right edge become styled blanks. Frames are complete
+row replacements, not terminal command streams; PTY cursor movement and erasure
+are interpreted by the emulator before those rows reach the compositor.
+
+Changed source rows are resolved once at presentation; unchanged rows reuse
+cached strings. Snapshot reads do no parsing or recolouring. Page/size changes
+rebuild resolved rows and advance the existing revision, waking local and mesh
+observers even without producer output. Already published snapshots stay intact.
+The existing mesh row format carries explicit resolved colours, so peers require
+no page-policy support or protocol change. A versioned public cell-snapshot API
+is separate work; this API still exports styled rows.
+
+PTY OSC 10/11 colour queries use the viewport's page at query time. Explicit
+program palettes are not automatically recoloured, and changing the page does
+not force a third-party program to query again or rebuild its own palette.
+Physical presentation clears old rows before painting, preserving full-width
+coloured blanks and the bottom-right cell under delayed autowrap.
 
 ## Minimal composite example
 

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -178,6 +178,12 @@ executors.
 
 ## Process-bound mounts over the mesh
 
+See the [agent workflow guide](../../../../tests/tty-mesh/LUA_GUIDE.md) for
+node/host identity, controller discovery, simulated input, and restart handling.
+`tty.MountRights` names the grant options; `tty.InputEvent` describes synthetic
+input (modifier flags default to false), while `tty.TTYEvent` describes received
+events. Input channels support both `receive()` and `case_receive()`.
+
 A viewport owner can delegate independent observation, input, and resize rights
 using a mount reference. The reference is bound to an exact process PID,
 including its node. It is not a reusable bearer credential: another process,

--- a/runtime/lua/modules/tty/surface_test.go
+++ b/runtime/lua/modules/tty/surface_test.go
@@ -30,8 +30,8 @@ func TestSurfacePresentDiffsRowsAndSkipsUnchangedFrame(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, changed)
 	assert.Equal(t, output.Len(), written)
-	assert.Contains(t, output.String(), "\x1b[1;1Hone")
-	assert.Contains(t, output.String(), "\x1b[3;1Hthree")
+	assert.Contains(t, output.String(), "\x1b[1;1H\x1b[0m\x1b[Kone")
+	assert.Contains(t, output.String(), "\x1b[3;1H\x1b[0m\x1b[Kthree")
 
 	output.Reset()
 	changed, written, err = surface.present([]string{"one", "two", "three"})
@@ -45,7 +45,7 @@ func TestSurfacePresentDiffsRowsAndSkipsUnchangedFrame(t *testing.T) {
 	assert.Equal(t, 1, changed)
 	assert.Equal(t, output.Len(), written)
 	assert.NotContains(t, output.String(), "\x1b[1;1H")
-	assert.Contains(t, output.String(), "\x1b[2;1Hchanged")
+	assert.Contains(t, output.String(), "\x1b[2;1H\x1b[0m\x1b[Kchanged")
 }
 
 func TestSurfacePresentClearsRemovedRows(t *testing.T) {

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -36,7 +36,7 @@ var styleType = typ.NewInterface("tty.Style", []typ.Method{
 
 // KeyBinding interface returned by tty.bind()
 var keyBindingType = typ.NewInterface("tty.KeyBinding", []typ.Method{
-	{Name: "matches", Type: typ.Func().Param("self", typ.Self).Param("event", ttyEventType).Returns(typ.Boolean).Build()},
+	{Name: "matches", Type: typ.Func().Param("self", typ.Self).Param("event", inputEventType).Returns(typ.Boolean).Build()},
 	{Name: "set_enabled", Type: typ.Func().Param("self", typ.Self).Param("enabled", typ.Boolean).Returns(typ.Self).Build()},
 	{Name: "is_enabled", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
 	{Name: "help", Type: typ.Func().Param("self", typ.Self).Returns(bindingHelpType).Build()},
@@ -124,13 +124,41 @@ var ttyEventType = typ.NewUnion(
 	closeEventType,
 )
 
+// Input events accept omitted modifier flags, matching DecodeEvent. Events
+// returned by tty.events retain their fully populated output contract.
+var inputEventType = typ.NewUnion(
+	typ.NewRecord().
+		ReadonlyField("type", typ.LiteralString("key")).
+		ReadonlyField("key", typ.String).
+		ReadonlyField("key_type", typ.String).
+		ReadonlyField("action", typ.NewUnion(typ.LiteralString("press"), typ.LiteralString("release"))).
+		OptReadonlyField("alt", typ.Boolean).
+		OptReadonlyField("ctrl", typ.Boolean).
+		OptReadonlyField("shift", typ.Boolean).Build(),
+	typ.NewRecord().
+		ReadonlyField("type", typ.LiteralString("mouse")).
+		ReadonlyField("action", typ.NewUnion(typ.LiteralString("press"), typ.LiteralString("release"), typ.LiteralString("motion"), typ.LiteralString("wheel"))).
+		ReadonlyField("button", typ.String).
+		ReadonlyField("x", typ.Integer).
+		ReadonlyField("y", typ.Integer).
+		OptReadonlyField("alt", typ.Boolean).
+		OptReadonlyField("ctrl", typ.Boolean).
+		OptReadonlyField("shift", typ.Boolean).Build(),
+	resizeEventType, startEventType, focusEventType, visibilityEventType, pasteEventType, closeEventType,
+)
+
+// InputEventType exposes the event contract accepted by terminal input adapters.
+func InputEventType() typ.Type { return inputEventType }
+
 // EventType exposes the structural terminal event contract to optional Lua
 // adapters without making them duplicate or weaken it to any.
 func EventType() typ.Type { return ttyEventType }
 
 // Channel type for tty.events()
 var eventChannelType = typ.NewInterface("tty.EventChannel", []typ.Method{
-	{Name: "receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(ttyEventType)).Build()},
+	{Name: "receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(ttyEventType), typ.Boolean).Build()},
+	{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
+	{Name: "close", Type: typ.Func().Param("self", typ.Self).Build()},
 })
 
 var viewportUpdateChannelType = typ.NewInterface("tty.ViewportUpdateChannel", []typ.Method{
@@ -193,14 +221,19 @@ var viewportSnapshotType = typ.NewRecord().
 		Build()).
 	Build()
 
+var mountRightsType = typ.NewRecord().
+	OptField("observe", typ.Boolean).
+	OptField("input", typ.Boolean).
+	OptField("resize", typ.Boolean).Build()
+
 var viewportType = typ.NewInterface("tty.Viewport", []typ.Method{
-	{Name: "mount", Type: typ.Func().Param("self", typ.Self).Param("recipient", typ.String).Param("rights", typ.NewRecord().OptField("observe", typ.Boolean).OptField("input", typ.Boolean).OptField("resize", typ.Boolean).Build()).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "mount", Type: typ.Func().Param("self", typ.Self).Param("recipient", typ.String).Param("rights", mountRightsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "revoke", Type: typ.Func().Param("self", typ.Self).Param("reference", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "grant", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
-	{Name: "handle", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
+	{Name: "handle", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "snapshot", Type: typ.Func().Param("self", typ.Self).OptParam("after_revision", typ.Integer).Returns(typ.NewOptional(viewportSnapshotType), typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "updates", Type: typ.Func().Param("self", typ.Self).Returns(viewportUpdateChannelType, typ.NewOptional(typ.LuaError)).Build()},
-	{Name: "send", Type: typ.Func().Param("self", typ.Self).Param("event", ttyEventType).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "send", Type: typ.Func().Param("self", typ.Self).Param("event", inputEventType).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "resize", Type: typ.Func().Param("self", typ.Self).Param("width", typ.Integer).Param("height", typ.Integer).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 })
@@ -268,6 +301,8 @@ func ModuleTypes() *typio.Manifest {
 	m.DefineType("PasteEvent", pasteEventType)
 	m.DefineType("CloseEvent", closeEventType)
 	m.DefineType("TTYEvent", ttyEventType)
+	m.DefineType("InputEvent", inputEventType)
+	m.DefineType("MountRights", mountRightsType)
 	m.DefineType("EventChannel", eventChannelType)
 	m.DefineType("Surface", surfaceType)
 	m.DefineType("Canvas", canvasType)

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -194,9 +194,11 @@ var viewportSnapshotType = typ.NewRecord().
 	Build()
 
 var viewportType = typ.NewInterface("tty.Viewport", []typ.Method{
+	{Name: "mount", Type: typ.Func().Param("self", typ.Self).Param("recipient", typ.String).Param("rights", typ.NewRecord().OptField("observe", typ.Boolean).OptField("input", typ.Boolean).OptField("resize", typ.Boolean).Build()).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "revoke", Type: typ.Func().Param("self", typ.Self).Param("reference", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "grant", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "handle", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
-	{Name: "snapshot", Type: typ.Func().Param("self", typ.Self).OptParam("after_revision", typ.Integer).Returns(typ.NewOptional(viewportSnapshotType)).Build()},
+	{Name: "snapshot", Type: typ.Func().Param("self", typ.Self).OptParam("after_revision", typ.Integer).Returns(typ.NewOptional(viewportSnapshotType), typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "updates", Type: typ.Func().Param("self", typ.Self).Returns(viewportUpdateChannelType, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "send", Type: typ.Func().Param("self", typ.Self).Param("event", ttyEventType).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "resize", Type: typ.Func().Param("self", typ.Self).Param("width", typ.Integer).Param("height", typ.Integer).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -204,9 +204,15 @@ var canvasType = typ.NewInterface("tty.Canvas", []typ.Method{
 	{Name: "rows", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewArray(typ.String)).Build()},
 })
 
+var viewportPageType = typ.NewRecord().
+	Field("foreground", typ.String).
+	Field("background", typ.String).
+	Build()
+
 var viewportOptionsType = typ.NewRecord().
 	OptField("width", typ.Integer).
 	OptField("height", typ.Integer).
+	OptField("page", viewportPageType).
 	Build()
 
 var viewportSnapshotType = typ.NewRecord().
@@ -227,6 +233,7 @@ var mountRightsType = typ.NewRecord().
 	OptField("resize", typ.Boolean).Build()
 
 var viewportType = typ.NewInterface("tty.Viewport", []typ.Method{
+	{Name: "set_page", Type: typ.Func().Param("self", typ.Self).OptParam("page", typ.NewOptional(viewportPageType)).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "mount", Type: typ.Func().Param("self", typ.Self).Param("recipient", typ.String).Param("rights", mountRightsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "revoke", Type: typ.Func().Param("self", typ.Self).Param("reference", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "grant", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
@@ -310,6 +317,7 @@ func ModuleTypes() *typio.Manifest {
 	m.DefineType("SurfaceStats", surfaceStatsType)
 	m.DefineType("Viewport", viewportType)
 	m.DefineType("ViewportOptions", viewportOptionsType)
+	m.DefineType("ViewportPage", viewportPageType)
 	m.DefineType("ViewportSnapshot", viewportSnapshotType)
 
 	moduleMethodsType := typ.NewInterface("tty", []typ.Method{

--- a/runtime/lua/modules/tty/types_test.go
+++ b/runtime/lua/modules/tty/types_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/runtime/lua/code"
+)
+
+func TestAgentSurfaceSDKTypes(t *testing.T) {
+	config := code.DefaultTypeCheckConfig()
+	config.Enabled = true
+	config.SkipUntyped = false
+	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{Module})
+	_, diagnostics, err := checker.Check(`
+local tty = require("tty")
+local owner = tty.viewport({width=120,height=40})
+local ref = owner:mount("{remote@agents|agent}", {observe=true,input=true,resize=true})
+local view = tty.attach(ref)
+view:send({type="key",key="enter",key_type="enter",action="press"})
+view:send({type="mouse",action="press",button="left",x=1,y=1})
+view:send({type="paste",text="echo hello"})
+view:resize(100,30)
+local changes = view:updates()
+local revision, open = changes:receive()
+local update_case = changes:case_receive()
+local events = tty.events()
+local input_case = events:case_receive()
+local event, input_open = events:receive()
+local handle, handle_error = owner:handle()
+owner:revoke(ref)
+view:close()
+`, "agent_surface_types.lua", nil)
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "SDK rejects documented agent flow: %v", diagnostics)
+}
+
+func TestAgentSurfaceSDKRejectsInvalidInput(t *testing.T) {
+	config := code.DefaultTypeCheckConfig()
+	config.Enabled = true
+	config.SkipUntyped = false
+	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{Module})
+	_, diagnostics, err := checker.Check(`
+ local tty=require("tty")
+ local view=tty.attach("ref")
+ view:send({type="key",key="enter",key_type="enter",action="click"})
+ `, "invalid_surface_input.lua", nil)
+	require.NoError(t, err)
+	require.True(t, code.HasErrors(diagnostics), "invalid input must be rejected by SDK types")
+}

--- a/runtime/lua/modules/tty/types_test.go
+++ b/runtime/lua/modules/tty/types_test.go
@@ -17,7 +17,9 @@ func TestAgentSurfaceSDKTypes(t *testing.T) {
 	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{Module})
 	_, diagnostics, err := checker.Check(`
 local tty = require("tty")
-local owner = tty.viewport({width=120,height=40})
+local owner = tty.viewport({width=120,height=40,page={foreground="#102030",background="#f0e0d0"}})
+assert(owner:set_page({foreground="#ffffff",background="#000000"}))
+assert(owner:set_page(nil))
 local ref = owner:mount("{remote@agents|agent}", {observe=true,input=true,resize=true})
 local view = tty.attach(ref)
 view:send({type="key",key="enter",key_type="enter",action="press"})

--- a/runtime/lua/modules/tty/viewport.go
+++ b/runtime/lua/modules/tty/viewport.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/pid"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
 )
@@ -27,6 +28,7 @@ func init() {
 			"grant": viewportGrant, "handle": viewportHandle,
 			"snapshot": viewportSnapshot, "updates": viewportUpdates, "send": viewportSend,
 			"resize": viewportResize, "close": viewportClose,
+			"mount": viewportMount, "revoke": viewportRevoke,
 		})
 }
 
@@ -37,7 +39,12 @@ func ttyAttach(l *lua.LState) int {
 		l.Push(lua.NewLuaError(l, "tty service unavailable").WithKind(lua.Unavailable).WithRetryable(false))
 		return 2
 	}
-	view, err := service.Attach(l.Context(), l.CheckString(1))
+	handle := l.CheckString(1)
+	if remote, ok := service.(ttyapi.RemoteService); ok && remote.IsRemote(handle) {
+		l.Push(&ViewportIOYield{Command: ttyapi.ViewportIOCmd{Operation: "attach", Handle: handle}})
+		return -1
+	}
+	view, err := service.Attach(l.Context(), handle)
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.WrapErrorWithLua(l, err, "attach viewport"))
@@ -122,7 +129,11 @@ func checkViewport(l *lua.LState) *viewportWrapper {
 func viewportToString(l *lua.LState) int { l.Push(lua.LString("tty.Viewport{}")); return 1 }
 
 func viewportGrant(l *lua.LState) int {
-	grant := checkViewport(l).view.Grant()
+	view := checkViewport(l).view
+	if !checkViewportRight(l, view, "") {
+		return 2
+	}
+	grant := view.Grant()
 	if grant == "" {
 		return invalidArgument(l, "viewport has no producer grant")
 	}
@@ -132,12 +143,20 @@ func viewportGrant(l *lua.LState) int {
 }
 
 func viewportHandle(l *lua.LState) int {
-	l.Push(lua.LString(checkViewport(l).view.Handle()))
+	view := checkViewport(l).view
+	if !checkViewportRight(l, view, "") {
+		return 2
+	}
+	l.Push(lua.LString(view.Handle()))
 	return 1
 }
 
 func viewportSnapshot(l *lua.LState) int {
-	s := checkViewport(l).view.Snapshot()
+	view := checkViewport(l).view
+	if !checkViewportRight(l, view, ttyapi.RightObserve) {
+		return 2
+	}
+	s := view.Snapshot()
 	if l.GetTop() >= 2 {
 		after, ok := integerValue(l.Get(2))
 		if !ok {
@@ -172,6 +191,9 @@ func viewportSnapshot(l *lua.LState) int {
 
 func viewportUpdates(l *lua.LState) int {
 	v := checkViewport(l)
+	if !checkViewportRight(l, v.view, ttyapi.RightObserve) {
+		return 2
+	}
 	if v.updates == nil {
 		bridge, err := newUpdateBridge(l, v.view)
 		if err != nil {
@@ -188,9 +210,16 @@ func viewportUpdates(l *lua.LState) int {
 
 func viewportSend(l *lua.LState) int {
 	v := checkViewport(l)
+	if !checkViewportRight(l, v.view, ttyapi.RightInput) {
+		return 2
+	}
 	event, err := DecodeEvent(l.CheckTable(2))
 	if err != nil {
 		return invalidArgument(l, err.Error())
+	}
+	if remote, ok := v.view.(ttyapi.RemoteViewport); ok {
+		l.Push(&ViewportIOYield{Command: ttyapi.ViewportIOCmd{Operation: "send", View: remote, Event: event}})
+		return -1
 	}
 	if err := v.view.Send(event); err != nil {
 		l.Push(lua.LNil)
@@ -204,6 +233,9 @@ func viewportSend(l *lua.LState) int {
 
 func viewportResize(l *lua.LState) int {
 	v := checkViewport(l)
+	if !checkViewportRight(l, v.view, ttyapi.RightResize) {
+		return 2
+	}
 	width, err := viewportDimensionValue(l.Get(2), "width")
 	if err != nil {
 		return invalidArgument(l, err.Error())
@@ -214,6 +246,10 @@ func viewportResize(l *lua.LState) int {
 	}
 	if err := ttyapi.ValidateViewportSize(width, height); err != nil {
 		return invalidArgument(l, err.Error())
+	}
+	if remote, ok := v.view.(ttyapi.RemoteViewport); ok {
+		l.Push(&ViewportIOYield{Command: ttyapi.ViewportIOCmd{Operation: "resize", View: remote, Width: width, Height: height}})
+		return -1
 	}
 	err = v.view.Resize(width, height)
 	if err != nil {
@@ -228,12 +264,10 @@ func viewportResize(l *lua.LState) int {
 
 func viewportClose(l *lua.LState) int {
 	v := checkViewport(l)
-	v.once.Do(func() {
-		if v.updates != nil {
-			v.updates.close()
-		}
-		v.closeErr = v.view.Close()
-	})
+	if !checkViewportRight(l, v.view, "") {
+		return 2
+	}
+	v.close()
 	if v.closeErr != nil {
 		l.Push(lua.LNil)
 		l.Push(lua.WrapErrorWithLua(l, v.closeErr, "close viewport"))
@@ -244,4 +278,69 @@ func viewportClose(l *lua.LState) int {
 	return 2
 }
 
-func viewportGC(l *lua.LState) int { _ = viewportClose(l); l.Pop(2); return 0 }
+func (v *viewportWrapper) close() {
+	v.once.Do(func() {
+		if v.updates != nil {
+			v.updates.close()
+		}
+		v.closeErr = v.view.Close()
+	})
+}
+
+func viewportGC(l *lua.LState) int { checkViewport(l).close(); return 0 }
+
+func checkViewportRight(l *lua.LState, view ttyapi.Viewport, right string) bool {
+	if checked, ok := view.(ttyapi.CheckedViewport); ok {
+		if err := checked.Check(l.Context(), right); err != nil {
+			l.Push(lua.LNil)
+			l.Push(lua.WrapErrorWithLua(l, err, "viewport access"))
+			return false
+		}
+	}
+	return true
+}
+func viewportMount(l *lua.LState) int {
+	v := checkViewport(l)
+	issuer, ok := v.view.(ttyapi.MountableViewport)
+	if !ok {
+		return invalidArgument(l, "mounted view cannot delegate")
+	}
+	target, err := pid.ParsePID(l.CheckString(2))
+	if err != nil {
+		return invalidArgument(l, "mount recipient must be a process PID")
+	}
+	opts := l.CheckTable(3)
+	var rights ttyapi.MountRights
+	if rights.Observe, err = optionBool(opts, "observe"); err != nil {
+		return invalidArgument(l, err.Error())
+	}
+	if rights.Input, err = optionBool(opts, "input"); err != nil {
+		return invalidArgument(l, err.Error())
+	}
+	if rights.Resize, err = optionBool(opts, "resize"); err != nil {
+		return invalidArgument(l, err.Error())
+	}
+	ref, err := issuer.Mount(l.Context(), target, rights)
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "mount viewport"))
+		return 2
+	}
+	l.Push(lua.LString(ref))
+	l.Push(lua.LNil)
+	return 2
+}
+func viewportRevoke(l *lua.LState) int {
+	issuer, ok := checkViewport(l).view.(ttyapi.MountableViewport)
+	if !ok {
+		return invalidArgument(l, "mounted view cannot revoke")
+	}
+	if err := issuer.Revoke(l.Context(), l.CheckString(2)); err != nil {
+		l.Push(lua.LNil)
+		l.Push(lua.WrapErrorWithLua(l, err, "revoke viewport mount"))
+		return 2
+	}
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}

--- a/runtime/lua/modules/tty/viewport.go
+++ b/runtime/lua/modules/tty/viewport.go
@@ -18,7 +18,9 @@ type viewportWrapper struct {
 	view     ttyapi.Viewport
 	updates  *updateBridge
 	closeErr error
-	once     sync.Once
+	// Lua-thread-only cache of immutable string values, never returned as a table.
+	rows []lua.LValue
+	once sync.Once
 }
 
 func init() {
@@ -152,7 +154,8 @@ func viewportHandle(l *lua.LState) int {
 }
 
 func viewportSnapshot(l *lua.LState) int {
-	view := checkViewport(l).view
+	v := checkViewport(l)
+	view := v.view
 	if !checkViewportRight(l, view, ttyapi.RightObserve) {
 		return 2
 	}
@@ -169,8 +172,15 @@ func viewportSnapshot(l *lua.LState) int {
 		}
 	}
 	rows := l.CreateTable(len(s.Rows), 0)
+	if len(v.rows) != len(s.Rows) {
+		// Replace on resize so a smaller screen does not retain old rows.
+		v.rows = make([]lua.LValue, len(s.Rows))
+	}
 	for i, row := range s.Rows {
-		rows.RawSetInt(i+1, lua.LString(row))
+		if previous, ok := v.rows[i].(lua.LString); !ok || string(previous) != row {
+			v.rows[i] = lua.LString(row)
+		}
+		rows.RawSetInt(i+1, v.rows[i])
 	}
 	result := l.CreateTable(0, 4)
 	result.RawSetString("revision", lua.LInteger(s.Revision))
@@ -280,6 +290,7 @@ func viewportClose(l *lua.LState) int {
 
 func (v *viewportWrapper) close() {
 	v.once.Do(func() {
+		v.rows = nil
 		if v.updates != nil {
 			v.updates.close()
 		}

--- a/runtime/lua/modules/tty/viewport.go
+++ b/runtime/lua/modules/tty/viewport.go
@@ -31,6 +31,7 @@ func init() {
 			"snapshot": viewportSnapshot, "updates": viewportUpdates, "send": viewportSend,
 			"resize": viewportResize, "close": viewportClose,
 			"mount": viewportMount, "revoke": viewportRevoke,
+			"set_page": viewportSetPage,
 		})
 }
 
@@ -70,8 +71,12 @@ func ttyViewportNew(l *lua.LState) int {
 		return 2
 	}
 	width, height := 80, 24
+	var page *ttyapi.Page
 	if options := l.OptTable(1, nil); options != nil {
 		var err error
+		if page, err = pageFromLua(options.RawGetString("page")); err != nil {
+			return invalidArgument(l, err.Error())
+		}
 		if width, err = viewportDimension(options, "width", width); err != nil {
 			return invalidArgument(l, err.Error())
 		}
@@ -93,6 +98,19 @@ func ttyViewportNew(l *lua.LState) int {
 		l.Push(lua.NewLuaError(l, "created viewport is unavailable").
 			WithKind(lua.Internal).WithRetryable(false))
 		return 2
+	}
+	if page != nil {
+		setter, ok := view.(ttyapi.PageViewport)
+		if !ok {
+			_ = view.Close()
+			return invalidArgument(l, "viewport does not support page configuration")
+		}
+		if err := setter.SetPage(l.Context(), page); err != nil {
+			_ = view.Close()
+			l.Push(lua.LNil)
+			l.Push(lua.WrapErrorWithLua(l, err, "set viewport page"))
+			return 2
+		}
 	}
 	pushViewport(l, view)
 	return 2

--- a/runtime/lua/modules/tty/viewport_page_test.go
+++ b/runtime/lua/modules/tty/viewport_page_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+	"image/color"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	relaysys "github.com/wippyai/runtime/system/relay"
+	ttysys "github.com/wippyai/runtime/system/tty"
+)
+
+const (
+	luaPageForeground = "#e0def4"
+	luaPageBackground = "#191724"
+)
+
+type viewportInbox struct{ packages chan *relay.Package }
+
+func (i *viewportInbox) Send(*relay.Package) error { return nil }
+
+// viewportProcessContext wires the real viewport broker so Lua sees the rows a
+// producer publishes rather than a fixture.
+func viewportProcessContext(t *testing.T, service *ttysys.Service, id string) context.Context {
+	t.Helper()
+	ctx := ttyapi.WithService(ctxapi.NewRootContext(), service)
+	node := relaysys.NewNode("node")
+	require.NoError(t, node.RegisterHost("workers", &viewportInbox{packages: make(chan *relay.Package, 1)}))
+	ctx = relay.WithNode(ctx, node)
+	ctx, frame := ctxapi.OpenFrameContext(ctx)
+	t.Cleanup(func() { _ = frame.Close() })
+	require.NoError(t, frame.Set(runtime.FramePIDKey, pid.PID{Node: "node", Host: "workers", UniqID: id}))
+	return ctx
+}
+
+func luaViewportState(t *testing.T, service *ttysys.Service) *lua.LState {
+	t.Helper()
+	l := lua.NewState()
+	t.Cleanup(l.Close)
+	bindTTY(l)
+	l.SetContext(viewportProcessContext(t, service, "shell"))
+	return l
+}
+
+// present drives the producer side of a viewport created from Lua.
+func present(t *testing.T, service *ttysys.Service, grant string, rows []string) {
+	t.Helper()
+	binding, err := service.Binding(grant)
+	require.NoError(t, err)
+	port, err := binding.Resolve(viewportProcessContext(t, service, "producer"))
+	require.NoError(t, err)
+	surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	_, err = surface.Present(ttyapi.Frame{Rows: rows})
+	require.NoError(t, err)
+}
+
+func luaString(t *testing.T, l *lua.LState, name string) string {
+	t.Helper()
+	value, ok := l.GetGlobal(name).(lua.LString)
+	require.Truef(t, ok, "global %s must be a string", name)
+	return string(value)
+}
+
+// luaCells decodes a snapshot row back into styled cells.
+func luaCells(t *testing.T, row string, width int) uv.Line {
+	t.Helper()
+	screen := uv.NewScreenBuffer(width, 1)
+	screen.Method = ansi.GraphemeWidth
+	uv.NewStyledString(row).Draw(screen, screen.Bounds())
+	return screen.Line(0)
+}
+
+func luaSameColor(a, b color.Color) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	ar, ag, ab, _ := a.RGBA()
+	br, bg, bb, _ := b.RGBA()
+	return ar == br && ag == bg && ab == bb
+}
+
+func luaPageColors(t *testing.T) (color.Color, color.Color) {
+	t.Helper()
+	foreground, background := (ttyapi.Page{Foreground: luaPageForeground, Background: luaPageBackground}).Colors()
+	return foreground, background
+}
+
+func requireLuaPageRow(t *testing.T, row string, width int, foreground, background color.Color) {
+	t.Helper()
+	require.Equal(t, width, ansi.StringWidth(row), "row %q must cover the viewport width", row)
+	for index, cell := range luaCells(t, row, width) {
+		require.Truef(t, luaSameColor(cell.Style.Fg, foreground),
+			"cell %d of %q must carry the page foreground", index, row)
+		require.Truef(t, luaSameColor(cell.Style.Bg, background),
+			"cell %d of %q must carry the page background", index, row)
+	}
+}
+
+func TestLuaViewportPageResolvesDefaultCells(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	l := luaViewportState(t, service)
+
+	require.NoError(t, l.DoString(`
+		view = assert(tty.viewport({width = 6, height = 3,
+			page = {foreground = "`+luaPageForeground+`", background = "`+luaPageBackground+`"}}))
+		grant = assert(view:grant())
+	`))
+	present(t, service, luaString(t, l, "grant"), []string{"ab", "\x1b[0m  "})
+	require.NoError(t, l.DoString(`
+		local snapshot = view:snapshot()
+		assert(#snapshot.rows == 3)
+		row1, row2, row3 = snapshot.rows[1], snapshot.rows[2], snapshot.rows[3]
+	`))
+
+	foreground, background := luaPageColors(t)
+	for _, name := range []string{"row1", "row2", "row3"} {
+		requireLuaPageRow(t, luaString(t, l, name), 6, foreground, background)
+	}
+	require.Equal(t, "ab    ", ansi.Strip(luaString(t, l, "row1")))
+}
+
+func TestLuaViewportPagePreservesProducerColors(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	l := luaViewportState(t, service)
+
+	require.NoError(t, l.DoString(`
+		view = assert(tty.viewport({width = 4, height = 1,
+			page = {foreground = "`+luaPageForeground+`", background = "`+luaPageBackground+`"}}))
+		grant = assert(view:grant())
+	`))
+	present(t, service, luaString(t, l, "grant"), []string{"\x1b[38;2;255;0;0mR\x1b[0mx"})
+	require.NoError(t, l.DoString(`row1 = view:snapshot().rows[1]`))
+
+	foreground, background := luaPageColors(t)
+	line := luaCells(t, luaString(t, l, "row1"), 4)
+	require.Len(t, line, 4)
+	require.True(t, luaSameColor(line[0].Style.Fg, color.RGBA{R: 255, A: 255}))
+	require.True(t, luaSameColor(line[0].Style.Bg, background))
+	for index := 1; index < len(line); index++ {
+		require.True(t, luaSameColor(line[index].Style.Fg, foreground))
+		require.True(t, luaSameColor(line[index].Style.Bg, background))
+	}
+}
+
+func TestLuaViewportWithoutPageIsUnchanged(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	l := luaViewportState(t, service)
+
+	require.NoError(t, l.DoString(`
+		view = assert(tty.viewport({width = 6, height = 3}))
+		grant = assert(view:grant())
+	`))
+	present(t, service, luaString(t, l, "grant"), []string{"ab", "\x1b[0m  "})
+	require.NoError(t, l.DoString(`
+		local snapshot = view:snapshot()
+		assert(#snapshot.rows == 2, "a viewport without a page publishes producer rows verbatim")
+		row1, row2 = snapshot.rows[1], snapshot.rows[2]
+	`))
+	require.Equal(t, "ab", luaString(t, l, "row1"))
+	require.Equal(t, "\x1b[0m  ", luaString(t, l, "row2"))
+}
+
+func TestLuaViewportSetPageBumpsRevision(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	l := luaViewportState(t, service)
+
+	require.NoError(t, l.DoString(`
+		view = assert(tty.viewport({width = 4, height = 1}))
+		grant = assert(view:grant())
+	`))
+	present(t, service, luaString(t, l, "grant"), []string{"ab"})
+	require.NoError(t, l.DoString(`
+		local before = view:snapshot()
+		assert(view:snapshot(before.revision) == nil)
+		assert(view:set_page({foreground = "`+luaPageForeground+`", background = "`+luaPageBackground+`"}))
+		local after = view:snapshot(before.revision)
+		assert(after ~= nil and after.revision == before.revision + 1,
+			"a page change must invalidate the snapshot")
+		row1 = after.rows[1]
+		assert(view:set_page(nil))
+		local cleared = view:snapshot()
+		assert(cleared.revision == after.revision + 1)
+		cleared_row1 = cleared.rows[1]
+	`))
+	foreground, background := luaPageColors(t)
+	requireLuaPageRow(t, luaString(t, l, "row1"), 4, foreground, background)
+	require.Equal(t, "ab", luaString(t, l, "cleared_row1"))
+}
+
+func TestLuaViewportRejectsInvalidPage(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	l := luaViewportState(t, service)
+
+	require.NoError(t, l.DoString(`
+		local half, half_err = tty.viewport({width = 4, height = 1, page = {foreground = "`+luaPageForeground+`"}})
+		assert(half == nil and half_err)
+		local malformed, malformed_err = tty.viewport({width = 4, height = 1,
+			page = {foreground = "red", background = "`+luaPageBackground+`"}})
+		assert(malformed == nil and malformed_err)
+		local wrong_type, wrong_type_err = tty.viewport({width = 4, height = 1, page = "dark"})
+		assert(wrong_type == nil and wrong_type_err)
+		local empty, empty_err = tty.viewport({width = 4, height = 1, page = {}})
+		assert(empty == nil and empty_err)
+
+		local view = assert(tty.viewport({width = 4, height = 1}))
+		local set, set_err = view:set_page({background = "`+luaPageBackground+`"})
+		assert(set == nil and set_err)
+		set, set_err = view:set_page({foreground = "#12345", background = "`+luaPageBackground+`"})
+		assert(set == nil and set_err)
+	`))
+}
+
+func TestLuaAttachedViewerSeesResolvedRows(t *testing.T) {
+	service := ttysys.NewService()
+	defer service.Close()
+	l := luaViewportState(t, service)
+
+	require.NoError(t, l.DoString(`
+		view = assert(tty.viewport({width = 4, height = 1,
+			page = {foreground = "`+luaPageForeground+`", background = "`+luaPageBackground+`"}}))
+		grant = assert(view:grant())
+	`))
+	present(t, service, luaString(t, l, "grant"), []string{"ab"})
+	require.NoError(t, l.DoString(`
+		local viewer = assert(tty.attach(view:handle()))
+		attached_row1 = viewer:snapshot().rows[1]
+		owner_row1 = view:snapshot().rows[1]
+		assert(attached_row1 == owner_row1)
+	`))
+	foreground, background := luaPageColors(t)
+	requireLuaPageRow(t, luaString(t, l, "attached_row1"), 4, foreground, background)
+}

--- a/runtime/lua/modules/tty/viewport_test.go
+++ b/runtime/lua/modules/tty/viewport_test.go
@@ -94,6 +94,56 @@ func TestLuaViewportAttachHandleAndRevisionPolling(t *testing.T) {
 	require.True(t, attached.closed)
 }
 
+func TestLuaViewportSnapshotRowsRemainIndependent(t *testing.T) {
+	view := &viewportTestView{snapshot: ttyapi.Snapshot{
+		Revision: 1, Width: 10, Height: 2, Rows: []string{"first", "stable"},
+	}}
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+	l.SetContext(ttyapi.WithService(ctxapi.NewRootContext(), &viewportTestService{created: view}))
+	require.NoError(t, l.DoString(`
+		view = assert(tty.viewport())
+		old = view:snapshot()
+		edited = view:snapshot()
+		edited.rows[1] = "caller mutation"
+		edited.rows[2] = nil
+		edited.width = 99
+		fresh = view:snapshot()
+		assert(fresh.rows[1] == "first" and fresh.rows[2] == "stable")
+		assert(fresh.width == 10)
+	`))
+	view.snapshot.Revision++
+	view.snapshot.Rows = []string{"changed", "stable"}
+	require.NoError(t, l.DoString(`
+		new = view:snapshot(old.revision)
+		assert(new.rows[1] == "changed" and new.rows[2] == "stable")
+		assert(old.rows[1] == "first" and old.rows[2] == "stable")
+	`))
+	view.snapshot.Revision++
+	view.snapshot.Height = 1
+	view.snapshot.Rows = []string{"small"}
+	require.NoError(t, l.DoString(`
+		local small = view:snapshot()
+		assert(#small.rows == 1 and small.rows[1] == "small")
+		assert(new.rows[2] == "stable")
+	`))
+	wrapper := l.GetGlobal("view").(*lua.LUserData).Value.(*viewportWrapper)
+	require.Len(t, wrapper.rows, 1)
+	require.Equal(t, 1, cap(wrapper.rows))
+	view.snapshot.Revision++
+	view.snapshot.Rows = nil
+	require.NoError(t, l.DoString(`assert(#view:snapshot().rows == 0)`))
+	require.Empty(t, wrapper.rows)
+	view.snapshot.Rows = []string{"after clear"}
+	require.NoError(t, l.DoString(`
+		assert(view:snapshot().rows[1] == "after clear")
+		assert(view:close())
+		assert(old.rows[1] == "first" and new.rows[1] == "changed")
+	`))
+	require.Nil(t, wrapper.rows)
+}
+
 func TestLuaViewportRejectsMalformedInput(t *testing.T) {
 	created := &viewportTestView{}
 	service := &viewportTestService{created: created}

--- a/runtime/lua/modules/tty/yields.go
+++ b/runtime/lua/modules/tty/yields.go
@@ -11,6 +11,7 @@ import (
 )
 
 var yieldTypes = []luaYieldType{
+	{Sample: &ViewportIOYield{}, CmdID: ttyapi.ViewportIO},
 	{Sample: &StartInputYield{}, CmdID: ttyapi.StartInput},
 	{Sample: &StopInputYield{}, CmdID: ttyapi.StopInput},
 	{Sample: &ScreenSizeYield{}, CmdID: ttyapi.ScreenSize},
@@ -167,4 +168,24 @@ func handleBoolResult(l *lua.LState, data any, err error, op string) []lua.LValu
 		return []lua.LValue{lua.LNil, lua.NewLuaError(l, "invalid response type").
 			WithKind(lua.Internal).WithRetryable(false)}
 	}
+}
+
+// ViewportIOYield keeps network waits off the Lua scheduler.
+type ViewportIOYield struct{ Command ttyapi.ViewportIOCmd }
+
+func (*ViewportIOYield) String() string                  { return "<tty_viewport_io_yield>" }
+func (*ViewportIOYield) Type() lua.LValueType            { return lua.LTUserData }
+func (*ViewportIOYield) CmdID() dispatcher.CommandID     { return ttyapi.ViewportIO }
+func (y *ViewportIOYield) ToCommand() dispatcher.Command { return y.Command }
+func (y *ViewportIOYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	if err != nil {
+		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "remote viewport")}
+	}
+	if view, ok := data.(ttyapi.Viewport); ok {
+		pushViewport(l, view)
+		out := []lua.LValue{l.Get(-2), l.Get(-1)}
+		l.Pop(2)
+		return out
+	}
+	return handleBoolResult(l, data, nil, "remote viewport")
 }

--- a/service/terminal/page.go
+++ b/service/terminal/page.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package terminal
+
+import (
+	"image/color"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+// PageRenderer resolves default colors at the styled-cell boundary. One
+// bounded scratch row is reused; callers retain only rendered row strings.
+// It is confined to its owning viewport's presentation lock.
+type PageRenderer struct {
+	*uv.Buffer
+	foreground color.Color
+	background color.Color
+}
+
+func NewPageRenderer(width int, page ttyapi.Page) *PageRenderer {
+	fg, bg := page.Colors()
+	return &PageRenderer{Buffer: uv.NewBuffer(width, 1), foreground: fg, background: bg}
+}
+
+func (r *PageRenderer) WidthMethod() uv.WidthMethod { return ansi.GraphemeWidth }
+
+func (r *PageRenderer) SetCell(x, y int, cell *uv.Cell) {
+	if y != 0 || x < 0 || x >= r.Width() || (cell != nil && cell.Width <= 0) {
+		return
+	}
+	c := uv.EmptyCell
+	if cell != nil {
+		c = *cell
+	}
+	if c.Style.Fg == nil {
+		c.Style.Fg = r.foreground
+	}
+	if c.Style.Bg == nil {
+		c.Style.Bg = r.background
+	}
+	if x+c.Width > r.Width() {
+		c.Empty()
+		for column := x; column < r.Width(); column++ {
+			r.Buffer.SetCell(column, y, &c)
+		}
+		return
+	}
+	r.Buffer.SetCell(x, y, &c)
+}
+
+func (r *PageRenderer) RenderRow(row string) string {
+	// StyledString parses SGR, resets and hyperlinks into cells. Control-only
+	// decoder tails are rejected by SetCell, and wide cells clip to styled blanks.
+	uv.NewStyledString(row).Draw(r, r.Bounds())
+	return r.Render()
+}

--- a/service/terminal/page_test.go
+++ b/service/terminal/page_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package terminal
+
+import (
+	"bytes"
+	"image/color"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	vt "github.com/charmbracelet/x/vt"
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func TestPageSurvivesPhysicalPresentation(t *testing.T) {
+	for _, synchronized := range []bool{false, true} {
+		t.Run(map[bool]string{false: "plain", true: "synchronized"}[synchronized], func(t *testing.T) {
+			page := ttyapi.Page{Foreground: "#102030", Background: "#f0e0d0"}
+			renderer := NewPageRenderer(6, page)
+			var output bytes.Buffer
+			surface := NewSurface(&output, ttyapi.SurfaceOptions{Synchronized: synchronized})
+			screen := vt.NewEmulator(6, 2)
+			defer screen.Close()
+			paint := func(rows []string) {
+				output.Reset()
+				_, err := surface.Present(ttyapi.Frame{Rows: rows})
+				require.NoError(t, err)
+				_, err = screen.Write(output.Bytes())
+				require.NoError(t, err)
+			}
+			rows := []string{renderer.RenderRow("abcdef"), renderer.RenderRow("世界 X")}
+			paint(rows)
+			_, bg := page.Colors()
+			for y := range 2 {
+				for x := range 6 {
+					cell := screen.CellAt(x, y)
+					if cell.Width == 0 {
+						continue
+					}
+					require.NotNil(t, cell.Style.Bg, "cell (%d,%d)", x, y)
+					require.Equal(t, color.RGBAModel.Convert(bg), color.RGBAModel.Convert(cell.Style.Bg), "cell (%d,%d)", x, y)
+				}
+			}
+			require.Equal(t, "f", screen.CellAt(5, 0).Content)
+			require.Equal(t, "X", screen.CellAt(5, 1).Content)
+			paint([]string{renderer.RenderRow("x")})
+			require.Equal(t, "x", screen.CellAt(0, 0).Content)
+			for x := range 6 {
+				require.Equal(t, " ", screen.CellAt(x, 1).Content)
+			}
+			paint(rows)
+			require.Equal(t, "f", screen.CellAt(5, 0).Content, "full-width repaint must not scroll")
+		})
+	}
+}
+
+func TestPageRendererClipsWideCellsAndKeepsPaintedBlanks(t *testing.T) {
+	r := NewPageRenderer(3, ttyapi.Page{Foreground: "#102030", Background: "#f0e0d0"})
+	require.Equal(t, "a界", ansi.Strip(r.RenderRow("a界"))) // whole wide cell fits
+	require.Equal(t, "ab ", ansi.Strip(r.RenderRow("ab界")))
+	require.Equal(t, "   ", ansi.Strip(r.RenderRow("")))
+}

--- a/service/terminal/proxy/input.go
+++ b/service/terminal/proxy/input.go
@@ -105,6 +105,20 @@ func (s *inputState) key(event ttyapi.Event) string {
 		return "\x1b[" + final
 	}
 	if sequence, ok := fixedKeys[name]; ok {
+		if name == "tab" && event.Shift {
+			if event.Alt || event.Ctrl {
+				return "\x1b[1;" + strconv.Itoa(modifier(event)) + "Z"
+			}
+			return "\x1b[Z"
+		}
+		if event.Shift || event.Alt || event.Ctrl {
+			if strings.HasPrefix(sequence, "\x1b[") && strings.HasSuffix(sequence, "~") {
+				return strings.TrimSuffix(sequence, "~") + ";" + strconv.Itoa(modifier(event)) + "~"
+			}
+			if strings.HasPrefix(sequence, "\x1bO") {
+				return "\x1b[1;" + strconv.Itoa(modifier(event)) + sequence[2:]
+			}
+		}
 		if event.Alt {
 			return "\x1b" + sequence
 		}
@@ -126,10 +140,10 @@ func (s *inputState) key(event ttyapi.Event) string {
 	return sequence
 }
 
-var cursorKeys = map[string]string{"up": "A", "down": "B", "right": "C", "left": "D"}
+var cursorKeys = map[string]string{"up": "A", "down": "B", "right": "C", "left": "D", "home": "H", "end": "F"}
 var fixedKeys = map[string]string{
 	"enter": "\r", "tab": "\t", "backspace": "\x7f", "esc": "\x1b", "space": " ",
-	"insert": "\x1b[2~", "delete": "\x1b[3~", "home": "\x1b[H", "end": "\x1b[F",
+	"insert": "\x1b[2~", "delete": "\x1b[3~",
 	"pgup": "\x1b[5~", "pgdown": "\x1b[6~", "f1": "\x1bOP", "f2": "\x1bOQ",
 	"f3": "\x1bOR", "f4": "\x1bOS", "f5": "\x1b[15~", "f6": "\x1b[17~",
 	"f7": "\x1b[18~", "f8": "\x1b[19~", "f9": "\x1b[20~", "f10": "\x1b[21~",

--- a/service/terminal/proxy/navigation_test.go
+++ b/service/terminal/proxy/navigation_test.go
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
+
 package proxy
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	ttyapi "github.com/wippyai/runtime/api/tty"
-	"testing"
 )
 
 func TestLegacyNavigationMatrix(t *testing.T) {

--- a/service/terminal/proxy/navigation_test.go
+++ b/service/terminal/proxy/navigation_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MPL-2.0
+package proxy
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"testing"
+)
+
+func TestLegacyNavigationMatrix(t *testing.T) {
+	for name, code := range map[string]string{
+		"up": "A", "down": "B", "right": "C", "left": "D", "home": "H", "end": "F",
+		"insert": "2~", "delete": "3~", "pgup": "5~", "pgdown": "6~",
+		"f1": "P", "f2": "Q", "f3": "R", "f4": "S", "f5": "15~", "f6": "17~",
+		"f7": "18~", "f8": "19~", "f9": "20~", "f10": "21~", "f11": "23~", "f12": "24~",
+	} {
+		for mask := 0; mask < 8; mask++ {
+			for _, application := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/mod%d/app%t", name, mask, application), func(t *testing.T) {
+					var input inputState
+					input.appCursor.Store(application)
+					event := ttyapi.Event{Type: "key", KeyType: name, Action: "press", Shift: mask&1 != 0, Alt: mask&2 != 0, Ctrl: mask&4 != 0}
+					want := "\x1b[" + code
+					if mask != 0 {
+						if code[len(code)-1] == '~' {
+							want = fmt.Sprintf("\x1b[%s;%d~", code[:len(code)-1], mask+1)
+						} else {
+							want = fmt.Sprintf("\x1b[1;%d%s", mask+1, code)
+						}
+					} else if (application && len(code) == 1) || (name == "f1" || name == "f2" || name == "f3" || name == "f4") {
+						want = "\x1bO" + code
+					}
+					require.Equal(t, want, input.key(event))
+					event.Action = "release"
+					require.Empty(t, input.key(event))
+				})
+			}
+		}
+	}
+}
+
+func TestLegacyNavigationModifiers(t *testing.T) {
+	for _, item := range []struct {
+		name, want       string
+		shift, alt, ctrl bool
+	}{
+		{"home", "\x1b[1;5H", false, false, true},
+		{"end", "\x1b[1;2F", true, false, false},
+		{"delete", "\x1b[3;5~", false, false, true},
+		{"insert", "\x1b[2;2~", true, false, false},
+		{"pgup", "\x1b[5;3~", false, true, false},
+		{"pgdown", "\x1b[6;6~", true, false, true},
+		{"tab", "\x1b[Z", true, false, false},
+		{"f5", "\x1b[15;5~", false, false, true},
+	} {
+		t.Run(item.name, func(t *testing.T) {
+			var input inputState
+			event := ttyapi.Event{Type: "key", KeyType: item.name, Action: "press", Shift: item.shift, Alt: item.alt, Ctrl: item.ctrl}
+			require.Equal(t, item.want, input.key(event))
+			event.Action = "release"
+			require.Empty(t, input.key(event))
+		})
+	}
+}

--- a/service/terminal/proxy/page.go
+++ b/service/terminal/proxy/page.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/charmbracelet/x/ansi"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func (p *Proxy) installPageHandlers() {
+	provider, ok := p.surface.(ttyapi.PageProvider)
+	if !ok {
+		return
+	}
+	for _, command := range []int{10, 11} {
+		p.screen.RegisterOscHandler(command, func(data []byte) bool {
+			parts := bytes.Split(data, []byte{';'})
+			if len(parts) != 2 || !bytes.Equal(parts[1], []byte{'?'}) {
+				return false
+			}
+			page, present := provider.Page()
+			if !present {
+				return false
+			}
+			fg, bg := page.Colors()
+			response := ansi.SetForegroundColor(ansi.XRGBColor{Color: fg}.String())
+			if command == 11 {
+				response = ansi.SetBackgroundColor(ansi.XRGBColor{Color: bg}.String())
+			}
+			_, _ = io.WriteString(p.screen.InputPipe(), response)
+			return true
+		})
+	}
+}

--- a/service/terminal/proxy/page_test.go
+++ b/service/terminal/proxy/page_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"image/color"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+// pagedTestSurface reports the page at the moment the producer's reply is
+// composed, the way the viewport broker does.
+type pagedTestSurface struct {
+	colors func() (color.Color, color.Color, bool)
+	testSurface
+}
+
+func (s *pagedTestSurface) Page() (ttyapi.Page, bool) {
+	fg, bg, ok := s.colors()
+	if !ok {
+		return ttyapi.Page{}, false
+	}
+	hex := func(c color.Color) string {
+		r, g, b, _ := c.RGBA()
+		return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)
+	}
+	return ttyapi.Page{Foreground: hex(fg), Background: hex(bg)}, true
+}
+
+func runQueryProxy(t *testing.T, surface ttyapi.Surface, queries string, replies int) []string {
+	t.Helper()
+	process := &testProcess{
+		stdout: io.NopCloser(strings.NewReader(queries)),
+		input:  make(chan []byte, replies),
+	}
+	proxy, err := New(process, surface, 10, 2)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- proxy.Run(context.Background(), make(chan ttyapi.Event)) }()
+	answers := make([]string, 0, replies)
+	for len(answers) < replies {
+		select {
+		case reply := <-process.input:
+			answers = append(answers, string(reply))
+		case <-time.After(time.Second):
+			t.Fatal("terminal color query was never answered")
+		}
+	}
+	require.NoError(t, <-done)
+	return answers
+}
+
+func TestProxyAnswersColorQueriesWithViewportPage(t *testing.T) {
+	surface := &pagedTestSurface{colors: func() (color.Color, color.Color, bool) {
+		return color.RGBA{R: 0xe0, G: 0xde, B: 0xf4, A: 0xff},
+			color.RGBA{R: 0x19, G: 0x17, B: 0x24, A: 0xff}, true
+	}}
+	replies := runQueryProxy(t, surface, "\x1b]11;?\x07\x1b]10;?\x07", 2)
+	require.Equal(t, "\x1b]11;rgb:1919/1717/2424\x07", replies[0])
+	require.Equal(t, "\x1b]10;rgb:e0e0/dede/f4f4\x07", replies[1])
+}
+
+func TestProxyWithoutPageKeepsEmulatorDefaultColors(t *testing.T) {
+	replies := runQueryProxy(t, &testSurface{}, "\x1b]11;?\x07", 1)
+	require.Equal(t, "\x1b]11;rgb:0000/0000/0000\x07", replies[0])
+
+	unset := &pagedTestSurface{colors: func() (color.Color, color.Color, bool) { return nil, nil, false }}
+	replies = runQueryProxy(t, unset, "\x1b]11;?\x07", 1)
+	require.Equal(t, "\x1b]11;rgb:0000/0000/0000\x07", replies[0],
+		"a viewport without a page keeps the emulator's own default colors")
+}
+
+func TestProxyColorQueryNeverAnswersWithSupersededPage(t *testing.T) {
+	var mu sync.Mutex
+	background := color.RGBA{R: 0x19, G: 0x17, B: 0x24, A: 0xff}
+	surface := &pagedTestSurface{}
+	surface.colors = func() (color.Color, color.Color, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		current := background
+		// The desktop theme changes while the query is in flight.
+		background = color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+		return color.RGBA{A: 0xff}, current, true
+	}
+	replies := runQueryProxy(t, surface, "\x1b]11;?\x07\x1b]11;?\x07", 2)
+	require.Equal(t, "\x1b]11;rgb:1919/1717/2424\x07", replies[0])
+	require.Equal(t, "\x1b]11;rgb:ffff/ffff/ffff\x07", replies[1],
+		"a reply must carry the page in effect when it is written")
+}

--- a/service/terminal/proxy/proxy.go
+++ b/service/terminal/proxy/proxy.go
@@ -107,6 +107,7 @@ func New(process execapi.PTYProcess, surface ttyapi.Surface, width, height int) 
 		CursorVisibility: p.cursorVisible.Store,
 	})
 	p.installKeyboardHandlers()
+	p.installPageHandlers()
 	return p, nil
 }
 

--- a/service/terminal/surface.go
+++ b/service/terminal/surface.go
@@ -69,8 +69,11 @@ func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 		output = append(output, '\x1b', '[')
 		output = strconv.AppendInt(output, int64(index+1), 10)
 		output = append(output, ';', '1', 'H')
-		output = append(output, current...)
+		// Clear the old extent before painting. EL after a full-width row
+		// erases its last cell while the terminal is in delayed autowrap.
 		output = append(output, "\x1b[0m\x1b[K"...)
+		output = append(output, current...)
+		output = append(output, "\x1b[0m"...)
 	}
 	if s.invalid && limit == 0 {
 		output = append(output, "\x1b[H\x1b[0m\x1b[J"...)

--- a/service/terminal/tty/dispatcher.go
+++ b/service/terminal/tty/dispatcher.go
@@ -34,11 +34,14 @@ func WithWorkers(n int) Option {
 
 // Dispatcher handles terminal I/O commands via an async worker pool.
 type Dispatcher struct {
-	ctx     context.Context
-	jobs    chan job
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	workers int
+	ctx        context.Context
+	jobs       chan job
+	cancel     context.CancelFunc
+	asyncSlots chan struct{}
+	wg         sync.WaitGroup
+	workers    int
+	asyncMu    sync.Mutex
+	stopping   bool
 }
 
 type job struct {
@@ -50,7 +53,7 @@ type job struct {
 
 // NewDispatcher creates a terminal I/O dispatcher with default 1 worker.
 func NewDispatcher(opts ...Option) *Dispatcher {
-	d := &Dispatcher{workers: 1}
+	d := &Dispatcher{workers: 1, asyncSlots: make(chan struct{}, 128)}
 	for _, opt := range opts {
 		opt(d)
 	}
@@ -70,6 +73,9 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 
 // Stop shuts down the dispatcher and drains pending jobs.
 func (d *Dispatcher) Stop(_ context.Context) error {
+	d.asyncMu.Lock()
+	d.stopping = true
+	d.asyncMu.Unlock()
 	if d.cancel != nil {
 		d.cancel()
 	}
@@ -245,6 +251,7 @@ func (d *Dispatcher) handle(ctx context.Context, cmd dispatcher.Command, tag uin
 
 // RegisterAll registers all terminal I/O handlers.
 func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispatcher.Handler)) {
+	register(ttyapi.ViewportIO, dispatcher.HandlerFunc(d.handleViewportIO))
 	h := dispatcher.HandlerFunc(d.handle)
 	register(ttyapi.Read, h)
 	register(ttyapi.ReadLine, h)
@@ -255,4 +262,62 @@ func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispat
 	register(ttyapi.ScreenSize, h)
 	register(ttyapi.EnableMouse, h)
 	register(ttyapi.DisableMouse, h)
+}
+
+// Remote operations must never occupy the terminal read worker or a Lua
+// scheduler worker. Admission is bounded and cancellation releases the slot.
+func (d *Dispatcher) handleViewportIO(ctx context.Context, command dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
+	c := command.(ttyapi.ViewportIOCmd)
+	d.asyncMu.Lock()
+	if d.stopping {
+		d.asyncMu.Unlock()
+		return ttyapi.ErrServiceUnavailable
+	}
+	select {
+	case d.asyncSlots <- struct{}{}:
+	default:
+		d.asyncMu.Unlock()
+		return ttyapi.ErrMeshBusy
+	}
+	d.wg.Add(1)
+	d.asyncMu.Unlock()
+	go func() {
+		defer d.wg.Done()
+		defer func() { <-d.asyncSlots }()
+		runCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		if d.ctx != nil {
+			stop := context.AfterFunc(d.ctx, cancel)
+			defer stop()
+		}
+		var result any
+		var err error
+		switch c.Operation {
+		case "attach":
+			service := ttyapi.GetService(runCtx)
+			if service == nil {
+				err = ttyapi.ErrServiceUnavailable
+			} else {
+				result, err = service.Attach(runCtx, c.Handle)
+			}
+		case "send":
+			if c.View == nil {
+				err = ttyapi.ErrInvalidPort
+			} else {
+				err = c.View.SendContext(runCtx, c.Event)
+				result = true
+			}
+		case "resize":
+			if c.View == nil {
+				err = ttyapi.ErrInvalidPort
+			} else {
+				err = c.View.ResizeContext(runCtx, c.Width, c.Height)
+				result = true
+			}
+		default:
+			err = ttyapi.ErrInvalidPort
+		}
+		receiver.CompleteYield(tag, result, err)
+	}()
+	return nil
 }

--- a/system/tty/README.md
+++ b/system/tty/README.md
@@ -1,0 +1,42 @@
+# Terminal broker and mesh mounts
+
+The existing broker remains local: it owns the producer, immutable screen
+snapshots, and bounded update watermarks. Mesh mounts add consumers to that
+broker without changing the producer's terminal API or transmitting file
+handles, Go pointers, or process context.
+
+A mount record binds an opaque random reference to its issuing viewport, exact
+recipient PID, independent rights, and lease. Requests arrive through a
+dedicated internode receiver whose peer identity comes from the authenticated
+connection. The wire has no selectable target surface/process: the owner-side
+record chooses both. Generic `process.send` cannot reach this protocol.
+
+Observation uses a notification / snapshot / acknowledgement cycle with at
+most one outstanding notification per mount. Intermediate frames coalesce in
+the local broker. Each attachment serializes its RPCs and numbers them; the
+owner caches its latest response so transport batch replay cannot execute input
+twice. A timeout fails the mount rather than retrying an uncertain input action.
+Snapshots are whole current frames, not a history of ANSI byte writes. This
+keeps initial attachment and skipped revisions independent of a delta baseline.
+
+Limits are explicit: 128 issued mounts per broker, 128 remote views and pending
+RPCs, 128 queued incoming requests, four request workers, and a 512 KiB wire
+frame limit. The mesh surface queue admits 32 frames per peer, with space reserved
+for another 32-frame in-flight batch to survive failed writes without dropping
+accepted input. New admission rejects overflow; repeated reconnects cannot grow
+the combined queue and in-flight batch beyond 64 frames.
+Surface and ordinary application frames take alternating turns after existing
+control traffic. Snapshots that exceed the protocol limit close their mount;
+there is no unbounded backlog or implicit truncation of terminal content.
+
+Unredeemed grants expire after 30 seconds. Remote requests renew that lease;
+clients send an idle renewal every 10 seconds. Closing the issuer, process exit,
+explicit revoke, or lease expiry releases the underlying observer and closes its
+updates. On disconnect, a mount fails on its request timeout / renewal failure;
+a new attachment requires a fresh mount. Already delivered screen contents
+remain known to their recipient, as with any read capability.
+
+The security boundary trusts each participating runtime to identify its own
+processes. An unrelated peer cannot use a claimed PID to redeem a mount for
+another node. A runtime compromised on the authorized recipient's own node is
+inside that runtime trust boundary.

--- a/system/tty/README.md
+++ b/system/tty/README.md
@@ -40,3 +40,18 @@ The security boundary trusts each participating runtime to identify its own
 processes. An unrelated peer cannot use a claimed PID to redeem a mount for
 another node. A runtime compromised on the authorized recipient's own node is
 inside that runtime trust boundary.
+
+Closing a remote view wakes both its in-flight RPC and operations queued behind
+it immediately; caller cancellation also interrupts queue admission. Neither
+path waits for the peer's five-second response timeout. A close that races with
+attachment cannot repopulate the closed view's cached screen. Owner exit and
+revocation notify input-only attachments too; they do not depend on an
+observation pump or the next heartbeat. Supervised restarts require new mounts
+for the new process PID; old references never regain authority.
+
+Local and remote views expose the same cached snapshot and update interface.
+A shell can clip their rows into canvas regions and present the composed frame
+through one physical Surface, with local controls painted outside those regions.
+Translate input coordinates into the focused region. Forward remote input from
+a separate Lua coroutine so network waits cannot block local exit controls;
+use a bounded input queue and report overflow instead of discarding clicks.

--- a/system/tty/mesh.go
+++ b/system/tty/mesh.go
@@ -284,7 +284,7 @@ func (m *meshService) handle(peer string, f wireFrame) {
 }
 func (m *meshService) watch(record *mountRecord) {
 	defer m.wg.Done()
-	defer func() { _ = m.send(record.recipient.Node, wireFrame{Op: opClosed, Ref: record.ref}) }()
+	defer m.service.removeMount(record.ref)
 	for {
 		select {
 		case <-m.done:
@@ -311,7 +311,7 @@ func (m *meshService) watch(record *mountRecord) {
 		}
 	}
 }
-func (m *meshService) rpc(ctx context.Context, peer string, f wireFrame) (wireFrame, error) {
+func (m *meshService) rpc(ctx context.Context, peer string, f wireFrame, closed <-chan struct{}) (wireFrame, error) {
 	if err := ctx.Err(); err != nil {
 		return wireFrame{}, err
 	}
@@ -335,6 +335,8 @@ func (m *meshService) rpc(ctx context.Context, peer string, f wireFrame) (wireFr
 		return wireFrame{}, err
 	}
 	select {
+	case <-closed:
+		return wireFrame{}, ttyapi.ErrMountExpired
 	case reply := <-p.reply:
 		return reply, fromWireError(reply.Error)
 	case <-ctx.Done():
@@ -358,7 +360,7 @@ func (m *meshService) attach(ctx context.Context, ref string, owner pid.PID) (tt
 	if owner.Node != m.local || owner.Host == "" || owner.UniqID == "" {
 		return nil, ttyapi.ErrPermissionDenied
 	}
-	v := &remoteViewport{mesh: m, peer: peer, ref: ref, owner: owner, dirty: make(chan struct{}, 1), updates: make(chan ttyapi.Update, 1), done: make(chan struct{})}
+	v := &remoteViewport{callGate: make(chan struct{}, 1), mesh: m, peer: peer, ref: ref, owner: owner, dirty: make(chan struct{}, 1), updates: make(chan ttyapi.Update, 1), done: make(chan struct{})}
 	m.mu.Lock()
 	if m.closed || len(m.views) >= maxMounts {
 		m.mu.Unlock()
@@ -380,6 +382,13 @@ func (m *meshService) attach(ctx context.Context, ref string, owner pid.PID) (tt
 		return nil, err
 	}
 	v.mu.Lock()
+	select {
+	case <-v.done:
+		v.mu.Unlock()
+		m.wg.Done()
+		return nil, ttyapi.ErrMountExpired
+	default:
+	}
 	v.rights = reply.Rights
 	v.snapshot = reply.Snapshot
 	v.mu.Unlock()
@@ -419,6 +428,7 @@ func (m *meshService) close() {
 
 type remoteViewport struct {
 	updates  chan ttyapi.Update
+	callGate chan struct{}
 	done     chan struct{}
 	dirty    chan struct{}
 	mesh     *meshService
@@ -428,7 +438,6 @@ type remoteViewport struct {
 	snapshot ttyapi.Snapshot
 	seq      uint64
 	once     sync.Once
-	callMu   sync.Mutex
 	mu       sync.Mutex
 	rights   ttyapi.MountRights
 }
@@ -463,8 +472,16 @@ func (v *remoteViewport) Snapshot() ttyapi.Snapshot {
 	return v.snapshot
 }
 func (v *remoteViewport) call(ctx context.Context, f wireFrame) (wireFrame, error) {
-	v.callMu.Lock()
-	defer v.callMu.Unlock()
+	select {
+	case v.callGate <- struct{}{}:
+		defer func() { <-v.callGate }()
+	case <-ctx.Done():
+		return wireFrame{}, ctx.Err()
+	case <-v.done:
+		return wireFrame{}, ttyapi.ErrMountExpired
+	case <-v.mesh.done:
+		return wireFrame{}, ttyapi.ErrServiceUnavailable
+	}
 	if err := ctx.Err(); err != nil {
 		return wireFrame{}, err
 	}
@@ -477,7 +494,7 @@ func (v *remoteViewport) call(ctx context.Context, f wireFrame) (wireFrame, erro
 	f.Seq = v.seq
 	f.Ref = v.ref
 	f.Caller = v.owner
-	return v.mesh.rpc(ctx, v.peer, f)
+	return v.mesh.rpc(ctx, v.peer, f, v.done)
 }
 func (v *remoteViewport) Send(e ttyapi.Event) error { return v.send(context.Background(), e) }
 func (v *remoteViewport) SendContext(ctx context.Context, e ttyapi.Event) error {

--- a/system/tty/mesh.go
+++ b/system/tty/mesh.go
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/runtime"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+const (
+	wireVersion    = 1
+	maxWireBytes   = 512 << 10
+	maxMeshPending = 128
+	meshTimeout    = 5 * time.Second
+)
+
+const (
+	opAttach uint8 = iota + 1
+	opSnapshot
+	opInput
+	opResize
+	opPing
+	opRelease
+	opNotify
+	opClosed
+	opReply
+)
+
+// Sequence numbers are per attachment, not per TCP connection. Internode can
+// replay a partially flushed batch after reconnect; input must execute once.
+type wireFrame struct {
+	Caller   pid.PID
+	Ref      string
+	Error    string
+	Snapshot ttyapi.Snapshot
+	Event    ttyapi.Event
+	ID       uint64
+	Seq      uint64
+	Width    int
+	Height   int
+	Rights   ttyapi.MountRights
+	Version  uint8
+	Op       uint8
+}
+type incomingFrame struct {
+	peer  string
+	frame wireFrame
+}
+type pendingFrame struct {
+	reply chan wireFrame
+	peer  string
+	ref   string
+}
+
+type meshService struct {
+	transport ttyapi.MeshTransport
+	views     map[string]*remoteViewport
+	service   *Service
+	requests  chan incomingFrame
+	done      chan struct{}
+	pending   map[uint64]pendingFrame
+	local     string
+	codec     codec.MsgpackHandle
+	wg        sync.WaitGroup
+	next      atomic.Uint64
+	once      sync.Once
+	mu        sync.Mutex
+	closed    bool
+}
+
+// SetMesh installs the optional transport before the broker is exposed to
+// processes. Local-only boot retains the zero-goroutine service.
+func (s *Service) SetMesh(local string, transport ttyapi.MeshTransport) error {
+	if local == "" || transport == nil {
+		return ttyapi.ErrServiceUnavailable
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.mesh != nil {
+		return ttyapi.ErrServiceUnavailable
+	}
+	m := &meshService{service: s, transport: transport, local: local, requests: make(chan incomingFrame, 128), done: make(chan struct{}), pending: make(map[uint64]pendingFrame), views: make(map[string]*remoteViewport)}
+	m.codec.WriteExt = true
+	m.codec.MaxInitLen = 1024
+	if err := transport.Receive(m.receive); err != nil {
+		return err
+	}
+	s.mesh = m
+	for range 4 {
+		m.wg.Add(1)
+		go m.worker()
+	}
+	return nil
+}
+func (m *meshService) send(peer string, f wireFrame) error {
+	f.Version = wireVersion
+	var b bytes.Buffer
+	if err := codec.NewEncoder(&b, &m.codec).Encode(f); err != nil {
+		return err
+	}
+	if b.Len() > maxWireBytes {
+		return ttyapi.ErrMeshProtocol
+	}
+	return m.transport.Send(peer, b.Bytes())
+}
+func (m *meshService) receive(peer string, data []byte) {
+	if len(data) == 0 || len(data) > maxWireBytes {
+		return
+	}
+	select {
+	case <-m.done:
+		return
+	default:
+	}
+	var f wireFrame
+	if err := codec.NewDecoderBytes(data, &m.codec).Decode(&f); err != nil || f.Version != wireVersion || len(f.Ref) > 512 {
+		return
+	}
+	switch f.Op {
+	case opReply:
+		m.mu.Lock()
+		p, ok := m.pending[f.ID]
+		m.mu.Unlock()
+		if ok && p.peer == peer && p.ref == f.Ref {
+			select {
+			case p.reply <- f:
+			default:
+			}
+		}
+	case opNotify, opClosed:
+		m.mu.Lock()
+		v := m.views[f.Ref]
+		m.mu.Unlock()
+		if v == nil || v.peer != peer {
+			return
+		}
+		if f.Op == opClosed {
+			v.finish(false)
+			return
+		}
+		select {
+		case v.dirty <- struct{}{}:
+		default:
+		}
+	default:
+		select {
+		case m.requests <- incomingFrame{peer: peer, frame: f}:
+		case <-m.done:
+		default:
+			// Bounded admission. A caller times out and closes its attachment; the
+			// connection reader never waits for a slow actor or a terminal consumer.
+		}
+	}
+}
+func (m *meshService) worker() {
+	defer m.wg.Done()
+	for {
+		select {
+		case <-m.done:
+			return
+		case request := <-m.requests:
+			m.handle(request.peer, request.frame)
+		}
+	}
+}
+func wireError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ttyapi.ErrPermissionDenied):
+		return "permission"
+	case errors.Is(err, ttyapi.ErrInputInactive):
+		return "inactive"
+	case errors.Is(err, ttyapi.ErrInvalidViewportSize):
+		return "size"
+	default:
+		return "closed"
+	}
+}
+func fromWireError(code string) error {
+	switch code {
+	case "":
+		return nil
+	case "permission":
+		return ttyapi.ErrPermissionDenied
+	case "inactive":
+		return ttyapi.ErrInputInactive
+	case "size":
+		return ttyapi.ErrInvalidViewportSize
+	default:
+		return ttyapi.ErrMountExpired
+	}
+}
+func (m *meshService) handle(peer string, f wireFrame) {
+	reply := wireFrame{Op: opReply, Ref: f.Ref, ID: f.ID, Seq: f.Seq}
+	s := m.service
+	s.mu.Lock()
+	record := s.mounts[f.Ref]
+	s.mu.Unlock()
+	if record == nil || peer != record.recipient.Node || !samePID(f.Caller, record.recipient) {
+		reply.Error = "permission"
+		_ = m.send(peer, reply)
+		return
+	}
+	if f.Op == opRelease {
+		s.removeMount(f.Ref)
+		return
+	}
+	record.mu.Lock()
+	select {
+	case <-record.done:
+		record.mu.Unlock()
+		reply.Error = "closed"
+		_ = m.send(peer, reply)
+		return
+	default:
+	}
+	if f.Seq == record.lastSeq && f.ID == record.lastReply.ID && record.lastSeq != 0 {
+		reply = record.lastReply
+		record.mu.Unlock()
+		_ = m.send(peer, reply)
+		return
+	}
+	if f.Seq != record.lastSeq+1 || (record.attached && f.Op == opAttach) || (!record.attached && f.Op != opAttach) {
+		record.mu.Unlock()
+		reply.Error = "closed"
+		_ = m.send(peer, reply)
+		return
+	}
+	var err error
+	startPump := false
+	switch f.Op {
+	case opAttach:
+		record.attached = true
+		reply.Rights = record.rights
+		if record.rights.Observe {
+			reply.Snapshot = record.view.Snapshot()
+			startPump = true
+		}
+	case opSnapshot:
+		if !record.rights.Observe {
+			err = ttyapi.ErrPermissionDenied
+		} else {
+			reply.Snapshot = record.view.Snapshot()
+			select {
+			case record.ack <- struct{}{}:
+			default:
+			}
+		}
+	case opInput:
+		if len(f.Event.Paste) > 64<<10 || len(f.Event.Key) > 256 {
+			err = ttyapi.ErrMeshProtocol
+		} else {
+			err = record.view.Send(f.Event)
+		}
+	case opResize:
+		err = record.view.Resize(f.Width, f.Height)
+	case opPing:
+	default:
+		err = ttyapi.ErrMeshProtocol
+	}
+	reply.Error = wireError(err)
+	record.lastSeq = f.Seq
+	record.lastReply = reply
+	record.timer.Reset(mountLease)
+	record.mu.Unlock()
+	if err := m.send(peer, reply); err != nil {
+		s.removeMount(f.Ref)
+		return
+	}
+	if startPump {
+		m.wg.Add(1)
+		go m.watch(record)
+	}
+}
+func (m *meshService) watch(record *mountRecord) {
+	defer m.wg.Done()
+	defer func() { _ = m.send(record.recipient.Node, wireFrame{Op: opClosed, Ref: record.ref}) }()
+	for {
+		select {
+		case <-m.done:
+			return
+		case <-record.done:
+			return
+		case _, ok := <-record.view.Updates():
+			if !ok {
+				return
+			}
+			if err := m.send(record.recipient.Node, wireFrame{Op: opNotify, Ref: record.ref}); err != nil {
+				m.service.removeMount(record.ref)
+				return
+			}
+			// One outstanding notification per mount. Intermediate presents coalesce
+			// in the broker, so a slow observer never queues a history of screen frames.
+			select {
+			case <-record.ack:
+			case <-record.done:
+				return
+			case <-m.done:
+				return
+			}
+		}
+	}
+}
+func (m *meshService) rpc(ctx context.Context, peer string, f wireFrame) (wireFrame, error) {
+	if err := ctx.Err(); err != nil {
+		return wireFrame{}, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, meshTimeout)
+	defer cancel()
+	f.ID = m.next.Add(1)
+	p := pendingFrame{peer: peer, ref: f.Ref, reply: make(chan wireFrame, 1)}
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return wireFrame{}, ttyapi.ErrServiceUnavailable
+	}
+	if len(m.pending) >= maxMeshPending {
+		m.mu.Unlock()
+		return wireFrame{}, ttyapi.ErrMeshBusy
+	}
+	m.pending[f.ID] = p
+	m.mu.Unlock()
+	defer func() { m.mu.Lock(); delete(m.pending, f.ID); m.mu.Unlock() }()
+	if err := m.send(peer, f); err != nil {
+		return wireFrame{}, err
+	}
+	select {
+	case reply := <-p.reply:
+		return reply, fromWireError(reply.Error)
+	case <-ctx.Done():
+		return wireFrame{}, ctx.Err()
+	case <-m.done:
+		return wireFrame{}, ttyapi.ErrServiceUnavailable
+	}
+}
+func (m *meshService) attach(ctx context.Context, ref string, owner pid.PID) (ttyapi.Viewport, error) {
+	peer, err := mountNode(ref)
+	if err != nil {
+		return nil, err
+	}
+	if checker, ok := m.transport.(ttyapi.MeshPeerChecker); ok {
+		if err := checker.CheckPeer(peer); err != nil {
+			return nil, err
+		}
+	}
+	// A remote node may attest only processes hosted on itself. Never forward
+	// an arbitrary caller PID obtained from a Lua argument or a relay payload.
+	if owner.Node != m.local || owner.Host == "" || owner.UniqID == "" {
+		return nil, ttyapi.ErrPermissionDenied
+	}
+	v := &remoteViewport{mesh: m, peer: peer, ref: ref, owner: owner, dirty: make(chan struct{}, 1), updates: make(chan ttyapi.Update, 1), done: make(chan struct{})}
+	m.mu.Lock()
+	if m.closed || len(m.views) >= maxMounts {
+		m.mu.Unlock()
+		return nil, ttyapi.ErrMeshBusy
+	}
+	if m.views[ref] != nil {
+		m.mu.Unlock()
+		return nil, ttyapi.ErrInvalidGrant
+	}
+	m.views[ref] = v
+	// Own the goroutine before releasing the lifecycle lock; Close can safely
+	// Wait even when an attachment is still awaiting its first response.
+	m.wg.Add(1)
+	m.mu.Unlock()
+	reply, err := v.call(ctx, wireFrame{Op: opAttach})
+	if err != nil {
+		v.finish(true)
+		m.wg.Done()
+		return nil, err
+	}
+	v.mu.Lock()
+	v.rights = reply.Rights
+	v.snapshot = reply.Snapshot
+	v.mu.Unlock()
+	go func() { defer m.wg.Done(); v.run() }()
+	return v, nil
+}
+func (m *meshService) closeOwner(owner pid.PID) {
+	m.mu.Lock()
+	var views []*remoteViewport
+	for _, v := range m.views {
+		if samePID(v.owner, owner) {
+			views = append(views, v)
+		}
+	}
+	m.mu.Unlock()
+	for _, v := range views {
+		v.finish(true)
+	}
+}
+func (m *meshService) close() {
+	m.once.Do(func() {
+		m.mu.Lock()
+		m.closed = true
+		close(m.done)
+		views := make([]*remoteViewport, 0, len(m.views))
+		for _, v := range m.views {
+			views = append(views, v)
+		}
+		m.mu.Unlock()
+		for _, v := range views {
+			v.finish(true)
+		}
+		m.wg.Wait()
+		_ = m.transport.Receive(nil)
+	})
+}
+
+type remoteViewport struct {
+	updates  chan ttyapi.Update
+	done     chan struct{}
+	dirty    chan struct{}
+	mesh     *meshService
+	owner    pid.PID
+	ref      string
+	peer     string
+	snapshot ttyapi.Snapshot
+	seq      uint64
+	once     sync.Once
+	callMu   sync.Mutex
+	mu       sync.Mutex
+	rights   ttyapi.MountRights
+}
+
+func (v *remoteViewport) Grant() string                 { return "" }
+func (v *remoteViewport) Handle() string                { return v.ref }
+func (v *remoteViewport) Updates() <-chan ttyapi.Update { return v.updates }
+func (v *remoteViewport) Check(ctx context.Context, right string) error {
+	owner, ok := runtime.GetFramePID(ctx)
+	v.mu.Lock()
+	allowed := right == "" || hasRight(v.rights, right)
+	v.mu.Unlock()
+	if !ok || !samePID(owner, v.owner) || !allowed {
+		return ttyapi.ErrPermissionDenied
+	}
+	if right == "" {
+		return nil
+	}
+	select {
+	case <-v.done:
+		return ttyapi.ErrMountExpired
+	default:
+		return nil
+	}
+}
+func (v *remoteViewport) Snapshot() ttyapi.Snapshot {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if !v.rights.Observe {
+		return ttyapi.Snapshot{}
+	}
+	return v.snapshot
+}
+func (v *remoteViewport) call(ctx context.Context, f wireFrame) (wireFrame, error) {
+	v.callMu.Lock()
+	defer v.callMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return wireFrame{}, err
+	}
+	select {
+	case <-v.done:
+		return wireFrame{}, ttyapi.ErrMountExpired
+	default:
+	}
+	v.seq++
+	f.Seq = v.seq
+	f.Ref = v.ref
+	f.Caller = v.owner
+	return v.mesh.rpc(ctx, v.peer, f)
+}
+func (v *remoteViewport) Send(e ttyapi.Event) error { return v.send(context.Background(), e) }
+func (v *remoteViewport) SendContext(ctx context.Context, e ttyapi.Event) error {
+	if err := v.Check(ctx, ttyapi.RightInput); err != nil {
+		return err
+	}
+	return v.send(ctx, e)
+}
+func (v *remoteViewport) send(ctx context.Context, e ttyapi.Event) error {
+	v.mu.Lock()
+	allowed := v.rights.Input
+	v.mu.Unlock()
+	if !allowed {
+		return ttyapi.ErrPermissionDenied
+	}
+	if e.Type == "resize" {
+		return v.resize(ctx, e.Width, e.Height)
+	}
+	_, err := v.call(ctx, wireFrame{Op: opInput, Event: e})
+	if err != nil && !errors.Is(err, ttyapi.ErrInputInactive) && !errors.Is(err, ttyapi.ErrPermissionDenied) {
+		v.finish(true)
+	}
+	return err
+}
+func (v *remoteViewport) Resize(w, h int) error { return v.resize(context.Background(), w, h) }
+func (v *remoteViewport) ResizeContext(ctx context.Context, w, h int) error {
+	if err := v.Check(ctx, ttyapi.RightResize); err != nil {
+		return err
+	}
+	return v.resize(ctx, w, h)
+}
+func (v *remoteViewport) resize(ctx context.Context, w, h int) error {
+	v.mu.Lock()
+	allowed := v.rights.Resize
+	v.mu.Unlock()
+	if !allowed {
+		return ttyapi.ErrPermissionDenied
+	}
+	if err := ttyapi.ValidateViewportSize(w, h); err != nil {
+		return err
+	}
+	_, err := v.call(ctx, wireFrame{Op: opResize, Width: w, Height: h})
+	if err != nil {
+		v.finish(true)
+	}
+	return err
+}
+func (v *remoteViewport) run() {
+	ticker := time.NewTicker(mountLease / 3)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-v.done:
+			return
+		case <-v.mesh.done:
+			v.finish(false)
+			return
+		case <-ticker.C:
+			if _, err := v.call(context.Background(), wireFrame{Op: opPing}); err != nil {
+				v.finish(true)
+				return
+			}
+		case <-v.dirty:
+			reply, err := v.call(context.Background(), wireFrame{Op: opSnapshot})
+			if err != nil {
+				v.finish(true)
+				return
+			}
+			v.mu.Lock()
+			select {
+			case <-v.done:
+				v.mu.Unlock()
+				return
+			default:
+			}
+			if reply.Snapshot.Revision >= v.snapshot.Revision {
+				v.snapshot = reply.Snapshot
+				publishLatest(v.updates, ttyapi.Update{Revision: v.snapshot.Revision})
+			}
+			v.mu.Unlock()
+		}
+	}
+}
+func (v *remoteViewport) finish(release bool) {
+	v.once.Do(func() {
+		v.mu.Lock()
+		close(v.done)
+		close(v.updates)
+		v.snapshot = ttyapi.Snapshot{}
+		v.mu.Unlock()
+		v.mesh.mu.Lock()
+		if v.mesh.views[v.ref] == v {
+			delete(v.mesh.views, v.ref)
+		}
+		v.mesh.mu.Unlock()
+		if release {
+			_ = v.mesh.send(v.peer, wireFrame{Op: opRelease, Ref: v.ref, Caller: v.owner})
+		}
+	})
+}
+func (v *remoteViewport) Close() error { v.finish(true); return nil }

--- a/system/tty/mesh_bench_test.go
+++ b/system/tty/mesh_bench_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/runtime"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func BenchmarkMeshSnapshotFanout(b *testing.B) {
+	for _, count := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("observers=%d", count), func(b *testing.B) {
+			a, peer, ta, tb := meshFixture(b)
+			owner, _ := meshContext(b, a, "a", "owner")
+			view, err := a.Create(owner, 120, 40)
+			require.NoError(b, err)
+			binding, err := a.Binding(view.Grant())
+			require.NoError(b, err)
+			port, err := binding.Resolve(owner)
+			require.NoError(b, err)
+			surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+			require.NoError(b, err)
+			views := make([]ttyapi.Viewport, 0, count)
+			for i := range count {
+				agent, _ := meshContext(b, peer, "b", strconv.Itoa(i))
+				target, _ := runtime.GetFramePID(agent)
+				ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+				require.NoError(b, err)
+				remote, err := peer.Attach(agent, ref)
+				require.NoError(b, err)
+				views = append(views, remote)
+			}
+			before := ta.sent.Load() + tb.sent.Load()
+			rows := make([]string, 40)
+			fill := strings.Repeat("x", 120)
+			for i := range rows {
+				rows[i] = fill
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := range b.N {
+				rows[0] = strconv.Itoa(i) + fill[20:]
+				if _, err := surface.Present(ttyapi.Frame{Rows: rows}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			revision := view.Snapshot().Revision
+			require.Eventually(b, func() bool {
+				for _, v := range views {
+					if v.Snapshot().Revision != revision {
+						return false
+					}
+				}
+				return true
+			}, time.Second, time.Millisecond)
+			b.ReportMetric(float64(ta.sent.Load()+tb.sent.Load()-before)/float64(b.N), "wire_frames/present")
+		})
+	}
+}
+
+func BenchmarkRemoteCachedSnapshot(b *testing.B) {
+	a, peer, _, _ := meshFixture(b)
+	owner, _ := meshContext(b, a, "a", "owner")
+	agent, _ := meshContext(b, peer, "b", "agent")
+	view, err := a.Create(owner, 120, 40)
+	require.NoError(b, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+	require.NoError(b, err)
+	remote, err := peer.Attach(agent, ref)
+	require.NoError(b, err)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = remote.Snapshot()
+	}
+}

--- a/system/tty/mount.go
+++ b/system/tty/mount.go
@@ -141,8 +141,17 @@ func (m *mountRecord) close() {
 		m.mu.Lock()
 		m.timer.Stop()
 		close(m.done)
+		attached := m.attached
 		m.mu.Unlock()
 		_ = m.view.Close()
+		m.service.mu.Lock()
+		mesh := m.service.mesh
+		m.service.mu.Unlock()
+		// Revocation is independent of observation: input-only mounts have no
+		// snapshot pump, but must learn of owner exit without waiting for a ping.
+		if attached && mesh != nil && m.recipient.Node != mesh.local {
+			_ = mesh.send(m.recipient.Node, wireFrame{Op: opClosed, Ref: m.ref})
+		}
 	})
 }
 func (s *Service) revokeIssuer(v *viewport) {

--- a/system/tty/mount.go
+++ b/system/tty/mount.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/security"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+const maxMounts = 128
+const mountLease = 30 * time.Second
+
+// A reference is only a lookup key. Authority remains in this owner-side
+// record, bound to the exact recipient process and authenticated peer.
+type mountRecord struct {
+	done      chan struct{}
+	issuer    *viewport
+	view      *viewport
+	service   *Service
+	timer     *time.Timer
+	ack       chan struct{}
+	recipient pid.PID
+	ref       string
+	lastReply wireFrame
+	lastSeq   uint64
+	once      sync.Once
+	mu        sync.Mutex
+	rights    ttyapi.MountRights
+	attached  bool
+}
+
+func samePID(a, b pid.PID) bool { return a.Node == b.Node && a.Host == b.Host && a.UniqID == b.UniqID }
+func hasRight(r ttyapi.MountRights, right string) bool {
+	switch right {
+	case ttyapi.RightObserve:
+		return r.Observe
+	case ttyapi.RightInput:
+		return r.Input
+	case ttyapi.RightResize:
+		return r.Resize
+	}
+	return false
+}
+func isMountRef(ref string) bool { return strings.HasPrefix(ref, "ttym1.") }
+func mountNode(ref string) (string, error) {
+	parts := strings.Split(ref, ".")
+	if len(parts) != 3 || parts[0] != "ttym1" || len(parts[2]) != 32 {
+		return "", ttyapi.ErrInvalidGrant
+	}
+	b, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || len(b) == 0 || len(b) > 255 {
+		return "", ttyapi.ErrInvalidGrant
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(parts[2]); err != nil {
+		return "", ttyapi.ErrInvalidGrant
+	}
+	return string(b), nil
+}
+
+func (v *viewport) Mount(ctx context.Context, recipient pid.PID, rights ttyapi.MountRights) (string, error) {
+	owner, ok := runtime.GetFramePID(ctx)
+	if !ok || !samePID(owner, v.owner) || !samePID(owner, v.session.creator) || v.producerGrant == "" ||
+		!security.IsAllowed(ctx, "tty.mount", v.Handle(), nil) {
+		return "", ttyapi.ErrPermissionDenied
+	}
+	if recipient.Node == "" || recipient.Host == "" || recipient.UniqID == "" || (!rights.Observe && !rights.Input && !rights.Resize) {
+		return "", ttyapi.ErrInvalidGrant
+	}
+	for _, right := range []string{ttyapi.RightObserve, ttyapi.RightInput, ttyapi.RightResize} {
+		if hasRight(rights, right) && (!hasRight(v.rights, right) || !security.IsAllowed(ctx, right, v.Handle(), nil)) {
+			return "", ttyapi.ErrPermissionDenied
+		}
+	}
+	key, err := token("")
+	if err != nil {
+		return "", err
+	}
+	ref := "ttym1." + base64.RawURLEncoding.EncodeToString([]byte(v.owner.Node)) + "." + key
+	s := v.session.service
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || v.closed.Load() {
+		return "", ttyapi.ErrViewportClosed
+	}
+	if len(s.mounts) >= maxMounts {
+		return "", ttyapi.ErrMeshBusy
+	}
+	ss := v.session
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	if ss.closed {
+		return "", ttyapi.ErrViewportClosed
+	}
+	ss.viewers[recipient]++
+	child := ss.newViewportLocked(recipient, "")
+	child.rights = rights
+	m := &mountRecord{service: s, issuer: v, view: child, recipient: recipient, rights: rights, ref: ref, done: make(chan struct{}), ack: make(chan struct{}, 1)}
+	// Timer setup is serialized with close by the service lock: the callback
+	// removes the record before closing it, and cannot run until insertion ends.
+	m.timer = time.AfterFunc(mountLease, func() { s.removeMount(ref) })
+	s.mounts[ref] = m
+	return ref, nil
+}
+
+func (v *viewport) Revoke(ctx context.Context, ref string) error {
+	owner, ok := runtime.GetFramePID(ctx)
+	if !ok || !samePID(owner, v.owner) {
+		return ttyapi.ErrPermissionDenied
+	}
+	s := v.session.service
+	s.mu.Lock()
+	m := s.mounts[ref]
+	if m == nil || m.issuer != v {
+		s.mu.Unlock()
+		return ttyapi.ErrInvalidGrant
+	}
+	delete(s.mounts, ref)
+	s.mu.Unlock()
+	m.close()
+	return nil
+}
+func (s *Service) removeMount(ref string) {
+	s.mu.Lock()
+	m := s.mounts[ref]
+	delete(s.mounts, ref)
+	s.mu.Unlock()
+	if m != nil {
+		m.close()
+	}
+}
+func (m *mountRecord) close() {
+	m.once.Do(func() {
+		m.mu.Lock()
+		m.timer.Stop()
+		close(m.done)
+		m.mu.Unlock()
+		_ = m.view.Close()
+	})
+}
+func (s *Service) revokeIssuer(v *viewport) {
+	s.mu.Lock()
+	var revoked []*mountRecord
+	for ref, m := range s.mounts {
+		if m.issuer == v {
+			revoked = append(revoked, m)
+			delete(s.mounts, ref)
+		}
+	}
+	s.mu.Unlock()
+	for _, m := range revoked {
+		m.close()
+	}
+}
+func (s *Service) closeOwnerMounts(owner pid.PID) {
+	s.mu.Lock()
+	var revoked []*mountRecord
+	for ref, m := range s.mounts {
+		if samePID(owner, m.issuer.owner) || samePID(owner, m.recipient) {
+			revoked = append(revoked, m)
+			delete(s.mounts, ref)
+		}
+	}
+	mesh := s.mesh
+	s.mu.Unlock()
+	for _, m := range revoked {
+		m.close()
+	}
+	if mesh != nil {
+		mesh.closeOwner(owner)
+	}
+}
+func (s *Service) IsRemote(ref string) bool {
+	node, err := mountNode(ref)
+	if err != nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mesh != nil && node != s.mesh.local
+}
+func (s *Service) attachMount(ctx context.Context, ref string) (ttyapi.Viewport, error) {
+	node, err := mountNode(ref)
+	if err != nil {
+		return nil, err
+	}
+	owner, ok := runtime.GetFramePID(ctx)
+	if !ok {
+		return nil, ttyapi.ErrPermissionDenied
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ttyapi.ErrServiceUnavailable
+	}
+	mesh := s.mesh
+	if mesh != nil && node != mesh.local {
+		s.mu.Unlock()
+		return mesh.attach(ctx, ref, owner)
+	}
+	m := s.mounts[ref]
+	s.mu.Unlock()
+	if m == nil || !samePID(owner, m.recipient) {
+		return nil, ttyapi.ErrPermissionDenied
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	select {
+	case <-m.done:
+		return nil, ttyapi.ErrMountExpired
+	default:
+	}
+	if m.attached {
+		return nil, ttyapi.ErrInvalidGrant
+	}
+	m.attached = true
+	// Local references are frame-owned. A remote mount instead renews a lease.
+	m.timer.Stop()
+	return &mountedViewport{record: m}, nil
+}
+
+type mountedViewport struct{ record *mountRecord }
+
+func (v *mountedViewport) Grant() string  { return "" }
+func (v *mountedViewport) Handle() string { return v.record.ref }
+func (v *mountedViewport) Check(ctx context.Context, right string) error {
+	owner, ok := runtime.GetFramePID(ctx)
+	if !ok || !samePID(owner, v.record.recipient) || (right != "" && !hasRight(v.record.rights, right)) {
+		return ttyapi.ErrPermissionDenied
+	}
+	if right == "" {
+		return nil
+	}
+	select {
+	case <-v.record.done:
+		return ttyapi.ErrMountExpired
+	default:
+		return nil
+	}
+}
+func (v *mountedViewport) Snapshot() ttyapi.Snapshot {
+	select {
+	case <-v.record.done:
+		return ttyapi.Snapshot{}
+	default:
+		return v.record.view.Snapshot()
+	}
+}
+func (v *mountedViewport) Updates() <-chan ttyapi.Update { return v.record.view.Updates() }
+func (v *mountedViewport) Send(e ttyapi.Event) error     { return v.record.view.Send(e) }
+func (v *mountedViewport) Resize(w, h int) error         { return v.record.view.Resize(w, h) }
+func (v *mountedViewport) Close() error                  { v.record.service.removeMount(v.record.ref); return nil }

--- a/system/tty/mount.go
+++ b/system/tty/mount.go
@@ -118,7 +118,11 @@ func (v *viewport) Revoke(ctx context.Context, ref string) error {
 	s := v.session.service
 	s.mu.Lock()
 	m := s.mounts[ref]
-	if m == nil || m.issuer != v {
+	if m == nil {
+		s.mu.Unlock()
+		return nil // Recipient EXIT or an earlier revoke already removed this mount.
+	}
+	if m.issuer != v {
 		s.mu.Unlock()
 		return ttyapi.ErrInvalidGrant
 	}

--- a/system/tty/mount_test.go
+++ b/system/tty/mount_test.go
@@ -129,7 +129,7 @@ func (t *testSurfaceTransport) Send(peer string, b []byte) error {
 	}
 	return nil
 }
-func meshFixture(t *testing.T) (*Service, *Service, *testSurfaceTransport, *testSurfaceTransport) {
+func meshFixture(t testing.TB) (*Service, *Service, *testSurfaceTransport, *testSurfaceTransport) {
 	t.Helper()
 	n := &testSurfaceNetwork{}
 	a, b := NewService(), NewService()
@@ -139,7 +139,7 @@ func meshFixture(t *testing.T) (*Service, *Service, *testSurfaceTransport, *test
 	t.Cleanup(func() { require.NoError(t, a.Close()); require.NoError(t, b.Close()) })
 	return a, b, ta, tb
 }
-func meshContext(t *testing.T, s *Service, node, id string) (context.Context, *inbox) {
+func meshContext(t testing.TB, s *Service, node, id string) (context.Context, *inbox) {
 	t.Helper()
 	ctx := ttyapi.WithService(ctxapi.NewRootContext(), s)
 	relayNode := relaysys.NewNode(node)
@@ -258,6 +258,11 @@ func TestInputOnlyMountCannotReadSnapshot(t *testing.T) {
 	require.Empty(t, remote.Snapshot().Rows)
 	require.Zero(t, remote.Snapshot().Width)
 	require.ErrorIs(t, remote.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve), ttyapi.ErrPermissionDenied)
+	ownerPID, _ := runtime.GetFramePID(owner)
+	a.OnComplete(owner, ownerPID, nil)
+	require.Eventually(t, func() bool {
+		return remote.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightInput) != nil
+	}, time.Second, time.Millisecond, "input-only mounts must be notified on owner exit")
 	require.NoError(t, remote.Close())
 }
 
@@ -280,4 +285,149 @@ func TestMeshMountLeaseExpiryClosesObservation(t *testing.T) {
 	record.mu.Unlock()
 	require.Eventually(t, func() bool { return remote.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve) != nil }, time.Second, time.Millisecond)
 	require.Zero(t, remote.Snapshot().Width)
+}
+
+func TestRemoteCloseInterruptsOutstandingAndQueuedCalls(t *testing.T) {
+	for _, closeKind := range []string{"viewport", "owner", "service"} {
+		t.Run(closeKind, func(t *testing.T) {
+			a, b, _, tb := meshFixture(t)
+			owner, _ := meshContext(t, a, "a", "owner")
+			agent, _ := meshContext(t, b, "b", "agent")
+			view, err := a.Create(owner, 80, 24)
+			require.NoError(t, err)
+			target, _ := runtime.GetFramePID(agent)
+			ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+			require.NoError(t, err)
+			mounted, err := b.Attach(agent, ref)
+			require.NoError(t, err)
+			remote := mounted.(*remoteViewport)
+			tb.drop.Store(true)
+			results := make(chan error, 2)
+			call := func() {
+				_, err := remote.call(context.Background(), wireFrame{Op: opPing})
+				results <- err
+			}
+			go call()
+			require.Eventually(t, func() bool {
+				b.mesh.mu.Lock()
+				defer b.mesh.mu.Unlock()
+				return len(b.mesh.pending) == 1
+			}, time.Second, time.Millisecond)
+			go call()
+			switch closeKind {
+			case "viewport":
+				require.NoError(t, remote.Close())
+			case "owner":
+				b.mesh.closeOwner(target)
+			case "service":
+				require.NoError(t, b.Close())
+			}
+			for range 2 {
+				select {
+				case err := <-results:
+					require.Error(t, err)
+				case <-time.After(time.Second):
+					t.Fatal("close waited for the remote RPC timeout")
+				}
+			}
+			b.mesh.mu.Lock()
+			require.Empty(t, b.mesh.pending)
+			b.mesh.mu.Unlock()
+			require.Zero(t, remote.Snapshot().Width)
+		})
+	}
+}
+
+func TestRemoteQueuedCallHonorsCancellation(t *testing.T) {
+	a, b, _, tb := meshFixture(t)
+	owner, _ := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+	require.NoError(t, err)
+	mounted, err := b.Attach(agent, ref)
+	require.NoError(t, err)
+	remote := mounted.(*remoteViewport)
+	defer remote.Close()
+	tb.drop.Store(true)
+	first := make(chan error, 1)
+	go func() {
+		_, err := remote.call(context.Background(), wireFrame{Op: opPing})
+		first <- err
+	}()
+	require.Eventually(t, func() bool {
+		b.mesh.mu.Lock()
+		defer b.mesh.mu.Unlock()
+		return len(b.mesh.pending) == 1
+	}, time.Second, time.Millisecond)
+	ctx, cancel := context.WithCancel(agent)
+	cancel()
+	second := make(chan error, 1)
+	go func() { _, err := remote.call(ctx, wireFrame{Op: opPing}); second <- err }()
+	select {
+	case err := <-second:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("cancelled call waited behind an unresponsive peer")
+	}
+	require.NoError(t, remote.Close())
+	select {
+	case err := <-first:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("outstanding call did not exit")
+	}
+}
+
+func TestStalledPeerDoesNotBlockHealthySurface(t *testing.T) {
+	a, b, ta, _ := meshFixture(t)
+	c := NewService()
+	tc := ta.network.node("c")
+	require.NoError(t, c.SetMesh("c", tc))
+	defer c.Close()
+	owner, _ := meshContext(t, a, "a", "owner")
+	healthy, _ := meshContext(t, b, "b", "healthy")
+	stalled, _ := meshContext(t, c, "c", "stalled")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	binding, err := a.Binding(view.Grant())
+	require.NoError(t, err)
+	port, err := binding.Resolve(owner)
+	require.NoError(t, err)
+	surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	mount := func(ctx context.Context, service *Service) *remoteViewport {
+		target, _ := runtime.GetFramePID(ctx)
+		ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+		require.NoError(t, err)
+		remote, err := service.Attach(ctx, ref)
+		require.NoError(t, err)
+		return remote.(*remoteViewport)
+	}
+	good, bad := mount(healthy, b), mount(stalled, c)
+	defer good.Close()
+	defer bad.Close()
+	tc.drop.Store(true)
+	blocked := make(chan error, 1)
+	go func() { _, err := bad.call(context.Background(), wireFrame{Op: opPing}); blocked <- err }()
+	require.Eventually(t, func() bool { c.mesh.mu.Lock(); defer c.mesh.mu.Unlock(); return len(c.mesh.pending) == 1 }, time.Second, time.Millisecond)
+	for range 1000 {
+		_, err = surface.Present(ttyapi.Frame{Rows: []string{"healthy remains responsive"}})
+		require.NoError(t, err)
+	}
+	require.Eventually(t, func() bool {
+		s := good.Snapshot()
+		return len(s.Rows) == 1 && s.Rows[0] == "healthy remains responsive"
+	}, time.Second, time.Millisecond)
+	require.NoError(t, bad.Close())
+	select {
+	case err := <-blocked:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("stalled peer did not close")
+	}
+	// Releasing the stalled consumer must not revoke another peer's authority.
+	require.NoError(t, good.Check(healthy, ttyapi.RightObserve))
 }

--- a/system/tty/mount_test.go
+++ b/system/tty/mount_test.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/security"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	relaysys "github.com/wippyai/runtime/system/relay"
+	securitysys "github.com/wippyai/runtime/system/security"
+)
+
+type ttyTestPolicy map[string]bool
+
+func (ttyTestPolicy) ID() registry.ID { return registry.NewID("test", "tty") }
+func (p ttyTestPolicy) Evaluate(_ security.Actor, action, _ string, _ attrs.Bag) security.Result {
+	if p[action] {
+		return security.Allow
+	}
+	return security.Deny
+}
+func allowTTY(ctx context.Context, t testing.TB, actions ...string) {
+	t.Helper()
+	p := ttyTestPolicy{}
+	for _, action := range actions {
+		p[action] = true
+	}
+	require.NoError(t, security.SetActor(ctx, security.Actor{ID: "test"}))
+	require.NoError(t, security.SetScope(ctx, securitysys.NewScope([]security.Policy{p})))
+}
+
+func TestMountPermissionsRecipientAndRevocation(t *testing.T) {
+	s := NewService()
+	defer s.Close()
+	ctx, frame, _ := processContextFor(t, s, "owner")
+	defer frame.Close()
+	agent, af, _ := processContextFor(t, s, "agent")
+	defer af.Close()
+	stranger, sf, _ := processContextFor(t, s, "stranger")
+	defer sf.Close()
+	allowTTY(stranger, t)
+	v, err := s.Create(ctx, 80, 24)
+	require.NoError(t, err)
+	_, err = s.Attach(stranger, v.Handle())
+	require.ErrorIs(t, err, ttyapi.ErrPermissionDenied, "a handle is not observe authority")
+	target, _ := runtime.GetFramePID(agent)
+	issuer := v.(ttyapi.MountableViewport)
+	allowTTY(ctx, t, "tty.mount")
+	_, err = issuer.Mount(ctx, target, ttyapi.MountRights{Observe: true})
+	require.ErrorIs(t, err, ttyapi.ErrPermissionDenied)
+	allowTTY(ctx, t, "tty.mount", ttyapi.RightObserve)
+	ref, err := issuer.Mount(ctx, target, ttyapi.MountRights{Observe: true})
+	require.NoError(t, err)
+	_, err = s.Attach(stranger, ref)
+	require.ErrorIs(t, err, ttyapi.ErrPermissionDenied)
+	mounted, err := s.Attach(agent, ref)
+	require.NoError(t, err)
+	require.NoError(t, mounted.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve))
+	require.ErrorIs(t, mounted.(ttyapi.CheckedViewport).Check(stranger, ttyapi.RightObserve), ttyapi.ErrPermissionDenied)
+	require.ErrorIs(t, mounted.Send(ttyapi.Event{Type: "key", Key: "x"}), ttyapi.ErrPermissionDenied)
+	require.ErrorIs(t, mounted.Resize(40, 12), ttyapi.ErrPermissionDenied)
+	_, err = s.Attach(agent, ref)
+	require.ErrorIs(t, err, ttyapi.ErrInvalidGrant)
+	require.NoError(t, issuer.Revoke(ctx, ref))
+	require.ErrorIs(t, mounted.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve), ttyapi.ErrMountExpired)
+	require.Zero(t, mounted.Snapshot().Width)
+	_, open := <-mounted.Updates()
+	require.False(t, open)
+}
+
+type testSurfaceNetwork struct {
+	nodes map[string]*testSurfaceTransport
+	mu    sync.Mutex
+}
+type testSurfaceTransport struct {
+	network   *testSurfaceNetwork
+	receiver  func(string, []byte)
+	local     string
+	sent      atomic.Int64
+	duplicate atomic.Bool
+	drop      atomic.Bool
+}
+
+func (n *testSurfaceNetwork) node(id string) *testSurfaceTransport {
+	if n.nodes == nil {
+		n.nodes = make(map[string]*testSurfaceTransport)
+	}
+	c := &testSurfaceTransport{network: n, local: id}
+	n.nodes[id] = c
+	return c
+}
+func (t *testSurfaceTransport) Receive(fn func(string, []byte)) error {
+	t.network.mu.Lock()
+	t.receiver = fn
+	t.network.mu.Unlock()
+	return nil
+}
+func (t *testSurfaceTransport) Send(peer string, b []byte) error {
+	t.sent.Add(1)
+	if t.drop.Load() {
+		return nil
+	}
+	t.network.mu.Lock()
+	remote := t.network.nodes[peer]
+	var fn func(string, []byte)
+	if remote != nil {
+		fn = remote.receiver
+	}
+	t.network.mu.Unlock()
+	if fn == nil {
+		return ttyapi.ErrServiceUnavailable
+	}
+	fn(t.local, b)
+	if t.duplicate.Load() {
+		fn(t.local, b)
+	}
+	return nil
+}
+func meshFixture(t *testing.T) (*Service, *Service, *testSurfaceTransport, *testSurfaceTransport) {
+	t.Helper()
+	n := &testSurfaceNetwork{}
+	a, b := NewService(), NewService()
+	ta, tb := n.node("a"), n.node("b")
+	require.NoError(t, a.SetMesh("a", ta))
+	require.NoError(t, b.SetMesh("b", tb))
+	t.Cleanup(func() { require.NoError(t, a.Close()); require.NoError(t, b.Close()) })
+	return a, b, ta, tb
+}
+func meshContext(t *testing.T, s *Service, node, id string) (context.Context, *inbox) {
+	t.Helper()
+	ctx := ttyapi.WithService(ctxapi.NewRootContext(), s)
+	relayNode := relaysys.NewNode(node)
+	box := &inbox{packages: make(chan *relay.Package, 8)}
+	require.NoError(t, relayNode.RegisterHost("workers", box))
+	ctx = relay.WithNode(ctx, relayNode)
+	ctx, frame := ctxapi.OpenFrameContext(ctx)
+	require.NoError(t, frame.Set(runtime.FramePIDKey, pid.PID{Node: node, Host: "workers", UniqID: id}))
+	allowTTY(ctx, t, "tty.mount", ttyapi.RightObserve, ttyapi.RightInput, ttyapi.RightResize)
+	t.Cleanup(func() { require.NoError(t, frame.Close()) })
+	return ctx, box
+}
+func TestMeshMountDuplexSnapshotsInputAndDuplicateFrames(t *testing.T) {
+	a, b, ta, tb := meshFixture(t)
+	owner, box := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	binding, err := a.Binding(view.Grant())
+	require.NoError(t, err)
+	port, err := binding.Resolve(owner)
+	require.NoError(t, err)
+	require.NoError(t, port.InputController().Start())
+	surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"ready"}, Cursor: &ttyapi.Cursor{Column: 3, Visible: true}})
+	require.NoError(t, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true, Input: true})
+	require.NoError(t, err)
+	remote, err := b.Attach(agent, ref)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ready"}, remote.Snapshot().Rows)
+	require.Equal(t, 3, remote.Snapshot().Cursor.Column)
+	tb.duplicate.Store(true)
+	ta.duplicate.Store(true)
+	require.NoError(t, remote.(ttyapi.RemoteViewport).SendContext(agent, ttyapi.Event{Type: "paste", Paste: "echo hello"}))
+	select {
+	case pkg := <-box.packages:
+		require.Equal(t, "echo hello", pkg.Messages[0].Payloads[0].Data().(*ttyapi.Event).Paste)
+	case <-time.After(time.Second):
+		t.Fatal("no input")
+	}
+	select {
+	case <-box.packages:
+		t.Fatal("replayed input executed twice")
+	case <-time.After(20 * time.Millisecond):
+	}
+	require.ErrorIs(t, remote.(ttyapi.RemoteViewport).ResizeContext(agent, 40, 12), ttyapi.ErrPermissionDenied)
+	require.ErrorIs(t, remote.(ttyapi.RemoteViewport).SendContext(agent, ttyapi.Event{Type: "resize", Width: 40, Height: 12}), ttyapi.ErrPermissionDenied)
+	for range 1000 {
+		_, err = surface.Present(ttyapi.Frame{Rows: []string{"updated"}})
+		require.NoError(t, err)
+	}
+	require.Eventually(t, func() bool { s := remote.Snapshot(); return len(s.Rows) == 1 && s.Rows[0] == "updated" }, time.Second, time.Millisecond)
+	require.Less(t, ta.sent.Load()+tb.sent.Load(), int64(100), "unchanged frames do not cross the mesh")
+	require.NoError(t, view.(ttyapi.MountableViewport).Revoke(owner, ref))
+	require.Eventually(t, func() bool { return remote.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve) != nil }, time.Second, time.Millisecond)
+	require.Zero(t, remote.Snapshot().Width)
+}
+func TestMeshRejectsWrongPeerAndClaimedProcess(t *testing.T) {
+	a, b, _, tb := meshFixture(t)
+	owner, _ := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	stranger, _ := meshContext(t, b, "b", "stranger")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+	require.NoError(t, err)
+	_, err = b.Attach(stranger, ref)
+	require.ErrorIs(t, err, ttyapi.ErrPermissionDenied)
+	// Forge the recipient in a payload arriving from an unrelated authenticated
+	// peer. It must not redeem or alter the legitimate mount's sequence state.
+	f := wireFrame{Version: wireVersion, Op: opAttach, Ref: ref, Caller: target, ID: 12, Seq: 1}
+	var data []byte
+	require.NoError(t, codec.NewEncoderBytes(&data, &a.mesh.codec).Encode(f))
+	a.mesh.receive("unrelated-peer", data)
+	require.Eventually(t, func() bool { return len(a.mesh.requests) == 0 }, time.Second, time.Millisecond)
+	tb.duplicate.Store(true)
+	remote, err := b.Attach(agent, ref)
+	require.NoError(t, err)
+	require.Equal(t, 80, remote.Snapshot().Width)
+	require.NoError(t, remote.Close())
+}
+func TestMeshCancellationAndCloseReleaseResources(t *testing.T) {
+	a, b, _, tb := meshFixture(t)
+	owner, _ := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+	require.NoError(t, err)
+	tb.drop.Store(true)
+	ctx, cancel := context.WithTimeout(agent, 20*time.Millisecond)
+	defer cancel()
+	_, err = b.Attach(ctx, ref)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	b.mesh.mu.Lock()
+	require.Empty(t, b.mesh.pending)
+	require.Empty(t, b.mesh.views)
+	b.mesh.mu.Unlock()
+}
+func TestInputOnlyMountCannotReadSnapshot(t *testing.T) {
+	a, b, _, _ := meshFixture(t)
+	owner, _ := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Input: true})
+	require.NoError(t, err)
+	remote, err := b.Attach(agent, ref)
+	require.NoError(t, err)
+	require.Empty(t, remote.Snapshot().Rows)
+	require.Zero(t, remote.Snapshot().Width)
+	require.ErrorIs(t, remote.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve), ttyapi.ErrPermissionDenied)
+	require.NoError(t, remote.Close())
+}
+
+func TestMeshMountLeaseExpiryClosesObservation(t *testing.T) {
+	a, b, _, _ := meshFixture(t)
+	owner, _ := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	view, err := a.Create(owner, 80, 24)
+	require.NoError(t, err)
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+	require.NoError(t, err)
+	remote, err := b.Attach(agent, ref)
+	require.NoError(t, err)
+	a.mu.Lock()
+	record := a.mounts[ref]
+	a.mu.Unlock()
+	record.mu.Lock()
+	record.timer.Reset(time.Millisecond)
+	record.mu.Unlock()
+	require.Eventually(t, func() bool { return remote.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve) != nil }, time.Second, time.Millisecond)
+	require.Zero(t, remote.Snapshot().Width)
+}

--- a/system/tty/mount_test.go
+++ b/system/tty/mount_test.go
@@ -75,6 +75,8 @@ func TestMountPermissionsRecipientAndRevocation(t *testing.T) {
 	_, err = s.Attach(agent, ref)
 	require.ErrorIs(t, err, ttyapi.ErrInvalidGrant)
 	require.NoError(t, issuer.Revoke(ctx, ref))
+	require.NoError(t, issuer.Revoke(ctx, ref), "revocation is idempotent after recipient cleanup")
+	require.ErrorIs(t, issuer.Revoke(stranger, ref), ttyapi.ErrPermissionDenied)
 	require.ErrorIs(t, mounted.(ttyapi.CheckedViewport).Check(agent, ttyapi.RightObserve), ttyapi.ErrMountExpired)
 	require.Zero(t, mounted.Snapshot().Width)
 	_, open := <-mounted.Updates()

--- a/system/tty/page.go
+++ b/system/tty/page.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/runtime"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/service/terminal"
+)
+
+func (v *viewport) SetPage(ctx context.Context, page *ttyapi.Page) error {
+	owner, ok := runtime.GetFramePID(ctx)
+	s := v.session
+	if !ok || !samePID(owner, v.owner) || !samePID(owner, s.creator) {
+		return ttyapi.ErrPermissionDenied
+	}
+	var next *ttyapi.Page
+	if page != nil {
+		validated, err := page.Canonical()
+		if err != nil {
+			return err
+		}
+		next = &validated
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || v.closed.Load() {
+		return ttyapi.ErrViewportClosed
+	}
+	if (next == nil && s.page == nil) || (next != nil && s.page != nil && *next == *s.page) {
+		return nil
+	}
+	s.page = next
+	s.pageRenderer = nil
+	s.resolvePageRows(nil, nil)
+	s.revision++
+	for _, watcher := range s.watches {
+		publishLatest(watcher.ch, ttyapi.Update{Revision: s.revision})
+	}
+	return nil
+}
+
+// resolvePageRows runs under session.mu. Unchanged source rows reuse the
+// previously resolved string; Snapshot never parses or recolors anything.
+func (s *session) resolvePageRows(previousSource, previousRows []string) {
+	if s.page == nil {
+		s.rows = s.sourceRows
+		return
+	}
+	if s.pageRenderer == nil || s.pageRenderer.Width() != s.width {
+		s.pageRenderer = terminal.NewPageRenderer(s.width, *s.page)
+		previousSource, previousRows = nil, nil
+	}
+	rows := make([]string, s.height)
+	blank := ""
+	for y := range rows {
+		raw := ""
+		if y < len(s.sourceRows) {
+			raw = s.sourceRows[y]
+		}
+		if y < len(previousSource) && y < len(previousRows) && raw == previousSource[y] {
+			rows[y] = previousRows[y]
+		} else if raw == "" {
+			if blank == "" {
+				blank = s.pageRenderer.RenderRow("")
+			}
+			rows[y] = blank
+		} else {
+			rows[y] = s.pageRenderer.RenderRow(raw)
+		}
+	}
+	s.rows = rows
+}
+
+func (s *surface) Page() (ttyapi.Page, bool) {
+	s.session.mu.RLock()
+	defer s.session.mu.RUnlock()
+	if s.session.page == nil {
+		return ttyapi.Page{}, false
+	}
+	return *s.session.page, true
+}

--- a/system/tty/page_test.go
+++ b/system/tty/page_test.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+	"image/color"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/runtime"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+const (
+	pageForeground = "#e0def4"
+	pageBackground = "#191724"
+)
+
+func pageColors(t *testing.T) (color.Color, color.Color) {
+	t.Helper()
+	foreground, background := (ttyapi.Page{Foreground: pageForeground, Background: pageBackground}).Colors()
+	return foreground, background
+}
+
+// rowCells decodes a rendered row back into styled cells without reusing the
+// resolver's own composition helpers.
+func rowCells(t *testing.T, row string, width int) uv.Line {
+	t.Helper()
+	screen := uv.NewScreenBuffer(width, 1)
+	screen.Method = ansi.GraphemeWidth
+	uv.NewStyledString(row).Draw(screen, screen.Bounds())
+	return screen.Line(0)
+}
+
+func sameColor(a, b color.Color) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	ar, ag, ab, _ := a.RGBA()
+	br, bg, bb, _ := b.RGBA()
+	return ar == br && ag == bg && ab == bb
+}
+
+func requirePageRow(t *testing.T, row string, width int, foreground, background color.Color) {
+	t.Helper()
+	require.Equal(t, width, ansi.StringWidth(row), "row %q must cover the viewport width", row)
+	for index, cell := range rowCells(t, row, width) {
+		// Zero-width cells are wide-glyph placeholders and carry no style.
+		if cell.Width < 1 {
+			continue
+		}
+		require.Truef(t, sameColor(cell.Style.Fg, foreground),
+			"cell %d of %q must carry the page foreground", index, row)
+		require.Truef(t, sameColor(cell.Style.Bg, background),
+			"cell %d of %q must carry the page background", index, row)
+	}
+}
+
+func producerSurface(t *testing.T, service *Service, view ttyapi.Viewport) ttyapi.Surface {
+	t.Helper()
+	ctx, frame, _ := processContextFor(t, service, "producer")
+	t.Cleanup(func() { _ = frame.Close() })
+	binding, err := service.Binding(view.Grant())
+	require.NoError(t, err)
+	port, err := binding.Resolve(ctx)
+	require.NoError(t, err)
+	surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	return surface
+}
+
+func TestViewportPageResolvesProducerDefaultCells(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	page := &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 6, Height: 3, Page: page})
+	require.NoError(t, err)
+	surface := producerSurface(t, service, view)
+
+	// An unstyled row, an explicit SGR reset, and a row the producer left short
+	// of the viewport width all describe terminal-default cells.
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"ab", "\x1b[0m  ", ""}})
+	require.NoError(t, err)
+
+	foreground, background := pageColors(t)
+	rows := view.Snapshot().Rows
+	require.Len(t, rows, 3)
+	for _, row := range rows {
+		requirePageRow(t, row, 6, foreground, background)
+	}
+	require.Equal(t, "ab    ", ansi.Strip(rows[0]))
+	require.Equal(t, page, view.(*viewport).session.page)
+}
+
+func TestViewportPagePreservesProducerColors(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 4, Height: 1,
+		Page: &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}})
+	require.NoError(t, err)
+	surface := producerSurface(t, service, view)
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"\x1b[38;2;255;0;0;48;2;0;0;255mR\x1b[0mx"}})
+	require.NoError(t, err)
+
+	foreground, background := pageColors(t)
+	line := rowCells(t, view.Snapshot().Rows[0], 4)
+	require.Len(t, line, 4)
+	require.True(t, sameColor(line[0].Style.Fg, color.RGBA{R: 255, A: 255}),
+		"an explicit producer foreground must survive composition")
+	require.True(t, sameColor(line[0].Style.Bg, color.RGBA{B: 255, A: 255}),
+		"an explicit producer background must survive composition")
+	for index := 1; index < len(line); index++ {
+		require.True(t, sameColor(line[index].Style.Fg, foreground))
+		require.True(t, sameColor(line[index].Style.Bg, background))
+	}
+}
+
+func TestViewportPageResolvesWideCellsAndClippedSequences(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 6, Height: 2,
+		Page: &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}})
+	require.NoError(t, err)
+	surface := producerSurface(t, service, view)
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"世界", "ok\x1b[31"}})
+	require.NoError(t, err)
+
+	foreground, background := pageColors(t)
+	rows := view.Snapshot().Rows
+	require.Equal(t, 6, ansi.StringWidth(rows[0]))
+	require.Equal(t, "世界  ", ansi.Strip(rows[0]))
+	requirePageRow(t, rows[0], 6, foreground, background)
+	require.NotContains(t, rows[1], "\x1b[31", "a clipped sequence must not reach a composited row")
+	requirePageRow(t, rows[1], 6, foreground, background)
+	require.Equal(t, "ok    ", ansi.Strip(rows[1]))
+}
+
+func TestViewportWithoutPagePublishesProducerRows(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 6, Height: 3})
+	require.NoError(t, err)
+	require.Nil(t, view.(*viewport).session.page)
+	surface := producerSurface(t, service, view)
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"ab", "\x1b[0m  "}})
+	require.NoError(t, err)
+	require.Equal(t, []string{"ab", "\x1b[0m  "}, view.Snapshot().Rows)
+}
+
+func TestViewportSetPageBumpsRevisionAndWakesViewers(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 4, Height: 1})
+	require.NoError(t, err)
+	viewer, err := service.Attach(ctx, view.Handle())
+	require.NoError(t, err)
+	surface := producerSurface(t, service, view)
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"ab"}})
+	require.NoError(t, err)
+	drain(view.Updates())
+	drain(viewer.Updates())
+	revision := view.Snapshot().Revision
+
+	page := &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}
+	require.NoError(t, view.(ttyapi.PageViewport).SetPage(ctx, page))
+	require.Equal(t, revision+1, view.Snapshot().Revision,
+		"a page change must invalidate the snapshot even when content is unchanged")
+	require.Equal(t, ttyapi.Update{Revision: revision + 1}, <-view.Updates())
+	require.Equal(t, ttyapi.Update{Revision: revision + 1}, <-viewer.Updates())
+
+	foreground, background := pageColors(t)
+	rows := viewer.Snapshot().Rows
+	require.Equal(t, view.Snapshot().Rows, rows, "every viewer reads the same resolved rows")
+	requirePageRow(t, rows[0], 4, foreground, background)
+
+	require.NoError(t, view.(ttyapi.PageViewport).SetPage(ctx, nil))
+	require.Nil(t, view.(*viewport).session.page)
+	require.Equal(t, revision+2, view.Snapshot().Revision)
+	require.Equal(t, []string{"ab"}, view.Snapshot().Rows)
+}
+
+func TestViewportRejectsIncompletePage(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	_, err := createPageView(ctx, service, pageTestOptions{Width: 4, Height: 1,
+		Page: &ttyapi.Page{Foreground: pageForeground}})
+	require.Error(t, err)
+
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 4, Height: 1})
+	require.NoError(t, err)
+	require.Error(t, view.(ttyapi.PageViewport).SetPage(ctx, &ttyapi.Page{Foreground: "#zzzzzz", Background: pageBackground}))
+	require.Error(t, view.(ttyapi.PageViewport).SetPage(ctx, &ttyapi.Page{Background: pageBackground}))
+	require.Nil(t, view.(*viewport).session.page)
+}
+
+func TestProducerSurfaceReportsLivePageColors(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 4, Height: 1})
+	require.NoError(t, err)
+	surface := producerSurface(t, service, view)
+	paged, ok := surface.(ttyapi.PageProvider)
+	require.True(t, ok, "a virtual surface must expose its viewport page to the producer")
+	_, hasPage := paged.Page()
+	require.False(t, hasPage)
+
+	require.NoError(t, view.(ttyapi.PageViewport).SetPage(ctx, &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}))
+	foreground, background := pageColors(t)
+	page, hasPage := paged.Page()
+	resolvedForeground, resolvedBackground := page.Colors()
+	require.True(t, hasPage)
+	require.True(t, sameColor(resolvedForeground, foreground))
+	require.True(t, sameColor(resolvedBackground, background))
+}
+
+func drain(updates <-chan ttyapi.Update) {
+	for {
+		select {
+		case <-updates:
+		default:
+			return
+		}
+	}
+}
+
+// Keep the existing Service.Create API compatible for embedders.
+type pageTestOptions struct {
+	Page          *ttyapi.Page
+	Width, Height int
+}
+
+func createPageView(ctx context.Context, service *Service, options pageTestOptions) (ttyapi.Viewport, error) {
+	view, err := service.Create(ctx, options.Width, options.Height)
+	if err != nil {
+		return nil, err
+	}
+	if err := view.(ttyapi.PageViewport).SetPage(ctx, options.Page); err != nil {
+		_ = view.Close()
+		return nil, err
+	}
+	return view, nil
+}
+
+func TestPageOwnerAuthorityResizeAndCachedSnapshots(t *testing.T) {
+	service := NewService()
+	defer service.Close()
+	ctx, frame, _ := processContext(t, service)
+	defer frame.Close()
+	view, err := createPageView(ctx, service, pageTestOptions{Width: 4, Height: 2, Page: &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}})
+	require.NoError(t, err)
+	require.Len(t, view.Snapshot().Rows, 2, "page exists before first producer frame")
+	surface := producerSurface(t, service, view)
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"a", "b"}})
+	require.NoError(t, err)
+	before := view.Snapshot()
+	require.NoError(t, view.(ttyapi.PageViewport).SetPage(ctx, &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}))
+	require.Equal(t, before.Revision, view.Snapshot().Revision, "same page is a no-op")
+	other, otherFrame, _ := processContextFor(t, service, "other")
+	defer otherFrame.Close()
+	require.ErrorIs(t, view.(ttyapi.PageViewport).SetPage(other, nil), ttyapi.ErrPermissionDenied)
+	attached, err := service.Attach(ctx, view.Handle())
+	require.NoError(t, err)
+	require.NoError(t, attached.(ttyapi.PageViewport).SetPage(ctx, &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}), "the creator can recover page control after reattaching")
+	outsider, err := service.Attach(other, view.Handle())
+	require.NoError(t, err)
+	require.ErrorIs(t, outsider.(ttyapi.PageViewport).SetPage(other, nil), ttyapi.ErrPermissionDenied)
+	require.NoError(t, view.Resize(2, 3))
+	foreground, background := pageColors(t)
+	for _, row := range view.Snapshot().Rows {
+		requirePageRow(t, row, 2, foreground, background)
+	}
+	require.Equal(t, "a   ", ansi.Strip(before.Rows[0]), "retained snapshots stay immutable")
+	_, err = surface.Present(ttyapi.Frame{Rows: []string{"a"}})
+	require.NoError(t, err)
+	require.Equal(t, "  ", ansi.Strip(view.Snapshot().Rows[1]), "omitted row clears stale content")
+	require.Zero(t, testing.AllocsPerRun(100, func() { _ = view.Snapshot() }))
+	require.NoError(t, view.Close())
+	require.ErrorIs(t, view.(ttyapi.PageViewport).SetPage(ctx, nil), ttyapi.ErrViewportClosed)
+}
+
+func TestMeshPageChangePublishesResolvedRows(t *testing.T) {
+	a, b, _, _ := meshFixture(t)
+	owner, _ := meshContext(t, a, "a", "owner")
+	agent, _ := meshContext(t, b, "b", "agent")
+	view, err := a.Create(owner, 4, 2)
+	require.NoError(t, err)
+	require.NoError(t, view.(ttyapi.PageViewport).SetPage(owner, &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}))
+	target, _ := runtime.GetFramePID(agent)
+	ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+	require.NoError(t, err)
+	remote, err := b.Attach(agent, ref)
+	require.NoError(t, err)
+	require.Equal(t, view.Snapshot().Rows, remote.Snapshot().Rows)
+	_, canSet := remote.(ttyapi.PageViewport)
+	require.False(t, canSet, "mesh mounts cannot mutate owner page policy")
+	revision := remote.Snapshot().Revision
+	require.NoError(t, view.(ttyapi.PageViewport).SetPage(owner, &ttyapi.Page{Foreground: "#102030", Background: "#f0e0d0"}))
+	require.Eventually(t, func() bool { return remote.Snapshot().Revision > revision }, time.Second, time.Millisecond)
+	require.Equal(t, view.Snapshot().Rows, remote.Snapshot().Rows)
+}
+
+func BenchmarkPagePresent(b *testing.B) {
+	for _, mode := range []string{"unchanged", "one-row", "all-rows"} {
+		b.Run(mode, func(b *testing.B) {
+			service := NewService()
+			defer service.Close()
+			ctx, frame, _ := processContext(b, service)
+			defer frame.Close()
+			view, err := createPageView(ctx, service, pageTestOptions{Width: 120, Height: 40, Page: &ttyapi.Page{Foreground: pageForeground, Background: pageBackground}})
+			require.NoError(b, err)
+			binding, err := service.Binding(view.Grant())
+			require.NoError(b, err)
+			port, err := binding.Resolve(ctx)
+			require.NoError(b, err)
+			surface, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+			require.NoError(b, err)
+			rows := make([]string, 40)
+			for y := range rows {
+				rows[y] = strings.Repeat("content ", 15)
+			}
+			_, err = surface.Present(ttyapi.Frame{Rows: rows})
+			require.NoError(b, err)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if mode != "unchanged" {
+					limit := 1
+					if mode == "all-rows" {
+						limit = len(rows)
+					}
+					for y := 0; y < limit; y++ {
+						rows[y] = strings.Repeat("content ", 14) + strconv.Itoa(n%2)
+					}
+				}
+				_, _ = surface.Present(ttyapi.Frame{Rows: rows})
+			}
+		})
+	}
+}

--- a/system/tty/port.go
+++ b/system/tty/port.go
@@ -66,7 +66,7 @@ func (s *surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 		ss.mu.Unlock()
 		return ttyapi.PresentStats{}, ttyapi.ErrViewportClosed
 	}
-	changed := changedRows(ss.rows, frame.Rows)
+	changed := changedRows(ss.sourceRows, frame.Rows)
 	forced := ss.invalid
 	if forced && changed == 0 {
 		changed = len(frame.Rows)
@@ -75,7 +75,9 @@ func (s *surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 	// matching the Frame contract and physical surface implementation.
 	cursorChanged := frame.Cursor != nil && !sameCursor(ss.cursor, frame.Cursor)
 	if forced || changed != 0 || cursorChanged {
-		ss.rows = append([]string(nil), frame.Rows...)
+		previousSource, previousRows := ss.sourceRows, ss.rows
+		ss.sourceRows = append([]string(nil), frame.Rows...)
+		ss.resolvePageRows(previousSource, previousRows)
 		ss.invalid = false
 		if frame.Cursor != nil {
 			copy := *frame.Cursor

--- a/system/tty/service.go
+++ b/system/tty/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wippyai/runtime/api/runtime"
 	"github.com/wippyai/runtime/api/security"
 	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/service/terminal"
 )
 
 // Service is a zero-goroutine, in-memory viewport broker. The AppContext owns
@@ -29,26 +30,29 @@ type Service struct {
 }
 
 type session struct {
-	router    relay.Receiver
-	watches   map[uint64]watch
-	service   *Service
-	cursor    *ttyapi.Cursor
-	viewers   map[pid.PID]int
-	creator   pid.PID
-	target    pid.PID
-	grant     string
-	handle    string
-	rows      []string
-	nextWatch uint64
-	revision  uint64
-	width     int
-	height    int
-	bindings  int
-	mu        sync.RWMutex
-	inputOpen bool
-	producer  bool
-	invalid   bool
-	closed    bool
+	page         *ttyapi.Page
+	pageRenderer *terminal.PageRenderer
+	sourceRows   []string
+	router       relay.Receiver
+	watches      map[uint64]watch
+	service      *Service
+	cursor       *ttyapi.Cursor
+	viewers      map[pid.PID]int
+	creator      pid.PID
+	target       pid.PID
+	grant        string
+	handle       string
+	rows         []string
+	nextWatch    uint64
+	revision     uint64
+	width        int
+	height       int
+	bindings     int
+	mu           sync.RWMutex
+	inputOpen    bool
+	producer     bool
+	invalid      bool
+	closed       bool
 }
 
 type watch struct {

--- a/system/tty/service.go
+++ b/system/tty/service.go
@@ -13,12 +13,15 @@ import (
 	processapi "github.com/wippyai/runtime/api/process"
 	"github.com/wippyai/runtime/api/relay"
 	"github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/security"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
 
 // Service is a zero-goroutine, in-memory viewport broker. The AppContext owns
 // the service; process frames own bindings and redeemed ports.
 type Service struct {
+	mounts   map[string]*mountRecord
+	mesh     *meshService
 	sessions map[string]*session
 	grants   map[string]*session
 	mu       sync.Mutex
@@ -31,6 +34,7 @@ type session struct {
 	service   *Service
 	cursor    *ttyapi.Cursor
 	viewers   map[pid.PID]int
+	creator   pid.PID
 	target    pid.PID
 	grant     string
 	handle    string
@@ -53,7 +57,7 @@ type watch struct {
 }
 
 func NewService() *Service {
-	return &Service{sessions: make(map[string]*session), grants: make(map[string]*session)}
+	return &Service{mounts: make(map[string]*mountRecord), sessions: make(map[string]*session), grants: make(map[string]*session)}
 }
 
 func token(prefix string) (string, error) {
@@ -81,7 +85,7 @@ func (s *Service) Create(ctx context.Context, width, height int) (ttyapi.Viewpor
 		return nil, ttyapi.ErrInvalidGrant
 	}
 	ss := &session{
-		service: s, grant: grant, handle: handle, width: width, height: height,
+		service: s, creator: owner, grant: grant, handle: handle, width: width, height: height,
 		viewers: map[pid.PID]int{owner: 1}, watches: make(map[uint64]watch),
 	}
 	s.mu.Lock()
@@ -95,6 +99,9 @@ func (s *Service) Create(ctx context.Context, width, height int) (ttyapi.Viewpor
 }
 
 func (s *Service) Attach(ctx context.Context, handle string) (ttyapi.Viewport, error) {
+	if isMountRef(handle) {
+		return s.attachMount(ctx, handle)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
@@ -108,6 +115,9 @@ func (s *Service) Attach(ctx context.Context, handle string) (ttyapi.Viewport, e
 	if !ok {
 		return nil, ttyapi.ErrInvalidGrant
 	}
+	if !samePID(owner, ss.creator) && !security.IsAllowed(ctx, ttyapi.RightObserve, handle, nil) {
+		return nil, ttyapi.ErrPermissionDenied
+	}
 	ss.mu.Lock()
 	if ss.closed {
 		ss.mu.Unlock()
@@ -115,6 +125,7 @@ func (s *Service) Attach(ctx context.Context, handle string) (ttyapi.Viewport, e
 	}
 	ss.viewers[owner]++
 	view := ss.newViewportLocked(owner, "")
+	view.rights = ttyapi.MountRights{Observe: true, Input: samePID(owner, ss.creator) || security.IsAllowed(ctx, ttyapi.RightInput, handle, nil), Resize: samePID(owner, ss.creator) || security.IsAllowed(ctx, ttyapi.RightResize, handle, nil)}
 	ss.mu.Unlock()
 	return view, nil
 }
@@ -144,9 +155,18 @@ func (s *Service) Close() error {
 	}
 	s.closed = true
 	sessions := s.sessions
+	mounts := s.mounts
+	mesh := s.mesh
+	s.mounts = nil
 	s.sessions = nil
 	s.grants = nil
 	s.mu.Unlock()
+	if mesh != nil {
+		mesh.close()
+	}
+	for _, m := range mounts {
+		m.close()
+	}
 	for _, ss := range sessions {
 		ss.closeAll()
 	}
@@ -158,6 +178,7 @@ func (s *Service) OnStart(context.Context, pid.PID, processapi.Process) error { 
 // OnComplete deterministically detaches views owned by the exiting process.
 // The producer and terminal state remain alive for another shell to attach.
 func (s *Service) OnComplete(ctx context.Context, owner pid.PID, _ *runtime.Result) {
+	s.closeOwnerMounts(owner)
 	// The frame owns either the unresolved binding or its resolved port. Frame
 	// contexts do not close stored values themselves, so the lifecycle hook is
 	// the canonical release barrier for both paths.

--- a/system/tty/service_test.go
+++ b/system/tty/service_test.go
@@ -34,6 +34,7 @@ func processContextFor(t testing.TB, service *Service, id string) (context.Conte
 	ctx = relay.WithNode(ctx, node)
 	ctx, frame := ctxapi.OpenFrameContext(ctx)
 	require.NoError(t, frame.Set(runtime.FramePIDKey, pid.PID{Node: "node", Host: "workers", UniqID: id}))
+	allowTTY(ctx, t, "tty.mount", ttyapi.RightObserve, ttyapi.RightInput, ttyapi.RightResize)
 	return ctx, frame, box
 }
 

--- a/system/tty/supervision_test.go
+++ b/system/tty/supervision_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/runtime"
+	supervisorapi "github.com/wippyai/runtime/api/supervisor"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	supervisorsys "github.com/wippyai/runtime/system/supervisor"
+)
+
+// This adapter uses the real supervisor controller and the same OnComplete
+// barrier used by process lifecycle. Each restart receives a new process PID.
+type mountSupervisionAdapter struct {
+	start func() (<-chan any, error)
+	stop  func()
+}
+
+func (a mountSupervisionAdapter) Start(context.Context) (<-chan any, error) { return a.start() }
+func (a mountSupervisionAdapter) Stop(context.Context) error                { a.stop(); return nil }
+
+type mountGeneration struct {
+	service *Service
+	ctx     context.Context
+	remote  ttyapi.Viewport
+	details chan any
+	ref     string
+	owner   pid.PID
+	once    sync.Once
+}
+
+func (g *mountGeneration) finish() {
+	g.once.Do(func() {
+		g.service.OnComplete(g.ctx, g.owner, nil)
+		close(g.details)
+	})
+}
+
+func TestSupervisedMountRestartRequiresFreshAuthority(t *testing.T) {
+	for _, role := range []string{"owner", "consumer"} {
+		t.Run(role, func(t *testing.T) {
+			a, b, _, _ := meshFixture(t)
+			owners := make([]context.Context, 2)
+			agents := make([]context.Context, 2)
+			for i := range 2 {
+				owners[i], _ = meshContext(t, a, "a", fmt.Sprintf("owner-%d", i))
+				agents[i], _ = meshContext(t, b, "b", fmt.Sprintf("agent-%d", i))
+			}
+			fixed, err := a.Create(owners[0], 80, 24)
+			require.NoError(t, err)
+			var generation atomic.Int32
+			var current atomic.Pointer[mountGeneration]
+			started := make(chan *mountGeneration, 2)
+			adapter := mountSupervisionAdapter{
+				start: func() (<-chan any, error) {
+					index := int(generation.Add(1)) - 1
+					if index >= 2 {
+						return nil, fmt.Errorf("unexpected third generation")
+					}
+					owner, agent, view := owners[0], agents[0], fixed
+					if role == "owner" {
+						owner = owners[index]
+						var err error
+						view, err = a.Create(owner, 80, 24)
+						if err != nil {
+							return nil, err
+						}
+					} else {
+						agent = agents[index]
+					}
+					target, _ := runtime.GetFramePID(agent)
+					ref, err := view.(ttyapi.MountableViewport).Mount(owner, target, ttyapi.MountRights{Observe: true})
+					if err != nil {
+						return nil, err
+					}
+					remote, err := b.Attach(agent, ref)
+					if err != nil {
+						return nil, err
+					}
+					g := &mountGeneration{service: b, ctx: agent, owner: target, ref: ref, remote: remote, details: make(chan any)}
+					if role == "owner" {
+						g.service = a
+						g.ctx = owner
+						g.owner, _ = runtime.GetFramePID(owner)
+					}
+					current.Store(g)
+					started <- g
+					return g.details, nil
+				},
+				stop: func() {
+					if g := current.Load(); g != nil {
+						g.finish()
+					}
+				},
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			controller := supervisorsys.NewController(ctx, adapter, supervisorapi.LifecycleConfig{
+				StartTimeout: time.Second, StopTimeout: time.Second, StableThreshold: time.Hour,
+				RetryPolicy: supervisorapi.RetryPolicy{MaxAttempts: 3, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond},
+			}, nil)
+			require.NoError(t, controller.Start())
+			defer controller.Stop()
+			first := <-started
+			first.finish() // Unexpected exit closes the status stream and triggers retry.
+			var second *mountGeneration
+			select {
+			case second = <-started:
+			case <-time.After(2 * time.Second):
+				t.Fatal("supervisor did not restart")
+			}
+			require.NotEqual(t, first.ref, second.ref)
+			require.Eventually(t, func() bool { return first.remote.Snapshot().Width == 0 }, time.Second, time.Millisecond)
+			require.Equal(t, 80, second.remote.Snapshot().Width)
+			agent := agents[0]
+			if role == "consumer" {
+				agent = agents[1]
+			}
+			_, err = b.Attach(agent, first.ref)
+			require.Error(t, err, "restart must not revive a previous mount")
+			require.NoError(t, controller.Stop())
+			require.Eventually(t, func() bool {
+				a.mu.Lock()
+				mounts := len(a.mounts)
+				a.mu.Unlock()
+				b.mesh.mu.Lock()
+				views := len(b.mesh.views)
+				b.mesh.mu.Unlock()
+				return mounts == 0 && views == 0
+			}, time.Second, time.Millisecond, "supervised stop must release every generation's mounts")
+		})
+	}
+}

--- a/system/tty/viewport.go
+++ b/system/tty/viewport.go
@@ -3,12 +3,14 @@
 package tty
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
 
@@ -20,6 +22,7 @@ type viewport struct {
 	watchID       uint64
 	once          sync.Once
 	closed        atomic.Bool
+	rights        ttyapi.MountRights
 }
 
 func (s *session) newViewport(owner pid.PID, grant string) *viewport {
@@ -32,7 +35,7 @@ func (s *session) newViewportLocked(owner pid.PID, grant string) *viewport {
 	s.nextWatch++
 	ch := make(chan ttyapi.Update, 1)
 	s.watches[s.nextWatch] = watch{owner: owner, ch: ch}
-	return &viewport{session: s, owner: owner, producerGrant: grant, watchID: s.nextWatch, updates: ch}
+	return &viewport{rights: ttyapi.MountRights{Observe: true, Input: true, Resize: true}, session: s, owner: owner, producerGrant: grant, watchID: s.nextWatch, updates: ch}
 }
 
 func (v *viewport) Grant() string                 { return v.producerGrant }
@@ -40,7 +43,7 @@ func (v *viewport) Handle() string                { return v.session.handle }
 func (v *viewport) Updates() <-chan ttyapi.Update { return v.updates }
 
 func (v *viewport) Snapshot() ttyapi.Snapshot {
-	if v.closed.Load() {
+	if v.closed.Load() || !v.rights.Observe {
 		return ttyapi.Snapshot{}
 	}
 	v.session.mu.RLock()
@@ -55,6 +58,12 @@ func (v *viewport) Snapshot() ttyapi.Snapshot {
 }
 
 func (v *viewport) Send(event ttyapi.Event) error {
+	if !v.rights.Input {
+		return ttyapi.ErrPermissionDenied
+	}
+	if event.Type == "resize" {
+		return v.Resize(event.Width, event.Height)
+	}
 	if v.closed.Load() {
 		return ttyapi.ErrViewportClosed
 	}
@@ -73,6 +82,9 @@ func (v *viewport) Send(event ttyapi.Event) error {
 }
 
 func (v *viewport) Resize(width, height int) error {
+	if !v.rights.Resize {
+		return ttyapi.ErrPermissionDenied
+	}
 	if err := ttyapi.ValidateViewportSize(width, height); err != nil {
 		return err
 	}
@@ -105,6 +117,7 @@ func (v *viewport) Resize(width, height int) error {
 func (v *viewport) Close() error {
 	v.once.Do(func() {
 		v.closed.Store(true)
+		v.session.service.revokeIssuer(v)
 		v.session.mu.Lock()
 		if watcher, ok := v.session.watches[v.watchID]; ok {
 			close(watcher.ch)
@@ -128,6 +141,17 @@ func sendEvent(router relay.Receiver, target pid.PID, event ttyapi.Event) error 
 	if err := router.Send(pkg); err != nil {
 		relay.ReleasePackage(pkg)
 		return err
+	}
+	return nil
+}
+
+func (v *viewport) Check(ctx context.Context, right string) error {
+	owner, ok := runtime.GetFramePID(ctx)
+	if !ok || !samePID(owner, v.owner) || (right != "" && !hasRight(v.rights, right)) {
+		return ttyapi.ErrPermissionDenied
+	}
+	if right != "" && v.closed.Load() {
+		return ttyapi.ErrViewportClosed
 	}
 	return nil
 }

--- a/system/tty/viewport.go
+++ b/system/tty/viewport.go
@@ -99,6 +99,9 @@ func (v *viewport) Resize(width, height int) error {
 	changed := v.session.width != width || v.session.height != height
 	v.session.width, v.session.height = width, height
 	if changed {
+		if v.session.page != nil {
+			v.session.resolvePageRows(nil, nil)
+		}
 		v.session.revision++
 		update := ttyapi.Update{Revision: v.session.revision}
 		for _, watcher := range v.session.watches {

--- a/tests/tty-mesh/LUA_GUIDE.md
+++ b/tests/tty-mesh/LUA_GUIDE.md
@@ -1,0 +1,158 @@
+# Lua agents and remote terminal surfaces
+
+The SDK is sufficient for a V1 agent to observe and control a terminal on another
+mesh node. The two nodes must already be members of the runtime mesh. Lua uses
+process identities and mount references; it does not open a socket to a terminal
+IP address.
+
+A **node** is a runtime instance in the mesh. A process **host** is the scheduler
+or execution host inside that runtime, not a machine IP. A PID identifies both,
+for example `{node-b@agents|unique-process-id}`. Obtain PIDs from `process.pid()`,
+spawn results, or your application's process discovery; do not fabricate them.
+
+| Object/action | Meaning |
+|---|---|
+| `tty.surface()` | Output owned by the current process; presents composed rows. |
+| `tty.viewport()` | A local broker that stores a producer's current terminal frame. |
+| `view:grant()` | One-use producer binding, supplied through the child's `terminal` option. |
+| `view:mount(pid, rights)` | One-use observer/controller reference for that exact process, including its node. |
+| `tty.attach(ref)` | Consume a local or remote mount; the returned viewport API is the same. |
+| `view:snapshot()` / `updates()` | Observe the cached current frame and revision notifications. |
+| `view:send(event)` / `resize(w,h)` | Deliver input or resize under the mount's independent rights. |
+| `view:close()` | Detach this view. Closing an issuing viewport also revokes its mounts. |
+| `owner:revoke(ref)` | Revoke a specific issued mount. |
+
+`grant()` and `mount()` serve different roles. An agent's observation mount
+cannot present output, mint producer bindings, or delegate access to another
+agent. Create a separate mount for each agent. Combine rights in one mount when
+one agent needs them all, or use separate observation and control mounts.
+
+## Connecting an agent on node A to a terminal on node B
+
+1. Your application locates an authorized controller process on node B. An
+   existing `process.send(remote_controller_pid, topic, payload)` can reach it.
+2. That controller creates the viewport and starts a producer **on node B** with
+   its producer grant. The producer signals readiness after `tty.start()` and,
+   for a native command, after attaching the PTY session.
+3. The controller creates a mount bound to the agent's actual PID on node A and
+   sends the reference back with ordinary process messaging.
+4. The agent calls `tty.attach(ref)`, subscribes to updates, and reads snapshots.
+   It can send input and resize if granted those rights.
+
+A process running on A does not cause `tty.viewport()` or `process.spawn()` to
+execute on B merely by using B's IP as a host argument. Remote startup is an
+application/controller action; the mount connects the resulting surface.
+
+On the owner, after the producer is ready and the application has authorized
+`agent_pid`:
+
+```lua
+local tty = require("tty")
+local process = require("process")
+
+-- view is the viewport whose grant was given to the local producer.
+local ref, err = view:mount(agent_pid, {
+    observe = true, input = true, resize = true,
+})
+if not ref then error(tostring(err)) end
+local sent, send_err = process.send(agent_pid, "terminal.mount", {ref = ref})
+if not sent then
+    view:revoke(ref)
+    error(tostring(send_err))
+end
+```
+
+The owner needs `tty.mount` plus each delegated right on that viewport. Normal
+process messaging, spawning, and executor permissions still apply. A privileged
+controller must authorize requests before minting mounts; never turn an arbitrary
+PID in an incoming payload into an automatic access grant.
+
+On the agent, subscribe **before** requesting a surface so a fast reply cannot
+arrive before the listener exists:
+
+```lua
+local tty = require("tty")
+local process = require("process")
+
+local replies = process.listen("terminal.mount", {message = true})
+-- Request through your controller's application protocol here.
+local message, open = replies:receive()
+if not open then return end
+-- controller_pid is the exact owner PID resolved by the application.
+if message:from() ~= controller_pid then error("unexpected controller") end
+local reply = message:payload():data()
+local view, err = tty.attach(reply.ref)
+if not view then error(tostring(err)) end
+local updates, update_err = view:updates()
+if not updates then error(tostring(update_err)) end
+local snapshot, snapshot_err = view:snapshot()
+if not snapshot then error(tostring(snapshot_err)) end
+
+local ok, send_err = view:send({type = "paste", text = "echo hello"})
+if not ok then error(tostring(send_err)) end
+ok, send_err = view:send({
+    type = "key", key = "enter", key_type = "enter", action = "press",
+})
+if not ok then error(tostring(send_err)) end
+
+while true do
+    local revision, alive = updates:receive()
+    if not alive then break end
+    local current, read_err = view:snapshot(snapshot.revision)
+    if read_err then break end
+    if current then
+        snapshot = current
+        -- Inspect snapshot.rows, or composite them into a local canvas.
+    end
+end
+view:close()
+```
+
+This illustrates the mount flow, not a complete controller protocol. A controller
+also needs request correlation, authorization, startup deadlines, and producer
+exit handling. The executable harness in this directory verifies the real Lua,
+PTY, mesh, and snapshot path independently of those application choices.
+
+## Simulation, observation, and local controls
+
+`tty.InputEvent` accepts synthetic key/mouse events with omitted `alt`, `ctrl`,
+and `shift` flags; they default to false. Keys require `key`, `key_type`, and
+`action`. Mouse coordinates are one-based cells relative to the remote viewport:
+
+```lua
+view:send({type="mouse", action="press", button="left", x=12, y=3})
+view:send({type="mouse", action="release", button="left", x=12, y=3})
+```
+
+`send()` success means the owner broker accepted the event for the producer. It
+is not proof that a shell command finished or that the application acted on a
+click. Confirm completion through a unique output marker or an explicit
+application acknowledgement. Snapshots contain styled terminal rows and cursor
+state, not the application's internal model or a complete output history. Wait
+on updates and use `snapshot(last_revision)` to avoid allocating a new Lua
+screen table when the revision is unchanged.
+
+Local and remote snapshots compose the same way: clip rows into canvas regions,
+paint local controls outside those regions, then present through one Surface.
+Translate mouse coordinates into the focused region. Forward remote events from
+a separate coroutine with a bounded queue, so a slow request cannot block local
+close controls. Report discrete-input overflow; coalesce only transient motion.
+
+## Exit, restart, and reconnect
+
+Close detaches a consumer; it does not inherently kill a producer. A `close`
+event is a request the producer must handle. To terminate a process, use the
+application's explicit stop operation or authorized process cancellation.
+
+Observation, input, and resize permissions are independent. Input-only mounts
+still receive owner-exit/revocation notifications. Closed views reject further
+operations and clear their cached screens. Content already delivered to an
+agent cannot be recalled.
+
+Owner or agent restart invalidates that generation's mounts. Rediscover the new
+PID and request fresh references. A transport interruption may recover an
+in-flight request, with duplicate input suppressed, but a timed-out attachment
+fails closed. Do not automatically replay an uncertain command after reattaching.
+Unused references expire after 30 seconds; active remote mounts renew their
+lease. Operations have a five-second response timeout, while caller cancellation
+and local close interrupt waits immediately.

--- a/tests/tty-mesh/README.md
+++ b/tests/tty-mesh/README.md
@@ -1,0 +1,47 @@
+# Bidirectional Lua / PTY mesh proof
+
+This harness runs two independent Wippy actor schedulers and the real internode
+connection manager. Each node starts a Bash PTY behind the existing Lua `exec`
+and terminal proxy APIs, then mounts the other node's viewport from a Lua agent.
+Each agent has a separate observation reference and input/resize reference.
+
+It verifies 20 commands in each direction, screen contents after ANSI clear and
+cursor commands, resize propagation, observe-only input rejection, and
+input-only snapshot/update rejection. The marker is split in the echoed shell
+command, so a matching screen proves command execution rather than input echo.
+One scheduler worker per node verifies that remote waits yield.
+
+Build and run locally:
+
+```bash
+GOWORK=off go build -o /tmp/wippy-tty-mesh-proof ./tests/tty-mesh
+python3 tests/tty-mesh/run.py
+```
+
+Run across an authorized SSH host (Linux, x86-64 when using the same binary):
+
+```bash
+python3 tests/tty-mesh/run.py \
+  --ssh user@REMOTE_IP \
+  --peer-address REMOTE_IP \
+  --local-address LOCAL_REACHABLE_IP
+```
+
+The hosts need Bash, SSH/SCP connectivity, and reachability on the selected mesh
+ports (19470/19471 by default; `--port` changes the pair). SSH bootstraps the
+second test process and exchanges its process-bound references. All terminal
+input, snapshots, updates, and operation responses travel over the real mesh.
+The proof generates temporary Ed25519 identities and mutual TLS credentials;
+existing cluster credentials and running Wippy instances are not used or changed.
+Temporary binaries, keys, and references are removed afterward.
+
+The executable accepts a single real native executor through a small fixture
+registry; Lua runs its normal `exec.get` / `exec.run` permission checks. This
+keeps the proof independent of registry databases and application boot YAML.
+It does not add an unrestricted remote execution endpoint to the runtime.
+
+The reported p50/p95 is elapsed time from issuing a shell command in Lua until
+that agent sees the command's resulting screen, including PTY/VT batching and
+network round trips. These measurements are a smoke benchmark, not a capacity
+claim for a larger mesh. Deterministic permission, replay, cancellation, queue,
+and lifecycle tests live in `system/tty` and `cluster/internode`.

--- a/tests/tty-mesh/README.md
+++ b/tests/tty-mesh/README.md
@@ -1,11 +1,12 @@
-# Bidirectional Lua / PTY mesh proof
+# Concurrent Lua / PTY mesh proof
 
-This harness runs two independent Wippy actor schedulers and the real internode
-connection manager. Each node starts a Bash PTY behind the existing Lua `exec`
-and terminal proxy APIs, then mounts the other node's viewport from a Lua agent.
+This harness runs 2–8 independent Wippy actor schedulers and the real internode
+connection manager in a fully connected mesh. Each node starts a Bash PTY behind
+the existing Lua `exec` and terminal proxy APIs. Agents drive the next node in
+a ring concurrently, so every runtime both produces and consumes a surface.
 Each agent has a separate observation reference and input/resize reference.
 
-It verifies 20 commands in each direction, screen contents after ANSI clear and
+By default it verifies 20 commands per node, screen contents after ANSI clear and
 cursor commands, resize propagation, observe-only input rejection, and
 input-only snapshot/update rejection. The marker is split in the echoed shell
 command, so a matching screen proves command execution rather than input echo.
@@ -28,7 +29,7 @@ python3 tests/tty-mesh/run.py \
 ```
 
 The hosts need Bash, SSH/SCP connectivity, and reachability on the selected mesh
-ports (19470/19471 by default; `--port` changes the pair). SSH bootstraps the
+ports (`--port` through `--port + --nodes - 1`, starting at 19470). SSH bootstraps the
 second test process and exchanges its process-bound references. All terminal
 input, snapshots, updates, and operation responses travel over the real mesh.
 The proof generates temporary Ed25519 identities and mutual TLS credentials;
@@ -42,6 +43,30 @@ It does not add an unrestricted remote execution endpoint to the runtime.
 
 The reported p50/p95 is elapsed time from issuing a shell command in Lua until
 that agent sees the command's resulting screen, including PTY/VT batching and
-network round trips. These measurements are a smoke benchmark, not a capacity
-claim for a larger mesh. Deterministic permission, replay, cancellation, queue,
-and lifecycle tests live in `system/tty` and `cluster/internode`.
+network round trips. All peer connections must be established before agents run;
+reports include peer counts. Producers remain alive until every agent reports
+success, then the orchestrator releases all nodes together. Shutdown cancels
+runtime work before waiting for the scheduler. SSH never reads terminal stdin,
+and bootstrap commands have bounded timeouts.
+
+Exercise eight runtimes with 200 commands each by adding
+`--nodes 8 --commands 200` to either command above. In SSH mode node b runs remotely and the other
+runtimes run locally. This is an eight-runtime test on two physical hosts,
+not a capacity claim for eight hosts or a larger production mesh.
+
+Deterministic permission, replay, cancellation, queue, stalled-peer isolation,
+and supervisor-controller restart tests live in `system/tty` and
+`cluster/internode`. The restart tests use the process OnComplete barrier and
+verify that owner/consumer crashes invalidate old mounts and that restarted
+processes need fresh references. They do not boot registry-driven application
+supervision.
+
+Measure cached observation and coalescing with 120×40 frames and 1/8/32 observers:
+
+```bash
+GOWORK=off go test ./system/tty -run '^$' \
+  -bench 'BenchmarkMeshSnapshotFanout|BenchmarkRemoteCachedSnapshot' -benchmem
+```
+
+These in-memory transport benchmarks include snapshot encoding/decoding and
+report coalesced wire frames per presentation; they do not measure network RTT.

--- a/tests/tty-mesh/README.md
+++ b/tests/tty-mesh/README.md
@@ -1,5 +1,8 @@
 # Concurrent Lua / PTY mesh proof
 
+See the [Lua agent guide](LUA_GUIDE.md) for the cross-node API workflow and
+the [V1 assessment](V1_REVIEW.md) for evidence and remaining shared-mesh limits.
+
 This harness runs 2–8 independent Wippy actor schedulers and the real internode
 connection manager in a fully connected mesh. Each node starts a Bash PTY behind
 the existing Lua `exec` and terminal proxy APIs. Agents drive the next node in

--- a/tests/tty-mesh/V1_REVIEW.md
+++ b/tests/tty-mesh/V1_REVIEW.md
@@ -38,8 +38,16 @@ snapshot materialization path, with populated 120×40 rows:
 
 | Operation | Approximate time/call | Allocation/call |
 |---|---:|---:|
-| Full `snapshot()` | 1.03 µs | 1,879 bytes, 45 allocations |
-| `snapshot(last_revision)` when unchanged | 140 ns | 7 bytes amortized; allocations/op rounds to zero |
+| Full `snapshot()`, unchanged row content, warmed cache | 0.79 µs | 1,239 bytes, 5 allocations |
+| `snapshot(last_revision)` when unchanged | 149 ns | 7 bytes amortized; allocations/op rounds to zero |
+
+The viewport reuses boxed Lua strings for unchanged rows. This reduced repeated
+full reads from 1,879 bytes / 45 allocations and about 1.03 µs. Each changed row
+still needs a new string wrapper; the Go string conversion shares its backing
+bytes. Each call returns independent mutable snapshot and row tables, so caller
+edits cannot corrupt later reads or retained snapshots. The cache holds only one
+screen of row values, replaces its storage on row-count changes, and clears on
+close. It does not pool returned tables or change the Lua API.
 
 The unchanged check avoids building a screen table. Prefer update-driven reads
 and keep the last revision; do not poll full snapshots in a tight loop. These

--- a/tests/tty-mesh/V1_REVIEW.md
+++ b/tests/tty-mesh/V1_REVIEW.md
@@ -1,0 +1,78 @@
+# V1 review: Lua surface SDK and mesh
+
+The surface feature is suitable for a controlled V1 agent/debugging workflow.
+The core API covers producing, delegating, attaching, observing, input, resize,
+revocation, and composition without exposing transport internals to producers.
+Use [the Lua guide](LUA_GUIDE.md) for the cross-node workflow and its lifecycle.
+The whole mesh should not yet be described as memory-bounded under arbitrary
+outage and sustained overload.
+
+## Evidence
+
+- Eight independent runtimes on two Linux hosts, each connected to seven peers,
+  passed 1,600 concurrent Lua/Bash command-to-screen checks under the Go race
+  detector. Repeated runs showed per-node p95 varying roughly 13–34 ms. This is
+  a functional load test, not an eight-host capacity result or latency guarantee.
+- Populated 120×40-frame benchmarks cover 1, 8, and 32 observers. They verify
+  eventual latest-revision convergence and report wire frames per presentation.
+  The Go cached-snapshot read allocates zero bytes. These use an in-memory
+  transport; Lua table materialization is measured separately below.
+- The broader `go test -race ./cluster/...` suite passed, including membership,
+  Raft, multiplexing, and cluster/test-network packages.
+- Real-socket three-node, large-message, bidirectional, short-disruption,
+  repeated-reconnection, and failed-write requeue tests passed three race runs.
+  The existing test called HighThroughput sends only 100 paced messages; it is
+  not a sustained throughput benchmark.
+- Supervisor-controller tests exercise automatic owner/consumer restart through
+  the process lifecycle barrier, old-reference rejection, and complete mount
+  cleanup. They do not boot an entire registry-driven supervised application.
+- Surface regressions cover peer/PID checks, separate rights, replay suppression,
+  leases, queued cancellation, input-only revocation, stalled-peer isolation,
+  and retry reserve capacity. New SDK tests check valid and invalid simulated
+  events and selectable event channels.
+
+## Lua observation cost
+
+A local non-race benchmark on an AMD Ryzen 9 7950X3D measured the shared Lua
+snapshot materialization path, with populated 120×40 rows:
+
+| Operation | Approximate time/call | Allocation/call |
+|---|---:|---:|
+| Full `snapshot()` | 1.03 µs | 1,879 bytes, 45 allocations |
+| `snapshot(last_revision)` when unchanged | 140 ns | 7 bytes amortized; allocations/op rounds to zero |
+
+The unchanged check avoids building a screen table. Prefer update-driven reads
+and keep the last revision; do not poll full snapshots in a tight loop. These
+numbers do not include rendering, network RTT, or application command execution.
+
+```bash
+GOWORK=off go test ./runtime/lua/modules/tty -run '^$' \
+  -bench BenchmarkLuaViewportSnapshot -benchmem
+```
+
+## Remaining limits in the shared mesh
+
+1. **Reliable queues can grow during a long outage.** In
+   `cluster/internode/state_manager.go`, zero-capacity queues for process
+   broadcast and Raft traffic are deliberately unbounded while the peer remains
+   managed. This preserves accepted messages but does not bound memory if
+   producers keep sending to an unreachable peer. Surface admission is bounded;
+   that bound does not cover the other classes. A separate shared-mesh change
+   needs byte accounting and backpressure coordinated with those producers.
+2. **Control traffic has strict priority.** Application classes alternate fairly
+   with each other, after control/Raft/gossip traffic. Sustained control-plane
+   saturation can delay application traffic. The tests do not establish an
+   interactive latency bound during a Raft snapshot or membership storm.
+3. **Input acknowledgement stops at the broker.** End-to-end application
+   completion needs an observed marker or application acknowledgement. General
+   process messaging is not made exactly-once by surface RPC deduplication.
+4. **Overload/disconnection may end an attachment.** Bounded admission and RPC
+   timeouts intentionally fail rather than accumulate indefinitely. Reattachment
+   needs a fresh reference; there is no durable input log or automatic command
+   replay across process/node restarts.
+
+These shared-mesh policies predate the surface feature. Changing their delivery
+or priority semantics should remain separate from the surface PR. Before claiming
+larger production-scale robustness, add long-outage memory measurements,
+mixed Raft/process/surface saturation tests, and tests on more physical hosts.
+No new shared-mesh delivery failure was observed in the checks above.

--- a/tests/tty-mesh/main.go
+++ b/tests/tty-mesh/main.go
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// tty-mesh proves the real Lua -> actor -> authenticated internode -> viewport
+// -> Lua -> native PTY -> VT -> snapshot path between two independent nodes.
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/attrs"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/pid"
+	processapi "github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/resource"
+	"github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/security"
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/cluster/internode"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	luaexec "github.com/wippyai/runtime/runtime/lua/modules/exec"
+	luatty "github.com/wippyai/runtime/runtime/lua/modules/tty"
+	execdispatcher "github.com/wippyai/runtime/service/exec"
+	"github.com/wippyai/runtime/service/exec/native"
+	ttydispatcher "github.com/wippyai/runtime/service/terminal/tty"
+	relaysys "github.com/wippyai/runtime/system/relay"
+	"github.com/wippyai/runtime/system/scheduler"
+	"github.com/wippyai/runtime/system/scheduler/actor"
+	securitysys "github.com/wippyai/runtime/system/security"
+	ttysys "github.com/wippyai/runtime/system/tty"
+	"go.uber.org/zap"
+)
+
+type proofKeys struct {
+	A, B   []byte
+	Secret []byte
+}
+type references struct{ Observe, Input string }
+type transport struct{ cm internode.ConnectionManager }
+
+func (t transport) Send(peer string, b []byte) error {
+	return t.cm.SendToNode(peer, b, internode.ClassSurface)
+}
+func (t transport) Receive(fn func(string, []byte)) error {
+	if !t.cm.RegisterClassReceiver(internode.ClassSurface, fn) {
+		return errors.New("receiver already installed")
+	}
+	return nil
+}
+
+// The proof registers one real native executor without booting a registry DB.
+// All Lua security checks and the normal exec/PTY implementation still run.
+type executorRegistry struct{ executor execapi.ProcessExecutor }
+
+func (r executorRegistry) Acquire(_ context.Context, id registry.ID, _ resource.AccessMode) (resource.Resource[any], error) {
+	if id.String() != "proof:exec" {
+		return nil, errors.New("unknown executor")
+	}
+	return &executorResource{value: r.executor}, nil
+}
+func (executorRegistry) List() ([]registry.ID, error) {
+	return []registry.ID{registry.ParseID("proof:exec")}, nil
+}
+func (executorRegistry) Exists(id registry.ID) bool { return id.String() == "proof:exec" }
+
+type executorResource struct{ value any }
+
+func (r *executorResource) Get() (any, error) { return r.value, nil }
+func (*executorResource) Release()            {}
+
+type proofPolicy struct{}
+
+func (proofPolicy) ID() registry.ID { return registry.ParseID("proof:policy") }
+func (proofPolicy) Evaluate(_ security.Actor, action, _ string, _ attrs.Bag) security.Result {
+	switch action {
+	case "tty.mount", ttyapi.RightObserve, ttyapi.RightInput, ttyapi.RightResize, "exec.get", "exec.run":
+		return security.Allow
+	}
+	return security.Deny
+}
+
+type completion struct {
+	result *runtime.Result
+	pid    pid.PID
+}
+type lifecycle struct {
+	service   *ttysys.Service
+	completed chan completion
+}
+
+func (*lifecycle) OnStart(context.Context, pid.PID, processapi.Process) error { return nil }
+func (l *lifecycle) OnComplete(ctx context.Context, p pid.PID, r *runtime.Result) {
+	l.service.OnComplete(ctx, p, r)
+	l.completed <- completion{pid: p, result: r}
+}
+
+type runner struct {
+	root      context.Context
+	scheduler *actor.Scheduler
+	service   *ttysys.Service
+	completed chan completion
+	local     string
+	peer      string
+	out       string
+	frames    []ctxapi.FrameContext
+	latencies []time.Duration
+	mu        sync.Mutex
+}
+
+func (r *runner) spawn(id, script, grant string, refs references) error {
+	ctx, frame := ctxapi.OpenFrameContext(r.root)
+	p := pid.PID{Node: r.local, Host: "agents", UniqID: id}
+	if err := frame.Set(runtime.FramePIDKey, p); err != nil {
+		return err
+	}
+	if err := security.SetActor(ctx, security.Actor{ID: "proof:" + id}); err != nil {
+		return err
+	}
+	if err := security.SetScope(ctx, securitysys.NewScope([]security.Policy{proofPolicy{}})); err != nil {
+		return err
+	}
+	if grant != "" {
+		options := attrs.NewBagFrom(map[string]any{ttyapi.OptionTerminal: grant})
+		pairs, err := ttyapi.ResolveTerminalOption(ctx, options)
+		if err != nil {
+			return err
+		}
+		if err := frame.SetMultiple(pairs...); err != nil {
+			return err
+		}
+	}
+	r.mu.Lock()
+	r.frames = append(r.frames, frame)
+	r.mu.Unlock()
+	proc, err := engine.NewProcess(engine.WithScript("local raw_assert = assert; local function assert(ok, err) return raw_assert(ok, tostring(err)) end\n"+script, id+".lua"), engine.WithModuleBinder(func(l *lua.LState) error {
+		engine.BindCachedLibs(l)
+		engine.LoadModuleDef(l, engine.ChannelModule)
+		engine.LoadModuleDef(l, luatty.Module)
+		engine.LoadModuleDef(l, luaexec.Module)
+		l.SetGlobal("recipient", lua.LString((&pid.PID{Node: r.peer, Host: "agents", UniqID: "agent"}).String()))
+		l.SetGlobal("observe_ref", lua.LString(refs.Observe))
+		l.SetGlobal("input_ref", lua.LString(refs.Input))
+		l.SetGlobal("spawn_child", lua.LGoFunc(func(l *lua.LState) int {
+			if err := r.spawn("child", childScript, l.CheckString(1), references{}); err != nil {
+				l.RaiseError("spawn: %v", err)
+			}
+			return 0
+		}))
+		l.SetGlobal("publish", lua.LGoFunc(func(l *lua.LState) int {
+			b, err := json.Marshal(references{Observe: l.CheckString(1), Input: l.CheckString(2)})
+			if err == nil {
+				err = os.WriteFile(r.out, b, 0600)
+			}
+			if err != nil {
+				l.RaiseError("publish: %v", err)
+			}
+			return 0
+		}))
+		var start time.Time
+		l.SetGlobal("measure", lua.LGoFunc(func(l *lua.LState) int {
+			if l.CheckString(1) == "start" {
+				start = time.Now()
+			} else {
+				r.mu.Lock()
+				r.latencies = append(r.latencies, time.Since(start))
+				r.mu.Unlock()
+			}
+			return 0
+		}))
+		return nil
+	}))
+	if err != nil {
+		return err
+	}
+	if _, err = r.scheduler.Submit(ctx, p, proc, "", nil); err != nil {
+		proc.Close()
+		return err
+	}
+	return nil
+}
+
+const ownerScript = `
+local view = assert(tty.viewport({width=80,height=24}))
+local observe = assert(view:mount(recipient,{observe=true}))
+local input = assert(view:mount(recipient,{input=true,resize=true}))
+spawn_child(assert(view:grant()))
+publish(observe,input)
+channel.new():receive()
+`
+
+// The child is unchanged by transport placement. It receives only its normal
+// terminal binding, just like tests/tty-surface-demo/src/child.lua.
+const childScript = `
+local events = assert(tty.events())
+assert(tty.start())
+local executor = assert(exec.get("proof:exec"))
+local child = assert(executor:exec("/bin/bash --noprofile --norc", {pty={term="xterm-256color"},env={PS1="MESH_READY> "}}))
+local session = assert(child:attach_terminal())
+local done = session:done()
+while true do
+ local selected=channel.select({events:case_receive(),done:case_receive()})
+ if not selected.ok or selected.channel==done then break end
+ if selected.value.type=="close" then break end
+ assert(session:send(selected.value))
+end
+assert(session:close())
+assert(executor:release())
+`
+const agentScript = `
+local observer=assert(tty.attach(observe_ref))
+local control=assert(tty.attach(input_ref))
+local denied,err=observer:send({type="key",key="x",key_type="runes",action="press"})
+assert(denied==nil and err,"observe mount gained input")
+local hidden,read_err=control:snapshot()
+assert(hidden==nil and read_err,"input mount leaked snapshot")
+local stream,stream_err=control:updates()
+assert(stream==nil and stream_err,"input mount leaked updates")
+local updates=assert(observer:updates())
+local function wait_for(marker)
+ while true do
+  local snapshot=assert(observer:snapshot())
+  if string.find(table.concat(snapshot.rows,"\n"),marker,1,true) then return snapshot end
+  local _,open=updates:receive()
+  assert(open,"observer closed before expected screen")
+ end
+end
+wait_for("MESH_READY>")
+assert(control:resize(100,30))
+for i=1,20 do
+ measure("start")
+ -- Split the marker in the echoed command so only executed Bash output can
+ -- satisfy the screen assertion. Clear the screen to test actual VT state.
+ local cmd="printf '\\033[2J\\033[H%s\\n' 'MESH_'\"PROOF_"..i.."\""
+ assert(control:send({type="paste",text=cmd}))
+ assert(control:send({type="key",key="enter",key_type="enter",action="press"}))
+ local snapshot=wait_for("MESH_PROOF_"..i)
+ assert(snapshot.width==100 and snapshot.height==30)
+ measure("end")
+end
+assert(control:close())
+assert(observer:close())
+return "mesh Lua PTY proof passed"
+`
+
+func initKeys(dir, ips string) error {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	_, a, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	_, b, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	secret := make([]byte, 32)
+	if _, err = rand.Read(secret); err != nil {
+		return err
+	}
+	data, err := json.Marshal(proofKeys{A: a, B: b, Secret: secret})
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(filepath.Join(dir, "keys.json"), data, 0600); err != nil {
+		return err
+	}
+	pub, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	cert := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "tty-mesh-proof"}, NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(24 * time.Hour), IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}}
+	for _, s := range strings.Split(ips, ",") {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			return fmt.Errorf("invalid IP %q", s)
+		}
+		cert.IPAddresses = append(cert.IPAddresses, ip)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, cert, cert, pub, key)
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(filepath.Join(dir, "cert.pem"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		return err
+	}
+	der, err = x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "key.pem"), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0600)
+}
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+func run() error {
+	initDir := flag.String("init", "", "generate disposable proof identities and TLS certificate")
+	ips := flag.String("ips", "127.0.0.1", "comma-separated certificate IPs")
+	keysDir := flag.String("keys", "", "proof identity directory")
+	local := flag.String("node", "a", "a or b")
+	bind := flag.String("bind", "127.0.0.1", "listen address")
+	port := flag.Int("port", 19470, "internode listen port")
+	peerAddr := flag.String("peer-address", "127.0.0.1", "peer address")
+	peerPort := flag.Int("peer-port", 19471, "peer port")
+	out := flag.String("refs-out", "", "local references file")
+	peerFile := flag.String("peer-refs", "", "peer references file")
+	hold := flag.Duration("hold", 3*time.Second, "keep local producer alive after agent completes")
+	flag.Parse()
+	if *initDir != "" {
+		return initKeys(*initDir, *ips)
+	}
+	if *keysDir == "" || *out == "" || *peerFile == "" || (*local != "a" && *local != "b") {
+		return errors.New("keys, refs-out, peer-refs and node a/b are required")
+	}
+	data, err := os.ReadFile(filepath.Join(*keysDir, "keys.json"))
+	if err != nil {
+		return err
+	}
+	var keys proofKeys
+	if err = json.Unmarshal(data, &keys); err != nil {
+		return err
+	}
+	peer := "b"
+	own, other := keys.A, keys.B
+	if *local == "b" {
+		peer = "a"
+		own, other = keys.B, keys.A
+	}
+	if len(own) != ed25519.PrivateKeySize || len(other) != ed25519.PrivateKeySize {
+		return errors.New("invalid proof key")
+	}
+	cfg := internode.DefaultManagerConfig()
+	cfg.LocalNodeID = *local
+	cfg.BindAddr = *bind
+	cfg.BindPort = *port
+	cfg.AutoPort = false
+	cfg.Logger = zap.NewNop()
+	cfg.AuthenticationKey = keys.Secret
+	cfg.SigningKey = ed25519.PrivateKey(own)
+	cfg.ResolvePeerKey = func(id string) (ed25519.PublicKey, bool) {
+		return ed25519.PrivateKey(other).Public().(ed25519.PublicKey), id == peer
+	}
+	cfg.AuthorizePeer = func(id string, _ net.Addr) bool { return id == peer }
+	cfg.TLS = internode.ManagerTLSConfig{Enabled: true, CertFile: filepath.Join(*keysDir, "cert.pem"), CAFile: filepath.Join(*keysDir, "cert.pem"), KeyFile: filepath.Join(*keysDir, "key.pem")}
+	cm := internode.NewConnectionManager(cfg, nil)
+	ctx, cancel := context.WithTimeout(ctxapi.NewRootContext(), 90*time.Second)
+	defer cancel()
+	if err = cm.Start(ctx, func(string, []byte) {}); err != nil {
+		return err
+	}
+	defer func() { _ = cm.Stop() }()
+	cm.AddManagedNode(peer)
+	cm.EnsureConnection(peer, *peerAddr, *peerPort)
+	service := ttysys.NewService()
+	defer service.Close()
+	if err = service.SetMesh(*local, transport{cm}); err != nil {
+		return err
+	}
+	root := ttyapi.WithService(ctx, service)
+	root = resource.WithRegistry(root, executorRegistry{native.NewNativeExecutor(zap.NewNop(), &execapi.NativeExecutorConfig{})})
+	dispatch := ttydispatcher.NewDispatcher()
+	if err = dispatch.Start(ctx); err != nil {
+		return err
+	}
+	defer func() { _ = dispatch.Stop(context.Background()) }()
+	reg := scheduler.NewRegistry()
+	dispatch.RegisterAll(reg.Register)
+	execdispatcher.NewDispatcher().RegisterAll(reg.Register)
+	completed := make(chan completion, 16)
+	sched := actor.NewScheduler(reg, actor.WithWorkers(1), actor.WithLifecycle(&lifecycle{service, completed}))
+	node := relaysys.NewNode(*local)
+	if err = node.RegisterHost("agents", sched); err != nil {
+		return err
+	}
+	root = relay.WithNode(root, node)
+	sched.Start()
+
+	r := &runner{root: root, scheduler: sched, service: service, local: *local, peer: peer, out: *out, completed: completed}
+	defer func() {
+		stop, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		sched.Stop(stop)
+		for _, f := range r.frames {
+			_ = f.Close()
+		}
+	}()
+	if err = r.spawn("owner", ownerScript, "", references{}); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	var refs references
+waitPeer:
+	for {
+		select {
+		case c := <-completed:
+			if c.result != nil && c.result.Error != nil {
+				return c.result.Error
+			}
+			return fmt.Errorf("%s ended before peer attached", c.pid.UniqID)
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			data, err = os.ReadFile(*peerFile)
+			if err == nil && json.Unmarshal(data, &refs) == nil && refs.Observe != "" && len(cm.ConnectedNodes()) > 0 {
+				break waitPeer
+			}
+		}
+	}
+	if err = r.spawn("agent", agentScript, "", refs); err != nil {
+		return err
+	}
+	for {
+		select {
+		case c := <-completed:
+			if c.result != nil && c.result.Error != nil {
+				return fmt.Errorf("%s: %w", c.pid.UniqID, c.result.Error)
+			}
+			if c.pid.UniqID != "agent" {
+				return fmt.Errorf("unexpected process exit: %s", c.pid.UniqID)
+			}
+			r.mu.Lock()
+			samples := append([]time.Duration(nil), r.latencies...)
+			r.mu.Unlock()
+			if len(samples) != 20 {
+				return fmt.Errorf("expected 20 command results, got %d", len(samples))
+			}
+			sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+			report := map[string]any{"node": *local, "peer": peer, "commands": len(samples), "p50_ms": float64(samples[len(samples)/2]) / float64(time.Millisecond), "p95_ms": float64(samples[len(samples)*95/100]) / float64(time.Millisecond), "result": "PASS", "transport": "mutual TLS + authenticated internode", "lua_workers": 1}
+			encoded, _ := json.Marshal(report)
+			fmt.Println(string(encoded))
+			select {
+			case <-time.After(*hold):
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/tests/tty-mesh/main.go
+++ b/tests/tty-mesh/main.go
@@ -52,7 +52,7 @@ import (
 )
 
 type proofKeys struct {
-	A, B   []byte
+	Nodes  map[string][]byte
 	Secret []byte
 }
 type references struct{ Observe, Input string }
@@ -121,9 +121,11 @@ type runner struct {
 	completed chan completion
 	local     string
 	peer      string
+	recipient string
 	out       string
 	frames    []ctxapi.FrameContext
 	latencies []time.Duration
+	commands  int
 	mu        sync.Mutex
 }
 
@@ -157,7 +159,8 @@ func (r *runner) spawn(id, script, grant string, refs references) error {
 		engine.LoadModuleDef(l, engine.ChannelModule)
 		engine.LoadModuleDef(l, luatty.Module)
 		engine.LoadModuleDef(l, luaexec.Module)
-		l.SetGlobal("recipient", lua.LString((&pid.PID{Node: r.peer, Host: "agents", UniqID: "agent"}).String()))
+		l.SetGlobal("commands", lua.LInteger(r.commands))
+		l.SetGlobal("recipient", lua.LString((&pid.PID{Node: r.recipient, Host: "agents", UniqID: "agent"}).String()))
 		l.SetGlobal("observe_ref", lua.LString(refs.Observe))
 		l.SetGlobal("input_ref", lua.LString(refs.Input))
 		l.SetGlobal("spawn_child", lua.LGoFunc(func(l *lua.LState) int {
@@ -246,7 +249,7 @@ local function wait_for(marker)
 end
 wait_for("MESH_READY>")
 assert(control:resize(100,30))
-for i=1,20 do
+for i=1,commands do
  measure("start")
  -- Split the marker in the echoed command so only executed Bash output can
  -- satisfy the screen assertion. Clear the screen to test actual VT state.
@@ -262,23 +265,26 @@ assert(observer:close())
 return "mesh Lua PTY proof passed"
 `
 
-func initKeys(dir, ips string) error {
+func initKeys(dir, ips string, count int) error {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-	_, a, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return err
+	if count < 2 || count > 8 {
+		return errors.New("node count must be 2..8")
 	}
-	_, b, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return err
+	nodes := make(map[string][]byte, count)
+	for i := range count {
+		_, key, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return err
+		}
+		nodes[string(rune('a'+i))] = key
 	}
 	secret := make([]byte, 32)
-	if _, err = rand.Read(secret); err != nil {
+	if _, err := rand.Read(secret); err != nil {
 		return err
 	}
-	data, err := json.Marshal(proofKeys{A: a, B: b, Secret: secret})
+	data, err := json.Marshal(proofKeys{Nodes: nodes, Secret: secret})
 	if err != nil {
 		return err
 	}
@@ -320,7 +326,13 @@ func run() error {
 	initDir := flag.String("init", "", "generate disposable proof identities and TLS certificate")
 	ips := flag.String("ips", "127.0.0.1", "comma-separated certificate IPs")
 	keysDir := flag.String("keys", "", "proof identity directory")
-	local := flag.String("node", "a", "a or b")
+	local := flag.String("node", "a", "local node ID")
+	count := flag.Int("nodes", 2, "number of generated identities, 2..8")
+	peerID := flag.String("peer-node", "", "node whose terminal this agent drives")
+	recipient := flag.String("recipient-node", "", "node allowed to attach to this producer")
+	meshFile := flag.String("mesh-peers", "", "JSON map of node IDs to address/port")
+	commands := flag.Int("commands", 20, "commands executed by each agent")
+	releaseFile := flag.String("release-file", "", "keep producer alive until orchestrator creates this file")
 	bind := flag.String("bind", "127.0.0.1", "listen address")
 	port := flag.Int("port", 19470, "internode listen port")
 	peerAddr := flag.String("peer-address", "127.0.0.1", "peer address")
@@ -330,10 +342,10 @@ func run() error {
 	hold := flag.Duration("hold", 3*time.Second, "keep local producer alive after agent completes")
 	flag.Parse()
 	if *initDir != "" {
-		return initKeys(*initDir, *ips)
+		return initKeys(*initDir, *ips, *count)
 	}
-	if *keysDir == "" || *out == "" || *peerFile == "" || (*local != "a" && *local != "b") {
-		return errors.New("keys, refs-out, peer-refs and node a/b are required")
+	if *keysDir == "" || *out == "" || *peerFile == "" || *commands < 1 {
+		return errors.New("keys, refs-out, peer-refs and positive commands are required")
 	}
 	data, err := os.ReadFile(filepath.Join(*keysDir, "keys.json"))
 	if err != nil {
@@ -343,14 +355,33 @@ func run() error {
 	if err = json.Unmarshal(data, &keys); err != nil {
 		return err
 	}
-	peer := "b"
-	own, other := keys.A, keys.B
-	if *local == "b" {
-		peer = "a"
-		own, other = keys.B, keys.A
+	peer := *peerID
+	if peer == "" {
+		peer = "b"
+		if *local == "b" {
+			peer = "a"
+		}
 	}
-	if len(own) != ed25519.PrivateKeySize || len(other) != ed25519.PrivateKeySize {
-		return errors.New("invalid proof key")
+	if *recipient == "" {
+		*recipient = peer
+	}
+	own := keys.Nodes[*local]
+	if len(own) != ed25519.PrivateKeySize || len(keys.Nodes[peer]) != ed25519.PrivateKeySize {
+		return errors.New("invalid proof identity")
+	}
+	type endpoint struct {
+		Address string
+		Port    int
+	}
+	peers := map[string]endpoint{peer: {Address: *peerAddr, Port: *peerPort}}
+	if *meshFile != "" {
+		data, err := os.ReadFile(*meshFile)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, &peers); err != nil {
+			return err
+		}
 	}
 	cfg := internode.DefaultManagerConfig()
 	cfg.LocalNodeID = *local
@@ -361,9 +392,13 @@ func run() error {
 	cfg.AuthenticationKey = keys.Secret
 	cfg.SigningKey = ed25519.PrivateKey(own)
 	cfg.ResolvePeerKey = func(id string) (ed25519.PublicKey, bool) {
-		return ed25519.PrivateKey(other).Public().(ed25519.PublicKey), id == peer
+		key := keys.Nodes[id]
+		if len(key) != ed25519.PrivateKeySize {
+			return nil, false
+		}
+		return ed25519.PrivateKey(key).Public().(ed25519.PublicKey), id != *local
 	}
-	cfg.AuthorizePeer = func(id string, _ net.Addr) bool { return id == peer }
+	cfg.AuthorizePeer = func(id string, _ net.Addr) bool { return id != *local && len(keys.Nodes[id]) == ed25519.PrivateKeySize }
 	cfg.TLS = internode.ManagerTLSConfig{Enabled: true, CertFile: filepath.Join(*keysDir, "cert.pem"), CAFile: filepath.Join(*keysDir, "cert.pem"), KeyFile: filepath.Join(*keysDir, "key.pem")}
 	cm := internode.NewConnectionManager(cfg, nil)
 	ctx, cancel := context.WithTimeout(ctxapi.NewRootContext(), 90*time.Second)
@@ -372,8 +407,14 @@ func run() error {
 		return err
 	}
 	defer func() { _ = cm.Stop() }()
-	cm.AddManagedNode(peer)
-	cm.EnsureConnection(peer, *peerAddr, *peerPort)
+	expectedPeers := 0
+	for id, address := range peers {
+		if id != *local {
+			expectedPeers++
+			cm.AddManagedNode(id)
+			cm.EnsureConnection(id, address.Address, address.Port)
+		}
+	}
 	service := ttysys.NewService()
 	defer service.Close()
 	if err = service.SetMesh(*local, transport{cm}); err != nil {
@@ -398,8 +439,9 @@ func run() error {
 	root = relay.WithNode(root, node)
 	sched.Start()
 
-	r := &runner{root: root, scheduler: sched, service: service, local: *local, peer: peer, out: *out, completed: completed}
+	r := &runner{recipient: *recipient, commands: *commands, root: root, scheduler: sched, service: service, local: *local, peer: peer, out: *out, completed: completed}
 	defer func() {
+		cancel()
 		stop, c := context.WithTimeout(context.Background(), 5*time.Second)
 		defer c()
 		sched.Stop(stop)
@@ -425,7 +467,7 @@ waitPeer:
 			return ctx.Err()
 		case <-ticker.C:
 			data, err = os.ReadFile(*peerFile)
-			if err == nil && json.Unmarshal(data, &refs) == nil && refs.Observe != "" && len(cm.ConnectedNodes()) > 0 {
+			if err == nil && json.Unmarshal(data, &refs) == nil && refs.Observe != "" && len(cm.ConnectedNodes()) >= expectedPeers {
 				break waitPeer
 			}
 		}
@@ -445,13 +487,25 @@ waitPeer:
 			r.mu.Lock()
 			samples := append([]time.Duration(nil), r.latencies...)
 			r.mu.Unlock()
-			if len(samples) != 20 {
-				return fmt.Errorf("expected 20 command results, got %d", len(samples))
+			if len(samples) != *commands {
+				return fmt.Errorf("expected %d command results, got %d", *commands, len(samples))
 			}
 			sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
-			report := map[string]any{"node": *local, "peer": peer, "commands": len(samples), "p50_ms": float64(samples[len(samples)/2]) / float64(time.Millisecond), "p95_ms": float64(samples[len(samples)*95/100]) / float64(time.Millisecond), "result": "PASS", "transport": "mutual TLS + authenticated internode", "lua_workers": 1}
+			report := map[string]any{"node": *local, "peer": peer, "commands": len(samples), "connected_peers": len(cm.ConnectedNodes()), "p50_ms": float64(samples[len(samples)/2]) / float64(time.Millisecond), "p95_ms": float64(samples[len(samples)*95/100]) / float64(time.Millisecond), "result": "PASS", "transport": "mutual TLS + authenticated internode", "lua_workers": 1}
 			encoded, _ := json.Marshal(report)
 			fmt.Println(string(encoded))
+			if *releaseFile != "" {
+				for {
+					if _, err := os.Stat(*releaseFile); err == nil {
+						return nil
+					}
+					select {
+					case <-ticker.C:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
 			select {
 			case <-time.After(*hold):
 				return nil

--- a/tests/tty-mesh/run.py
+++ b/tests/tty-mesh/run.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+"""Run the symmetric Lua/PTY proof locally or over an authorized SSH host."""
+import argparse
+import json
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default="/tmp/wippy-tty-mesh-proof")
+    parser.add_argument("--ssh", help="SSH target for node b")
+    parser.add_argument("--peer-address", help="mesh IP of SSH host")
+    parser.add_argument("--local-address", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19470)
+    args = parser.parse_args()
+    if args.ssh and (not args.peer_address or args.local_address == "127.0.0.1"):
+        parser.error("SSH mode requires --peer-address and a reachable --local-address")
+    binary = str(Path(args.binary).resolve())
+    peer_address = args.peer_address or "127.0.0.1"
+    processes = []
+    remote_dir = None
+
+    def ssh(command, **kwargs):
+        return subprocess.run(["ssh", "-o", "BatchMode=yes", args.ssh, shlex.join(command)], check=True, **kwargs)
+
+    with tempfile.TemporaryDirectory(prefix="tty-mesh-proof-") as directory:
+        scratch = Path(directory)
+        subprocess.run([binary, "-init", directory, "-ips", f"127.0.0.1,{args.local_address},{peer_address}"], check=True)
+        try:
+            if args.ssh:
+                remote_dir = ssh(["mktemp", "-d", "/tmp/tty-mesh-proof-XXXXXXXX"], capture_output=True, text=True).stdout.strip()
+                if not remote_dir.startswith("/tmp/tty-mesh-proof-") or "/" in remote_dir[len("/tmp/"):]:
+                    raise RuntimeError("unexpected remote scratch path")
+                subprocess.run(["scp", "-q", binary, str(scratch / "keys.json"), str(scratch / "cert.pem"), str(scratch / "key.pem"), f"{args.ssh}:{remote_dir}/"], check=True)
+            else:
+                remote_dir = directory
+            a_command = [binary, "-keys", directory, "-node", "a", "-bind", args.local_address,
+                         "-port", str(args.port), "-peer-address", peer_address, "-peer-port", str(args.port + 1),
+                         "-refs-out", str(scratch / "a.json"), "-peer-refs", str(scratch / "b.json")]
+            b_command = [f"{remote_dir}/{Path(binary).name}" if args.ssh else binary,
+                         "-keys", remote_dir, "-node", "b", "-bind", peer_address,
+                         "-port", str(args.port + 1), "-peer-address", args.local_address, "-peer-port", str(args.port),
+                         "-refs-out", f"{remote_dir}/b.json", "-peer-refs", f"{remote_dir}/a.json"]
+            if args.ssh:
+                # Save the process ID so failed proofs can terminate only their
+                # own remote process, without touching the host's other work.
+                command = f"echo $$ > {shlex.quote(remote_dir + '/pid')}; exec {shlex.join(b_command)}"
+                b_command = ["ssh", "-o", "BatchMode=yes", args.ssh, command]
+            logs = [open(scratch / f"{name}.log", "w+") for name in ("a", "b")]
+            for command, log in zip((a_command, b_command), logs):
+                processes.append(subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT))
+            deadline = time.monotonic() + 100
+            exchanged = not args.ssh
+            while time.monotonic() < deadline and any(p.poll() is None for p in processes):
+                if any(p.poll() not in (None, 0) for p in processes):
+                    break
+                if not exchanged and (scratch / "a.json").exists():
+                    exists = subprocess.run(["ssh", "-o", "BatchMode=yes", args.ssh,
+                                             shlex.join(["test", "-s", remote_dir + "/b.json"])], capture_output=True).returncode == 0
+                    if exists:
+                        subprocess.run(["scp", "-q", str(scratch / "a.json"), f"{args.ssh}:{remote_dir}/a.json"], check=True)
+                        subprocess.run(["scp", "-q", f"{args.ssh}:{remote_dir}/b.json", str(scratch / "b.json")], check=True)
+                        exchanged = True
+                time.sleep(0.1)
+            success = all(p.poll() == 0 for p in processes)
+            for name, log in zip(("a", "b"), logs):
+                log.flush()
+                log.seek(0)
+                output = log.read()
+                print(f"node {name}:\n{output}", flush=True)
+                if not any(line.startswith("{") and json.loads(line).get("result") == "PASS" for line in output.splitlines()):
+                    success = False
+            if not success:
+                raise RuntimeError("two-node Lua/PTY proof failed")
+        finally:
+            for process in processes:
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait()
+            if args.ssh and remote_dir:
+                # The private keys and bound test references never leave the
+                # disposable directories and are removed after the proof.
+                command = f"if test -f {shlex.quote(remote_dir + '/pid')}; then kill $(cat {shlex.quote(remote_dir + '/pid')}) 2>/dev/null || true; fi"
+                subprocess.run(["ssh", "-o", "BatchMode=yes", args.ssh, command], check=False)
+                ssh(["rm", "-rf", "--", remote_dir])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tty-mesh/run.py
+++ b/tests/tty-mesh/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MPL-2.0
-"""Run the symmetric Lua/PTY proof locally or over an authorized SSH host."""
+"""Run concurrent Lua/PTY agents on a fully connected 2..8-node mesh."""
 import argparse
 import json
 from pathlib import Path
@@ -13,85 +13,118 @@ import time
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--binary", default="/tmp/wippy-tty-mesh-proof")
-    parser.add_argument("--ssh", help="SSH target for node b")
+    parser.add_argument("--ssh", help="SSH target for node b; other nodes run locally")
     parser.add_argument("--peer-address", help="mesh IP of SSH host")
     parser.add_argument("--local-address", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=19470)
+    parser.add_argument("--nodes", type=int, default=2, choices=range(2, 9))
+    parser.add_argument("--commands", type=int, default=20)
     args = parser.parse_args()
+    if args.commands < 1:
+        parser.error("commands must be positive")
     if args.ssh and (not args.peer_address or args.local_address == "127.0.0.1"):
         parser.error("SSH mode requires --peer-address and a reachable --local-address")
     binary = str(Path(args.binary).resolve())
-    peer_address = args.peer_address or "127.0.0.1"
-    processes = []
+    nodes = [chr(ord('a') + i) for i in range(args.nodes)]
+    peers = {node: {"Address": args.peer_address if args.ssh and node == 'b' else args.local_address,
+                    "Port": args.port + i} for i, node in enumerate(nodes)}
+    processes, logs = [], []
     remote_dir = None
+    ssh_options = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5", "-o", "ServerAliveInterval=2", "-o", "ServerAliveCountMax=2"]
+
+    def run(command, **kwargs):
+        kwargs.setdefault("timeout", 15)
+        kwargs.setdefault("stdin", subprocess.DEVNULL)
+        kwargs.setdefault("check", True)
+        return subprocess.run(command, **kwargs)
 
     def ssh(command, **kwargs):
-        return subprocess.run(["ssh", "-o", "BatchMode=yes", args.ssh, shlex.join(command)], check=True, **kwargs)
+        return run(["ssh", "-n", *ssh_options, args.ssh, shlex.join(command)], **kwargs)
+
+    def copy(*paths):
+        run(["scp", "-q", *ssh_options, *paths], timeout=30)
+
+    def reports():
+        result = {}
+        for node, log in zip(nodes, logs):
+            log.seek(0)
+            for line in log.read().splitlines():
+                if line.startswith("{"):
+                    report = json.loads(line)
+                    if report.get("result") == "PASS":
+                        result[node] = report
+        return result
 
     with tempfile.TemporaryDirectory(prefix="tty-mesh-proof-") as directory:
         scratch = Path(directory)
-        subprocess.run([binary, "-init", directory, "-ips", f"127.0.0.1,{args.local_address},{peer_address}"], check=True)
+        run([binary, "-init", directory, "-nodes", str(args.nodes), "-ips",
+             ",".join(sorted({"127.0.0.1", *(peer["Address"] for peer in peers.values())}))])
+        (scratch / "peers.json").write_text(json.dumps(peers))
         try:
             if args.ssh:
                 remote_dir = ssh(["mktemp", "-d", "/tmp/tty-mesh-proof-XXXXXXXX"], capture_output=True, text=True).stdout.strip()
                 if not remote_dir.startswith("/tmp/tty-mesh-proof-") or "/" in remote_dir[len("/tmp/"):]:
+                    remote_dir = None
                     raise RuntimeError("unexpected remote scratch path")
-                subprocess.run(["scp", "-q", binary, str(scratch / "keys.json"), str(scratch / "cert.pem"), str(scratch / "key.pem"), f"{args.ssh}:{remote_dir}/"], check=True)
-            else:
-                remote_dir = directory
-            a_command = [binary, "-keys", directory, "-node", "a", "-bind", args.local_address,
-                         "-port", str(args.port), "-peer-address", peer_address, "-peer-port", str(args.port + 1),
-                         "-refs-out", str(scratch / "a.json"), "-peer-refs", str(scratch / "b.json")]
-            b_command = [f"{remote_dir}/{Path(binary).name}" if args.ssh else binary,
-                         "-keys", remote_dir, "-node", "b", "-bind", peer_address,
-                         "-port", str(args.port + 1), "-peer-address", args.local_address, "-peer-port", str(args.port),
-                         "-refs-out", f"{remote_dir}/b.json", "-peer-refs", f"{remote_dir}/a.json"]
-            if args.ssh:
-                # Save the process ID so failed proofs can terminate only their
-                # own remote process, without touching the host's other work.
-                command = f"echo $$ > {shlex.quote(remote_dir + '/pid')}; exec {shlex.join(b_command)}"
-                b_command = ["ssh", "-o", "BatchMode=yes", args.ssh, command]
-            logs = [open(scratch / f"{name}.log", "w+") for name in ("a", "b")]
-            for command, log in zip((a_command, b_command), logs):
-                processes.append(subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT))
+                copy(binary, *(str(scratch / name) for name in ("keys.json", "cert.pem", "key.pem", "peers.json")), f"{args.ssh}:{remote_dir}/")
+            for i, node in enumerate(nodes):
+                remote = bool(args.ssh and node == "b")
+                root = remote_dir if remote else directory
+                command = [f"{root}/{Path(binary).name}" if remote else binary,
+                           "-keys", root, "-node", node, "-bind", peers[node]["Address"], "-port", str(peers[node]["Port"]),
+                           "-peer-node", nodes[(i + 1) % len(nodes)], "-recipient-node", nodes[(i - 1) % len(nodes)],
+                           "-mesh-peers", root + "/peers.json", "-commands", str(args.commands),
+                           "-refs-out", f"{root}/{node}.json", "-peer-refs", f"{root}/{nodes[(i + 1) % len(nodes)]}.json",
+                           "-release-file", root + "/release"]
+                if remote:
+                    launch = f"echo $$ > {shlex.quote(root + '/pid')}; exec {shlex.join(command)}"
+                    command = ["ssh", "-n", *ssh_options, args.ssh, launch]
+                log = open(scratch / f"{node}.log", "w+")
+                logs.append(log)
+                processes.append(subprocess.Popen(command, stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT))
             deadline = time.monotonic() + 100
-            exchanged = not args.ssh
+            exchanged, released = not args.ssh, False
             while time.monotonic() < deadline and any(p.poll() is None for p in processes):
                 if any(p.poll() not in (None, 0) for p in processes):
                     break
-                if not exchanged and (scratch / "a.json").exists():
-                    exists = subprocess.run(["ssh", "-o", "BatchMode=yes", args.ssh,
-                                             shlex.join(["test", "-s", remote_dir + "/b.json"])], capture_output=True).returncode == 0
-                    if exists:
-                        subprocess.run(["scp", "-q", str(scratch / "a.json"), f"{args.ssh}:{remote_dir}/a.json"], check=True)
-                        subprocess.run(["scp", "-q", f"{args.ssh}:{remote_dir}/b.json", str(scratch / "b.json")], check=True)
+                if not exchanged:
+                    next_node = nodes[2 % len(nodes)]
+                    if (scratch / f"{next_node}.json").exists() and ssh(["test", "-s", remote_dir + "/b.json"], check=False).returncode == 0:
+                        copy(str(scratch / f"{next_node}.json"), f"{args.ssh}:{remote_dir}/{next_node}.json")
+                        copy(f"{args.ssh}:{remote_dir}/b.json", str(scratch / "b.json"))
                         exchanged = True
-                time.sleep(0.1)
-            success = all(p.poll() == 0 for p in processes)
-            for name, log in zip(("a", "b"), logs):
-                log.flush()
+                if not released and len(reports()) == args.nodes:
+                    (scratch / "release").touch()
+                    if args.ssh:
+                        ssh(["touch", remote_dir + "/release"])
+                    released = True
+                time.sleep(.05)
+            result = reports()
+            for node, log in zip(nodes, logs):
                 log.seek(0)
-                output = log.read()
-                print(f"node {name}:\n{output}", flush=True)
-                if not any(line.startswith("{") and json.loads(line).get("result") == "PASS" for line in output.splitlines()):
-                    success = False
-            if not success:
-                raise RuntimeError("two-node Lua/PTY proof failed")
+                print(f"node {node}:\n{log.read()}", flush=True)
+            if (len(result) != args.nodes or not all(p.poll() == 0 for p in processes)
+                    or any(report.get("connected_peers") != args.nodes - 1 for report in result.values())):
+                raise RuntimeError("multi-node Lua/PTY proof failed")
         finally:
-            for process in processes:
-                if process.poll() is None:
-                    process.terminate()
-                    try:
-                        process.wait(timeout=5)
-                    except subprocess.TimeoutExpired:
-                        process.kill()
-                        process.wait()
-            if args.ssh and remote_dir:
-                # The private keys and bound test references never leave the
-                # disposable directories and are removed after the proof.
-                command = f"if test -f {shlex.quote(remote_dir + '/pid')}; then kill $(cat {shlex.quote(remote_dir + '/pid')}) 2>/dev/null || true; fi"
-                subprocess.run(["ssh", "-o", "BatchMode=yes", args.ssh, command], check=False)
-                ssh(["rm", "-rf", "--", remote_dir])
+            # Kill the owned remote node before terminating its bootstrap SSH.
+            try:
+                if args.ssh and remote_dir:
+                    command = f"if test -f {shlex.quote(remote_dir + '/pid')}; then kill $(cat {shlex.quote(remote_dir + '/pid')}) 2>/dev/null || true; fi"
+                    ssh(["sh", "-c", command], check=False)
+            finally:
+                for process in processes:
+                    if process.poll() is None:
+                        process.terminate()
+                        try:
+                            process.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                            process.wait()
+                for log in logs:
+                    log.close()
+                if args.ssh and remote_dir:
+                    ssh(["rm", "-rf", "--", remote_dir])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Viewport revocation can race recipient cleanup: the recipient exit removes the mount before its issuer revokes it, causing cleanup to report an invalid grant even though access has already ended.

Treat an absent mount as successfully revoked after checking issuer authority. Existing mounts owned by another issuer still return an invalid grant. The regression exercises repeated revocation and rejects a foreign actor after cleanup.

Stacked on #653, which introduces viewport mounts. Validation: the TTY service race suite passed; pinned golangci-lint v2.13.2 reported zero issues for the package.

Extracted from Bee's local runtime patch. GitHub CI is skipped on this preparation commit to conserve Actions quota; local checks are complete.
