### PR TITLE
fix(lint): render parse errors consistently

### DIFF
--- a/cmd/wippy/cmd/lint.go
+++ b/cmd/wippy/cmd/lint.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"context"
 	stdjson "encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -649,16 +650,7 @@ func lintOneEntry(entry regapi.Entry, data entryData, linter *lint.Linter, manif
 
 	stmts, parseErr := parse.ParseString(data.Source, entryID)
 	if parseErr != nil {
-		return &entryResult{
-			entryID: entry.ID,
-			diagnostics: []Diagnostic{{
-				EntryID:  entryID,
-				Code:     "P0001",
-				Severity: "error",
-				Message:  parseErr.Error(),
-			}},
-			errors: 1,
-		}
+		return parseErrorResult(entry.ID, parseErr, sourceLines)
 	}
 
 	imports := make(map[string]*io.Manifest)
@@ -747,6 +739,42 @@ func lintOneEntry(entry regapi.Entry, data entryData, linter *lint.Linter, manif
 	}
 
 	return er
+}
+
+// parseErrorResult reports a syntax error the same way a type error is
+// reported: counted, listed, and rendered with its line so it cannot pass
+// unnoticed in the terminal report.
+func parseErrorResult(id regapi.ID, parseErr error, sourceLines diag.SourceLines) *entryResult {
+	entryID := id.String()
+	message := parseErr.Error()
+	position := diag.Position{File: entryID, Line: 1, Column: 1}
+	var syntaxErr *parse.Error
+	if errors.As(parseErr, &syntaxErr) {
+		message = syntaxErr.Message
+		if syntaxErr.Pos.Line == parse.EOF {
+			position.Line = len(sourceLines)
+			if position.Line < 1 {
+				position.Line = 1
+			}
+		} else if syntaxErr.Pos.Line > 0 {
+			position.Line = syntaxErr.Pos.Line
+			position.Column = syntaxErr.Pos.Column
+		}
+	}
+	rendered := diag.Diagnostic{Severity: diag.SeverityError, Message: message, Position: position}
+	return &entryResult{
+		entryID: id,
+		diagnostics: []Diagnostic{{
+			EntryID:  entryID,
+			Code:     "P0001",
+			Severity: severityError.String(),
+			Message:  message,
+			Line:     position.Line,
+			Column:   position.Column,
+		}},
+		rich:   []RichDiagnostic{{EntryID: entryID, Diag: rendered, Source: sourceLines}},
+		errors: 1,
+	}
 }
 
 func mergeEntryResult(result *LintResult, er *entryResult, manifestMap map[regapi.ID]*io.Manifest, reportSet map[regapi.ID]bool) {

--- a/cmd/wippy/cmd/lint.go
+++ b/cmd/wippy/cmd/lint.go
@@ -165,9 +165,10 @@ type Diagnostic struct {
 
 // RichDiagnostic holds a diagnostic with source for rendering.
 type RichDiagnostic struct {
-	EntryID string
-	Diag    diag.Diagnostic
-	Source  diag.SourceLines
+	EntryID     string
+	displayCode string
+	Diag        diag.Diagnostic
+	Source      diag.SourceLines
 }
 
 // LintResult holds the complete lint results.
@@ -197,6 +198,8 @@ type entryData struct {
 	Source  string
 	Method  string
 }
+
+const parseErrorCode = "P0001"
 
 // lintConfig holds runtime configuration for a lint session.
 type lintConfig struct {
@@ -758,7 +761,9 @@ func parseErrorResult(id regapi.ID, parseErr error, sourceLines diag.SourceLines
 			}
 		} else if syntaxErr.Pos.Line > 0 {
 			position.Line = syntaxErr.Pos.Line
-			position.Column = syntaxErr.Pos.Column
+			if syntaxErr.Pos.Column > 0 {
+				position.Column = syntaxErr.Pos.Column
+			}
 		}
 	}
 	rendered := diag.Diagnostic{Severity: diag.SeverityError, Message: message, Position: position}
@@ -766,13 +771,18 @@ func parseErrorResult(id regapi.ID, parseErr error, sourceLines diag.SourceLines
 		entryID: id,
 		diagnostics: []Diagnostic{{
 			EntryID:  entryID,
-			Code:     "P0001",
+			Code:     parseErrorCode,
 			Severity: severityError.String(),
 			Message:  message,
 			Line:     position.Line,
 			Column:   position.Column,
 		}},
-		rich:   []RichDiagnostic{{EntryID: entryID, Diag: rendered, Source: sourceLines}},
+		rich: []RichDiagnostic{{
+			EntryID:     entryID,
+			Diag:        rendered,
+			Source:      sourceLines,
+			displayCode: parseErrorCode,
+		}},
 		errors: 1,
 	}
 }
@@ -1153,10 +1163,17 @@ func renderRichDiag(rd RichDiagnostic, noColor bool) string {
 	} else {
 		rendered = rd.Diag.RenderColored(rd.Source)
 	}
-	if rd.Diag.Code >= lint.LintCodeBase {
-		rendered = strings.Replace(rendered, rd.Diag.Code.Name(), lint.FormatLintCode(rd.Diag.Code), 1)
+	if code := richDiagnosticCode(rd); code != rd.Diag.Code.Name() {
+		rendered = strings.Replace(rendered, rd.Diag.Code.Name(), code, 1)
 	}
 	return rendered
+}
+
+func richDiagnosticCode(rd RichDiagnostic) string {
+	if rd.displayCode != "" {
+		return rd.displayCode
+	}
+	return formatDiagCode(rd.Diag.Code)
 }
 
 func sortLintResults(result *LintResult) {
@@ -1194,8 +1211,9 @@ func sortLintResults(result *LintResult) {
 		if a.Diag.Position.Column != b.Diag.Position.Column {
 			return a.Diag.Position.Column < b.Diag.Position.Column
 		}
-		if a.Diag.Code != b.Diag.Code {
-			return a.Diag.Code < b.Diag.Code
+		aCode, bCode := richDiagnosticCode(a), richDiagnosticCode(b)
+		if aCode != bCode {
+			return aCode < bCode
 		}
 		return a.Diag.Message < b.Diag.Message
 	})
@@ -1224,7 +1242,7 @@ func filterByCode(result *LintResult, codes []string) *LintResult {
 	}
 
 	for _, rd := range result.RichDiagnostics {
-		if codeSet[strings.ToUpper(formatDiagCode(rd.Diag.Code))] {
+		if codeSet[strings.ToUpper(richDiagnosticCode(rd))] {
 			filtered.RichDiagnostics = append(filtered.RichDiagnostics, rd)
 		}
 	}

--- a/cmd/wippy/cmd/lint_test.go
+++ b/cmd/wippy/cmd/lint_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 
 	"github.com/wippyai/go-lua/compiler/parse"
+	"github.com/wippyai/go-lua/types/diag"
 	"github.com/wippyai/go-lua/types/io"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/registry"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/runtime/lua/code"
+	"github.com/wippyai/runtime/runtime/lua/code/lint"
 	"github.com/wippyai/runtime/runtime/lua/component"
 	"github.com/wippyai/runtime/runtime/lua/engine"
 	transcoder "github.com/wippyai/runtime/system/payload"
@@ -206,5 +209,29 @@ func TestLintRequireDeclarations_NonAmbientRegisteredModuleMustBeDeclared(t *tes
 		map[string]registry.ID{"json": registry.NewID("wippy.json", "json")}, builtins)
 	if len(clean) != 0 {
 		t.Fatalf("declared json import must clear the diagnostic, got %v", clean)
+	}
+}
+
+func TestLintOneEntryRendersParseErrors(t *testing.T) {
+	typeChecker := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+	linter := lint.New(typeChecker, lint.NewRegistry())
+	entry := registry.Entry{ID: registry.NewID("app", "broken"), Kind: luaapi.Library}
+	data := entryData{Source: "local M = {}\nlocal interface = 1\nreturn M\n"}
+	result := lintOneEntry(entry, data, linter, map[registry.ID]*io.Manifest{}, severityWarning, lintCache{}, lintFingerprints{})
+	if result == nil || result.errors != 1 || len(result.diagnostics) != 1 {
+		t.Fatalf("parse failure must produce exactly one error, got %+v", result)
+	}
+	if result.diagnostics[0].Line != 2 {
+		t.Fatalf("parse error line = %d, want 2", result.diagnostics[0].Line)
+	}
+	if len(result.rich) != 1 {
+		t.Fatalf("parse error must be rendered like every other diagnostic, rich = %d", len(result.rich))
+	}
+	rich := result.rich[0]
+	if rich.Diag.Severity != diag.SeverityError || rich.Diag.Position.Line != 2 || rich.Source == nil {
+		t.Fatalf("rendered parse error lacks position or source: %+v", rich.Diag)
+	}
+	if !strings.Contains(renderRichDiag(rich, true), "interface") {
+		t.Fatalf("rendered parse error must show the offending line, got %q", renderRichDiag(rich, true))
 	}
 }

--- a/cmd/wippy/cmd/lint_test.go
+++ b/cmd/wippy/cmd/lint_test.go
@@ -4,9 +4,11 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/wippyai/go-lua/compiler/ast"
 	"github.com/wippyai/go-lua/compiler/parse"
 	"github.com/wippyai/go-lua/types/diag"
 	"github.com/wippyai/go-lua/types/io"
@@ -224,6 +226,9 @@ func TestLintOneEntryRendersParseErrors(t *testing.T) {
 	if result.diagnostics[0].Line != 2 {
 		t.Fatalf("parse error line = %d, want 2", result.diagnostics[0].Line)
 	}
+	if result.diagnostics[0].Code != "P0001" {
+		t.Fatalf("parse error code = %q, want P0001", result.diagnostics[0].Code)
+	}
 	if len(result.rich) != 1 {
 		t.Fatalf("parse error must be rendered like every other diagnostic, rich = %d", len(result.rich))
 	}
@@ -231,7 +236,79 @@ func TestLintOneEntryRendersParseErrors(t *testing.T) {
 	if rich.Diag.Severity != diag.SeverityError || rich.Diag.Position.Line != 2 || rich.Source == nil {
 		t.Fatalf("rendered parse error lacks position or source: %+v", rich.Diag)
 	}
-	if !strings.Contains(renderRichDiag(rich, true), "interface") {
-		t.Fatalf("rendered parse error must show the offending line, got %q", renderRichDiag(rich, true))
+	rendered := renderRichDiag(rich, true)
+	hasCode := strings.Contains(rendered, "error[P0001]")
+	hasLocation := strings.Contains(rendered, "app:broken:2:")
+	hasSource := strings.Contains(rendered, "interface")
+	if !hasCode || !hasLocation || !hasSource {
+		t.Fatalf("rendered parse error must show its code, location, and source, got %q", rendered)
+	}
+
+	lintResult := &LintResult{
+		Diagnostics:     result.diagnostics,
+		RichDiagnostics: result.rich,
+		TotalEntries:    1,
+		ErrorCount:      1,
+	}
+	filtered := filterByCode(lintResult, []string{"P0001"})
+	if len(filtered.Diagnostics) != 1 || len(filtered.RichDiagnostics) != 1 || filtered.ErrorCount != 1 {
+		t.Fatalf("P0001 filter dropped parse error: %+v", filtered)
+	}
+	if got := filterByCode(lintResult, []string{"E0000"}); len(got.Diagnostics) != 0 || len(got.RichDiagnostics) != 0 {
+		t.Fatalf("parse error leaked through E0000 filter: %+v", got)
+	}
+}
+
+func TestParseErrorResultUsesSafeFallbackPositions(t *testing.T) {
+	tests := []struct {
+		err         error
+		name        string
+		wantMessage string
+		source      diag.SourceLines
+		wantLine    int
+		wantColumn  int
+	}{
+		{
+			name:        "EOF uses last source line",
+			err:         &parse.Error{Pos: ast.Position{Line: parse.EOF}, Message: "unexpected EOF"},
+			source:      diag.ParseSource("local function broken()\nreturn 1"),
+			wantLine:    2,
+			wantColumn:  1,
+			wantMessage: "unexpected EOF",
+		},
+		{
+			name:        "missing parser column stays one based",
+			err:         &parse.Error{Pos: ast.Position{Line: 2}, Message: "unexpected token"},
+			source:      diag.ParseSource("first\nsecond"),
+			wantLine:    2,
+			wantColumn:  1,
+			wantMessage: "unexpected token",
+		},
+		{
+			name:        "opaque error uses origin",
+			err:         errors.New("parser failed"),
+			source:      nil,
+			wantLine:    1,
+			wantColumn:  1,
+			wantMessage: "parser failed",
+		},
+	}
+
+	id := registry.NewID("app", "broken")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseErrorResult(id, tt.err, tt.source)
+			if len(result.diagnostics) != 1 || len(result.rich) != 1 || result.errors != 1 {
+				t.Fatalf("parse error result shape = %+v", result)
+			}
+			got := result.diagnostics[0]
+			if got.Code != parseErrorCode || got.Message != tt.wantMessage ||
+				got.Line != tt.wantLine || got.Column != tt.wantColumn {
+				t.Fatalf("parse error diagnostic = %+v, want %s at %d:%d", got, tt.wantMessage, tt.wantLine, tt.wantColumn)
+			}
+			if richDiagnosticCode(result.rich[0]) != parseErrorCode {
+				t.Fatalf("rich parse code = %q, want %s", richDiagnosticCode(result.rich[0]), parseErrorCode)
+			}
+		})
 	}
 }


### PR DESCRIPTION
A Lua parse failure was counted but omitted from rich diagnostics, so terminal output could say No issues found while lint exited with an error. Filtering by P0001 could also hide the error because the renderer internally treated it as E0000.

This change renders parse failures with their message, source location, and excerpt; keeps P0001 consistent across JSON, terminal rendering, sorting, and code filtering; and uses safe one-based fallback positions for EOF and opaque parser errors.

Validation:
- the rendering regression fails on the parent and passes after the fix
- focused parse, filter, EOF, and fallback cases pass repeatedly
- the full command package passes under the race detector
- repository-pinned full-project lint reports zero issues

No runtime API, Lua/native binding, protocol, persisted state, or configuration surface changes.