### PR TITLE
feat(exec): process groups for native children, group signalling and proc:pid()

### DIFF
--- a/api/service/exec/api.go
+++ b/api/service/exec/api.go
@@ -20,9 +20,13 @@ const (
 
 // ProcessOptions defines options for creating a new process
 type ProcessOptions struct {
-	Env     map[string]string
-	PTY     *PTYOptions
-	WorkDir string
+	Env map[string]string
+	PTY *PTYOptions
+	// ProcessGroup places the child in its own process group so that signals
+	// addressed to the process reach its descendants as well. Nil selects the
+	// executor default.
+	ProcessGroup *bool
+	WorkDir      string
 }
 
 type PTYOptions struct {
@@ -99,6 +103,13 @@ type Process interface {
 type PTYProcess interface {
 	Process
 	Resize(width, height int) error
+}
+
+// ProcessIdentity is an optional capability exposed by processes that carry an
+// operating system process identifier on the host running the runtime.
+type ProcessIdentity interface {
+	// Pid returns the identifier of the started child process.
+	Pid() (int, error)
 }
 
 // WaitCanceler is an optional lifecycle capability for remote executors whose

--- a/api/service/exec/config.go
+++ b/api/service/exec/config.go
@@ -12,6 +12,10 @@ type NativeExecutorConfig struct {
 
 	// Command whitelist - if set, only commands in this list will be allowed
 	CommandWhitelist []string `json:"command_whitelist"`
+
+	// Start every process in its own process group so signals reach the whole
+	// tree. A per-command process_group option overrides this default.
+	ProcessGroup bool `json:"process_group"`
 }
 
 // DockerExecutorConfig defines configuration for Docker container execution

--- a/api/service/exec/errors.go
+++ b/api/service/exec/errors.go
@@ -13,4 +13,6 @@ var ErrInvalidPTYSize = apierror.New(apierror.Invalid, "PTY dimensions must be p
 
 var ErrCommandRequired = apierror.New(apierror.Invalid, "command is required").WithRetryable(apierror.False)
 
+var ErrProcessGroupUnsupported = apierror.New(apierror.Unavailable, "process groups are not supported on this platform").WithRetryable(apierror.False)
+
 var ErrInvalidCommand = apierror.New(apierror.Invalid, "invalid command").WithRetryable(apierror.False)

--- a/runtime/lua/modules/exec/executor.go
+++ b/runtime/lua/modules/exec/executor.go
@@ -161,9 +161,10 @@ func processSecurityMeta(options apiexec.ProcessOptions) attrs.Bag {
 		terminal["width"], terminal["height"], terminal["term"] = width, height, options.PTY.Term
 	}
 	return attrs.Bag{
-		"work_dir":  options.WorkDir,
-		"env_names": envNames,
-		"pty":       terminal,
+		"work_dir":      options.WorkDir,
+		"env_names":     envNames,
+		"pty":           terminal,
+		"process_group": options.ProcessGroup != nil && *options.ProcessGroup,
 	}
 }
 

--- a/runtime/lua/modules/exec/options.go
+++ b/runtime/lua/modules/exec/options.go
@@ -49,6 +49,14 @@ func parseProcessOptions(value lua.LValue) (apiexec.ProcessOptions, error) {
 			return apiexec.ProcessOptions{}, envErr
 		}
 	}
+	if value := table.RawGetString("process_group"); value != lua.LNil {
+		enabled, ok := value.(lua.LBool)
+		if !ok {
+			return apiexec.ProcessOptions{}, fmt.Errorf("process_group must be a boolean")
+		}
+		group := bool(enabled)
+		options.ProcessGroup = &group
+	}
 	if value := table.RawGetString("pty"); value != lua.LNil {
 		pty, ok := value.(*lua.LTable)
 		if !ok {

--- a/runtime/lua/modules/exec/pgroup_test.go
+++ b/runtime/lua/modules/exec/pgroup_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package exec
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	rtresource "github.com/wippyai/runtime/api/runtime/resource"
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	"github.com/wippyai/runtime/service/exec/native"
+	"go.uber.org/zap"
+)
+
+// processTreeCommand prints the pid of a grandchild that only a group-wide
+// signal can reach, then keeps the direct child alive until it is stopped.
+const processTreeCommand = "sh -c 'sleep 300 & echo $!; wait'"
+
+// treeAlive reports whether the pid is still signalable; a reaped process
+// answers ESRCH.
+func treeAlive(pid int) bool { return syscall.Kill(pid, 0) == nil }
+
+// newTreeProcess builds a real native process in its own process group and
+// wraps it in the Lua handle, exactly as executor:exec does.
+func newTreeProcess(ctx context.Context, t *testing.T, group bool) (*Process, io.Reader) {
+	t.Helper()
+	executor := native.NewNativeExecutor(zap.NewNop(), &execapi.NativeExecutorConfig{ProcessGroup: group})
+	handle, err := executor.NewProcess(processTreeCommand, execapi.ProcessOptions{})
+	require.NoError(t, err)
+	return NewProcess(ctx, handle), handle.Stdout()
+}
+
+// startTree drives the Lua start binding and returns the grandchild pid the
+// child reports.
+func startTree(t *testing.T, l *lua.LState, process *Process, stdout io.Reader) int {
+	t.Helper()
+	value.PushTypedUserData(l, process, processTypeName)
+	require.Equal(t, 2, procStart(l))
+	l.SetTop(1)
+
+	pids := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		if scanner.Scan() {
+			pids <- strings.TrimSpace(scanner.Text())
+		}
+		close(pids)
+	}()
+	select {
+	case line, ok := <-pids:
+		require.True(t, ok, "child produced no output")
+		pid, err := strconv.Atoi(line)
+		require.NoErrorf(t, err, "expected a pid on the first output line, got %q", line)
+		t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+		return pid
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the grandchild pid")
+		return 0
+	}
+}
+
+// close() releases the whole tree a harness spawned, not just the command it
+// started: the tool subprocesses are grandchildren of that command.
+func TestCloseReleasesTheProcessGroupTree(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+	grandchild := startTree(t, l, process, stdout)
+	require.True(t, treeAlive(grandchild))
+
+	procClose(l)
+
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !treeAlive(grandchild) }),
+		"grandchild %d survived close() of a process-group child", grandchild)
+}
+
+// The forced close escalates straight to SIGKILL, which must also address the
+// group.
+func TestForcedCloseKillsTheProcessGroupTree(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+	grandchild := startTree(t, l, process, stdout)
+
+	l.Push(lua.LTrue)
+	procClose(l)
+
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !treeAlive(grandchild) }),
+		"grandchild %d survived close(true) of a process-group child", grandchild)
+}
+
+// The cleanup that runs when the owning Lua process exits takes the same path,
+// so it must release the tree too.
+func TestRuntimeCleanupReleasesTheProcessGroupTree(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+	grandchild := startTree(t, l, process, stdout)
+
+	require.NoError(t, store.Close())
+
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !treeAlive(grandchild) }),
+		"grandchild %d outlived the owning process", grandchild)
+}
+
+// Without the option the child shares the runtime's group, so only it is
+// signaled. That is the defined behavior for callers that rely on it.
+func TestCloseWithoutProcessGroupLeavesTheGrandchild(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, false)
+	grandchild := startTree(t, l, process, stdout)
+
+	procClose(l)
+
+	assert.True(t, treeAlive(grandchild),
+		"the default close must not reach beyond the direct child")
+}
+
+// pid() is the evidence a caller records for an attempt.
+func TestProcessPidBinding(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+
+	value.PushTypedUserData(l, process, processTypeName)
+	require.Equal(t, 2, procPid(l))
+	require.Equal(t, lua.LNil, l.Get(-2))
+	pidErr, ok := l.Get(-1).(*lua.Error)
+	require.True(t, ok)
+	assert.Contains(t, pidErr.Error(), "process not started")
+	l.SetTop(0)
+
+	grandchild := startTree(t, l, process, stdout)
+
+	require.Equal(t, 2, procPid(l))
+	pid, ok := l.Get(-2).(lua.LInteger)
+	require.True(t, ok, "pid must be an integer")
+	assert.Positive(t, int(pid))
+	assert.NotEqual(t, grandchild, int(pid))
+	l.SetTop(1)
+
+	procClose(l)
+}
+
+func TestParseProcessOptionsProcessGroup(t *testing.T) {
+	l := setupState()
+	defer l.Close()
+
+	table := l.NewTable()
+	table.RawSetString("process_group", lua.LTrue)
+	options, err := parseProcessOptions(table)
+	require.NoError(t, err)
+	require.NotNil(t, options.ProcessGroup)
+	assert.True(t, *options.ProcessGroup)
+	assert.Equal(t, true, processSecurityMeta(options)["process_group"])
+
+	table.RawSetString("process_group", lua.LFalse)
+	options, err = parseProcessOptions(table)
+	require.NoError(t, err)
+	require.NotNil(t, options.ProcessGroup)
+	assert.False(t, *options.ProcessGroup)
+	assert.Equal(t, false, processSecurityMeta(options)["process_group"])
+
+	table.RawSetString("process_group", lua.LString("yes"))
+	_, err = parseProcessOptions(table)
+	require.ErrorContains(t, err, "process_group must be a boolean")
+
+	// An unset option leaves the executor default in force and reports nothing
+	// requested to the policy.
+	empty, err := parseProcessOptions(l.NewTable())
+	require.NoError(t, err)
+	assert.Nil(t, empty.ProcessGroup)
+	assert.Equal(t, false, processSecurityMeta(empty)["process_group"])
+}

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -173,6 +173,7 @@ var processMethods = map[string]lua.LGoFunc{
 	"write_stdin":     procWriteStdin,
 	"stdout_stream":   procStdout,
 	"stderr_stream":   procStderr,
+	"pid":             procPid,
 	"close":           procClose,
 	"resize":          procResize,
 	"attach_terminal": procAttachTerminal,
@@ -298,6 +299,45 @@ func procWait(l *lua.LState) int {
 
 	l.Push(yield)
 	return -1
+}
+
+func procPid(l *lua.LState) int {
+	p := checkProcess(l, 1)
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process is closed").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	if !p.started {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process not started: call start() first").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	handle := p.handle
+	p.mu.Unlock()
+
+	identity, ok := handle.(apiexec.ProcessIdentity)
+	if !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process has no host process id").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	pid, err := identity.Pid()
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(wrapExecError(l, err, "read process id", lua.Internal))
+		return 2
+	}
+
+	l.Push(lua.LInteger(pid))
+	l.Push(lua.LNil)
+	return 2
 }
 
 func procSignal(l *lua.LState) int {

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -81,6 +81,7 @@ Creates a new process with the specified command.
 | work_dir | string | nil | Working directory for the process |
 | env | {[string]: string} | nil | Environment variables as key-value map |
 | pty | PTYOptions | nil | Allocate a pseudo-terminal for the child |
+| process_group | boolean | executor default | Start the child in its own process group so `signal()` and `close()` reach its descendants |
 
 **PTYOptions fields:**
 
@@ -89,6 +90,25 @@ Creates a new process with the specified command.
 | width | integer | 80 | Initial PTY columns |
 | height | integer | 24 | Initial PTY rows |
 | term | string | nil | Child `TERM` value, such as `xterm-256color` |
+
+**Process groups**
+
+By default the child shares the runtime's process group, so a signal reaches
+only the child itself; anything it spawns survives and is reparented. With
+`process_group = true` the child leads a group of its own, and `signal()`,
+`close()` and the cleanup that runs when the owning process exits address the
+whole group. Use it for a command that spawns its own subprocesses, such as a
+tool harness or a language server.
+
+The executor entry sets the default with its `process_group` config field; the
+per-command option overrides it in both directions. A PTY-backed child already
+has a session of its own, so the option only changes how signals are addressed
+there. Process groups are a Unix facility: on Windows the option is rejected
+with `errors.UNAVAILABLE` rather than silently ignored.
+
+A container executor confines the tree to the container's pid namespace, where
+signaling the container's first process already ends everything it spawned, so
+the option carries no additional meaning there.
 
 **Returns:**
 - Success: `Process, nil` - process object (not started)
@@ -102,6 +122,7 @@ Creates a new process with the specified command.
 | cmd is empty string | errors.INVALID | no |
 | cmd contains an unclosed quote | errors.INVALID | no |
 | permission denied | errors.INVALID | no |
+| process_group requested on Windows | errors.UNAVAILABLE | no |
 | process creation failed | errors.INTERNAL | no |
 
 **Example:**
@@ -134,7 +155,8 @@ Returned by `executor:exec()`. Represents a process instance.
 |--------|-----------|---------|-------|
 | start | () | boolean, error | Starts the process |
 | wait | () | integer, error | Waits for process to exit, yields |
-| signal | (sig: integer) | boolean, error | Sends signal to process |
+| signal | (sig: integer) | boolean, error | Sends signal to process, or to its group when `process_group` is set |
+| pid | () | integer, error | Host process id of the started child |
 | write_stdin | (data: string) | boolean, error | Writes to process stdin |
 | stdout_stream | () | Stream, error | Returns stdout stream |
 | stderr_stream | () | Stream, error | Returns stderr stream |
@@ -167,7 +189,9 @@ Ordinary pipe-backed processes return an error.
 #### process:close(force?: boolean) → boolean, error
 
 Releases the process. A started child is sent `SIGTERM`, or `SIGKILL` when
-`force` is true, then reaped; an unstarted handle is simply invalidated.
+`force` is true, then reaped; an unstarted handle is simply invalidated. A
+process started with `process_group` is signaled as a group, so its descendants
+go with it.
 
 Reaping is what releases the child's entry in the OS process table; without it a
 stopped process lingers as a zombie for the lifetime of the runtime. It happens
@@ -239,7 +263,8 @@ end
 
 #### process:signal(sig: integer) → boolean, error
 
-Sends a signal to the running process.
+Sends a signal to the running process, or to its whole process group when the
+process was created with `process_group = true`.
 
 | Param | Type | Required | Default | Notes |
 |-------|------|----------|---------|-------|
@@ -263,6 +288,31 @@ Sends a signal to the running process.
 local SIGTERM = 15
 proc:start()
 local ok, err = proc:signal(SIGTERM)
+if err then error(err) end
+```
+
+#### process:pid() → integer, error
+
+Returns the operating system process id of the started child, for recording
+which process an attempt ran as.
+
+**Returns:**
+- Success: `pid: integer, nil`
+- Error: `nil, error` - error is structured
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| process closed | errors.INVALID | no |
+| process not started | errors.INVALID | no |
+| executor exposes no host pid | errors.UNAVAILABLE | no |
+
+**Example:**
+
+```lua
+proc:start()
+local pid, err = proc:pid()
 if err then error(err) end
 ```
 
@@ -364,7 +414,7 @@ if err then
 end
 ```
 
-**Possible kinds:** `errors.INVALID`, `errors.INTERNAL`
+**Possible kinds:** `errors.INVALID`, `errors.INTERNAL`, `errors.UNAVAILABLE`
 
 ## Example
 

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -25,6 +25,7 @@ func init() {
 		OptField("work_dir", typ.String).
 		OptField("env", typ.NewMap(typ.String, typ.String)).
 		OptField("pty", ptyOptionsType).
+		OptField("process_group", typ.Boolean).
 		Build()
 	terminalCompletionType = typ.NewInterface("exec.TerminalCompletionChannel", []typ.Method{
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
@@ -47,6 +48,7 @@ func init() {
 		{Name: "start", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "wait", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "signal", Type: typ.Func().Param("self", typ.Self).Param("sig", typ.Number).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "pid", Type: typ.Func().Param("self", typ.Self).Returns(typ.Integer, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "write_stdin", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "stdout_stream", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "stderr_stream", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -24,6 +24,7 @@ import (
 var (
 	_ execapi.ProcessExecutor = (*Executor)(nil)
 	_ execapi.Process         = (*ProcessExecutor)(nil)
+	_ execapi.ProcessIdentity = (*ProcessExecutor)(nil)
 	_ execapi.PTYProcess      = (*ptyProcess)(nil)
 )
 
@@ -39,6 +40,7 @@ type Executor struct {
 	defaultEnv       map[string]string
 	defaultWD        string
 	commandWhitelist []string
+	processGroup     bool
 }
 
 // NewNativeExecutor creates a new native process executor
@@ -48,6 +50,7 @@ func NewNativeExecutor(log *zap.Logger, config *execapi.NativeExecutorConfig) *E
 		defaultEnv:       config.DefaultEnv,
 		defaultWD:        config.DefaultWorkDir,
 		commandWhitelist: config.CommandWhitelist,
+		processGroup:     config.ProcessGroup,
 	}
 }
 
@@ -63,6 +66,13 @@ func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execa
 		if _, _, err := ptyOptions.Dimensions(); err != nil {
 			return nil, err
 		}
+	}
+	processGroup := e.processGroup
+	if options.ProcessGroup != nil {
+		processGroup = *options.ProcessGroup
+	}
+	if processGroup && !processGroupSupported {
+		return nil, execapi.ErrProcessGroupUnsupported
 	}
 	if len(e.commandWhitelist) > 0 {
 		allowed := false
@@ -108,6 +118,7 @@ func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execa
 		WithWorkingDir(workDir),
 		WithEnv(env),
 		WithPTY(ptyOptions),
+		WithProcessGroup(processGroup),
 	)
 	if ptyOptions != nil {
 		return &ptyProcess{ProcessExecutor: process}, nil
@@ -122,22 +133,24 @@ type ptyProcess struct{ *ProcessExecutor }
 
 // ProcessExecutor represents a native process implementation
 type ProcessExecutor struct {
-	stderrp     io.ReadCloser
-	stdoutp     io.ReadCloser
-	stdinPipe   io.WriteCloser
-	cmd         *exec.Cmd
-	log         *zap.Logger
-	envs        map[string]string
-	ptyMaster   *os.File
-	pty         *execapi.PTYOptions
-	wd          string
-	state       string
-	command     string
-	pid         int
-	mu          sync.RWMutex
-	ptyClose    sync.Once
-	stopped     atomic.Bool
-	stdoutOwned bool
+	stderrp      io.ReadCloser
+	stdoutp      io.ReadCloser
+	stdinPipe    io.WriteCloser
+	cmd          *exec.Cmd
+	log          *zap.Logger
+	envs         map[string]string
+	ptyMaster    *os.File
+	pty          *execapi.PTYOptions
+	wd           string
+	state        string
+	command      string
+	pid          int
+	pgid         int
+	mu           sync.RWMutex
+	ptyClose     sync.Once
+	stopped      atomic.Bool
+	stdoutOwned  bool
+	processGroup bool
 }
 
 // NewProcessExecutor creates a new process executor
@@ -184,6 +197,13 @@ func NewProcessExecutor(log *zap.Logger, opts ...Option) *ProcessExecutor {
 		command.Dir = e.wd
 	}
 
+	// A PTY child is started through pty.StartWithAttrs, which replaces
+	// SysProcAttr with a session of its own; setsid already makes that child the
+	// leader of a fresh process group, and adding setpgid on top of it fails.
+	if e.processGroup && e.pty == nil {
+		applyProcessGroup(command)
+	}
+
 	// we can safely skip the error here
 	// because we don't initialize stderrpipe twice or after the process was already started
 	if e.pty == nil {
@@ -225,8 +245,29 @@ func (e *ProcessExecutor) Start() error {
 	}
 
 	e.pid = e.cmd.Process.Pid
+	// Both paths that give the child a group of its own make it the leader:
+	// setpgid with a zero target group, and the PTY path's setsid. The group
+	// identifier is therefore the child pid.
+	if e.processGroup {
+		e.pgid = e.pid
+	}
 	e.state = running
 	return nil
+}
+
+// Pid implements exec.ProcessIdentity. It reports the identifier of the started
+// child so callers can record which OS process an attempt ran as.
+func (e *ProcessExecutor) Pid() (int, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if e.state == notStarted {
+		return 0, ErrProcessNotStarted
+	}
+	if e.pid <= 0 {
+		return 0, ErrInvalidPID
+	}
+	return e.pid, nil
 }
 
 func (p *ptyProcess) Resize(width, height int) error {
@@ -298,6 +339,14 @@ func (e *ProcessExecutor) Signal(sig int) error {
 		return ErrInvalidPID
 	}
 
+	if e.processGroup {
+		if err := signalProcessGroup(e.pgid, syscall.Signal(sig)); err != nil {
+			e.log.Error("error sending signal to process group", zap.Error(err))
+			return err
+		}
+		return nil
+	}
+
 	// we're using os.FindProcess to avoid touching e.cmd
 	pp, err := os.FindProcess(e.pid)
 	if err != nil {
@@ -349,14 +398,18 @@ func (e *ProcessExecutor) Stop() {
 		return
 	}
 
-	pp, err := os.FindProcess(e.pid)
-	if err != nil {
-		e.log.Error("error finding process", zap.Error(err))
-		return
-	}
+	if e.processGroup {
+		_ = signalProcessGroup(e.pgid, syscall.SIGKILL)
+	} else {
+		pp, err := os.FindProcess(e.pid)
+		if err != nil {
+			e.log.Error("error finding process", zap.Error(err))
+			return
+		}
 
-	// kill the process
-	_ = pp.Kill()
+		// kill the process
+		_ = pp.Kill()
+	}
 	// to prevent multiple calls to close()
 	e.pid = 0
 	e.state = terminated

--- a/service/exec/native/options.go
+++ b/service/exec/native/options.go
@@ -31,3 +31,9 @@ func WithCmd(cmd string) Option {
 func WithPTY(options *execapi.PTYOptions) Option {
 	return func(e *ProcessExecutor) { e.pty = options }
 }
+
+// WithProcessGroup starts the process in a process group of its own so signals
+// addressed to it reach its descendants.
+func WithProcessGroup(enabled bool) Option {
+	return func(e *ProcessExecutor) { e.processGroup = enabled }
+}

--- a/service/exec/native/pgroup_test.go
+++ b/service/exec/native/pgroup_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package native
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/service/exec"
+	"go.uber.org/zap"
+)
+
+// treeCommand prints the pid of a grandchild that outlives a signal sent to the
+// direct child alone, then keeps the child alive until it is stopped.
+const treeCommand = "sh -c 'sleep 300 & echo $!; wait'"
+
+// readPID takes the first line the child writes and reads it as a pid.
+func readPID(t *testing.T, reader io.Reader) int {
+	t.Helper()
+	lines := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(reader)
+		if scanner.Scan() {
+			lines <- strings.TrimSpace(scanner.Text())
+		}
+		close(lines)
+	}()
+	select {
+	case line, ok := <-lines:
+		require.True(t, ok, "child produced no output")
+		pid, err := strconv.Atoi(line)
+		require.NoErrorf(t, err, "expected a pid on the first output line, got %q", line)
+		return pid
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the grandchild pid")
+		return 0
+	}
+}
+
+// alive reports whether the pid can still be signaled. A pid that has been
+// reaped answers ESRCH.
+func alive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func waitGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !alive(pid) {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return !alive(pid)
+}
+
+// A signal sent to a process started with its own process group reaches every
+// descendant that has not left the group, which is the whole point of the
+// option: a harness spawns its tools as grandchildren.
+func TestProcessGroupSignalReachesGrandchild(t *testing.T) {
+	enabled := true
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(treeCommand, exec.ProcessOptions{ProcessGroup: &enabled})
+	require.NoError(t, err)
+
+	stdout := process.Stdout()
+	require.NoError(t, process.Start())
+	grandchild := readPID(t, stdout)
+	require.True(t, alive(grandchild), "grandchild should be running")
+
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+
+	assert.True(t, waitGone(grandchild, 5*time.Second),
+		"grandchild %d survived a signal sent to the process group", grandchild)
+}
+
+// The default keeps the child in the runtime's own group, where a group signal
+// would reach the runtime itself. Only the direct child is signaled.
+func TestWithoutProcessGroupOnlyTheDirectChildIsSignaled(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(treeCommand, exec.ProcessOptions{})
+	require.NoError(t, err)
+
+	stdout := process.Stdout()
+	require.NoError(t, process.Start())
+	grandchild := readPID(t, stdout)
+	t.Cleanup(func() { _ = syscall.Kill(grandchild, syscall.SIGKILL) })
+
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+
+	assert.True(t, alive(grandchild),
+		"a signal to the direct child must not reach the grandchild by default")
+}
+
+// close(force) escalation and the runtime's owner-exit cleanup both go through
+// Signal, so SIGTERM must address the group as well.
+func TestProcessGroupTerminationReachesGrandchild(t *testing.T) {
+	enabled := true
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(
+		// The trap is set after the grandchild starts: a disposition of SIG_IGN
+		// is inherited, so an earlier trap would make the grandchild ignore TERM
+		// as well and the test would prove nothing.
+		"sh -c 'sleep 300 & echo $!; trap \"\" TERM; wait'",
+		exec.ProcessOptions{ProcessGroup: &enabled},
+	)
+	require.NoError(t, err)
+
+	stdout := process.Stdout()
+	require.NoError(t, process.Start())
+	grandchild := readPID(t, stdout)
+	t.Cleanup(func() { _ = syscall.Kill(grandchild, syscall.SIGKILL) })
+
+	// The child ignores TERM; the grandchild does not, so the group delivery is
+	// what is observed here.
+	require.NoError(t, process.Signal(int(syscall.SIGTERM)))
+	assert.True(t, waitGone(grandchild, 5*time.Second),
+		"grandchild %d survived SIGTERM sent to the process group", grandchild)
+
+	// The child's own wait returns once the grandchild is gone, so it exits too.
+	_ = process.Wait()
+}
+
+// A PTY child is already a session leader of its own group. Requesting a
+// process group there must not add a conflicting setpgid that fails the start.
+func TestProcessGroupWithPTYStartsAndSignalsTheSession(t *testing.T) {
+	enabled := true
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(treeCommand, exec.ProcessOptions{
+		PTY:          &exec.PTYOptions{Width: 80, Height: 24},
+		ProcessGroup: &enabled,
+	})
+	require.NoError(t, err)
+
+	// A PTY child has no pipes: the master exists only once the process starts,
+	// and the caller that acquires it owns its close.
+	require.NoError(t, process.Start())
+	stdout := process.Stdout()
+	require.NotNil(t, stdout)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	grandchild := readPID(t, stdout)
+	t.Cleanup(func() { _ = syscall.Kill(grandchild, syscall.SIGKILL) })
+
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+
+	assert.True(t, waitGone(grandchild, 5*time.Second),
+		"grandchild %d survived a signal sent to the PTY session group", grandchild)
+}
+
+// The executor default applies when the command says nothing, and an explicit
+// per-command value wins in both directions.
+func TestProcessGroupExecutorDefaultAndPerCommandOverride(t *testing.T) {
+	enabled, disabled := true, false
+	tests := []struct {
+		option      *bool
+		name        string
+		configured  bool
+		wantEnabled bool
+	}{
+		{name: "default off", configured: false, option: nil, wantEnabled: false},
+		{name: "default on", configured: true, option: nil, wantEnabled: true},
+		{name: "command enables", configured: false, option: &enabled, wantEnabled: true},
+		{name: "command disables", configured: true, option: &disabled, wantEnabled: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{ProcessGroup: test.configured})
+			process, err := executor.NewProcess("true", exec.ProcessOptions{ProcessGroup: test.option})
+			require.NoError(t, err)
+
+			native, ok := process.(*ProcessExecutor)
+			require.True(t, ok)
+			assert.Equal(t, test.wantEnabled, native.processGroup)
+			if test.wantEnabled {
+				require.NotNil(t, native.cmd.SysProcAttr)
+				assert.True(t, native.cmd.SysProcAttr.Setpgid)
+			} else if native.cmd.SysProcAttr != nil {
+				assert.False(t, native.cmd.SysProcAttr.Setpgid)
+			}
+		})
+	}
+}
+
+// The pid is the evidence a caller records for an attempt, so it is readable
+// only once there is a child to identify.
+func TestProcessPidRequiresAStartedChild(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess("sh -c 'exit 0'", exec.ProcessOptions{})
+	require.NoError(t, err)
+
+	identity, ok := process.(exec.ProcessIdentity)
+	require.True(t, ok, "native processes expose their pid")
+
+	_, err = identity.Pid()
+	require.ErrorIs(t, err, ErrProcessNotStarted)
+
+	require.NoError(t, process.Start())
+	pid, err := identity.Pid()
+	require.NoError(t, err)
+	assert.Positive(t, pid)
+	assert.Equal(t, process.(*ProcessExecutor).cmd.Process.Pid, pid)
+
+	require.NoError(t, process.Wait())
+}

--- a/service/exec/native/pgroup_unix.go
+++ b/service/exec/native/pgroup_unix.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package native
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// processGroupSupported reports whether this platform can start a child in its
+// own process group.
+const processGroupSupported = true
+
+// applyProcessGroup makes the child the leader of a new process group. Every
+// process it spawns inherits that group unless it deliberately leaves it, so a
+// signal addressed to the group reaches the whole tree.
+func applyProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// signalProcessGroup delivers sig to every member of the group led by pgid.
+func signalProcessGroup(pgid int, sig syscall.Signal) error {
+	return syscall.Kill(-pgid, sig)
+}

--- a/service/exec/native/pgroup_windows.go
+++ b/service/exec/native/pgroup_windows.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package native
+
+import (
+	"os/exec"
+	"syscall"
+
+	execapi "github.com/wippyai/runtime/api/service/exec"
+)
+
+// processGroupSupported reports whether this platform can start a child in its
+// own process group. Windows groups a process tree with a Job Object, which
+// this executor does not yet create, so the option is refused rather than
+// accepted and ignored.
+const processGroupSupported = false
+
+func applyProcessGroup(_ *exec.Cmd) {}
+
+func signalProcessGroup(_ int, _ syscall.Signal) error {
+	return execapi.ErrProcessGroupUnsupported
+}


### PR DESCRIPTION
## Gap

The native executor starts pipe-backed children in the runtime's own process group and session, and `Signal`/`Stop` address the direct pid only. Measured against a child `sh -c 'echo $$; sleep 300 & echo $!; wait'`:

| Case | Direct child | Grandchild |
|---|---|---|
| `close()` (TERM) | dies | survives, reparented |
| `close(true)` (KILL) | dies | survives |
| child ignoring TERM, `close()` | dies after the grace | survives |
| owning Lua process exits without `close` | cleaned up | survives |

A harness such as Claude Code or Codex spawns tool subprocesses and MCP servers as grandchildren, so whole-tree cleanup is impossible through the runtime API today.

## Change

- `ProcessOptions.ProcessGroup` (per exec, `process_group = true` from Lua) and `NativeExecutorConfig.ProcessGroup` (executor default, per-command override in both directions).
- Pipe-backed children start with `Setpgid`; the PTY path keeps `setsid` (already a group leader).
- `Signal`, `Stop`, `close()` with its grace escalation, and the owner-exit cleanup path all deliver to the group when enabled.
- `proc:pid()` (new `ProcessIdentity` capability) so callers can record execution evidence.
- `exec.run` policy metadata carries `process_group`.
- Windows: the option returns `errors.UNAVAILABLE` instead of being ignored.
- Docs in `runtime/lua/modules/exec/spec.md`.

Group signalling controls what remains in the created group; a descendant that calls `setsid` escapes it, which a container executor confines by construction.

## Tests

Tests were written first and fail on main. `service/exec/native/pgroup_test.go` and `runtime/lua/modules/exec/pgroup_test.go` drive real trees through the Go API and the Lua bindings, including the with/without differential pair, TERM-ignoring children, the PTY path, executor default versus override, and the runtime resource-store cleanup on owner exit.

`go test ./service/exec/... ./runtime/lua/modules/exec/... ./api/service/exec/...`, `go vet`, golangci-lint and a `GOOS=windows` build all pass.