### PR TITLE
fix(metrics): exclude in-flight sends before collector shutdown

### DIFF
--- a/service/metrics/collector.go
+++ b/service/metrics/collector.go
@@ -19,6 +19,7 @@ type collector struct {
 	wg        sync.WaitGroup
 	dropped   atomic.Uint64
 	exportMu  sync.RWMutex
+	recordMu  sync.RWMutex // excludes in-flight send admission from shutdown
 	closed    atomic.Bool
 }
 
@@ -67,6 +68,15 @@ func (c *collector) HistogramObserve(name string, value float64, labels api.Labe
 }
 
 func (c *collector) record(name string, typ api.MetricType, value float64, labels api.Labels) {
+	if c.closed.Load() {
+		c.dropped.Add(1)
+		return
+	}
+
+	c.recordMu.RLock()
+	defer c.recordMu.RUnlock()
+	// Close may have won after the fast check. A read lock held through send
+	// admission ensures the export loop cannot close the channel underneath it.
 	if c.closed.Load() {
 		c.dropped.Add(1)
 		return
@@ -135,10 +145,14 @@ func (c *collector) flush(batch []recordEvent) {
 }
 
 func (c *collector) Close() error {
+	c.recordMu.Lock()
 	if !c.closed.CompareAndSwap(false, true) {
+		c.recordMu.Unlock()
 		return nil
 	}
+	// All admitted senders have left; later record calls observe closed.
 	close(c.stopCh)
+	c.recordMu.Unlock()
 	c.wg.Wait()
 
 	c.exportMu.RLock()

--- a/service/metrics/collector.go
+++ b/service/metrics/collector.go
@@ -3,6 +3,7 @@
 package metrics
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,6 +13,7 @@ import (
 )
 
 type collector struct {
+	closeErr  error
 	recordCh  chan recordEvent
 	stopCh    chan struct{}
 	exporters []api.Exporter
@@ -20,8 +22,11 @@ type collector struct {
 	dropped   atomic.Uint64
 	exportMu  sync.RWMutex
 	recordMu  sync.RWMutex // excludes in-flight send admission from shutdown
+	closeOnce sync.Once
 	closed    atomic.Bool
 }
+
+var errCollectorClosed = errors.New("metrics collector is closed")
 
 type recordEvent struct {
 	labels api.Labels
@@ -96,6 +101,9 @@ func (c *collector) Dropped() uint64 {
 func (c *collector) RegisterExporter(e api.Exporter) error {
 	c.exportMu.Lock()
 	defer c.exportMu.Unlock()
+	if c.closed.Load() {
+		return errCollectorClosed
+	}
 	c.exporters = append(c.exporters, e)
 	return nil
 }
@@ -120,14 +128,20 @@ func (c *collector) exportLoop() {
 				batch = batch[:0]
 			}
 		case <-c.stopCh:
-			close(c.recordCh)
-			for ev := range c.recordCh {
-				batch = append(batch, ev)
+			// Close establishes a send-admission barrier before signaling stop,
+			// so no producer can add another event while this drains the buffer.
+			// The receiving goroutine therefore does not need to close recordCh.
+			for {
+				select {
+				case ev := <-c.recordCh:
+					batch = append(batch, ev)
+				default:
+					if len(batch) > 0 {
+						c.flush(batch)
+					}
+					return
+				}
 			}
-			if len(batch) > 0 {
-				c.flush(batch)
-			}
-			return
 		}
 	}
 }
@@ -145,22 +159,25 @@ func (c *collector) flush(batch []recordEvent) {
 }
 
 func (c *collector) Close() error {
-	c.recordMu.Lock()
-	if !c.closed.CompareAndSwap(false, true) {
+	c.closeOnce.Do(func() {
+		c.recordMu.Lock()
+		c.closed.Store(true)
+		// All admitted senders have left; later record calls observe closed.
+		close(c.stopCh)
 		c.recordMu.Unlock()
-		return nil
-	}
-	// All admitted senders have left; later record calls observe closed.
-	close(c.stopCh)
-	c.recordMu.Unlock()
-	c.wg.Wait()
+		c.wg.Wait()
 
-	c.exportMu.RLock()
-	exporters := c.exporters
-	c.exportMu.RUnlock()
+		c.exportMu.RLock()
+		exporters := append([]api.Exporter(nil), c.exporters...)
+		c.exportMu.RUnlock()
 
-	for _, e := range exporters {
-		_ = e.Close()
-	}
-	return nil
+		var errs []error
+		for _, e := range exporters {
+			if err := e.Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		c.closeErr = errors.Join(errs...)
+	})
+	return c.closeErr
 }

--- a/service/metrics/collector_shutdown_test.go
+++ b/service/metrics/collector_shutdown_test.go
@@ -3,12 +3,62 @@
 package metrics
 
 import (
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	api "github.com/wippyai/runtime/api/metrics"
 	apicfg "github.com/wippyai/runtime/api/service/metrics"
 )
+
+type blockingCloseExporter struct {
+	started  chan struct{}
+	release  chan struct{}
+	closeErr error
+	once     sync.Once
+}
+
+func (e *blockingCloseExporter) Name() string { return "blocking-close" }
+
+func (e *blockingCloseExporter) Record(string, api.MetricType, float64, api.Labels) error {
+	return nil
+}
+
+func (e *blockingCloseExporter) Close() error {
+	e.once.Do(func() { close(e.started) })
+	<-e.release
+	return e.closeErr
+}
+
+type closeErrorExporter struct {
+	err error
+}
+
+func (e *closeErrorExporter) Name() string { return "close-error" }
+
+func (e *closeErrorExporter) Record(string, api.MetricType, float64, api.Labels) error {
+	return nil
+}
+
+func (e *closeErrorExporter) Close() error { return e.err }
+
+type countingCloseExporter struct {
+	closed atomic.Int32
+}
+
+func (e *countingCloseExporter) Name() string { return "counting-close" }
+
+func (e *countingCloseExporter) Record(string, api.MetricType, float64, api.Labels) error {
+	return nil
+}
+
+func (e *countingCloseExporter) Close() error {
+	e.closed.Add(1)
+	return nil
+}
 
 // Concurrent producers and shutdown must account for every metric: either it
 // was admitted and flushed, or it was explicitly counted as dropped. In
@@ -41,5 +91,78 @@ func TestCollectorConcurrentCloseAccountsForAllRecords(t *testing.T) {
 		before := c.Dropped()
 		c.CounterInc("after-close", nil)
 		require.Equal(t, before+1, c.Dropped())
+	}
+}
+
+func TestCollectorConcurrentCloseWaitsForExporterShutdown(t *testing.T) {
+	c := NewCollector(apicfg.Config{}).(*collector)
+	exporter := &blockingCloseExporter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	require.NoError(t, c.RegisterExporter(exporter))
+
+	first := make(chan error, 1)
+	go func() { first <- c.Close() }()
+	<-exporter.started
+
+	second := make(chan error, 1)
+	go func() { second <- c.Close() }()
+	select {
+	case err := <-second:
+		t.Fatalf("concurrent Close returned before exporter shutdown completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(exporter.release)
+	require.NoError(t, <-first)
+	require.NoError(t, <-second)
+}
+
+func TestCollectorRejectsExporterRegistrationAfterClose(t *testing.T) {
+	c := NewCollector(apicfg.Config{}).(*collector)
+	require.NoError(t, c.Close())
+	require.ErrorIs(t, c.RegisterExporter(&mockExporter{}), errCollectorClosed)
+}
+
+func TestCollectorCloseJoinsExporterErrorsAndIsIdempotent(t *testing.T) {
+	c := NewCollector(apicfg.Config{}).(*collector)
+	firstErr := errors.New("first exporter close")
+	secondErr := errors.New("second exporter close")
+	require.NoError(t, c.RegisterExporter(&closeErrorExporter{err: firstErr}))
+	require.NoError(t, c.RegisterExporter(&closeErrorExporter{err: secondErr}))
+
+	err := c.Close()
+	require.ErrorIs(t, err, firstErr)
+	require.ErrorIs(t, err, secondErr)
+	require.Equal(t, err, c.Close())
+}
+
+func TestCollectorRegisterExporterRaceWithCloseDoesNotLeak(t *testing.T) {
+	for range 1000 {
+		c := NewCollector(apicfg.Config{}).(*collector)
+		exporter := &countingCloseExporter{}
+		start := make(chan struct{})
+		registered := make(chan error, 1)
+		closed := make(chan error, 1)
+
+		go func() {
+			<-start
+			registered <- c.RegisterExporter(exporter)
+		}()
+		go func() {
+			<-start
+			closed <- c.Close()
+		}()
+		close(start)
+
+		regErr := <-registered
+		require.NoError(t, <-closed)
+		if regErr == nil {
+			require.EqualValues(t, 1, exporter.closed.Load())
+		} else {
+			require.ErrorIs(t, regErr, errCollectorClosed)
+			require.Zero(t, exporter.closed.Load())
+		}
 	}
 }

--- a/service/metrics/collector_shutdown_test.go
+++ b/service/metrics/collector_shutdown_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apicfg "github.com/wippyai/runtime/api/service/metrics"
+)
+
+// Concurrent producers and shutdown must account for every metric: either it
+// was admitted and flushed, or it was explicitly counted as dropped. In
+// particular an atomic closed check alone cannot protect channel send/close.
+func TestCollectorConcurrentCloseAccountsForAllRecords(t *testing.T) {
+	for range 100 {
+		cfg := apicfg.Config{}
+		cfg.Buffer.Size = 64
+		c := NewCollector(cfg).(*collector)
+		exporter := &mockExporter{}
+		require.NoError(t, c.RegisterExporter(exporter))
+		start := make(chan struct{})
+		var workers sync.WaitGroup
+		const producers = 8
+		const records = 1000
+		for range producers {
+			workers.Go(func() {
+				<-start
+				for range records {
+					c.CounterInc("shutdown", nil)
+				}
+			})
+		}
+		stopped := make(chan error, 1)
+		go func() { <-start; stopped <- c.Close() }()
+		close(start)
+		workers.Wait()
+		require.NoError(t, <-stopped)
+		require.EqualValues(t, producers*records, uint64(exporter.count())+c.Dropped())
+		before := c.Dropped()
+		c.CounterInc("after-close", nil)
+		require.Equal(t, before+1, c.Dropped())
+	}
+}


### PR DESCRIPTION
## Problem

A producer could pass the collector's atomic `closed` check immediately before shutdown closed `recordCh`. The later send then raced with channel close and could panic. This surfaced during teardown of the race-enabled cluster harness and is reproduced by the focused regression test against the pre-fix source.

## Fix

- Add a send-admission barrier around the final closed check and non-blocking enqueue.
- Make shutdown set `closed` only after excluding admitted senders, then signal the export loop to drain without closing the producer-owned record channel.
- Make concurrent `Close` calls wait for the same completed shutdown.
- Reject exporter registration after shutdown begins while preserving exporters whose registration won the race.
- Close every registered exporter once and join their errors.

No exporter method runs while the send-admission lock is held, and the change adds no worker or timer.

## Regression coverage

- Concurrent producers versus shutdown: every attempt is exported or counted as dropped; no send/close race or panic.
- Post-close records are counted as dropped.
- Concurrent `Close` callers wait for exporter shutdown and receive the same result.
- Exporter close errors are joined and retained across repeated `Close` calls.
- Registration racing with shutdown is linearizable: the exporter is either accepted and closed exactly once, or rejected with `metrics collector is closed`.

The focused race regression immediately reports a channel send/close race and `send on closed channel` panic on the pre-fix commit. On this head, `go test -race -count=10 ./service/metrics/...`, 50 repeated focused shutdown runs, and `go vet ./service/metrics/...` pass. The full CI matrix is green: lint, Ubuntu, Windows, native application, PostgreSQL/SQLite CDC race suites, and CodeQL.

## Cost

The admission lock adds measurable synchronization cost to the deliberately saturated zero-allocation microbenchmarks (roughly 2x in local runs) while retaining zero allocations. This is the explicit cost of making shutdown linearizable with in-flight producers.
