### PR TITLE
Add owned Lua image handles and typed terminal graphics presentation

### DIFF
--- a/api/service/terminal/context.go
+++ b/api/service/terminal/context.go
@@ -189,3 +189,14 @@ func WithTerminalContext(ctx context.Context, tc *PipeContext) error {
 	}
 	return fc.Set(ttyapi.PortKey(), tc)
 }
+
+func (s *leasedSurface) Capabilities() ttyapi.SurfaceCapabilities {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		if backend, ok := s.Surface.(ttyapi.CapableSurface); ok {
+			return backend.Capabilities()
+		}
+	}
+	return ttyapi.SurfaceCapabilities{Images: "none"}
+}

--- a/api/service/terminal/context_test.go
+++ b/api/service/terminal/context_test.go
@@ -207,3 +207,18 @@ func TestClipboardLeaseRejectsUnsupportedAndRetiredSurface(t *testing.T) {
 	require.NoError(t, surface.Close())
 	require.ErrorIs(t, copy.Clipboard("text"), ttyapi.ErrInvalidPort)
 }
+
+type capableTestSurface struct{ testSurface }
+
+func (*capableTestSurface) Capabilities() ttyapi.SurfaceCapabilities {
+	return ttyapi.SurfaceCapabilities{Images: "kitty"}
+}
+func TestSurfaceLeaseForwardsCapabilities(t *testing.T) {
+	tc := NewTerminalContext(nil, nil, nil)
+	tc.Surface = func(ttyapi.SurfaceOptions) (ttyapi.Surface, error) { return &capableTestSurface{}, nil }
+	s, err := tc.OpenSurface(ttyapi.SurfaceOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "kitty", s.(ttyapi.CapableSurface).Capabilities().Images)
+	require.NoError(t, s.Close())
+	require.Equal(t, "none", s.(ttyapi.CapableSurface).Capabilities().Images)
+}

--- a/api/tty/command.go
+++ b/api/tty/command.go
@@ -108,12 +108,22 @@ func (c DisableMouseCmd) CmdID() dispatcher.CommandID {
 // ViewportIOCmd runs only through the asynchronous terminal dispatcher.
 // Caller identity comes from its process context, never from command fields.
 type ViewportIOCmd struct {
-	View      RemoteViewport
-	Handle    string
-	Operation string
-	Event     Event
-	Width     int
-	Height    int
+	CaptureSource CaptureViewport
+	ImageData     []byte
+	View          RemoteViewport
+	Handle        string
+	Operation     string
+	Event         Event
+	Width         int
+	Height        int
 }
 
 func (ViewportIOCmd) CmdID() dispatcher.CommandID { return ViewportIO }
+
+// ImageIOResult transfers dispatcher cleanup ownership to the Lua wrapper.
+// Cancel unlinks frame cleanup; it does not close the resource.
+type ImageIOResult struct {
+	Image   *Image
+	Capture *Capture
+	Cancel  func()
+}

--- a/api/tty/image.go
+++ b/api/tty/image.go
@@ -303,3 +303,8 @@ func (c *Capture) Close() error {
 type CaptureViewport interface {
 	Capture(context.Context) (*Capture, error)
 }
+
+// SurfaceCapabilities describes the selected backend, not the producer protocol.
+// Images is "native", "kitty", "pending", or "none".
+type SurfaceCapabilities struct{ Images string }
+type CapableSurface interface{ Capabilities() SurfaceCapabilities }

--- a/runtime/lua/modules/tty/image.go
+++ b/runtime/lua/modules/tty/image.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MPL-2.0
+package tty
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+const imageTypeName = "tty.Image"
+const captureTypeName = "tty.Capture"
+
+type imageWrapper struct {
+	image  *ttyapi.Image
+	cancel func()
+	once   sync.Once
+}
+type captureWrapper struct {
+	capture *ttyapi.Capture
+	cancel  func()
+	once    sync.Once
+}
+
+func init() {
+	value.RegisterTypeMethods(nil, imageTypeName, map[string]lua.LGoFunc{"__gc": imageGC}, map[string]lua.LGoFunc{"info": imageInfo, "read": imageRead, "close": imageClose})
+	value.RegisterTypeMethods(nil, captureTypeName, map[string]lua.LGoFunc{"__gc": captureGC}, map[string]lua.LGoFunc{"snapshot": captureSnapshot, "image": captureImage, "close": captureClose})
+}
+func pushImage(l *lua.LState, img *ttyapi.Image, cleanup ...func()) {
+	h := &imageWrapper{image: img}
+	if len(cleanup) > 0 && cleanup[0] != nil {
+		h.cancel = cleanup[0]
+	} else if store := resource.GetStore(l.Context()); store != nil {
+		h.cancel = store.AddCleanup(img.Close)
+	}
+	value.PushTypedUserData(l, h, imageTypeName)
+	l.Push(lua.LNil)
+}
+func pushCapture(l *lua.LState, capture *ttyapi.Capture, cleanup ...func()) {
+	h := &captureWrapper{capture: capture}
+	if len(cleanup) > 0 && cleanup[0] != nil {
+		h.cancel = cleanup[0]
+	} else if store := resource.GetStore(l.Context()); store != nil {
+		h.cancel = store.AddCleanup(capture.Close)
+	}
+	value.PushTypedUserData(l, h, captureTypeName)
+	l.Push(lua.LNil)
+}
+func checkImage(l *lua.LState) *imageWrapper {
+	if h, ok := l.CheckUserData(1).Value.(*imageWrapper); ok {
+		return h
+	}
+	l.ArgError(1, "tty.Image expected")
+	return nil
+}
+func checkCapture(l *lua.LState) *captureWrapper {
+	if h, ok := l.CheckUserData(1).Value.(*captureWrapper); ok {
+		return h
+	}
+	l.ArgError(1, "tty.Capture expected")
+	return nil
+}
+func (h *imageWrapper) close() {
+	h.once.Do(func() {
+		if h.cancel != nil {
+			h.cancel()
+		}
+		_ = h.image.Close()
+	})
+}
+func (h *captureWrapper) close() {
+	h.once.Do(func() {
+		if h.cancel != nil {
+			h.cancel()
+		}
+		_ = h.capture.Close()
+	})
+}
+func imageGC(l *lua.LState) int      { checkImage(l).close(); return 0 }
+func captureGC(l *lua.LState) int    { checkCapture(l).close(); return 0 }
+func imageClose(l *lua.LState) int   { checkImage(l).close(); l.Push(lua.LTrue); return 1 }
+func captureClose(l *lua.LState) int { checkCapture(l).close(); l.Push(lua.LTrue); return 1 }
+func imageError(l *lua.LState, err error) int {
+	l.Push(lua.LNil)
+	l.Push(lua.WrapErrorWithLua(l, err, "terminal image"))
+	return 2
+}
+func ttyImageNew(l *lua.LState) int {
+	data := l.CheckString(1)
+	if len(data) == 0 || len(data) > ttyapi.MaxImageBytes {
+		return imageError(l, ttyapi.ErrImageInvalid)
+	}
+	l.Push(&ViewportIOYield{Command: ttyapi.ViewportIOCmd{Operation: "image_import", ImageData: []byte(data)}})
+	return -1
+}
+func imageInfoTable(l *lua.LState, info ttyapi.ImageInfo) *lua.LTable {
+	t := l.CreateTable(0, 5)
+	t.RawSetString("id", lua.LString(info.ID))
+	t.RawSetString("format", lua.LString(info.Format))
+	t.RawSetString("width", lua.LInteger(info.Width))
+	t.RawSetString("height", lua.LInteger(info.Height))
+	t.RawSetString("bytes", lua.LInteger(info.Bytes))
+	t.Immutable = true
+	return t
+}
+func imageInfo(l *lua.LState) int {
+	info, err := checkImage(l).image.Info()
+	if err != nil {
+		return imageError(l, err)
+	}
+	l.Push(imageInfoTable(l, info))
+	return 1
+}
+
+// read is explicit bounded export I/O, never the compositor or mesh data path.
+func imageRead(l *lua.LState) int {
+	img := checkImage(l).image
+	info, err := img.Info()
+	if err != nil {
+		return imageError(l, err)
+	}
+	data := make([]byte, info.Bytes)
+	if _, err := img.ReadAt(data, 0); err != nil {
+		return imageError(l, err)
+	}
+	l.Push(lua.LString(data))
+	return 1
+}
+func captureImage(l *lua.LState) int {
+	img, err := checkCapture(l).capture.Image(l.CheckString(2))
+	if err != nil {
+		return imageError(l, err)
+	}
+	pushImage(l, img)
+	return 2
+}
+func captureSnapshot(l *lua.LState) int {
+	l.Push(snapshotTable(l, checkCapture(l).capture.Snapshot()))
+	return 1
+}
+func viewportCapture(l *lua.LState) int {
+	v := checkViewport(l).view
+	if !checkViewportRight(l, v, ttyapi.RightObserve) {
+		return 2
+	}
+	capture, ok := v.(ttyapi.CaptureViewport)
+	if !ok {
+		return imageError(l, ttyapi.ErrGraphicsUnsupported)
+	}
+	l.Push(&ViewportIOYield{Command: ttyapi.ViewportIOCmd{Operation: "capture", CaptureSource: capture}})
+	return -1
+}
+func snapshotTable(l *lua.LState, s ttyapi.Snapshot) *lua.LTable {
+	t := l.CreateTable(0, 8)
+	rows := l.CreateTable(len(s.Rows), 0)
+	for i, row := range s.Rows {
+		rows.RawSetInt(i+1, lua.LString(row))
+	}
+	t.RawSetString("rows", rows)
+	t.RawSetString("revision", lua.LInteger(s.Revision))
+	t.RawSetString("width", lua.LInteger(s.Width))
+	t.RawSetString("height", lua.LInteger(s.Height))
+	if s.Cursor != nil {
+		c := l.CreateTable(0, 3)
+		c.RawSetString("x", lua.LInteger(s.Cursor.Column+1))
+		c.RawSetString("y", lua.LInteger(s.Cursor.Row+1))
+		c.RawSetString("visible", lua.LBool(s.Cursor.Visible))
+		t.RawSetString("cursor", c)
+	}
+	addSnapshotImages(l, t, s)
+	return t
+}
+func addSnapshotImages(l *lua.LState, t *lua.LTable, s ttyapi.Snapshot) {
+	images := l.CreateTable(len(s.Images), 0)
+	for i, p := range s.Images {
+		row := l.CreateTable(0, 10)
+		row.RawSetString("placement_id", lua.LString(p.ID))
+		row.RawSetString("image_id", lua.LString(p.Image.ID))
+		row.RawSetString("kind", lua.LString(p.Kind))
+		row.RawSetString("x", lua.LInteger(p.Destination.X+1))
+		row.RawSetString("y", lua.LInteger(p.Destination.Y+1))
+		row.RawSetString("cols", lua.LInteger(p.Destination.Cols))
+		row.RawSetString("rows", lua.LInteger(p.Destination.Rows))
+		row.RawSetString("z", lua.LInteger(p.Z))
+		row.RawSetString("alt", lua.LString(p.Alt))
+		row.RawSetString("resource", imageInfoTable(l, p.Image))
+		src := l.CreateTable(0, 4)
+		src.RawSetString("x", lua.LInteger(p.Source.X))
+		src.RawSetString("y", lua.LInteger(p.Source.Y))
+		src.RawSetString("width", lua.LInteger(p.Source.Width))
+		src.RawSetString("height", lua.LInteger(p.Source.Height))
+		row.RawSetString("src", src)
+		images.RawSetInt(i+1, row)
+	}
+	t.RawSetString("images", images)
+	layers := l.CreateTable(2, 0)
+	layers.RawSetInt(1, lua.LString("text"))
+	if len(s.Images) > 0 {
+		layers.RawSetInt(2, lua.LString("images"))
+	}
+	t.RawSetString("layers", layers)
+	t.RawSetString("images_omitted", lua.LBool(s.ImagesOmitted))
+}
+func placedImagesFromLua(v lua.LValue) ([]ttyapi.PlacedImage, error) {
+	if v == lua.LNil {
+		return nil, nil
+	}
+	table, ok := v.(*lua.LTable)
+	if !ok || table.Len() > ttyapi.MaxImagePlacements {
+		return nil, ttyapi.ErrImageInvalid
+	}
+	images := make([]ttyapi.PlacedImage, 0, table.Len())
+	for i := 1; i <= table.Len(); i++ {
+		t, ok := table.RawGetInt(i).(*lua.LTable)
+		if !ok {
+			return nil, ttyapi.ErrImageInvalid
+		}
+		ud, ok := t.RawGetString("image").(*lua.LUserData)
+		if !ok {
+			return nil, ttyapi.ErrImageInvalid
+		}
+		img, ok := ud.Value.(*imageWrapper)
+		if !ok {
+			return nil, ttyapi.ErrImageInvalid
+		}
+		id, ok := t.RawGetString("placement_id").(lua.LString)
+		if !ok {
+			return nil, ttyapi.ErrImageInvalid
+		}
+		p := ttyapi.Placement{ID: string(id), Kind: "rect"}
+		for _, f := range []struct {
+			dest *int
+			name string
+		}{{&p.Destination.X, "x"}, {&p.Destination.Y, "y"}, {&p.Destination.Cols, "cols"}, {&p.Destination.Rows, "rows"}} {
+			n, ok := integerValue(t.RawGetString(f.name))
+			if !ok || n < -ttyapi.MaxViewportDimension || n > ttyapi.MaxViewportDimension {
+				return nil, fmt.Errorf("image %s must be a bounded cell coordinate", f.name)
+			}
+			*f.dest = n
+		}
+		p.Destination.X--
+		p.Destination.Y--
+		if z := t.RawGetString("z"); z != lua.LNil {
+			n, ok := integerValue(z)
+			if !ok || n < math.MinInt32 || n > math.MaxInt32 {
+				return nil, ttyapi.ErrImageInvalid
+			}
+			p.Z = int32(n)
+		}
+		if alt := t.RawGetString("alt"); alt != lua.LNil {
+			a, ok := alt.(lua.LString)
+			if !ok {
+				return nil, ttyapi.ErrImageInvalid
+			}
+			p.Alt = string(a)
+		}
+		if crop := t.RawGetString("src"); crop != lua.LNil {
+			c, ok := crop.(*lua.LTable)
+			if !ok {
+				return nil, ttyapi.ErrImageInvalid
+			}
+			for _, f := range []struct {
+				dest *int
+				name string
+			}{{&p.Source.X, "x"}, {&p.Source.Y, "y"}, {&p.Source.Width, "width"}, {&p.Source.Height, "height"}} {
+				n, ok := integerValue(c.RawGetString(f.name))
+				if !ok || n < 0 || n > ttyapi.MaxImagePixels {
+					return nil, ttyapi.ErrImageInvalid
+				}
+				*f.dest = n
+			}
+		}
+		images = append(images, ttyapi.PlacedImage{Resource: img.image, Placement: p})
+	}
+	return images, nil
+}

--- a/runtime/lua/modules/tty/image_test.go
+++ b/runtime/lua/modules/tty/image_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+package tty
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func luaImageFixture(t *testing.T) (*ttyapi.ImageStore, *ttyapi.Image) {
+	t.Helper()
+	var b bytes.Buffer
+	require.NoError(t, png.Encode(&b, image.NewNRGBA(image.Rect(0, 0, 4, 4))))
+	store := ttyapi.NewImageStore(ttyapi.DefaultImageBudget)
+	img, err := store.ImportPNG(b.Bytes())
+	require.NoError(t, err)
+	return store, img
+}
+func TestLuaImageCaptureAndTypedPlacement(t *testing.T) {
+	store, img := luaImageFixture(t)
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+	pushImage(l, img)
+	l.Pop(1)
+	l.SetGlobal("image", l.Get(-1))
+	l.Pop(1)
+	require.NoError(t, l.DoString(`
+ local info=assert(image:info());assert(info.format=="png" and info.width==4)
+ assert(#image:read()==info.bytes)
+ placements={{placement_id="p",image=image,x=2,y=3,cols=4,rows=2,src={x=0,y=0,width=2,height=2},z=-1}}
+ `))
+	placements, err := placedImagesFromLua(l.GetGlobal("placements"))
+	require.NoError(t, err)
+	require.Equal(t, 1, placements[0].Placement.Destination.X)
+	capture, err := ttyapi.NewCapture(ttyapi.Snapshot{Rows: []string{"hello"}, Revision: 7}, placements)
+	require.NoError(t, err)
+	pushCapture(l, capture)
+	l.Pop(1)
+	l.SetGlobal("capture", l.Get(-1))
+	l.Pop(1)
+	require.NoError(t, l.DoString(`
+ assert(image:close())
+ local snap=capture:snapshot();assert(snap.revision==7 and snap.layers[2]=="images")
+ assert(snap.images[1].x==2 and snap.images[1].src.width==2)
+ local wrong,err=capture:image("foreign");assert(wrong==nil and err~=nil)
+ local pinned=assert(capture:image(snap.images[1].image_id))
+ assert(capture:close());assert(#pinned:read()>0);assert(pinned:close())
+ local gone,closed=image:read();assert(gone==nil and closed~=nil)
+ `))
+	require.Zero(t, store.Used())
+}
+func TestLuaImageRejectsForgedHandleAndFrameCleanup(t *testing.T) {
+	store, img := luaImageFixture(t)
+	resources := resource.NewStore()
+	defer resources.Close()
+	ctx, frame := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+	defer frame.Close()
+	require.NoError(t, resource.SetStore(ctx, resources))
+	l := lua.NewState()
+	defer l.Close()
+	l.SetContext(ctx)
+	bindTTY(l)
+	pushImage(l, img)
+	l.Pop(1)
+	l.SetGlobal("image", l.Get(-1))
+	l.Pop(1)
+	require.NoError(t, l.DoString(`bad={{placement_id="p",image="sha256:forged",x=1,y=1,cols=1,rows=1}}`))
+	_, err := placedImagesFromLua(l.GetGlobal("bad"))
+	require.Error(t, err)
+	require.NoError(t, resources.Close())
+	require.Zero(t, store.Used())
+}

--- a/runtime/lua/modules/tty/image_types.go
+++ b/runtime/lua/modules/tty/image_types.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+package tty
+
+import "github.com/wippyai/go-lua/types/typ"
+
+var imageInfoType = typ.NewRecord().ReadonlyField("id", typ.String).ReadonlyField("format", typ.String).ReadonlyField("width", typ.Integer).ReadonlyField("height", typ.Integer).ReadonlyField("bytes", typ.Integer).Build()
+var imageType = typ.NewInterface("tty.Image", []typ.Method{
+	{Name: "info", Type: typ.Func().Param("self", typ.Self).Returns(imageInfoType, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "read", Type: typ.Func().Param("self", typ.Self).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
+})
+var cropType = typ.NewRecord().Field("x", typ.Integer).Field("y", typ.Integer).Field("width", typ.Integer).Field("height", typ.Integer).Build()
+var placedImageType = typ.NewRecord().Field("placement_id", typ.String).Field("image", imageType).Field("x", typ.Integer).Field("y", typ.Integer).Field("cols", typ.Integer).Field("rows", typ.Integer).OptField("src", cropType).OptField("z", typ.Integer).OptField("alt", typ.String).Build()
+var snapshotImageType = typ.NewRecord().ReadonlyField("placement_id", typ.String).ReadonlyField("image_id", typ.String).ReadonlyField("kind", typ.String).ReadonlyField("x", typ.Integer).ReadonlyField("y", typ.Integer).ReadonlyField("cols", typ.Integer).ReadonlyField("rows", typ.Integer).ReadonlyField("src", cropType).ReadonlyField("z", typ.Integer).ReadonlyField("alt", typ.String).ReadonlyField("resource", imageInfoType).Build()
+var captureType = typ.NewInterface("tty.Capture", []typ.Method{
+	{Name: "snapshot", Type: typ.Func().Param("self", typ.Self).Returns(viewportSnapshotType).Build()},
+	{Name: "image", Type: typ.Func().Param("self", typ.Self).Param("id", typ.String).Returns(imageType, typ.NewOptional(typ.LuaError)).Build()},
+	{Name: "close", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
+})

--- a/runtime/lua/modules/tty/module.go
+++ b/runtime/lua/modules/tty/module.go
@@ -34,6 +34,7 @@ func buildModule() (*lua.LTable, []luaapi.YieldType) {
 	mod.RawSetString("screen_size", lua.LGoFunc(ttyScreenSize))
 	mod.RawSetString("events", lua.LGoFunc(ttyEvents))
 	mod.RawSetString("mouse", lua.LGoFunc(ttyMouse))
+	mod.RawSetString("image", lua.LGoFunc(ttyImageNew))
 	mod.RawSetString("surface", lua.LGoFunc(ttySurfaceNew))
 	mod.RawSetString("canvas", lua.LGoFunc(ttyCanvasNew))
 	mod.RawSetString("viewport", lua.LGoFunc(ttyViewportNew))

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -297,7 +297,6 @@ mount; transport reconnection does not permit replaying terminal input.
 Both nodes must advertise surface protocol version 1. Peers without that
 capability are rejected before writing a new protocol class to their connection.
 
-
 ### Physical clipboard request
 
 `surface:clipboard(text) -> (boolean, error?)` writes a bounded OSC52 clipboard
@@ -307,3 +306,32 @@ Success means the output accepted the request; terminal policy may still ignore
 it. No clipboard read, operating-system acknowledgement, replay, or persistence
 is provided. Virtual surfaces return unsupported; clients must route explicit
 copy operations to their own physical output instead of putting them in frames.
+
+### Retained images
+
+`tty.image(png_bytes) -> Image, error?` validates and imports a PNG in the
+asynchronous dispatcher. This is bounded ingress I/O, not pixel processing in
+Lua. `image:info()` returns `{id, format, width, height, bytes}`;
+`image:read()` explicitly exports its encoded PNG bytes; `image:close()` releases
+its reference. Process resource cleanup closes forgotten handles.
+
+`surface:present(rows, {images = {...}, cursor = ...})` accepts a complete image
+set. Each item has `placement_id`, an `image` handle, one-based cell `x, y`,
+positive `cols, rows`, optional signed `z`, source-pixel `src = {x, y, width,
+height}`, and `alt`. Source pixel coordinates are zero-based. Omitted `images`
+clears old placements. IDs are scoped to the producing surface. Image placement
+must be clipped by the compositor before physical presentation.
+
+`surface:capabilities()` returns `{images = "native" | "kitty" | "pending" |
+"none"}`. Start terminal input before probing. The physical backend queries
+through the existing input reader and times out after 250 ms. Polling before
+first presentation probes before entering the alternate screen. Unsupported or
+pending hosts display a dimmed text placeholder; virtual surfaces retain images.
+
+Snapshots add `images`, `layers`, and `images_omitted`. Image metadata contains
+`placement_id`, `image_id`, `kind`, destination and source geometry, `z`, `alt`,
+and `resource` metadata. A plain snapshot does not retain bytes. Use yielding
+`view:capture()` to atomically pin a revision and its resources, then
+`capture:snapshot()` and `capture:image(image_id)`. The latter returns a new
+owned Image reference. `capture:close()` releases the capture; already acquired
+image references remain valid. Hashes alone never grant resource access.

--- a/runtime/lua/modules/tty/surface.go
+++ b/runtime/lua/modules/tty/surface.go
@@ -22,10 +22,11 @@ func init() {
 			"__gc":       surfaceGC,
 		},
 		map[string]lua.LGoFunc{
-			"present":    surfacePresent,
-			"clipboard":  surfaceClipboard,
-			"invalidate": surfaceInvalidate,
-			"close":      surfaceClose,
+			"present":      surfacePresent,
+			"clipboard":    surfaceClipboard,
+			"capabilities": surfaceCapabilities,
+			"invalidate":   surfaceInvalidate,
+			"close":        surfaceClose,
 		})
 }
 
@@ -119,6 +120,11 @@ func surfacePresent(l *lua.LState) int {
 	}
 	frame := ttyapi.Frame{Rows: rows}
 	if options := l.OptTable(3, nil); options != nil {
+		var err error
+		frame.Images, err = placedImagesFromLua(options.RawGetString("images"))
+		if err != nil {
+			return imageError(l, err)
+		}
 		if value := options.RawGetString("cursor"); value != lua.LNil {
 			cursor, ok := value.(*lua.LTable)
 			if !ok {
@@ -250,4 +256,16 @@ func surfaceClipboard(l *lua.LState) int {
 	l.Push(lua.LTrue)
 	l.Push(lua.LNil)
 	return 2
+}
+
+func surfaceCapabilities(l *lua.LState) int {
+	caps := ttyapi.SurfaceCapabilities{Images: "none"}
+	if backend, ok := checkSurface(l).backend.(ttyapi.CapableSurface); ok {
+		caps = backend.Capabilities()
+	}
+	t := l.CreateTable(0, 1)
+	t.RawSetString("images", lua.LString(caps.Images))
+	t.Immutable = true
+	l.Push(t)
+	return 1
 }

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -182,9 +182,11 @@ var surfaceStatsType = typ.NewRecord().
 	Build()
 
 var surfaceType = typ.NewInterface("tty.Surface", []typ.Method{
+	{Name: "capabilities", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewRecord().ReadonlyField("images", typ.String).Build()).Build()},
 	{Name: "present", Type: typ.Func().Param("self", typ.Self).
 		Param("rows", typ.NewArray(typ.String)).
 		OptParam("options", typ.NewRecord().
+			OptField("images", typ.NewArray(placedImageType)).
 			OptField("cursor", typ.NewRecord().
 				Field("x", typ.Integer).
 				Field("y", typ.Integer).
@@ -221,6 +223,9 @@ var viewportOptionsType = typ.NewRecord().
 	Build()
 
 var viewportSnapshotType = typ.NewRecord().
+	ReadonlyField("images", typ.NewArray(snapshotImageType)).
+	ReadonlyField("layers", typ.NewArray(typ.String)).
+	ReadonlyField("images_omitted", typ.Boolean).
 	ReadonlyField("revision", typ.Integer).
 	ReadonlyField("width", typ.Integer).
 	ReadonlyField("height", typ.Integer).
@@ -238,6 +243,7 @@ var mountRightsType = typ.NewRecord().
 	OptField("resize", typ.Boolean).Build()
 
 var viewportType = typ.NewInterface("tty.Viewport", []typ.Method{
+	{Name: "capture", Type: typ.Func().Param("self", typ.Self).Returns(captureType, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "set_page", Type: typ.Func().Param("self", typ.Self).OptParam("page", typ.NewOptional(viewportPageType)).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "mount", Type: typ.Func().Param("self", typ.Self).Param("recipient", typ.String).Param("rights", mountRightsType).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
 	{Name: "revoke", Type: typ.Func().Param("self", typ.Self).Param("reference", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
@@ -317,6 +323,10 @@ func ModuleTypes() *typio.Manifest {
 	m.DefineType("InputEvent", inputEventType)
 	m.DefineType("MountRights", mountRightsType)
 	m.DefineType("EventChannel", eventChannelType)
+	m.DefineType("Image", imageType)
+	m.DefineType("ImageInfo", imageInfoType)
+	m.DefineType("ImagePlacement", placedImageType)
+	m.DefineType("Capture", captureType)
 	m.DefineType("Surface", surfaceType)
 	m.DefineType("Canvas", canvasType)
 	m.DefineType("SurfaceOptions", surfaceOptionsType)
@@ -332,6 +342,7 @@ func ModuleTypes() *typio.Manifest {
 		{Name: "screen_size", Type: typ.Func().Returns(typ.Integer, typ.Integer, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "events", Type: typ.Func().Returns(eventChannelType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "mouse", Type: typ.Func().Param("enable", typ.Boolean).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "image", Type: typ.Func().Param("png", typ.String).Returns(imageType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "surface", Type: typ.Func().OptParam("options", surfaceOptionsType).Returns(surfaceType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "canvas", Type: typ.Func().Param("width", typ.Integer).Param("height", typ.Integer).Returns(canvasType).Build()},
 		{Name: "viewport", Type: typ.Func().OptParam("options", viewportOptionsType).Returns(viewportType, typ.NewOptional(typ.LuaError)).Build()},

--- a/runtime/lua/modules/tty/viewport.go
+++ b/runtime/lua/modules/tty/viewport.go
@@ -31,7 +31,7 @@ func init() {
 			"snapshot": viewportSnapshot, "updates": viewportUpdates, "send": viewportSend,
 			"resize": viewportResize, "close": viewportClose,
 			"mount": viewportMount, "revoke": viewportRevoke,
-			"set_page": viewportSetPage,
+			"set_page": viewportSetPage, "capture": viewportCapture,
 		})
 }
 
@@ -213,6 +213,7 @@ func viewportSnapshot(l *lua.LState) int {
 		cursor.Immutable = true
 		result.RawSetString("cursor", cursor)
 	}
+	addSnapshotImages(l, result, s)
 	l.Push(result)
 	return 1
 }

--- a/runtime/lua/modules/tty/yields.go
+++ b/runtime/lua/modules/tty/yields.go
@@ -181,6 +181,19 @@ func (y *ViewportIOYield) HandleResult(l *lua.LState, data any, err error) []lua
 	if err != nil {
 		return []lua.LValue{lua.LNil, lua.WrapErrorWithLua(l, err, "remote viewport")}
 	}
+
+	if result, ok := data.(ttyapi.ImageIOResult); ok {
+		if result.Image != nil {
+			pushImage(l, result.Image, result.Cancel)
+		} else if result.Capture != nil {
+			pushCapture(l, result.Capture, result.Cancel)
+		} else {
+			return handleBoolResult(l, nil, ttyapi.ErrImageInvalid, "image result")
+		}
+		out := []lua.LValue{l.Get(-2), l.Get(-1)}
+		l.Pop(2)
+		return out
+	}
 	if view, ok := data.(ttyapi.Viewport); ok {
 		pushViewport(l, view)
 		out := []lua.LValue{l.Get(-2), l.Get(-1)}

--- a/service/terminal/graphics.go
+++ b/service/terminal/graphics.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MPL-2.0
+package terminal
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"sync/atomic"
+
+	"github.com/charmbracelet/x/ansi"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+var nextGraphicsID atomic.Uint32
+
+// graphicsState tracks only host encoding state. Resources belong to the input
+// frame while encoding; this backend never needs to keep pixel data afterward.
+type graphicsState struct {
+	known      map[string]uint32
+	placements map[string]hostPlacement
+}
+type hostPlacement struct {
+	placement            ttyapi.Placement
+	imageID, placementID uint32
+}
+
+func graphicsID() (uint32, error) {
+	for {
+		n := nextGraphicsID.Load()
+		if n >= 0xfffffeff {
+			return 0, ttyapi.ErrImageBudget
+		}
+		if nextGraphicsID.CompareAndSwap(n, n+1) {
+			return n + 1, nil
+		}
+	}
+}
+
+func deleteHostImage(out []byte, id uint32) []byte {
+	return fmt.Appendf(out, "\x1b_Ga=d,d=I,i=%d,q=2\x1b\\", id)
+}
+func deleteHostPlacement(out []byte, p hostPlacement) []byte {
+	return fmt.Appendf(out, "\x1b_Ga=d,d=p,i=%d,p=%d,q=2\x1b\\", p.imageID, p.placementID)
+}
+
+func (s *Surface) appendGraphics(out []byte, images []ttyapi.PlacedImage, enabled bool) ([]byte, map[string]hostPlacement, error) {
+	if s.graphics.known == nil {
+		s.graphics.known = make(map[string]uint32)
+	}
+	desired := make(map[string]hostPlacement, len(images))
+	wanted := make(map[string]bool, len(images))
+	if s.invalid {
+		for _, id := range s.graphics.known {
+			out = deleteHostImage(out, id)
+		}
+	}
+	if enabled {
+		for _, item := range images {
+			p := item.Placement
+			// Composition must clip at the destination viewport before host encoding.
+			if p.Destination.X < 0 || p.Destination.Y < 0 {
+				return nil, nil, ttyapi.ErrImageInvalid
+			}
+			imageID, known := s.graphics.known[p.Image.ID]
+			if !known {
+				if len(s.graphics.known) >= 2*ttyapi.MaxImagePlacements {
+					return nil, nil, ttyapi.ErrImageBudget
+				}
+				var err error
+				imageID, err = graphicsID()
+				if err != nil {
+					return nil, nil, err
+				}
+				s.graphics.known[p.Image.ID] = imageID
+			}
+			if (!known || s.invalid) && !wanted[p.Image.ID] {
+				var err error
+				out, err = appendImageUpload(out, item.Resource, imageID)
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+			wanted[p.Image.ID] = true
+			previous, exists := s.graphics.placements[p.ID]
+			if exists && previous.placement == p && !s.invalid {
+				desired[p.ID] = previous
+				continue
+			}
+			placementID := previous.placementID
+			if !exists {
+				var err error
+				placementID, err = graphicsID()
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+			if exists && !s.invalid {
+				out = deleteHostPlacement(out, previous)
+			}
+			out = fmt.Appendf(out, "\x1b[%d;%dH\x1b_Ga=p,i=%d,p=%d,c=%d,r=%d,x=%d,y=%d,w=%d,h=%d,z=%d,C=1,q=2\x1b\\",
+				p.Destination.Y+1, p.Destination.X+1, imageID, placementID, p.Destination.Cols, p.Destination.Rows, p.Source.X, p.Source.Y, p.Source.Width, p.Source.Height, p.Z)
+			desired[p.ID] = hostPlacement{placement: p, imageID: imageID, placementID: placementID}
+		}
+	}
+	for key, old := range s.graphics.placements {
+		if _, ok := desired[key]; !ok && !s.invalid {
+			out = deleteHostPlacement(out, old)
+		}
+	}
+	for hash, id := range s.graphics.known {
+		if !wanted[hash] {
+			out = deleteHostImage(out, id)
+		}
+	}
+	return out, desired, nil
+}
+func appendImageUpload(out []byte, img *ttyapi.Image, id uint32) ([]byte, error) {
+	info, err := img.Info()
+	if err != nil {
+		return nil, err
+	}
+	// 3072 raw bytes encode to kitty's maximum 4096-byte payload chunk.
+	raw := make([]byte, 3072)
+	encoded := make([]byte, 4096)
+	for offset := 0; offset < info.Bytes; {
+		n, err := img.ReadAt(raw, int64(offset))
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
+		if n == 0 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		more := 0
+		if offset+n < info.Bytes {
+			more = 1
+		}
+		if offset == 0 {
+			out = fmt.Appendf(out, "\x1b_Ga=t,f=100,i=%d,q=2,m=%d;", id, more)
+		} else {
+			out = fmt.Appendf(out, "\x1b_Gm=%d;", more)
+		}
+		base64.StdEncoding.Encode(encoded, raw[:n])
+		out = append(out, encoded[:base64.StdEncoding.EncodedLen(n)]...)
+		out = append(out, "\x1b\\"...)
+		offset += n
+	}
+	return out, nil
+}
+func (s *Surface) commitGraphics(placements map[string]hostPlacement) {
+	s.graphics.placements = placements
+	wanted := make(map[string]bool, len(placements))
+	for _, p := range placements {
+		wanted[p.placement.Image.ID] = true
+	}
+	for hash := range s.graphics.known {
+		if !wanted[hash] {
+			delete(s.graphics.known, hash)
+		}
+	}
+}
+func placeholderRows(rows []string, images []ttyapi.PlacedImage) []string {
+	out := slices.Clone(rows)
+	width := 0
+	for _, row := range rows {
+		width = max(width, ansi.StringWidth(row))
+	}
+	for _, item := range images {
+		p := item.Placement
+		d := p.Destination
+		left, right := max(0, d.X), min(width, d.X+d.Cols)
+		if left >= right {
+			continue
+		}
+		label := "[image]"
+		if p.Alt != "" {
+			label = "[image: " + ansi.Strip(p.Alt) + "]"
+		}
+		// Strip C0/C1 controls that are not escape sequences from alternative text.
+		label = strings.Map(func(r rune) rune {
+			if r < 32 || (r >= 127 && r <= 159) {
+				return -1
+			}
+			return r
+		}, label)
+		for y := max(0, d.Y); y < min(len(out), d.Y+d.Rows); y++ {
+			text := strings.Repeat("▄", right-left)
+			if y == max(0, d.Y) {
+				text = ansi.Truncate(label, right-left, "")
+				text += strings.Repeat(" ", right-left-ansi.StringWidth(text))
+			}
+			prefix := ansi.Cut(out[y], 0, left)
+			prefix += strings.Repeat(" ", max(0, left-ansi.StringWidth(prefix)))
+			out[y] = prefix + "\x1b[0;2m" + text + "\x1b[0m" + ansi.Cut(out[y], right, width)
+		}
+	}
+	return out
+}

--- a/service/terminal/graphics_probe.go
+++ b/service/terminal/graphics_probe.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+package terminal
+
+import (
+	"time"
+
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+const graphicsProbeID = 0xfffffffe
+const graphicsProbeTimeout = 250 * time.Millisecond
+
+// ProbeGraphics uses the existing input reader; it never steals stdin or waits
+// on a Lua scheduler worker. Polling distinguishes pending from unsupported.
+func (r *InputReader) ProbeGraphics() ttyapi.SurfaceCapabilities {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.started || r.stopping {
+		return ttyapi.SurfaceCapabilities{Images: "none"}
+	}
+	if r.graphicsProbeAt.IsZero() {
+		r.graphicsProbeAt = time.Now()
+		query := []byte("\x1b_Ga=q,i=4294967294,f=24,s=1,v=1;AAAA\x1b\\\x1b[c")
+		if n, err := r.output.Write(query); err != nil || n != len(query) {
+			r.graphicsMode = "none"
+		}
+	}
+	if r.graphicsMode != "" {
+		return ttyapi.SurfaceCapabilities{Images: r.graphicsMode}
+	}
+	if time.Since(r.graphicsProbeAt) >= graphicsProbeTimeout {
+		r.graphicsMode = "none"
+		return ttyapi.SurfaceCapabilities{Images: "none"}
+	}
+	return ttyapi.SurfaceCapabilities{Images: "pending"}
+}
+func (r *InputReader) graphicsReply(id int, payload []byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id == graphicsProbeID && !r.graphicsProbeAt.IsZero() && time.Since(r.graphicsProbeAt) < graphicsProbeTimeout {
+		r.graphicsMode = "none"
+		if string(payload) == "OK" {
+			r.graphicsMode = "kitty"
+		}
+	}
+	return true
+}

--- a/service/terminal/graphics_test.go
+++ b/service/terminal/graphics_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MPL-2.0
+package terminal
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+func graphicFixture(t *testing.T) (*ttyapi.ImageStore, *ttyapi.Image) {
+	t.Helper()
+	var data bytes.Buffer
+	rgba := image.NewNRGBA(image.Rect(0, 0, 80, 60))
+	for y := 0; y < 60; y++ {
+		for x := 0; x < 80; x++ {
+			rgba.Set(x, y, color.NRGBA{R: uint8(x * 3), G: uint8(y * 4), B: uint8(x * y), A: 255})
+		}
+	}
+	require.NoError(t, png.Encode(&data, rgba))
+	store := ttyapi.NewImageStore(ttyapi.DefaultImageBudget)
+	img, err := store.ImportPNG(data.Bytes())
+	require.NoError(t, err)
+	return store, img
+}
+func TestGraphicsTransmitOnceMoveDeleteAndRestoreCursor(t *testing.T) {
+	store, img := graphicFixture(t)
+	defer img.Close()
+	var out bytes.Buffer
+	s := NewSurface(&out, ttyapi.SurfaceOptions{Synchronized: true})
+	s.probe = func() ttyapi.SurfaceCapabilities { return ttyapi.SurfaceCapabilities{Images: "kitty"} }
+	frame := ttyapi.Frame{Rows: []string{strings.Repeat(" ", 40), strings.Repeat(" ", 40)}, Cursor: &ttyapi.Cursor{Column: 1, Row: 0}, Images: []ttyapi.PlacedImage{{Resource: img, Placement: ttyapi.Placement{ID: "chart", Destination: ttyapi.CellRect{Cols: 4, Rows: 2}}}}}
+	_, err := s.Present(frame)
+	require.NoError(t, err)
+	first := out.String()
+	require.Contains(t, first, "a=t,f=100")
+	require.Contains(t, first, "a=p,")
+	require.True(t, strings.HasPrefix(first, "\x1b[?2026h"))
+	require.True(t, strings.HasSuffix(first, "\x1b[1;2H\x1b[?25l\x1b[?2026l"))
+	for _, part := range strings.Split(first, "\x1b_G")[1:] {
+		end := strings.Index(part, "\x1b\\")
+		if end < 0 {
+			continue
+		}
+		payload := part[:end]
+		if pos := strings.Index(payload, ";"); pos >= 0 {
+			require.LessOrEqual(t, len(payload[pos+1:]), 4096)
+		}
+	}
+	out.Reset()
+	stats, err := s.Present(frame)
+	require.NoError(t, err)
+	require.Zero(t, stats.Bytes)
+	require.Zero(t, out.Len())
+	frame.Images[0].Placement.Destination.X = 5
+	out.Reset()
+	stats, err = s.Present(frame)
+	require.NoError(t, err)
+	require.Zero(t, stats.ChangedRows)
+	require.NotContains(t, out.String(), "a=t,")
+	require.Contains(t, out.String(), "a=p,")
+	out.Reset()
+	s.Invalidate()
+	_, err = s.Present(frame)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "a=t,")
+	out.Reset()
+	_, err = s.Present(ttyapi.Frame{Rows: frame.Rows})
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "a=d,d=I,")
+	require.NoError(t, s.Close())
+	require.NoError(t, img.Close())
+	require.Zero(t, store.Used())
+}
+func TestGraphicsFallbackDoesNotEmitImageOrAltEscapes(t *testing.T) {
+	_, img := graphicFixture(t)
+	defer img.Close()
+	var out bytes.Buffer
+	s := NewSurface(&out, ttyapi.SurfaceOptions{})
+	frame := ttyapi.Frame{Rows: []string{strings.Repeat(" ", 40)}, Images: []ttyapi.PlacedImage{{Resource: img, Placement: ttyapi.Placement{ID: "chart", Alt: "safe\x1b[2J\nlabel", Destination: ttyapi.CellRect{Cols: 30, Rows: 1}}}}}
+	_, err := s.Present(frame)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "[image: safelabel]")
+	require.NotContains(t, out.String(), "\x1b_G")
+	require.NotContains(t, out.String(), "\x1b[2J")
+	out.Reset()
+	stats, err := s.Present(frame)
+	require.NoError(t, err)
+	require.Zero(t, stats.Bytes)
+}
+func TestGraphicsProbeUsesExistingReaderAndTimesOut(t *testing.T) {
+	var out bytes.Buffer
+	r := &InputReader{started: true, output: &out}
+	require.Equal(t, "pending", r.ProbeGraphics().Images)
+	require.Contains(t, out.String(), "a=q,")
+	size := out.Len()
+	require.Equal(t, "pending", r.ProbeGraphics().Images)
+	require.Equal(t, size, out.Len())
+	r.graphicsReply(graphicsProbeID, []byte("OK"))
+	require.Equal(t, "kitty", r.ProbeGraphics().Images)
+	r = &InputReader{started: true, output: &out, graphicsProbeAt: time.Now().Add(-time.Second)}
+	require.Equal(t, "none", r.ProbeGraphics().Images)
+	r.graphicsReply(graphicsProbeID, []byte("OK"))
+	require.Equal(t, "none", r.ProbeGraphics().Images, "late reply cannot enable unsupported mode")
+}
+
+type partialGraphicsWriter struct {
+	output bytes.Buffer
+	fail   bool
+}
+
+func (w *partialGraphicsWriter) Write(p []byte) (int, error) {
+	if w.fail {
+		n := len(p) / 2
+		_, _ = w.output.Write(p[:n])
+		return n, nil
+	}
+	return w.output.Write(p)
+}
+func TestGraphicsPartialWriteInvalidatesUploadsAndCleansOnRetry(t *testing.T) {
+	_, img := graphicFixture(t)
+	defer img.Close()
+	writer := &partialGraphicsWriter{fail: true}
+	s := NewSurface(writer, ttyapi.SurfaceOptions{Synchronized: true})
+	s.probe = func() ttyapi.SurfaceCapabilities { return ttyapi.SurfaceCapabilities{Images: "kitty"} }
+	f := ttyapi.Frame{Images: []ttyapi.PlacedImage{{Resource: img, Placement: ttyapi.Placement{ID: "p", Destination: ttyapi.CellRect{Cols: 2, Rows: 2}}}}}
+	_, err := s.Present(f)
+	require.Error(t, err)
+	writer.fail = false
+	writer.output.Reset()
+	_, err = s.Present(f)
+	require.NoError(t, err)
+	wire := writer.output.String()
+	require.Contains(t, wire, "a=d,d=I,")
+	require.Contains(t, wire, "a=t,")
+	require.Less(t, strings.Index(wire, "a=d,d=I,"), strings.Index(wire, "a=t,"))
+	require.NoError(t, s.Close())
+}

--- a/service/terminal/host.go
+++ b/service/terminal/host.go
@@ -358,7 +358,9 @@ func (h *Host) prepareContext(ctx context.Context, processID pid.PID, start *pro
 	tc.Raw = h.raw
 	tc.Input = NewInputReader(os.Stdin, tc.Stdout, h.raw, h.scheduler, processID)
 	tc.Surface = func(options ttyapi.SurfaceOptions) (ttyapi.Surface, error) {
-		return NewSurface(os.Stdout, options), nil
+		s := NewSurface(os.Stdout, options)
+		s.probe = tc.Input.(*InputReader).ProbeGraphics
+		return s, nil
 	}
 	pairs[3] = ctxapi.Pair{Key: terminalapi.Key(), Value: tc}
 	copy(pairs[4:], start.Context)

--- a/service/terminal/input.go
+++ b/service/terminal/input.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/x/term"
 	"github.com/wippyai/runtime/api/payload"
@@ -19,24 +20,26 @@ import (
 
 // InputReader reads terminal input and delivers parsed events to a sink.
 type InputReader struct {
-	output       io.Writer
-	emitter      *inputEmitter
-	raw          *RawManager
-	sink         func(tty.Event)
-	reader       terminalInputReader
-	cancel       context.CancelFunc
-	stopDone     chan struct{}
-	stopErr      error
-	done         chan struct{}
-	err          error
-	stdin        *os.File
-	wg           sync.WaitGroup
-	mu           sync.Mutex
-	started      bool
-	stopping     bool
-	mouseEnabled bool
-	pasteEnabled bool
-	doneClosed   bool
+	graphicsProbeAt time.Time
+	output          io.Writer
+	emitter         *inputEmitter
+	raw             *RawManager
+	sink            func(tty.Event)
+	reader          terminalInputReader
+	cancel          context.CancelFunc
+	stopDone        chan struct{}
+	stopErr         error
+	done            chan struct{}
+	err             error
+	stdin           *os.File
+	graphicsMode    string
+	wg              sync.WaitGroup
+	mu              sync.Mutex
+	started         bool
+	stopping        bool
+	mouseEnabled    bool
+	pasteEnabled    bool
+	doneClosed      bool
 }
 
 // NewEventInputReader creates an InputReader that delivers events to the given sink
@@ -321,7 +324,7 @@ func (r *InputReader) readLoop(ctx context.Context, reader terminalInputReader, 
 		}
 	}()
 
-	readErr = streamTerminalInput(ctx, reader, r.sendEvent)
+	readErr = streamTerminalInput(ctx, reader, r.sendEvent, r.graphicsReply)
 }
 
 func (r *InputReader) emitResize() {

--- a/service/terminal/input_sink_test.go
+++ b/service/terminal/input_sink_test.go
@@ -263,9 +263,30 @@ func TestTerminalInputReleasesCompletedLargePasteBudget(t *testing.T) {
 		if event != nil && event.Type == "paste" {
 			got = append(got, event.Paste)
 		}
-	})
+	}, nil)
 	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, []string{first, second}, got)
+}
+
+func TestTerminalInputConsumesGraphicsReplyBeforeUserEvents(t *testing.T) {
+	input := &eofWithDataReader{data: []byte("\x1b_Gi=4294967294;OK\x1b\\z")}
+	var events []*TTYEvent
+	var replyID int
+	var replyPayload string
+	err := streamTerminalInput(context.Background(), input, func(event *TTYEvent) {
+		if event != nil {
+			events = append(events, event)
+		}
+	}, func(id int, payload []byte) bool {
+		replyID = id
+		replyPayload = string(payload)
+		return id == graphicsProbeID
+	})
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, graphicsProbeID, replyID)
+	require.Equal(t, "OK", replyPayload)
+	require.Len(t, events, 1)
+	require.Equal(t, "z", events[0].Key)
 }
 
 type eofWithDataReader struct {

--- a/service/terminal/input_stream.go
+++ b/service/terminal/input_stream.go
@@ -13,3 +13,4 @@ type terminalInputReader interface {
 }
 
 type inputEventSink func(*TTYEvent)
+type graphicsEventSink func(id int, payload []byte) bool

--- a/service/terminal/input_stream_other.go
+++ b/service/terminal/input_stream_other.go
@@ -14,7 +14,7 @@ func newTerminalInputReader(stdin *os.File, _ string) (terminalInputReader, erro
 	return uv.NewCancelReader(stdin)
 }
 
-func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink inputEventSink) error {
+func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink inputEventSink, graphics graphicsEventSink) error {
 	framed := newFramedTerminalInput(reader)
 	terminalReader := uv.NewTerminalReader(framed, os.Getenv("TERM"))
 	events := make(chan uv.Event)
@@ -34,6 +34,9 @@ func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink i
 			}
 			framed.acknowledgeEvent()
 			if !stopping {
+				if reply, ok := event.(uv.KittyGraphicsEvent); ok && graphics != nil && graphics(reply.Options.ID, reply.Payload) {
+					continue
+				}
 				sink(convertUVInputEvent(event))
 			}
 		case err := <-streamDone:

--- a/service/terminal/input_stream_windows.go
+++ b/service/terminal/input_stream_windows.go
@@ -19,7 +19,7 @@ func newTerminalInputReader(stdin *os.File, termType string) (terminalInputReade
 	return input.NewReader(stdin, termType, 0)
 }
 
-func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink inputEventSink) error {
+func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink inputEventSink, graphics graphicsEventSink) error {
 	legacy, ok := reader.(*input.Reader)
 	if !ok {
 		return errors.New("windows terminal input reader is not x/input")
@@ -33,6 +33,9 @@ func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink i
 
 		events, err := legacy.ReadEvents()
 		for _, event := range events {
+			if reply, ok := event.(input.KittyGraphicsEvent); ok && graphics != nil && graphics(reply.Options.ID, reply.Payload) {
+				continue
+			}
 			sink(ConvertInputEvent(event))
 		}
 		if err == nil {

--- a/service/terminal/surface.go
+++ b/service/terminal/surface.go
@@ -15,6 +15,8 @@ import (
 
 // Surface is the physical ANSI implementation of tty.Surface.
 type Surface struct {
+	probe    func() ttyapi.SurfaceCapabilities
+	graphics graphicsState
 	out      io.Writer
 	closeErr error
 	cursor   *ttyapi.Cursor
@@ -33,13 +35,22 @@ func NewSurface(out io.Writer, opts ttyapi.SurfaceOptions) *Surface {
 }
 
 func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
-	if len(frame.Images) != 0 {
-		return ttyapi.PresentStats{}, ttyapi.ErrGraphicsUnsupported
-	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return ttyapi.PresentStats{}, fmt.Errorf("surface is closed")
+	}
+	images, err := ttyapi.RetainPlacements(frame.Images)
+	if err != nil {
+		return ttyapi.PresentStats{}, err
+	}
+	defer ttyapi.ClosePlacements(images)
+	enabled := false
+	if len(images) > 0 {
+		enabled = s.capabilities().Images == "kitty"
+	}
+	if !enabled && len(images) > 0 {
+		frame.Rows = placeholderRows(frame.Rows, images)
 	}
 	output := s.scratch[:0]
 	if s.opts.Synchronized {
@@ -90,6 +101,17 @@ func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 	if s.invalid && limit == 0 {
 		output = append(output, "\x1b[H\x1b[0m\x1b[J"...)
 	}
+	graphicsStart := len(output)
+	var desired map[string]hostPlacement
+	if len(images) > 0 || len(s.graphics.known) > 0 {
+		var err error
+		output, desired, err = s.appendGraphics(output, images, enabled)
+		if err != nil {
+			s.invalid = true
+			return ttyapi.PresentStats{}, err
+		}
+	}
+	graphicsChanged := len(output) != graphicsStart
 	// Painting rows moves the physical terminal cursor even when the logical
 	// frame cursor itself did not change. Cursor placement is therefore dirty
 	// whenever either cell damage or cursor state changed, and must be the last
@@ -99,7 +121,7 @@ func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 		effectiveCursor = s.cursor
 	}
 	cursorChanged := frame.Cursor != nil && !sameSurfaceCursor(s.cursor, frame.Cursor)
-	if effectiveCursor != nil && (s.invalid || changed != 0 || cursorChanged) {
+	if effectiveCursor != nil && (s.invalid || changed != 0 || cursorChanged || graphicsChanged) {
 		output = append(output, '\x1b', '[')
 		output = strconv.AppendInt(output, int64(max(0, effectiveCursor.Row)+1), 10)
 		output = append(output, ';')
@@ -122,11 +144,16 @@ func (s *Surface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 		s.acquired = true
 		written, err := s.out.Write(output)
 		if err != nil {
+			s.invalid = true
 			return ttyapi.PresentStats{}, err
 		}
 		if written != len(output) {
+			s.invalid = true
 			return ttyapi.PresentStats{}, io.ErrShortWrite
 		}
+	}
+	if desired != nil {
+		s.commitGraphics(desired)
 	}
 	s.opened = true
 	s.invalid = false
@@ -165,6 +192,10 @@ func (s *Surface) Close() error {
 		return nil
 	}
 	restore := make([]byte, 0, 32)
+	for _, id := range s.graphics.known {
+		restore = deleteHostImage(restore, id)
+	}
+	s.graphics = graphicsState{}
 	if s.opts.Synchronized {
 		restore = append(restore, "\x1b[?2026l"...)
 	}
@@ -204,4 +235,17 @@ func (s *Surface) Clipboard(text string) error {
 		return io.ErrShortWrite
 	}
 	return err
+}
+
+func (s *Surface) Capabilities() ttyapi.SurfaceCapabilities {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.capabilities()
+}
+
+func (s *Surface) capabilities() ttyapi.SurfaceCapabilities {
+	if s.probe != nil {
+		return s.probe()
+	}
+	return ttyapi.SurfaceCapabilities{Images: "none"}
 }

--- a/service/terminal/tty/dispatcher.go
+++ b/service/terminal/tty/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/runtime/resource"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 )
 
@@ -346,6 +347,21 @@ func (d *Dispatcher) handleViewportIO(ctx context.Context, command dispatcher.Co
 		var result any
 		var err error
 		switch c.Operation {
+		case "image_import":
+			provider, ok := ttyapi.GetService(runCtx).(interface {
+				ImageStore() *ttyapi.ImageStore
+			})
+			if !ok {
+				err = ttyapi.ErrServiceUnavailable
+			} else {
+				result, err = provider.ImageStore().ImportPNG(c.ImageData)
+			}
+		case "capture":
+			if c.CaptureSource == nil {
+				err = ttyapi.ErrInvalidPort
+			} else {
+				result, err = c.CaptureSource.Capture(runCtx)
+			}
 		case "attach":
 			service := ttyapi.GetService(runCtx)
 			if service == nil {
@@ -370,6 +386,29 @@ func (d *Dispatcher) handleViewportIO(ctx context.Context, command dispatcher.Co
 		default:
 			err = ttyapi.ErrInvalidPort
 		}
+
+		if owned, ok := result.(interface{ Close() error }); ok && (c.Operation == "capture" || c.Operation == "image_import") {
+			transfer := ttyapi.ImageIOResult{}
+			if img, ok := result.(*ttyapi.Image); ok {
+				transfer.Image = img
+			}
+			if capture, ok := result.(*ttyapi.Capture); ok {
+				transfer.Capture = capture
+			}
+			if store := resource.GetStore(runCtx); store != nil {
+				transfer.Cancel = store.AddCleanup(owned.Close)
+			}
+			result = transfer
+			if runCtx.Err() != nil {
+				if transfer.Cancel != nil {
+					transfer.Cancel()
+				}
+				_ = owned.Close()
+				result = nil
+				err = runCtx.Err()
+			}
+		}
+
 		receiver.CompleteYield(tag, result, err)
 	}()
 	return nil

--- a/service/terminal/tty/dispatcher_test.go
+++ b/service/terminal/tty/dispatcher_test.go
@@ -6,12 +6,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"image"
+	"image/png"
 	"testing"
+	"time"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
 	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/runtime/resource"
 	"github.com/wippyai/runtime/api/service/terminal"
 	ttyapi "github.com/wippyai/runtime/api/tty"
+	systemtty "github.com/wippyai/runtime/system/tty"
 )
 
 type testReceiver struct {
@@ -19,9 +24,85 @@ type testReceiver struct {
 	err  error
 }
 
+type asyncResult struct {
+	data any
+	err  error
+}
+
+type asyncReceiver chan asyncResult
+
+func (r asyncReceiver) CompleteYield(_ uint64, data any, err error) {
+	r <- asyncResult{data: data, err: err}
+}
+
 func (r *testReceiver) CompleteYield(_ uint64, data any, err error) {
 	r.data = data
 	r.err = err
+}
+
+func TestDispatcherImageImportTransfersCleanupOwnership(t *testing.T) {
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, image.NewNRGBA(image.Rect(0, 0, 2, 2))); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cancelCleanup := range []bool{false, true} {
+		t.Run(map[bool]string{false: "frame_cleanup", true: "lua_ownership"}[cancelCleanup], func(t *testing.T) {
+			ctx := ctxapi.WithAppContext(context.Background(), ctxapi.NewAppContext())
+			ctx, frame := ctxapi.OpenFrameContext(ctx)
+			defer frame.Close()
+			resources := resource.NewStore()
+			if err := resource.SetStore(ctx, resources); err != nil {
+				t.Fatal(err)
+			}
+			service := systemtty.NewService()
+			defer service.Close()
+			ttyapi.WithService(ctx, service)
+
+			receiver := make(asyncReceiver, 1)
+			dispatcher := NewDispatcher()
+			if err := dispatcher.handleViewportIO(ctx, ttyapi.ViewportIOCmd{
+				Operation: "image_import",
+				ImageData: encoded.Bytes(),
+			}, 1, receiver); err != nil {
+				t.Fatal(err)
+			}
+
+			var completed asyncResult
+			select {
+			case completed = <-receiver:
+			case <-time.After(time.Second):
+				t.Fatal("image import did not complete")
+			}
+			if completed.err != nil {
+				t.Fatal(completed.err)
+			}
+			result, ok := completed.data.(ttyapi.ImageIOResult)
+			if !ok || result.Image == nil || result.Cancel == nil {
+				t.Fatalf("invalid image result: %#v", completed.data)
+			}
+			if cancelCleanup {
+				result.Cancel()
+			}
+			if err := resources.Close(); err != nil {
+				t.Fatal(err)
+			}
+			_, infoErr := result.Image.Info()
+			if cancelCleanup {
+				if infoErr != nil {
+					t.Fatalf("transferred image was closed: %v", infoErr)
+				}
+				if err := result.Image.Close(); err != nil {
+					t.Fatal(err)
+				}
+			} else if !errors.Is(infoErr, ttyapi.ErrImageClosed) {
+				t.Fatalf("frame cleanup left image open: %v", infoErr)
+			}
+			if used := service.ImageStore().Used(); used != 0 {
+				t.Fatalf("image budget leaked: %d", used)
+			}
+		})
+	}
 }
 
 type stubRawController struct {

--- a/system/tty/port.go
+++ b/system/tty/port.go
@@ -196,3 +196,7 @@ func (i *input) ScreenSize() (int, int, error) {
 }
 func (i *input) EnableMouse()  {}
 func (i *input) DisableMouse() {}
+
+func (s *surface) Capabilities() ttyapi.SurfaceCapabilities {
+	return ttyapi.SurfaceCapabilities{Images: "native"}
+}


### PR DESCRIPTION
Applications can create a bounded native PNG handle with `tty.image`, present a complete placement set alongside styled rows, and retain a viewport capture with process-owned cleanup. PNG validation and capture acquisition yield through the existing asynchronous dispatcher; only explicit export returns encoded bytes to Lua.

Physical surfaces probe Kitty graphics through the existing cancellable input reader, consume probe replies before user input delivery, upload each live image once, update placements without retransmitting pixels, and delete images inside synchronized presentation. Unsupported hosts render bounded text placeholders. Failed writes invalidate upload state for recovery.

This is the second terminal-image stage after #692. Authorized remote capture and resource fetch remain in stacked follow-up #697.

Validation:

- API, physical lease, broker, terminal/proxy/dispatcher, and Lua TTY suites pass under `-race`.
- Ownership-transfer coverage proves frame cleanup closes unclaimed images and Lua transfer preserves claimed images without leaking the image budget.
- Input coverage proves Kitty replies are consumed before ordinary terminal events.
- Repository-pinned golangci-lint v2.13.2, `go vet`, `go mod verify`, Windows compilation, and diff checks pass.
- Tests cover process-exit cleanup, forged handles, retained capture lifetime, protocol chunk bounds, cursor restoration, probe timeout, alternative-text control stripping, and short-write recovery.
