### PR TITLE
feat(exec): report process exit on a channel without consuming the handle

### DIFF
--- a/api/service/exec/exit.go
+++ b/api/service/exec/exit.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"errors"
+	osexec "os/exec"
+	"syscall"
+)
+
+// ExitStatus describes how a child process finished.
+//
+// Code is the exit code the child reported. A child killed by a signal has no
+// exit code of its own, so it is reported as 128+Signal, the encoding shells
+// use and the one the native executor produces.
+//
+// Signal carries the signal that killed the child, or 0 when the child exited
+// on its own or the executor reports only a code, as a container exit does.
+//
+// Err is set only when the exit could not be observed at all: a wait that could
+// not be performed, a transport failure to a remote executor. A non-zero exit
+// is not an error, it is Code.
+type ExitStatus struct {
+	Err    error
+	Code   int
+	Signal int
+}
+
+// ExitCoder is an error carrying the exit code of the process it describes.
+type ExitCoder interface {
+	ExitCode() int
+}
+
+// ExitReporter is a Process that owns the reap of its child and can therefore
+// report the outcome more than once. Wait can only be performed once, so a
+// caller that has an ExitReporter must use it instead: several parts of a
+// supervisor may need the exit of the same child.
+type ExitReporter interface {
+	AwaitExit() ExitStatus
+}
+
+// ClassifyExit turns the error Process.Wait returns into an exit status.
+func ClassifyExit(err error) ExitStatus {
+	if err == nil {
+		return ExitStatus{}
+	}
+
+	var coder ExitCoder
+	if !errors.As(err, &coder) {
+		return ExitStatus{Err: err}
+	}
+
+	status := ExitStatus{Code: coder.ExitCode(), Signal: exitSignal(err)}
+	if status.Signal != 0 && status.Code < 0 {
+		status.Code = 128 + status.Signal
+	}
+	return status
+}
+
+// WaitFor reports how a process finished, reaping it when it does not own its
+// own reap.
+func WaitFor(p Process) ExitStatus {
+	if reporter, ok := p.(ExitReporter); ok {
+		return reporter.AwaitExit()
+	}
+	return ClassifyExit(p.Wait())
+}
+
+// exitSignal reads the signal that killed the child from the platform wait
+// status. Executors that report only an exit code carry no wait status and
+// report no signal.
+func exitSignal(err error) int {
+	var exitErr *osexec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ProcessState == nil {
+		return 0
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() {
+		return 0
+	}
+	return int(status.Signal())
+}

--- a/api/service/exec/exit_test.go
+++ b/api/service/exec/exit_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"errors"
+	"io"
+	osexec "os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type codedExit struct{ code int }
+
+func (e *codedExit) Error() string { return "exited" }
+func (e *codedExit) ExitCode() int { return e.code }
+
+func TestClassifyExitReportsCleanExit(t *testing.T) {
+	require.Equal(t, ExitStatus{}, ClassifyExit(nil))
+}
+
+func TestClassifyExitReportsCodeFromExecutorError(t *testing.T) {
+	status := ClassifyExit(&codedExit{code: 137})
+
+	require.Equal(t, 137, status.Code)
+	require.Zero(t, status.Signal)
+	require.NoError(t, status.Err)
+}
+
+func TestClassifyExitKeepsAnErrorThatIsNotAnExit(t *testing.T) {
+	wait := errors.New("transport closed")
+
+	status := ClassifyExit(wait)
+
+	require.ErrorIs(t, status.Err, wait)
+	require.Zero(t, status.Code)
+}
+
+// A child killed by a signal has no exit code of its own. It is reported as
+// 128+signal, with the signal itself alongside.
+func TestClassifyExitReportsSignalDeath(t *testing.T) {
+	if _, err := osexec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sleep", "30")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Process.Signal(syscall.SIGKILL))
+
+	status := ClassifyExit(cmd.Wait())
+
+	require.Equal(t, int(syscall.SIGKILL), status.Signal)
+	require.Equal(t, 128+int(syscall.SIGKILL), status.Code)
+	require.NoError(t, status.Err)
+}
+
+func TestClassifyExitReportsOrdinaryExitCode(t *testing.T) {
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sh", "-c", "exit 5")
+
+	status := ClassifyExit(cmd.Run())
+
+	require.Equal(t, 5, status.Code)
+	require.Zero(t, status.Signal)
+	require.NoError(t, status.Err)
+}
+
+type reportingProcess struct {
+	status    ExitStatus
+	waitCalls int
+}
+
+func (p *reportingProcess) Start() error            { return nil }
+func (p *reportingProcess) Signal(int) error        { return nil }
+func (p *reportingProcess) WriteStdin([]byte) error { return nil }
+func (p *reportingProcess) Stdout() io.ReadCloser   { return nil }
+func (p *reportingProcess) Stderr() io.ReadCloser   { return nil }
+func (p *reportingProcess) AwaitExit() ExitStatus   { return p.status }
+func (p *reportingProcess) Wait() error             { p.waitCalls++; return nil }
+
+// A process that owns its own reap can report the exit repeatedly; waiting on
+// it a second time is what fails.
+func TestWaitForPrefersTheProcessOwnReap(t *testing.T) {
+	process := &reportingProcess{status: ExitStatus{Code: 143, Signal: 15}}
+
+	require.Equal(t, process.status, WaitFor(process))
+	require.Zero(t, process.waitCalls)
+}

--- a/runtime/lua/modules/exec/done_test.go
+++ b/runtime/lua/modules/exec/done_test.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"context"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
+	relayapi "github.com/wippyai/runtime/api/relay"
+	runtimeapi "github.com/wippyai/runtime/api/runtime"
+	securityapi "github.com/wippyai/runtime/api/security"
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	svcexec "github.com/wippyai/runtime/service/exec"
+	"github.com/wippyai/runtime/service/exec/native"
+	sysrelay "github.com/wippyai/runtime/system/relay"
+	"github.com/wippyai/runtime/system/scheduler"
+	"github.com/wippyai/runtime/system/scheduler/pool/inline"
+	sysstream "github.com/wippyai/runtime/system/stream"
+	"go.uber.org/zap"
+)
+
+const doneTestHost = "exec.done:test"
+
+// runExecScript runs a Lua script against a real native executor with the
+// production wiring done() depends on: an exec dispatcher for the wait yield, a
+// stream dispatcher for stdout reads, and a relay node that routes the exit
+// package back into the running process.
+func runExecScript(t *testing.T, script string) *lua.LTable {
+	t.Helper()
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	rootCtx := securityapi.SetStrictMode(ctxapi.NewRootContext(), false)
+	ctx, cancel := context.WithTimeout(rootCtx, 30*time.Second)
+	defer cancel()
+
+	reg := scheduler.NewRegistry()
+	register := func(id dispatcher.CommandID, h dispatcher.Handler) { reg.Register(id, h) }
+	svcexec.NewDispatcher().RegisterAll(register)
+	streams := sysstream.NewDispatcher()
+	require.NoError(t, streams.Start(ctx))
+	defer func() { _ = streams.Stop(ctx) }()
+	streams.RegisterAll(register)
+
+	factory := native.NewNativeExecutor(zap.NewNop(), &execapi.NativeExecutorConfig{})
+	procFactory := func() (process.Process, error) {
+		return engine.NewFactory(engine.FactoryConfig{
+			Script:     script,
+			ScriptName: "exec_done_test",
+			ModuleBinders: append(engine.CoreBinders(), func(l *lua.LState) error {
+				mod, _ := Module.Build()
+				l.SetGlobal(Module.Name, mod)
+				executor := value.PushTypedUserData(l, NewExecutor(ctx, nil, factory), executorTypeName)
+				l.Pop(1)
+				l.SetGlobal("executor", executor)
+				return nil
+			}),
+		})()
+	}
+
+	pool, err := inline.New(procFactory, reg)
+	require.NoError(t, err)
+	defer pool.Stop()
+
+	node := sysrelay.NewNode("exec-done-test-node")
+	require.NoError(t, node.RegisterHost(doneTestHost, pool))
+
+	frameCtx, frame := ctxapi.OpenFrameContext(ctx)
+	defer ctxapi.ReleaseFrameContext(frame)
+	rawPID := pid.PID{Host: doneTestHost, UniqID: "exec-done"}
+	target := rawPID.Precomputed()
+	require.NoError(t, runtimeapi.SetFramePID(frameCtx, target))
+	frameCtx = relayapi.WithNode(frameCtx, node)
+
+	result, err := pool.Call(frameCtx, "main", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Value)
+
+	out, ok := result.Value.Data().(*lua.LTable)
+	require.True(t, ok, "script must return a table, got %T", result.Value.Data())
+	return out
+}
+
+// luaInt reads a number the script returned under key.
+func luaInt(t *testing.T, table *lua.LTable, key string) int {
+	t.Helper()
+	field := table.RawGetString(key)
+	require.NotEqual(t, lua.LTNil, field.Type(), "script did not return %q", key)
+	return int(lua.LVAsNumber(field))
+}
+
+// A supervisor needs the exit and the handle at the same time: it keeps feeding
+// the child and steering it with signals while another coroutine waits for it to
+// finish. wait() cannot serve that, because it consumes the handle.
+func TestProcessDoneDeliversExitWhileHandleStaysUsable(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("cat")
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local observed = channel.new(1)
+    coroutine.spawn(function()
+        local selected = channel.select{ exit:case_receive() }
+        observed:send(selected.value)
+    end)
+
+    local wrote, werr = child:write_stdin("ping\n")
+    if not wrote then return nil, "write_stdin after done: " .. tostring(werr) end
+
+    local echoed, rerr = stdout:read()
+    if rerr then return nil, "read: " .. tostring(rerr) end
+
+    local signaled, sigerr = child:signal(15)
+    if not signaled then return nil, "signal after done: " .. tostring(sigerr) end
+
+    local status = observed:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    return { code = status.code, signal = status.signal, echoed = echoed }
+end
+
+return { main = main }
+`)
+
+	require.Equal(t, lua.LString("ping\n"), out.RawGetString("echoed"))
+	require.Equal(t, 143, luaInt(t, out, "code"))
+	require.Equal(t, 15, luaInt(t, out, "signal"))
+}
+
+// The exit is recorded once and reported to whoever asks for it, so a
+// supervisor that watched the child on done() can still read its code through
+// wait() afterwards.
+func TestProcessWaitAfterDoneReturnsExitCode(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"exit 7\"")
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    local code, werr = child:wait()
+    if werr then return nil, "wait after done: " .. tostring(werr) end
+
+    return { done_code = status.code, wait_code = code }
+end
+
+return { main = main }
+`)
+
+	require.Equal(t, 7, luaInt(t, out, "done_code"))
+	require.Equal(t, 7, luaInt(t, out, "wait_code"))
+}
+
+// Reading stdout to EOF is not an exit signal: a grandchild inherits the pipe
+// and holds it open long after the child itself is gone. done() reports the
+// child's own exit, so it arrives while the pipe is still open.
+func TestProcessDoneFiresWhileGrandchildHoldsStdout(t *testing.T) {
+	const grandchildLifetime = 5 * time.Second
+
+	start := time.Now()
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"sleep 5 & exit 3\"")
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+    if stdout == nil then return nil, "no stdout stream" end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    return { code = status.code }
+end
+
+return { main = main }
+`)
+	elapsed := time.Since(start)
+
+	require.Equal(t, 3, luaInt(t, out, "code"))
+	require.Less(t, elapsed, grandchildLifetime/2,
+		"the exit was reported only once the inherited stdout pipe closed")
+}
+
+// The scenario above only means anything if the grandchild really keeps stdout
+// open past the child's own exit, so that draining the pipe would report
+// nothing for as long as the grandchild lives.
+func TestGrandchildKeepsStdoutOpenAfterChildExits(t *testing.T) {
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sh", "-c", "sleep 5 & exit 3")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	// Process.Wait reaps the child without closing the pipes Cmd created, so
+	// the pipe can still be observed after the child is gone.
+	state, err := cmd.Process.Wait()
+	require.NoError(t, err)
+	require.Equal(t, 3, state.ExitCode())
+
+	read := make(chan error, 1)
+	go func() {
+		_, err := stdout.Read(make([]byte, 1))
+		read <- err
+	}()
+	select {
+	case err := <-read:
+		t.Fatalf("stdout ended with the child instead of with the grandchild: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+	require.NoError(t, stdout.Close())
+}
+
+// Whichever path observes the exit first owns the reap: the child is waited on
+// once, and close() still releases the handle afterwards.
+func TestProcessReapsChildOnceAcrossPaths(t *testing.T) {
+	probe := newReapProbe()
+	p := &Process{handle: probe, started: true}
+
+	require.Equal(t, execapi.ExitStatus{}, p.reap(probe))
+
+	l := setupState()
+	defer l.Close()
+	value.PushTypedUserData(l, p, processTypeName)
+	procClose(l)
+
+	require.True(t, waitFor(t, time.Second, func() bool {
+		return len(probe.sent()) == 1
+	}), "close must still signal the child")
+	require.Equal(t, 1, probe.waits(), "the child must be waited on exactly once")
+}

--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -150,7 +150,7 @@ func TestErrorMethods(t *testing.T) {
 }
 
 func TestProcessMethodsRegistered(t *testing.T) {
-	methods := []string{"start", "wait", "signal", "write_stdin", "stdout_stream", "stderr_stream", "close"}
+	methods := []string{"start", "wait", "done", "signal", "write_stdin", "stdout_stream", "stderr_stream", "close"}
 
 	for _, m := range methods {
 		if _, ok := processMethods[m]; !ok {

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -21,12 +21,66 @@ var errPTYOwnership = errors.New("PTY process is unavailable or already owned")
 type Process struct {
 	handle        apiexec.Process
 	cancelCleanup func()
+	exit          *apiexec.ExitStatus
+	waitErr       error
+	exited        chan struct{}
+	doneChannel   *lua.LUserData
 	stdoutID      uint64
 	stderrID      uint64
 	mu            sync.Mutex
 	started       bool
 	closed        bool
+	reaping       bool
 }
+
+// reap waits on the child exactly once and records how it exited. done(),
+// wait() and close() all funnel through here, so the child is waited on once
+// however many of them are in play, and every caller observes the same exit.
+func (p *Process) reap(handle apiexec.Process) apiexec.ExitStatus {
+	p.mu.Lock()
+	if p.exited == nil {
+		p.exited = make(chan struct{})
+	}
+	exited, owner := p.exited, !p.reaping
+	p.reaping = true
+	p.mu.Unlock()
+
+	if owner {
+		err := handle.Wait()
+		status := apiexec.ClassifyExit(err)
+		p.mu.Lock()
+		p.exit, p.waitErr = &status, err
+		p.mu.Unlock()
+		close(exited)
+	} else {
+		<-exited
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return *p.exit
+}
+
+// reapError reports the untouched error of the single wait, for callers that
+// classify it themselves.
+func (p *Process) reapError(handle apiexec.Process) error {
+	p.reap(handle)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.waitErr
+}
+
+// processReaper routes the wait yield through the wrapper's single reap. A
+// child that done() or close() already reaped still reports its exit instead of
+// failing a second wait.
+type processReaper struct {
+	apiexec.Process
+	proc *Process
+}
+
+func (r *processReaper) AwaitExit() apiexec.ExitStatus { return r.proc.reap(r.Process) }
+
+func (r *processReaper) Wait() error { return r.proc.reapError(r.Process) }
 
 func NewProcess(ctx context.Context, handle apiexec.Process) *Process {
 	p := &Process{
@@ -82,7 +136,7 @@ func (p *Process) close(force bool) {
 	// operation: the child may already have exited, but it must still be waited
 	// on so the OS can reclaim it.
 	_ = handle.Signal(int(signal))
-	go reapReleased(handle, force)
+	go p.reapReleased(handle, force)
 }
 
 // takePTYProcess transfers an unstarted PTY process out of its Lua exec
@@ -137,15 +191,15 @@ const reapGrace = 10 * time.Second
 // Wait closes the stdout and stderr pipes it created. That is inherent to
 // reaping and is the documented consequence of close(): the process is finished
 // with, and its streams along with it.
-func reapReleased(handle apiexec.Process, killed bool) {
-	reapReleasedWithGrace(handle, killed, reapGrace)
+func (p *Process) reapReleased(handle apiexec.Process, killed bool) {
+	p.reapReleasedWithGrace(handle, killed, reapGrace)
 }
 
-func reapReleasedWithGrace(handle apiexec.Process, killed bool, grace time.Duration) {
+func (p *Process) reapReleasedWithGrace(handle apiexec.Process, killed bool, grace time.Duration) {
 	exited := make(chan struct{})
 	go func() {
 		defer close(exited)
-		_ = handle.Wait()
+		p.reap(handle)
 	}()
 
 	if !killed {
@@ -169,6 +223,7 @@ func reapReleasedWithGrace(handle apiexec.Process, killed bool, grace time.Durat
 var processMethods = map[string]lua.LGoFunc{
 	"start":           procStart,
 	"wait":            procWait,
+	"done":            procDone,
 	"signal":          procSignal,
 	"write_stdin":     procWriteStdin,
 	"stdout_stream":   procStdout,
@@ -294,7 +349,7 @@ func procWait(l *lua.LState) int {
 	}
 
 	yield := AcquireProcessWaitYield()
-	yield.Process = handle
+	yield.Process = &processReaper{Process: handle, proc: p}
 
 	l.Push(yield)
 	return -1

--- a/runtime/lua/modules/exec/process_exit.go
+++ b/runtime/lua/modules/exec/process_exit.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+	apiexec "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+)
+
+var processExitID atomic.Uint64
+
+// procDone returns a one-shot channel carrying the child's exit.
+//
+// It is the observation half of wait(): the exit arrives on a channel the
+// caller can select on, and the handle stays open, so a supervisor can keep
+// writing stdin and signaling the child while it waits for the exit. Draining
+// stdout is not a substitute -- a grandchild can hold the pipe open long after
+// the child itself is gone.
+func procDone(l *lua.LState) int {
+	p := checkProcess(l, 1)
+	if p == nil {
+		return 0
+	}
+
+	p.mu.Lock()
+	if existing := p.doneChannel; existing != nil {
+		p.mu.Unlock()
+		l.Push(existing)
+		l.Push(lua.LNil)
+		return 2
+	}
+	if p.closed || p.handle == nil {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process is closed").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	if !p.started {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process not started: call start() first").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	handle := p.handle
+	p.mu.Unlock()
+
+	luaProcess := engine.GetProcess(l)
+	target, hasPID := runtime.GetFramePID(l.Context())
+	router := relay.GetNode(l.Context())
+	if luaProcess == nil || !hasPID || router == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process exit relay unavailable").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	topic := fmt.Sprintf("@exec/process/exit/%d", processExitID.Add(1))
+	ch := engine.NewChannel(1)
+	if err := luaProcess.SubscribeExisting(topic, ch); err != nil {
+		l.Push(lua.LNil)
+		l.Push(wrapExecError(l, err, "subscribe process exit", lua.Internal))
+		return 2
+	}
+	luaProcess.SetTopicHandler(topic, processExitHandler)
+	channel := engine.PushChannel(l, ch)
+	l.Pop(1)
+
+	ctx, cancel := context.WithCancel(l.Context())
+	if !luaProcess.SetSubscriptionCleanup(ch, cancel) {
+		luaProcess.UnsubscribeChannel(ch)
+		cancel()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process exit subscription unavailable").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	p.mu.Lock()
+	p.doneChannel = channel
+	p.mu.Unlock()
+
+	go func() {
+		deliverProcessExit(ctx, router, target, topic, p.reap(handle))
+	}()
+
+	l.Push(channel)
+	l.Push(lua.LNil)
+	return 2
+}
+
+// deliverProcessExit hands the exit to the waiting Lua process. The terminal
+// payload closes the channel behind the single value, so a second receive
+// reports the channel is finished instead of blocking forever.
+func deliverProcessExit(
+	ctx context.Context,
+	router relay.Receiver,
+	target pid.PID,
+	topic string,
+	status apiexec.ExitStatus,
+) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+	pkg := relay.AcquirePackage()
+	pkg.Target = target
+	pkg.AddMessage(topic, payload.New(&status), payload.NewTerminal())
+	if err := router.Send(pkg); err != nil {
+		relay.ReleasePackage(pkg)
+	}
+}
+
+func processExitHandler(
+	_ context.Context,
+	l *lua.LState,
+	_ pid.PID,
+	_ string,
+	payloads []payload.Payload,
+) lua.LValue {
+	if len(payloads) == 0 {
+		return lua.LNil
+	}
+	status, ok := payloads[0].Data().(*apiexec.ExitStatus)
+	if !ok {
+		return lua.LNil
+	}
+
+	exit := l.CreateTable(0, 3)
+	exit.RawSetString("code", lua.LInteger(status.Code))
+	if status.Signal != 0 {
+		exit.RawSetString("signal", lua.LInteger(status.Signal))
+	}
+	if status.Err != nil {
+		exit.RawSetString("error", wrapExecError(l, status.Err, "process exit", lua.Internal))
+	}
+	return exit
+}

--- a/runtime/lua/modules/exec/reap_test.go
+++ b/runtime/lua/modules/exec/reap_test.go
@@ -94,7 +94,7 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
 func TestReapReleasedWaitsOnGracefulStop(t *testing.T) {
 	probe := newReapProbe()
 
-	reapReleased(probe, false)
+	(&Process{}).reapReleased(probe, false)
 
 	if probe.waits() != 1 {
 		t.Fatalf("expected the released process to be waited on once, got %d", probe.waits())
@@ -104,7 +104,7 @@ func TestReapReleasedWaitsOnGracefulStop(t *testing.T) {
 func TestReapReleasedWaitsOnForcedStop(t *testing.T) {
 	probe := newReapProbe()
 
-	reapReleased(probe, true)
+	(&Process{}).reapReleased(probe, true)
 
 	if probe.waits() != 1 {
 		t.Fatalf("expected the killed process to be waited on once, got %d", probe.waits())
@@ -123,7 +123,7 @@ func TestReapReleasedEscalatesToKill(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		reapReleasedWithGrace(probe, false, 10*time.Millisecond)
+		(&Process{}).reapReleasedWithGrace(probe, false, 10*time.Millisecond)
 	}()
 
 	// Let the escalation fire, then release the stand-in child as a real one
@@ -228,7 +228,7 @@ func TestClosedProcessIsNotLeftAsZombie(t *testing.T) {
 	handle := &cmdProcess{cmd: cmd, stdout: stdout}
 
 	_ = handle.Signal(int(syscall.SIGTERM))
-	go reapReleased(handle, false)
+	go (&Process{}).reapReleased(handle, false)
 
 	// A reaped child leaves the process table entirely; an unreaped one lingers
 	// in state Z until the parent exits.

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -133,7 +133,8 @@ Returned by `executor:exec()`. Represents a process instance.
 | Method | Signature | Returns | Notes |
 |--------|-----------|---------|-------|
 | start | () | boolean, error | Starts the process |
-| wait | () | integer, error | Waits for process to exit, yields |
+| wait | () | integer, error | Waits for process to exit, consumes the handle, yields |
+| done | () | ProcessExitChannel, error | One-shot channel carrying the exit; keeps the handle usable |
 | signal | (sig: integer) | boolean, error | Sends signal to process |
 | write_stdin | (data: string) | boolean, error | Writes to process stdin |
 | stdout_stream | () | Stream, error | Returns stdout stream |
@@ -178,7 +179,8 @@ Because reaping closes the process's stdout and stderr pipes, its streams are
 finished with once it is closed. Read any output you need before calling this.
 
 After `close()` every method on the process, including `wait()`, reports
-`process closed`. Use `signal()` and `wait()` instead when the exit code matters.
+`process closed`. Use `done()` instead when the exit code matters and the
+handle has to stay usable, or `wait()` when it does not.
 
 **Returns:**
 - Success: `true, nil`
@@ -209,7 +211,22 @@ if err then error(err) end
 
 #### process:wait() → integer, error
 
-Waits for the process to exit and returns the exit code. Automatically closes the process.
+Waits for the process to exit and returns the exit code.
+
+`wait()` consumes the handle. The process is released the moment `wait()` is
+called, before it yields: every other method, `wait()` included, reports
+`process closed` from then on, and the stdout and stderr pipes are closed by
+the reap. Read the output you need first, and use `done()` when the handle must
+stay usable.
+
+A child killed by a signal has no exit code of its own; it is reported as
+`128 + signal`, so `SIGTERM` becomes 143 and `SIGKILL` 137. That is not an
+error: the error return is reserved for a failure to observe the exit at all.
+The signal number itself is on the `done()` value.
+
+`wait()` after `done()` has delivered the exit returns the recorded exit code
+rather than failing. The child is waited on once, whichever of `done()`,
+`wait()` and `close()` gets there first.
 
 **Yields:** until process exits
 
@@ -235,6 +252,60 @@ if err then error(err) end
 if exitCode ~= 0 then
     error("process failed with code " .. exitCode)
 end
+```
+
+#### process:done() → ProcessExitChannel, error
+
+Returns a channel that delivers the child's exit exactly once, then closes.
+Unlike `wait()` it leaves the handle open: `write_stdin()`, `signal()`, the
+streams and `close()` all keep working, so a supervisor can keep driving the
+child while another coroutine waits for it to finish.
+
+Draining stdout is not a substitute for this. A grandchild inherits the pipe
+and can hold it open long after the child itself is gone, so an EOF that never
+arrives says nothing about the exit.
+
+Calling `done()` again returns the same channel. Because the channel closes
+behind the single value, a second `receive()` reports `nil, false` instead of
+blocking.
+
+**The exit value:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| code | integer | Exit code, or `128 + signal` for a child killed by a signal |
+| signal | integer | Signal that killed the child; absent when it exited on its own |
+| error | error | Set only when the exit could not be observed at all |
+
+`done()` reaps the child as soon as it exits, and reaping closes its stdout and
+stderr pipes -- the same consequence `close()` documents. Read output as it
+arrives rather than after the exit.
+
+**Returns:**
+- Success: `channel, nil`
+- Error: `nil, error` - error is structured
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| process closed | errors.INVALID | no |
+| process not started | errors.INVALID | no |
+| process context unavailable | errors.UNAVAILABLE | no |
+
+**Example:**
+
+```lua
+proc:start()
+local exit = assert(proc:done())
+
+coroutine.spawn(function()
+    local status = channel.select{ exit:case_receive() }.value
+    print("child exited with", status.code, status.signal)
+end)
+
+proc:write_stdin("work\n")
+proc:signal(15)
 ```
 
 #### process:signal(sig: integer) → boolean, error
@@ -349,6 +420,15 @@ proc:start()
 proc:wait()
 ```
 
+### ProcessExitChannel
+
+Returned by `process:done()`. A standard channel carrying a single exit value.
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| receive | () | ProcessExit, boolean | Yields until the child exits; `nil, false` once the value has been taken |
+| case_receive | () | case | Case for `channel.select` |
+
 ## Errors
 
 This module returns structured errors. Check kind with `errors.*` constants:
@@ -364,7 +444,7 @@ if err then
 end
 ```
 
-**Possible kinds:** `errors.INVALID`, `errors.INTERNAL`
+**Possible kinds:** `errors.INVALID`, `errors.INTERNAL`, `errors.UNAVAILABLE`
 
 ## Example
 

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -10,6 +10,8 @@ import (
 
 var executorType typ.Type
 var processType typ.Type
+var processExitType typ.Type
+var processExitChannelType typ.Type
 var terminalCompletionType typ.Type
 var terminalSessionType typ.Type
 var ptyOptionsType typ.Type
@@ -26,6 +28,17 @@ func init() {
 		OptField("env", typ.NewMap(typ.String, typ.String)).
 		OptField("pty", ptyOptionsType).
 		Build()
+	processExitType = typ.NewRecord().
+		Field("code", typ.Integer).
+		OptField("signal", typ.Integer).
+		OptField("error", typ.LuaError).
+		Build()
+	processExitChannelType = typ.NewInterface("exec.ProcessExitChannel", []typ.Method{
+		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
+			Returns(typ.NewOptional(processExitType), typ.Boolean).Build()},
+		{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).
+			Returns(typ.Any).Build()},
+	})
 	terminalCompletionType = typ.NewInterface("exec.TerminalCompletionChannel", []typ.Method{
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.Boolean, typ.Boolean).Build()},
@@ -46,6 +59,7 @@ func init() {
 	processType = typ.NewInterface("exec.Process", []typ.Method{
 		{Name: "start", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "wait", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "done", Type: typ.Func().Param("self", typ.Self).Returns(processExitChannelType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "signal", Type: typ.Func().Param("self", typ.Self).Param("sig", typ.Number).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "write_stdin", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "stdout_stream", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
@@ -70,6 +84,8 @@ func ModuleTypes() *io.Manifest {
 
 	m.DefineType("Executor", executorType)
 	m.DefineType("Process", processType)
+	m.DefineType("ProcessExit", processExitType)
+	m.DefineType("ProcessExitChannel", processExitChannelType)
 	m.DefineType("TerminalCompletionChannel", terminalCompletionType)
 	m.DefineType("TerminalSession", terminalSessionType)
 	m.DefineType("PTYOptions", ptyOptionsType)

--- a/service/exec/dispatcher.go
+++ b/service/exec/dispatcher.go
@@ -10,11 +10,6 @@ import (
 	execapi "github.com/wippyai/runtime/api/service/exec"
 )
 
-// exitCoder is an interface for errors that have an exit code.
-type exitCoder interface {
-	ExitCode() int
-}
-
 // Dispatcher handles exec commands.
 type Dispatcher struct{}
 
@@ -42,18 +37,12 @@ func (d *Dispatcher) handleProcessWait(ctx context.Context, cmd dispatcher.Comma
 	waitCmd := cmd.(*execapi.ProcessWaitCmd)
 
 	go func() {
-		err := waitCmd.Process.Wait()
-
-		var exitCode int
-		if err == nil {
-			exitCode = 0
-		} else if ec, ok := err.(exitCoder); ok {
-			exitCode = ec.ExitCode()
-			err = nil
-		}
+		// WaitFor defers to a process that owns its own reap, so a child
+		// already reaped through another path still reports its exit here.
+		status := execapi.WaitFor(waitCmd.Process)
 
 		if ctx.Err() == nil {
-			receiver.CompleteYield(tag, execapi.ProcessWaitResponse{ExitCode: exitCode, Error: err}, nil)
+			receiver.CompleteYield(tag, execapi.ProcessWaitResponse{ExitCode: status.Code, Error: status.Err}, nil)
 		}
 	}()
 


### PR DESCRIPTION
## The gap

`proc:wait()` sets `closed = true` and drops the handle *before* it yields. Once
any coroutine calls `wait()`, every other method on that process -- `write_stdin`,
`signal`, `close`, the streams -- reports `process is closed`.

A supervisor that has to keep feeding a child and steering it with signals while
also learning when it exits could do neither: it either consumed the handle with
`wait()` or never learned the exit. Reading stdout to EOF is not a substitute
either -- a grandchild inherits the pipe and can hold it open long after the
child itself is gone. That consumption was also barely documented ("Automatically
closes the process").

## The behavior

**`proc:done()` -> channel, error.** A one-shot channel usable in
`channel.select` / `:receive()`. It delivers exactly one value when the child
exits:

| Field | Type | Notes |
|-------|------|-------|
| `code` | integer | exit code, or `128 + signal` for a child killed by a signal |
| `signal` | integer | the signal that killed the child; absent when it exited on its own |
| `error` | error | set only when the exit could not be observed at all |

The handle stays open: `signal()`, `write_stdin()`, the streams and `close()`
keep working until `close()` is called. Calling `done()` twice returns the same
channel; the channel closes behind its single value, so a second `receive()`
reports `nil, false` rather than blocking.

**One reap, owned by the runtime.** The wait moves into the process wrapper:
`done()`, `wait()` and `close()` all funnel through it, so the child is waited on
exactly once whichever gets there first, and every caller observes the same exit.
The wait yield now carries a wrapper that defers to that reap, so `wait()` after
`done()` has fired returns the recorded exit code instead of failing a second
`cmd.Wait` ("exec: Wait was already called"). `wait()` keeps its consume-the-
handle semantics otherwise, now spelled out in `spec.md`. Runtime-owned cleanup
(resource store close -> `close(false)`) still reaps correctly when `done()` was
used, and does not wait twice.

**Exit semantics on signal death.** Classification moves to
`api/service/exec.ClassifyExit`, one place instead of an inline branch in the
dispatcher. Go reports no exit code for a signaled child, so the code is
normalized to the conventional `128 + signal` the native executor already
produces, and the signal number is carried beside it. Executors that report only
a code (a container exit) report no signal. A non-zero exit stays a code, never
an error; `error` is reserved for failing to observe the exit at all.

`types.go` gains `exec.ProcessExit` / `exec.ProcessExitChannel` and the `done`
method; `spec.md` documents `done()`, the exit value, and what `wait()` consumes.

## Tests

`runtime/lua/modules/exec/done_test.go` drives real children through the Lua
bindings on a real engine process (inline pool, exec + stream dispatchers, relay
node routing the exit package back):

- a coroutine selects on `done()` while the main flow writes stdin, reads the
  echo back, then signals -- exit arrives as `code 143, signal 15`
- `wait()` after `done()` returns 7 for a child that exited 7 (fails with
  "exec: Wait was already called" without the shared reap)
- a grandchild holds stdout open for 5s while the direct child exits 3:
  `done()` fires immediately, with a separate test proving the premise (the pipe
  really has no EOF after the child is reaped)
- the child is waited on exactly once across `done()` and `close()`

`api/service/exec/exit_test.go` covers classification, including a really
signal-killed child.

`go test ./runtime/lua/modules/exec/... ./service/exec/...`, `go vet` and
golangci-lint are clean. (`runtime/lua/modules/tty` has one failure,
`TestSurfacePresentClearsRemovedRows`, that is pre-existing on other branches
from main and unrelated.)

## Relationship to #694

Independent of PR 694 (process groups). Both touch
`runtime/lua/modules/exec/process.go`: 694 changes how a child is signaled,
this changes how its exit is observed. Whichever lands second needs a small
merge in `close()` / the process struct, no design conflict.