### PR TITLE
Add bounded terminal image resources and retained captures

### DIFF
--- a/api/tty/image.go
+++ b/api/tty/image.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"image/png"
+	"io"
+	"sync"
+)
+
+const (
+	MaxImageBytes      = 8 << 20
+	MaxImagePixels     = 4 << 20
+	MaxImagePlacements = 256
+	DefaultImageBudget = 64 << 20
+)
+
+var (
+	ErrImageInvalid        = errors.New("invalid terminal image")
+	ErrImageBudget         = errors.New("terminal image budget exceeded")
+	ErrImageClosed         = errors.New("terminal image reference closed")
+	ErrGraphicsUnsupported = errors.New("terminal graphics unsupported")
+)
+
+// ImageInfo is immutable resource metadata. ID is content identity, not authority.
+// Encoded bytes never occur in Frame or Snapshot wire metadata.
+type ImageInfo struct {
+	ID     string
+	Format string
+	Width  int
+	Height int
+	Bytes  int
+}
+
+// ImageStore bounds resident encoded data plus its worst-case RGBA64 decode cost.
+// References, including captures, share this budget. There is no lookup by ID:
+// callers must already possess an Image or an authorized Capture.
+type ImageStore struct {
+	entries map[string]*imageData
+	mu      sync.Mutex
+	limit   int64
+	used    int64
+}
+type imageData struct {
+	encoded []byte
+	info    ImageInfo
+	refs    int
+	charge  int64
+}
+
+// Image is one owned reference. Retain creates an independent reference; Close
+// releases exactly once. Access and Close may run concurrently.
+type Image struct {
+	store *ImageStore
+	data  *imageData
+	mu    sync.Mutex
+}
+
+func NewImageStore(limit int64) *ImageStore {
+	return &ImageStore{limit: max(0, limit), entries: make(map[string]*imageData)}
+}
+
+// ImportPNG is a native ingress seam for file readers and future Wasm codecs.
+// Admission precedes full decoding and copying. No Lua pixel processing is needed.
+func (s *ImageStore) ImportPNG(encoded []byte) (*Image, error) {
+	if len(encoded) == 0 || len(encoded) > MaxImageBytes {
+		return nil, ErrImageInvalid
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(encoded))
+	if err != nil || config.Width < 1 || config.Height < 1 || config.Width > MaxImagePixels/config.Height {
+		return nil, ErrImageInvalid
+	}
+	sum := sha256.Sum256(encoded)
+	id := "sha256:" + hex.EncodeToString(sum[:])
+	charge := int64(len(encoded)) + int64(config.Width)*int64(config.Height)*8
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if d := s.entries[id]; d != nil {
+		d.refs++
+		return &Image{store: s, data: d}, nil
+	}
+	if charge > s.limit-s.used {
+		return nil, ErrImageBudget
+	}
+	// Decode validates the complete PNG, not merely an attacker-controlled header.
+	if _, err := png.Decode(bytes.NewReader(encoded)); err != nil {
+		return nil, ErrImageInvalid
+	}
+	d := &imageData{info: ImageInfo{ID: id, Format: "png", Width: config.Width, Height: config.Height, Bytes: len(encoded)}, encoded: bytes.Clone(encoded), refs: 1, charge: charge}
+	s.entries[id] = d
+	s.used += charge
+	return &Image{store: s, data: d}, nil
+}
+
+func (s *ImageStore) Used() int64 { s.mu.Lock(); defer s.mu.Unlock(); return s.used }
+
+func (i *Image) Info() (ImageInfo, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.data == nil {
+		return ImageInfo{}, ErrImageClosed
+	}
+	return i.data.info, nil
+}
+func (i *Image) Retain() (*Image, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.data == nil {
+		return nil, ErrImageClosed
+	}
+	i.store.mu.Lock()
+	i.data.refs++
+	i.store.mu.Unlock()
+	return &Image{store: i.store, data: i.data}, nil
+}
+func (i *Image) ReadAt(p []byte, offset int64) (int, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.data == nil {
+		return 0, ErrImageClosed
+	}
+	return bytes.NewReader(i.data.encoded).ReadAt(p, offset)
+}
+func (i *Image) WriteTo(w io.Writer) (int64, error) {
+	// Keep a private reference while calling an external writer.
+	ref, err := i.Retain()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ref.Close() }()
+	return bytes.NewReader(ref.data.encoded).WriteTo(w)
+}
+func (i *Image) Close() error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.data == nil {
+		return nil
+	}
+	s, d := i.store, i.data
+	i.data = nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d.refs--
+	if d.refs == 0 {
+		delete(s.entries, d.info.ID)
+		s.used -= d.charge
+	}
+	return nil
+}
+
+// PixelRect uses zero-based source pixels; CellRect uses zero-based cells in Go.
+// Lua projections translate destination cells to one-based coordinates.
+type PixelRect struct{ X, Y, Width, Height int }
+type CellRect struct{ X, Y, Cols, Rows int }
+
+// Placement describes resolved display state, not a protocol transaction.
+// Kind is currently "rect". Other kinds must be capability-gated before use.
+// IDs are scoped to a producer. Image identity is separate from placement identity.
+type Placement struct {
+	ID          string
+	Kind        string
+	Alt         string
+	Image       ImageInfo
+	Destination CellRect
+	Source      PixelRect
+	Z           int32
+}
+
+// PlacedImage is native authoring input. Resource is an owned capability, never
+// a string lookup. Present borrows it and retains its own reference on success.
+type PlacedImage struct {
+	Resource  *Image
+	Placement Placement
+}
+
+// RetainPlacements validates a complete replacement before publication. Failure
+// releases every temporary reference and leaves the previous frame unchanged.
+func RetainPlacements(images []PlacedImage) ([]PlacedImage, error) {
+	if len(images) == 0 {
+		return nil, nil
+	}
+	if len(images) > MaxImagePlacements {
+		return nil, ErrImageBudget
+	}
+	var out []PlacedImage
+	fail := func(err error) ([]PlacedImage, error) { ClosePlacements(out); return nil, err }
+	ids := make(map[string]bool, len(images))
+	for _, item := range images {
+		p := item.Placement
+		if p.Kind == "" {
+			p.Kind = "rect"
+		}
+		d := p.Destination
+		if p.ID == "" || len(p.ID) > 128 || ids[p.ID] || p.Kind != "rect" || item.Resource == nil || len(p.Alt) > 256 ||
+			d.X < -MaxViewportDimension || d.Y < -MaxViewportDimension || d.X > MaxViewportDimension || d.Y > MaxViewportDimension ||
+			ValidateViewportSize(d.Cols, d.Rows) != nil {
+			return fail(ErrImageInvalid)
+		}
+		ref, err := item.Resource.Retain()
+		if err != nil {
+			return fail(err)
+		}
+		info, _ := ref.Info()
+		src := p.Source
+		if src == (PixelRect{}) {
+			src = PixelRect{Width: info.Width, Height: info.Height}
+		}
+		if src.X < 0 || src.Y < 0 || src.Width < 1 || src.Height < 1 || src.X > info.Width-src.Width || src.Y > info.Height-src.Height {
+			_ = ref.Close()
+			return fail(ErrImageInvalid)
+		}
+		p.Image, p.Source = info, src
+		ids[p.ID] = true
+		out = append(out, PlacedImage{Placement: p, Resource: ref})
+	}
+	return out, nil
+}
+func ClosePlacements(images []PlacedImage) {
+	for _, i := range images {
+		_ = i.Resource.Close()
+	}
+}
+func PlacementMetadata(images []PlacedImage) []Placement {
+	if len(images) == 0 {
+		return nil
+	}
+	out := make([]Placement, len(images))
+	for n, i := range images {
+		out[n] = i.Placement
+	}
+	return out
+}
+
+// Capture pins the exact snapshot and all its resources. Its owner must Close.
+// A later producer delete cannot invalidate a successfully acquired capture.
+type Capture struct {
+	images   []PlacedImage
+	snapshot Snapshot
+	mu       sync.Mutex
+	closed   bool
+}
+
+func NewCapture(snapshot Snapshot, images []PlacedImage) (*Capture, error) {
+	refs, err := RetainPlacements(images)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.Rows = append([]string(nil), snapshot.Rows...)
+	if snapshot.Cursor != nil {
+		c := *snapshot.Cursor
+		snapshot.Cursor = &c
+	}
+	snapshot.Images = PlacementMetadata(refs)
+	return &Capture{snapshot: snapshot, images: refs}, nil
+}
+func (c *Capture) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return Snapshot{}
+	}
+	s := c.snapshot
+	s.Rows = append([]string(nil), s.Rows...)
+	s.Images = append([]Placement(nil), s.Images...)
+	if s.Cursor != nil {
+		cursor := *s.Cursor
+		s.Cursor = &cursor
+	}
+	return s
+}
+func (c *Capture) Image(id string) (*Image, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, ErrImageClosed
+	}
+	for _, p := range c.images {
+		if p.Placement.Image.ID == id {
+			return p.Resource.Retain()
+		}
+	}
+	return nil, ErrPermissionDenied
+}
+func (c *Capture) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.closed {
+		c.closed = true
+		ClosePlacements(c.images)
+		c.images = nil
+		c.snapshot = Snapshot{}
+	}
+	return nil
+}
+
+// CaptureViewport is optional so existing viewport implementations remain valid.
+// Remote implementations may yield; ordinary Snapshot always stays nonblocking.
+type CaptureViewport interface {
+	Capture(context.Context) (*Capture, error)
+}

--- a/api/tty/image_test.go
+++ b/api/tty/image_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MPL-2.0
+package tty
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testPNG(t *testing.T) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	img := image.NewNRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.NRGBA{R: 255, A: 255})
+	require.NoError(t, png.Encode(&b, img))
+	return b.Bytes()
+}
+func TestImageOwnershipAndBudget(t *testing.T) {
+	data := testPNG(t)
+	charge := int64(len(data) + 32)
+	store := NewImageStore(charge)
+	original, err := store.ImportPNG(data)
+	require.NoError(t, err)
+	same, err := store.ImportPNG(data)
+	require.NoError(t, err)
+	require.Equal(t, charge, store.Used())
+	data[0] = 0 // Store owns its bytes.
+	ref, err := original.Retain()
+	require.NoError(t, err)
+	require.NoError(t, original.Close())
+	require.NoError(t, original.Close())
+	_, err = original.Info()
+	require.ErrorIs(t, err, ErrImageClosed)
+	var b bytes.Buffer
+	_, err = ref.WriteTo(&b)
+	require.NoError(t, err)
+	require.Equal(t, byte(137), b.Bytes()[0])
+	require.NoError(t, ref.Close())
+	require.Equal(t, charge, store.Used())
+	require.NoError(t, same.Close())
+	require.Zero(t, store.Used())
+	_, err = NewImageStore(charge - 1).ImportPNG(b.Bytes())
+	require.ErrorIs(t, err, ErrImageBudget)
+}
+func TestImageRejectsCorruptionAndCapturePinsResources(t *testing.T) {
+	data := testPNG(t)
+	store := NewImageStore(DefaultImageBudget)
+	_, err := store.ImportPNG(data[:len(data)-8])
+	require.ErrorIs(t, err, ErrImageInvalid)
+	require.Zero(t, store.Used())
+	img, err := store.ImportPNG(data)
+	require.NoError(t, err)
+	info, _ := img.Info()
+	inputs := []PlacedImage{{Placement: Placement{ID: "chart", Destination: CellRect{Cols: 2, Rows: 2}}, Resource: img}}
+	capture, err := NewCapture(Snapshot{Rows: []string{"old"}, Revision: 7}, inputs)
+	require.NoError(t, err)
+	require.NoError(t, img.Close())
+	snapshot := capture.Snapshot()
+	snapshot.Rows[0] = "tampered"
+	snapshot.Images[0].ID = "tampered"
+	require.Equal(t, "old", capture.Snapshot().Rows[0])
+	require.Equal(t, "chart", capture.Snapshot().Images[0].ID)
+	_, err = capture.Image("foreign")
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	pinned, err := capture.Image(info.ID)
+	require.NoError(t, err)
+	require.NoError(t, capture.Close())
+	require.NoError(t, capture.Close())
+	got := make([]byte, info.Bytes)
+	_, err = pinned.ReadAt(got, 0)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+	_, err = pinned.ReadAt(got, int64(info.Bytes))
+	require.ErrorIs(t, err, io.EOF)
+	require.NoError(t, pinned.Close())
+	require.Zero(t, store.Used())
+}
+func TestPlacementsValidateAtomically(t *testing.T) {
+	store := NewImageStore(DefaultImageBudget)
+	img, err := store.ImportPNG(testPNG(t))
+	require.NoError(t, err)
+	good := PlacedImage{Placement: Placement{ID: "p", Destination: CellRect{Cols: 1, Rows: 1}}, Resource: img}
+	_, err = RetainPlacements([]PlacedImage{good, good})
+	require.ErrorIs(t, err, ErrImageInvalid)
+	bad := good
+	bad.Placement.ID = "other"
+	bad.Placement.Source = PixelRect{X: 1, Width: 2, Height: 1}
+	_, err = RetainPlacements([]PlacedImage{good, bad})
+	require.ErrorIs(t, err, ErrImageInvalid)
+	require.NoError(t, img.Close())
+	require.Zero(t, store.Used())
+}
+func TestImageConcurrentRetainClose(t *testing.T) {
+	store := NewImageStore(DefaultImageBudget)
+	img, err := store.ImportPNG(testPNG(t))
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			for range 100 {
+				ref, err := img.Retain()
+				if err == nil {
+					buf := make([]byte, 8)
+					_, _ = ref.ReadAt(buf, 0)
+					_ = ref.Close()
+				}
+			}
+		})
+	}
+	_ = img.Close()
+	wg.Wait()
+	require.Zero(t, store.Used())
+}

--- a/api/tty/port.go
+++ b/api/tty/port.go
@@ -33,6 +33,8 @@ type Cursor struct {
 // Frame augments surface rows with optional terminal state. A nil Cursor lets
 // a renderer preserve its configured cursor behavior.
 type Frame struct {
+	// Images is the complete placement set. Nil clears previously presented images.
+	Images []PlacedImage
 	Cursor *Cursor
 	Rows   []string
 }

--- a/api/tty/service.go
+++ b/api/tty/service.go
@@ -37,6 +37,8 @@ type Snapshot struct {
 	// Cursor is nil until a producer first publishes explicit cursor state.
 	// Row-only frames preserve the last explicit value.
 	Cursor *Cursor
+	// Images carries resolved metadata only. Capture pins resources atomically.
+	Images []Placement
 	// Rows is immutable and remains valid after later presents. Consumers must
 	// not modify it. This lets unchanged UI frames inspect snapshots without an
 	// allocation or copy.
@@ -44,6 +46,8 @@ type Snapshot struct {
 	Revision uint64
 	Width    int
 	Height   int
+	// ImagesOmitted reports an explicit text-only projection of graphical content.
+	ImagesOmitted bool
 }
 
 // Update announces that a newer snapshot may be read. Notifications are

--- a/service/terminal/surface.go
+++ b/service/terminal/surface.go
@@ -33,6 +33,9 @@ func NewSurface(out io.Writer, opts ttyapi.SurfaceOptions) *Surface {
 }
 
 func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
+	if len(frame.Images) != 0 {
+		return ttyapi.PresentStats{}, ttyapi.ErrGraphicsUnsupported
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {

--- a/system/tty/image_test.go
+++ b/system/tty/image_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MPL-2.0
+package tty
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func fixtureImage(t testing.TB, s *Service) *ttyapi.Image {
+	t.Helper()
+	var data bytes.Buffer
+	require.NoError(t, png.Encode(&data, image.NewNRGBA(image.Rect(0, 0, 8, 8))))
+	img, err := s.ImageStore().ImportPNG(data.Bytes())
+	require.NoError(t, err)
+	return img
+}
+func TestImagePublicationCaptureAndCleanup(t *testing.T) {
+	s := NewService()
+	defer s.Close()
+	ctx, frame, _ := processContext(t, s)
+	defer frame.Close()
+	v, err := s.Create(ctx, 20, 10)
+	require.NoError(t, err)
+	binding, err := s.Binding(v.Grant())
+	require.NoError(t, err)
+	port, err := binding.Resolve(ctx)
+	require.NoError(t, err)
+	output, err := port.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	img := fixtureImage(t, s)
+	item := ttyapi.PlacedImage{Resource: img, Placement: ttyapi.Placement{ID: "chart", Destination: ttyapi.CellRect{Cols: 4, Rows: 2}}}
+	f := ttyapi.Frame{Rows: []string{"text"}, Images: []ttyapi.PlacedImage{item}}
+	_, err = output.Present(f)
+	require.NoError(t, err)
+	before := v.Snapshot()
+	require.Len(t, before.Images, 1)
+	before.Images[0].ID = "tampered"
+	require.Equal(t, "chart", v.Snapshot().Images[0].ID, "snapshot metadata must not alias broker state")
+	stats, err := output.Present(f)
+	require.NoError(t, err)
+	require.Zero(t, stats.ChangedRows)
+	require.Equal(t, before.Revision, v.Snapshot().Revision)
+	f.Images[0].Placement.Destination.X = 3
+	stats, err = output.Present(f)
+	require.NoError(t, err)
+	require.Zero(t, stats.ChangedRows)
+	require.Greater(t, v.Snapshot().Revision, before.Revision)
+	require.Zero(t, before.Images[0].Destination.X, "old metadata remains immutable")
+	capture, err := v.(ttyapi.CaptureViewport).Capture(ctx)
+	require.NoError(t, err)
+	f.Images[0].Placement.Source = ttyapi.PixelRect{Width: 999, Height: 1}
+	_, err = output.Present(f)
+	require.ErrorIs(t, err, ttyapi.ErrImageInvalid)
+	require.Equal(t, capture.Snapshot().Revision, v.Snapshot().Revision, "failed present is atomic")
+	require.NoError(t, img.Close())
+	_, err = output.Present(ttyapi.Frame{Rows: []string{"text"}})
+	require.NoError(t, err)
+	require.Empty(t, v.Snapshot().Images)
+	require.Positive(t, s.ImageStore().Used(), "capture pins deleted image")
+	require.NoError(t, capture.Close())
+	require.Zero(t, s.ImageStore().Used())
+	require.NoError(t, port.Close())
+	require.NoError(t, v.Close())
+}
+func TestImageCaptureRequiresOwnerAndObservation(t *testing.T) {
+	s := NewService()
+	defer s.Close()
+	ctx, f, _ := processContextFor(t, s, "owner")
+	defer f.Close()
+	stranger, sf, _ := processContextFor(t, s, "other")
+	defer sf.Close()
+	v, err := s.Create(ctx, 20, 10)
+	require.NoError(t, err)
+	_, err = v.(ttyapi.CaptureViewport).Capture(stranger)
+	require.ErrorIs(t, err, ttyapi.ErrPermissionDenied)
+	require.NoError(t, v.Close())
+	_, err = v.(ttyapi.CaptureViewport).Capture(ctx)
+	require.ErrorIs(t, err, ttyapi.ErrViewportClosed)
+}
+func TestLastOwnerReleasesPublishedImages(t *testing.T) {
+	s := NewService()
+	defer s.Close()
+	ctx, f, _ := processContext(t, s)
+	defer f.Close()
+	v, err := s.Create(ctx, 20, 10)
+	require.NoError(t, err)
+	binding, err := s.Binding(v.Grant())
+	require.NoError(t, err)
+	p, err := binding.Resolve(ctx)
+	require.NoError(t, err)
+	output, err := p.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	img := fixtureImage(t, s)
+	_, err = output.Present(ttyapi.Frame{Images: []ttyapi.PlacedImage{{Resource: img, Placement: ttyapi.Placement{ID: "p", Destination: ttyapi.CellRect{Cols: 1, Rows: 1}}}}})
+	require.NoError(t, err)
+	require.NoError(t, img.Close())
+	require.NoError(t, p.Close())
+	require.Positive(t, s.ImageStore().Used())
+	require.NoError(t, v.Close())
+	require.Zero(t, s.ImageStore().Used())
+}

--- a/system/tty/mesh.go
+++ b/system/tty/mesh.go
@@ -102,6 +102,11 @@ func (s *Service) SetMesh(local string, transport ttyapi.MeshTransport) error {
 	return nil
 }
 func (m *meshService) send(peer string, f wireFrame) error {
+	// Image transport is enabled in the capability-gated resource stage.
+	if len(f.Snapshot.Images) != 0 {
+		f.Snapshot.ImagesOmitted = true
+		f.Snapshot.Images = nil
+	}
 	f.Version = wireVersion
 	var b bytes.Buffer
 	if err := codec.NewEncoder(&b, &m.codec).Encode(f); err != nil {

--- a/system/tty/mount.go
+++ b/system/tty/mount.go
@@ -270,3 +270,17 @@ func (v *mountedViewport) Updates() <-chan ttyapi.Update { return v.record.view.
 func (v *mountedViewport) Send(e ttyapi.Event) error     { return v.record.view.Send(e) }
 func (v *mountedViewport) Resize(w, h int) error         { return v.record.view.Resize(w, h) }
 func (v *mountedViewport) Close() error                  { v.record.service.removeMount(v.record.ref); return nil }
+
+func (v *mountedViewport) Capture(ctx context.Context) (*ttyapi.Capture, error) {
+	if err := v.Check(ctx, ttyapi.RightObserve); err != nil {
+		return nil, err
+	}
+	v.record.mu.Lock()
+	defer v.record.mu.Unlock()
+	select {
+	case <-v.record.done:
+		return nil, ttyapi.ErrMountExpired
+	default:
+	}
+	return v.record.view.Capture(ctx)
+}

--- a/system/tty/port.go
+++ b/system/tty/port.go
@@ -3,6 +3,7 @@
 package tty
 
 import (
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -66,6 +67,13 @@ func (s *surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 		ss.mu.Unlock()
 		return ttyapi.PresentStats{}, ttyapi.ErrViewportClosed
 	}
+	images, err := ttyapi.RetainPlacements(frame.Images)
+	if err != nil {
+		ss.mu.Unlock()
+		return ttyapi.PresentStats{}, err
+	}
+	placements := ttyapi.PlacementMetadata(images)
+	imagesChanged := !slices.Equal(ss.placements, placements)
 	changed := changedRows(ss.sourceRows, frame.Rows)
 	forced := ss.invalid
 	if forced && changed == 0 {
@@ -74,7 +82,10 @@ func (s *surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 	// A nil cursor means row-only presentation and preserves terminal state,
 	// matching the Frame contract and physical surface implementation.
 	cursorChanged := frame.Cursor != nil && !sameCursor(ss.cursor, frame.Cursor)
-	if forced || changed != 0 || cursorChanged {
+	if forced || changed != 0 || cursorChanged || imagesChanged {
+		ttyapi.ClosePlacements(ss.images)
+		ss.images, ss.placements = images, placements
+		images = nil
 		previousSource, previousRows := ss.sourceRows, ss.rows
 		ss.sourceRows = append([]string(nil), frame.Rows...)
 		ss.resolvePageRows(previousSource, previousRows)
@@ -89,6 +100,7 @@ func (s *surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 			publishLatest(watcher.ch, update)
 		}
 	}
+	ttyapi.ClosePlacements(images)
 	ss.mu.Unlock()
 	return ttyapi.PresentStats{Rows: len(frame.Rows), ChangedRows: changed}, nil
 }

--- a/system/tty/service.go
+++ b/system/tty/service.go
@@ -21,6 +21,7 @@ import (
 // Service is a zero-goroutine, in-memory viewport broker. The AppContext owns
 // the service; process frames own bindings and redeemed ports.
 type Service struct {
+	images   *ttyapi.ImageStore
 	mounts   map[string]*mountRecord
 	mesh     *meshService
 	sessions map[string]*session
@@ -30,6 +31,8 @@ type Service struct {
 }
 
 type session struct {
+	images       []ttyapi.PlacedImage
+	placements   []ttyapi.Placement
 	page         *ttyapi.Page
 	pageRenderer *terminal.PageRenderer
 	sourceRows   []string
@@ -61,8 +64,10 @@ type watch struct {
 }
 
 func NewService() *Service {
-	return &Service{mounts: make(map[string]*mountRecord), sessions: make(map[string]*session), grants: make(map[string]*session)}
+	return &Service{images: ttyapi.NewImageStore(ttyapi.DefaultImageBudget), mounts: make(map[string]*mountRecord), sessions: make(map[string]*session), grants: make(map[string]*session)}
 }
+
+func (s *Service) ImageStore() *ttyapi.ImageStore { return s.images }
 
 func token(prefix string) (string, error) {
 	var raw [24]byte
@@ -211,14 +216,16 @@ func (s *Service) OnComplete(ctx context.Context, owner pid.PID, _ *runtime.Resu
 func (s *Service) collect(ss *session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	ss.mu.RLock()
-	defer ss.mu.RUnlock()
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
 	if len(ss.viewers) != 0 || ss.bindings != 0 || ss.producer {
 		return
 	}
 	if s.sessions[ss.handle] == ss {
 		delete(s.sessions, ss.handle)
 		delete(s.grants, ss.grant)
+		ttyapi.ClosePlacements(ss.images)
+		ss.images, ss.placements = nil, nil
 	}
 }
 
@@ -229,6 +236,8 @@ func (s *session) closeAll() {
 		close(watcher.ch)
 		delete(s.watches, id)
 	}
+	ttyapi.ClosePlacements(s.images)
+	s.images, s.placements = nil, nil
 	s.rows, s.router, s.viewers = nil, nil, nil
 	s.mu.Unlock()
 }

--- a/system/tty/viewport.go
+++ b/system/tty/viewport.go
@@ -53,7 +53,7 @@ func (v *viewport) Snapshot() ttyapi.Snapshot {
 		copy := *v.session.cursor
 		cursor = &copy
 	}
-	return ttyapi.Snapshot{Revision: v.session.revision, Width: v.session.width,
+	return ttyapi.Snapshot{Images: append([]ttyapi.Placement(nil), v.session.placements...), Revision: v.session.revision, Width: v.session.width,
 		Height: v.session.height, Rows: v.session.rows, Cursor: cursor}
 }
 
@@ -157,4 +157,21 @@ func (v *viewport) Check(ctx context.Context, right string) error {
 		return ttyapi.ErrViewportClosed
 	}
 	return nil
+}
+
+// Capture obtains metadata and resource references under the same publication lock.
+func (v *viewport) Capture(ctx context.Context) (*ttyapi.Capture, error) {
+	if err := v.Check(ctx, ttyapi.RightObserve); err != nil {
+		return nil, err
+	}
+	ss := v.session
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	if ss.closed || v.closed.Load() {
+		return nil, ttyapi.ErrViewportClosed
+	}
+	if _, ok := ss.watches[v.watchID]; !ok {
+		return nil, ttyapi.ErrViewportClosed
+	}
+	return ttyapi.NewCapture(ttyapi.Snapshot{Rows: ss.rows, Cursor: ss.cursor, Revision: ss.revision, Width: ss.width, Height: ss.height}, ss.images)
 }


### PR DESCRIPTION
Terminal surfaces currently retain only text and cursor state. This adds bounded native PNG resources, complete image placement sets on virtual surfaces, and an optional capture API that pins metadata and resources at one revision. Moving or deleting an image updates the revision without changing text rows; a retained capture survives producer deletion.

Image handles are explicit owned references with no ambient lookup by content hash. Resources share a bounded broker budget, are validated before admission, and release deterministically. Physical graphics remain explicitly unsupported in this foundation PR; mesh projects text with an ImagesOmitted marker until capability-gated transfer lands.

This is the foundation leaf for #693 local Lua presentation and #697 authorized remote capture.

The current-main replay removes the unused ImageStoreProvider interface and copies placement metadata from Snapshot so callers cannot mutate broker-published state.

Validation: affected API, broker, and physical-terminal suites pass under the race detector; repository-pinned scoped lint, vet, module verification, Windows CGO build, and diff checks pass. Coverage includes corruption, budgets, deduplication, concurrent retain and close, atomic rejection, snapshot isolation, image-only revisions, mount authorization, and capture lifetime.