### PR TITLE
feat(exec): supervise process trees through exit channels

### DIFF
--- a/api/service/exec/api.go
+++ b/api/service/exec/api.go
@@ -20,9 +20,13 @@ const (
 
 // ProcessOptions defines options for creating a new process
 type ProcessOptions struct {
-	Env     map[string]string
-	PTY     *PTYOptions
-	WorkDir string
+	Env map[string]string
+	PTY *PTYOptions
+	// ProcessGroup places the child in its own process group so that signals
+	// addressed to the process reach its descendants as well. Nil selects the
+	// executor default.
+	ProcessGroup *bool
+	WorkDir      string
 }
 
 type PTYOptions struct {
@@ -107,6 +111,13 @@ type PTYProcess interface {
 // process has no separate stdin to close.
 type StdinCloser interface {
 	CloseStdin() error
+}
+
+// ProcessIdentity is an optional capability exposed by processes that carry an
+// operating system process identifier on the host running the runtime.
+type ProcessIdentity interface {
+	// Pid returns the identifier of the started child process.
+	Pid() (int, error)
 }
 
 // WaitCanceler is an optional lifecycle capability for remote executors whose

--- a/api/service/exec/config.go
+++ b/api/service/exec/config.go
@@ -12,6 +12,10 @@ type NativeExecutorConfig struct {
 
 	// Command whitelist - if set, only commands in this list will be allowed
 	CommandWhitelist []string `json:"command_whitelist"`
+
+	// Start every process in its own process group so signals reach the whole
+	// tree. A per-command process_group option overrides this default.
+	ProcessGroup bool `json:"process_group"`
 }
 
 // DockerExecutorConfig defines configuration for Docker container execution

--- a/api/service/exec/errors.go
+++ b/api/service/exec/errors.go
@@ -13,4 +13,6 @@ var ErrInvalidPTYSize = apierror.New(apierror.Invalid, "PTY dimensions must be p
 
 var ErrCommandRequired = apierror.New(apierror.Invalid, "command is required").WithRetryable(apierror.False)
 
+var ErrProcessGroupUnsupported = apierror.New(apierror.Unavailable, "process groups are not supported on this platform").WithRetryable(apierror.False)
+
 var ErrInvalidCommand = apierror.New(apierror.Invalid, "invalid command").WithRetryable(apierror.False)

--- a/api/service/exec/exit.go
+++ b/api/service/exec/exit.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"errors"
+	osexec "os/exec"
+	"syscall"
+)
+
+// ExitStatus describes how a child process finished.
+//
+// Code is the exit code the child reported. A child killed by a signal has no
+// exit code of its own, so it is reported as 128+Signal, the encoding shells
+// use and the one the native executor produces.
+//
+// Signal carries the signal that killed the child, or 0 when the child exited
+// on its own or the executor reports only a code, as a container exit does.
+//
+// Err is set only when the exit could not be observed at all: a wait that could
+// not be performed, a transport failure to a remote executor. A non-zero exit
+// is not an error, it is Code.
+type ExitStatus struct {
+	Err    error
+	Code   int
+	Signal int
+}
+
+// ExitCoder is an error carrying the exit code of the process it describes.
+type ExitCoder interface {
+	ExitCode() int
+}
+
+// ExitReporter is a Process that owns the reap of its child and can therefore
+// report the outcome more than once. Wait can only be performed once, so a
+// caller that has an ExitReporter must use it instead: several parts of a
+// supervisor may need the exit of the same child.
+type ExitReporter interface {
+	AwaitExit() ExitStatus
+}
+
+// ClassifyExit turns the error Process.Wait returns into an exit status.
+func ClassifyExit(err error) ExitStatus {
+	if err == nil {
+		return ExitStatus{}
+	}
+
+	var coder ExitCoder
+	if !errors.As(err, &coder) {
+		return ExitStatus{Err: err}
+	}
+
+	status := ExitStatus{Code: coder.ExitCode(), Signal: exitSignal(err)}
+	if status.Signal != 0 && status.Code < 0 {
+		status.Code = 128 + status.Signal
+	}
+	return status
+}
+
+// WaitFor reports how a process finished, reaping it when it does not own its
+// own reap.
+func WaitFor(p Process) ExitStatus {
+	if reporter, ok := p.(ExitReporter); ok {
+		return reporter.AwaitExit()
+	}
+	return ClassifyExit(p.Wait())
+}
+
+// exitSignal reads the signal that killed the child from the platform wait
+// status. Executors that report only an exit code carry no wait status and
+// report no signal.
+func exitSignal(err error) int {
+	var exitErr *osexec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ProcessState == nil {
+		return 0
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() {
+		return 0
+	}
+	return int(status.Signal())
+}

--- a/api/service/exec/exit.go
+++ b/api/service/exec/exit.go
@@ -4,8 +4,6 @@ package exec
 
 import (
 	"errors"
-	osexec "os/exec"
-	"syscall"
 )
 
 // ExitStatus describes how a child process finished.
@@ -64,19 +62,4 @@ func WaitFor(p Process) ExitStatus {
 		return reporter.AwaitExit()
 	}
 	return ClassifyExit(p.Wait())
-}
-
-// exitSignal reads the signal that killed the child from the platform wait
-// status. Executors that report only an exit code carry no wait status and
-// report no signal.
-func exitSignal(err error) int {
-	var exitErr *osexec.ExitError
-	if !errors.As(err, &exitErr) || exitErr.ProcessState == nil {
-		return 0
-	}
-	status, ok := exitErr.Sys().(syscall.WaitStatus)
-	if !ok || !status.Signaled() {
-		return 0
-	}
-	return int(status.Signal())
 }

--- a/api/service/exec/exit_signal_other.go
+++ b/api/service/exec/exit_signal_other.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !unix
+
+package exec
+
+// exitSignal reports no signal on platforms whose process wait status has no
+// Unix signal semantics.
+func exitSignal(error) int { return 0 }

--- a/api/service/exec/exit_signal_unix.go
+++ b/api/service/exec/exit_signal_unix.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build unix
+
+package exec
+
+import (
+	"errors"
+	osexec "os/exec"
+	"syscall"
+)
+
+// exitSignal reads the signal that killed the child from a Unix wait status.
+// Executors that report only an exit code carry no wait status and report no
+// signal.
+func exitSignal(err error) int {
+	var exitErr *osexec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ProcessState == nil {
+		return 0
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() {
+		return 0
+	}
+	return int(status.Signal())
+}

--- a/api/service/exec/exit_signal_unix_test.go
+++ b/api/service/exec/exit_signal_unix_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build unix
+
+package exec
+
+import (
+	osexec "os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A child killed by a signal has no exit code of its own. It is reported as
+// 128+signal, with the signal itself alongside.
+func TestClassifyExitReportsSignalDeath(t *testing.T) {
+	if _, err := osexec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sleep", "30")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Process.Signal(syscall.SIGKILL))
+
+	status := ClassifyExit(cmd.Wait())
+
+	require.Equal(t, int(syscall.SIGKILL), status.Signal)
+	require.Equal(t, 128+int(syscall.SIGKILL), status.Code)
+	require.NoError(t, status.Err)
+}

--- a/api/service/exec/exit_test.go
+++ b/api/service/exec/exit_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"errors"
+	"io"
+	osexec "os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type codedExit struct{ code int }
+
+func (e *codedExit) Error() string { return "exited" }
+func (e *codedExit) ExitCode() int { return e.code }
+
+func TestClassifyExitReportsCleanExit(t *testing.T) {
+	require.Equal(t, ExitStatus{}, ClassifyExit(nil))
+}
+
+func TestClassifyExitReportsCodeFromExecutorError(t *testing.T) {
+	status := ClassifyExit(&codedExit{code: 137})
+
+	require.Equal(t, 137, status.Code)
+	require.Zero(t, status.Signal)
+	require.NoError(t, status.Err)
+}
+
+func TestClassifyExitKeepsAnErrorThatIsNotAnExit(t *testing.T) {
+	wait := errors.New("transport closed")
+
+	status := ClassifyExit(wait)
+
+	require.ErrorIs(t, status.Err, wait)
+	require.Zero(t, status.Code)
+}
+
+// A child killed by a signal has no exit code of its own. It is reported as
+// 128+signal, with the signal itself alongside.
+func TestClassifyExitReportsSignalDeath(t *testing.T) {
+	if _, err := osexec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sleep", "30")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Process.Signal(syscall.SIGKILL))
+
+	status := ClassifyExit(cmd.Wait())
+
+	require.Equal(t, int(syscall.SIGKILL), status.Signal)
+	require.Equal(t, 128+int(syscall.SIGKILL), status.Code)
+	require.NoError(t, status.Err)
+}
+
+func TestClassifyExitReportsOrdinaryExitCode(t *testing.T) {
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sh", "-c", "exit 5")
+
+	status := ClassifyExit(cmd.Run())
+
+	require.Equal(t, 5, status.Code)
+	require.Zero(t, status.Signal)
+	require.NoError(t, status.Err)
+}
+
+type reportingProcess struct {
+	status    ExitStatus
+	waitCalls int
+}
+
+func (p *reportingProcess) Start() error            { return nil }
+func (p *reportingProcess) Signal(int) error        { return nil }
+func (p *reportingProcess) WriteStdin([]byte) error { return nil }
+func (p *reportingProcess) Stdout() io.ReadCloser   { return nil }
+func (p *reportingProcess) Stderr() io.ReadCloser   { return nil }
+func (p *reportingProcess) AwaitExit() ExitStatus   { return p.status }
+func (p *reportingProcess) Wait() error             { p.waitCalls++; return nil }
+
+// A process that owns its own reap can report the exit repeatedly; waiting on
+// it a second time is what fails.
+func TestWaitForPrefersTheProcessOwnReap(t *testing.T) {
+	process := &reportingProcess{status: ExitStatus{Code: 143, Signal: 15}}
+
+	require.Equal(t, process.status, WaitFor(process))
+	require.Zero(t, process.waitCalls)
+}

--- a/api/service/exec/exit_test.go
+++ b/api/service/exec/exit_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	osexec "os/exec"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,23 +35,6 @@ func TestClassifyExitKeepsAnErrorThatIsNotAnExit(t *testing.T) {
 
 	require.ErrorIs(t, status.Err, wait)
 	require.Zero(t, status.Code)
-}
-
-// A child killed by a signal has no exit code of its own. It is reported as
-// 128+signal, with the signal itself alongside.
-func TestClassifyExitReportsSignalDeath(t *testing.T) {
-	if _, err := osexec.LookPath("sleep"); err != nil {
-		t.Skip("sleep not available")
-	}
-	cmd := osexec.CommandContext(t.Context(), "sleep", "30")
-	require.NoError(t, cmd.Start())
-	require.NoError(t, cmd.Process.Signal(syscall.SIGKILL))
-
-	status := ClassifyExit(cmd.Wait())
-
-	require.Equal(t, int(syscall.SIGKILL), status.Signal)
-	require.Equal(t, 128+int(syscall.SIGKILL), status.Code)
-	require.NoError(t, status.Err)
 }
 
 func TestClassifyExitReportsOrdinaryExitCode(t *testing.T) {

--- a/runtime/lua/modules/exec/combined_test.go
+++ b/runtime/lua/modules/exec/combined_test.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package exec
+
+import (
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+)
+
+// luaBool reads a boolean the script returned under key.
+func luaBool(t *testing.T, table *lua.LTable, key string) bool {
+	t.Helper()
+	field := table.RawGetString(key)
+	require.NotEqual(t, lua.LTNil, field.Type(), "script did not return %q", key)
+	return lua.LVAsBool(field)
+}
+
+// luaText reads a string the script returned under key.
+func luaText(t *testing.T, table *lua.LTable, key string) string {
+	t.Helper()
+	field := table.RawGetString(key)
+	require.NotEqual(t, lua.LTNil, field.Type(), "script did not return %q", key)
+	return lua.LVAsString(field)
+}
+
+// grandchildPID reads the "child:<pid>" line the tree command writes on its
+// first line of output and registers a fallback kill for it.
+func grandchildPID(t *testing.T, table *lua.LTable, key string) int {
+	t.Helper()
+	line := luaText(t, table, key)
+	_, digits, found := strings.Cut(strings.TrimSpace(line), "child:")
+	require.Truef(t, found, "expected a child pid line, got %q", line)
+	pid, err := strconv.Atoi(strings.TrimSpace(digits))
+	require.NoErrorf(t, err, "expected a pid, got %q", digits)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	return pid
+}
+
+// groupAlive reports whether the pid can still be signaled; a reaped process
+// answers ESRCH.
+func groupAlive(pid int) bool { return syscall.Kill(pid, 0) == nil }
+
+// A child that is already gone when done() subscribes still has its exit
+// delivered: the reap that done() owns observes a finished child and reports
+// what it found, once.
+func TestGroupChildExitedBeforeDoneStillDeliversOnce(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"echo bye; exit 5\"", { process_group = true })
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    -- Draining to EOF proves the child is finished: nothing else holds the
+    -- write end of its stdout, so the pipe ends when the child does.
+    local seen = ""
+    while true do
+        local chunk, rerr = stdout:read()
+        if rerr then return nil, "read: " .. tostring(rerr) end
+        if chunk == nil then break end
+        seen = seen .. chunk
+    end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status, ok = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    local again, more = exit:receive()
+
+    return {
+        code = status.code,
+        output = seen,
+        first_ok = ok,
+        second_value = again ~= nil,
+        second_ok = more,
+    }
+end
+
+return { main = main }
+`)
+
+	assert.Equal(t, 5, luaInt(t, out, "code"))
+	assert.Equal(t, "bye\n", luaText(t, out, "output"))
+	assert.True(t, luaBool(t, out, "first_ok"), "the exit must arrive as an open receive")
+	assert.False(t, luaBool(t, out, "second_value"), "the exit must be delivered once")
+	assert.False(t, luaBool(t, out, "second_ok"), "the channel must be finished after the exit")
+}
+
+// A group signal sent while the child is on its way out races the reap. The
+// outcome is whichever the kernel settles on, but it is recorded once: done()
+// delivers a single value and wait() afterwards reports the same exit.
+func TestGroupSignalRacingExitIsRecordedOnce(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"exit 4\"", { process_group = true })
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    -- The child is exiting right now; the group signal may land before or
+    -- after it does, and either way must not produce a second exit.
+    local signaled, sigerr = child:signal(15)
+    local signal_error = ""
+    if not signaled then signal_error = tostring(sigerr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    local again, more = exit:receive()
+
+    local code, werr = child:wait()
+    if werr then return nil, "wait after done: " .. tostring(werr) end
+
+    local closed, cerr = child:close()
+    if not closed then return nil, "close: " .. tostring(cerr) end
+
+    return {
+        done_code = status.code,
+        wait_code = code,
+        second_value = again ~= nil,
+        second_ok = more,
+        signal_error = signal_error,
+    }
+end
+
+return { main = main }
+`)
+
+	doneCode := luaInt(t, out, "done_code")
+	assert.Contains(t, []int{4, 143}, doneCode,
+		"the child either finished on its own or was killed by the group signal")
+	assert.Equal(t, doneCode, luaInt(t, out, "wait_code"),
+		"wait() must report the exit done() already recorded")
+	assert.False(t, luaBool(t, out, "second_value"), "the exit must be delivered once")
+	assert.False(t, luaBool(t, out, "second_ok"), "the channel must be finished after the exit")
+	// A signal to a group whose last member has gone is refused, and that is the
+	// only failure the race may produce.
+	if signalErr := luaText(t, out, "signal_error"); signalErr != "" {
+		assert.Contains(t, signalErr, "process")
+	}
+}
+
+// A grandchild inherits stdout and holds it open, so the pipe says nothing
+// about the child. done() reports the child's own exit while the pipe is still
+// open, and close(true) then takes the whole group down.
+func TestGroupDoneOutrunsPipeHeldByDescendant(t *testing.T) {
+	// The exit must arrive on its own timing, not on the grandchild's: the
+	// descendant holding stdout lives far longer than this bound.
+	const exitDeadline = 5 * time.Second
+
+	start := time.Now()
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"sleep 300 & echo child:$!; exit 3\"", { process_group = true })
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local line, rerr = stdout:read()
+    if rerr then return nil, "read: " .. tostring(rerr) end
+    if line == nil then return nil, "child reported no grandchild" end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    local closed, cerr = child:close(true)
+    if not closed then return nil, "close: " .. tostring(cerr) end
+
+    return { code = status.code, line = line }
+end
+
+return { main = main }
+`)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, 3, luaInt(t, out, "code"))
+	assert.Less(t, elapsed, exitDeadline,
+		"the exit was reported only once the inherited stdout pipe closed")
+
+	grandchild := grandchildPID(t, out, "line")
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !groupAlive(grandchild) }),
+		"grandchild %d survived close(true) of a process-group child", grandchild)
+}
+
+// Output the child wrote just before it exited belongs to the caller that still
+// holds the handle. done() observes the exit without taking that output away.
+func TestGroupOutputWrittenBeforeExitSurvivesDone(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"echo final-bytes; exit 0\"", { process_group = true })
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    local chunk, rerr = stdout:read()
+    if rerr then return nil, "read after done: " .. tostring(rerr) end
+    if chunk == nil then return nil, "stdout ended without the child's last output" end
+
+    return { code = status.code, tail = chunk }
+end
+
+return { main = main }
+`)
+
+	assert.Equal(t, 0, luaInt(t, out, "code"))
+	assert.Equal(t, "final-bytes\n", luaText(t, out, "tail"))
+}
+
+// close() terminates the group, so the grandchild goes with the child, and the
+// exit done() reports is the signal death that close() caused.
+func TestGroupCloseKillsDescendantAndDoneReportsSignalDeath(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"sleep 300 & echo child:$!; wait\"", { process_group = true })
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local line, rerr = stdout:read()
+    if rerr then return nil, "read: " .. tostring(rerr) end
+    if line == nil then return nil, "child reported no grandchild" end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local closed, cerr = child:close()
+    if not closed then return nil, "close: " .. tostring(cerr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    return { code = status.code, signal = status.signal or 0, line = line }
+end
+
+return { main = main }
+`)
+
+	assert.Equal(t, 15, luaInt(t, out, "signal"), "close() terminates the group with SIGTERM")
+	assert.Equal(t, 128+15, luaInt(t, out, "code"), "a signal death is reported as 128+signal")
+
+	grandchild := grandchildPID(t, out, "line")
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !groupAlive(grandchild) }),
+		"grandchild %d survived close() of a process-group child", grandchild)
+}
+
+// The cleanup that runs when the owning Lua process ends releases the group
+// even though done() was the only observer and nothing ever received from it.
+func TestGroupOwnerExitCleanupReleasesTreeAfterUnreceivedDone(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"sleep 300 & echo child:$!; wait\"", { process_group = true })
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local line, rerr = stdout:read()
+    if rerr then return nil, "read: " .. tostring(rerr) end
+    if line == nil then return nil, "child reported no grandchild" end
+
+    -- Subscribed and never received: the exit has nowhere to go, and the tree
+    -- must still be released when the owning process ends.
+    local _, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    return { line = line }
+end
+
+return { main = main }
+`)
+
+	// runExecScript releases the frame it ran the script in, which closes the
+	// resource store the process owns and runs the exec cleanup.
+	grandchild := grandchildPID(t, out, "line")
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !groupAlive(grandchild) }),
+		"grandchild %d outlived the process that owned its group", grandchild)
+}

--- a/runtime/lua/modules/exec/done_test.go
+++ b/runtime/lua/modules/exec/done_test.go
@@ -5,6 +5,7 @@ package exec
 import (
 	"context"
 	osexec "os/exec"
+	"runtime"
 	"testing"
 	"time"
 
@@ -106,6 +107,9 @@ func luaInt(t *testing.T, table *lua.LTable, key string) int {
 // the child and steering it with signals while another coroutine waits for it to
 // finish. wait() cannot serve that, because it consumes the handle.
 func TestProcessDoneDeliversExitWhileHandleStaysUsable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("native signals are not supported on Windows")
+	}
 	out := runExecScript(t, `
 local function main()
     local child, err = executor:exec("cat")

--- a/runtime/lua/modules/exec/done_test.go
+++ b/runtime/lua/modules/exec/done_test.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"context"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
+	relayapi "github.com/wippyai/runtime/api/relay"
+	runtimeapi "github.com/wippyai/runtime/api/runtime"
+	securityapi "github.com/wippyai/runtime/api/security"
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	svcexec "github.com/wippyai/runtime/service/exec"
+	"github.com/wippyai/runtime/service/exec/native"
+	sysrelay "github.com/wippyai/runtime/system/relay"
+	"github.com/wippyai/runtime/system/scheduler"
+	"github.com/wippyai/runtime/system/scheduler/pool/inline"
+	sysstream "github.com/wippyai/runtime/system/stream"
+	"go.uber.org/zap"
+)
+
+const doneTestHost = "exec.done:test"
+
+// runExecScript runs a Lua script against a real native executor with the
+// production wiring done() depends on: an exec dispatcher for the wait yield, a
+// stream dispatcher for stdout reads, and a relay node that routes the exit
+// package back into the running process.
+func runExecScript(t *testing.T, script string) *lua.LTable {
+	t.Helper()
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	rootCtx := securityapi.SetStrictMode(ctxapi.NewRootContext(), false)
+	ctx, cancel := context.WithTimeout(rootCtx, 30*time.Second)
+	defer cancel()
+
+	reg := scheduler.NewRegistry()
+	register := func(id dispatcher.CommandID, h dispatcher.Handler) { reg.Register(id, h) }
+	svcexec.NewDispatcher().RegisterAll(register)
+	streams := sysstream.NewDispatcher()
+	require.NoError(t, streams.Start(ctx))
+	defer func() { _ = streams.Stop(ctx) }()
+	streams.RegisterAll(register)
+
+	factory := native.NewNativeExecutor(zap.NewNop(), &execapi.NativeExecutorConfig{})
+	procFactory := func() (process.Process, error) {
+		return engine.NewFactory(engine.FactoryConfig{
+			Script:     script,
+			ScriptName: "exec_done_test",
+			ModuleBinders: append(engine.CoreBinders(), func(l *lua.LState) error {
+				mod, _ := Module.Build()
+				l.SetGlobal(Module.Name, mod)
+				executor := value.PushTypedUserData(l, NewExecutor(ctx, nil, factory), executorTypeName)
+				l.Pop(1)
+				l.SetGlobal("executor", executor)
+				return nil
+			}),
+		})()
+	}
+
+	pool, err := inline.New(procFactory, reg)
+	require.NoError(t, err)
+	defer pool.Stop()
+
+	node := sysrelay.NewNode("exec-done-test-node")
+	require.NoError(t, node.RegisterHost(doneTestHost, pool))
+
+	frameCtx, frame := ctxapi.OpenFrameContext(ctx)
+	defer ctxapi.ReleaseFrameContext(frame)
+	rawPID := pid.PID{Host: doneTestHost, UniqID: "exec-done"}
+	target := rawPID.Precomputed()
+	require.NoError(t, runtimeapi.SetFramePID(frameCtx, target))
+	frameCtx = relayapi.WithNode(frameCtx, node)
+
+	result, err := pool.Call(frameCtx, "main", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Value)
+
+	out, ok := result.Value.Data().(*lua.LTable)
+	require.True(t, ok, "script must return a table, got %T", result.Value.Data())
+	return out
+}
+
+// luaInt reads a number the script returned under key.
+func luaInt(t *testing.T, table *lua.LTable, key string) int {
+	t.Helper()
+	field := table.RawGetString(key)
+	require.NotEqual(t, lua.LTNil, field.Type(), "script did not return %q", key)
+	return int(lua.LVAsNumber(field))
+}
+
+// A supervisor needs the exit and the handle at the same time: it keeps feeding
+// the child and steering it with signals while another coroutine waits for it to
+// finish. wait() cannot serve that, because it consumes the handle.
+func TestProcessDoneDeliversExitWhileHandleStaysUsable(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("cat")
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local observed = channel.new(1)
+    coroutine.spawn(function()
+        local selected = channel.select{ exit:case_receive() }
+        observed:send(selected.value)
+    end)
+
+    local wrote, werr = child:write_stdin("ping\n")
+    if not wrote then return nil, "write_stdin after done: " .. tostring(werr) end
+
+    local echoed, rerr = stdout:read()
+    if rerr then return nil, "read: " .. tostring(rerr) end
+
+    local signaled, sigerr = child:signal(15)
+    if not signaled then return nil, "signal after done: " .. tostring(sigerr) end
+
+    local status = observed:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    return { code = status.code, signal = status.signal, echoed = echoed }
+end
+
+return { main = main }
+`)
+
+	require.Equal(t, lua.LString("ping\n"), out.RawGetString("echoed"))
+	require.Equal(t, 143, luaInt(t, out, "code"))
+	require.Equal(t, 15, luaInt(t, out, "signal"))
+}
+
+// The exit is recorded once and reported to whoever asks for it, so a
+// supervisor that watched the child on done() can still read its code through
+// wait() afterwards.
+func TestProcessWaitAfterDoneReturnsExitCode(t *testing.T) {
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"exit 7\"")
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    local code, werr = child:wait()
+    if werr then return nil, "wait after done: " .. tostring(werr) end
+
+    return { done_code = status.code, wait_code = code }
+end
+
+return { main = main }
+`)
+
+	require.Equal(t, 7, luaInt(t, out, "done_code"))
+	require.Equal(t, 7, luaInt(t, out, "wait_code"))
+}
+
+// Reading stdout to EOF is not an exit signal: a grandchild inherits the pipe
+// and holds it open long after the child itself is gone. done() reports the
+// child's own exit, so it arrives while the pipe is still open.
+func TestProcessDoneFiresWhileGrandchildHoldsStdout(t *testing.T) {
+	const grandchildLifetime = 5 * time.Second
+
+	start := time.Now()
+	out := runExecScript(t, `
+local function main()
+    local child, err = executor:exec("sh -c \"sleep 5 & exit 3\"")
+    if err then return nil, "exec: " .. tostring(err) end
+
+    local stdout, serr = child:stdout_stream()
+    if serr then return nil, "stdout_stream: " .. tostring(serr) end
+    if stdout == nil then return nil, "no stdout stream" end
+
+    local started, terr = child:start()
+    if not started then return nil, "start: " .. tostring(terr) end
+
+    local exit, derr = child:done()
+    if derr then return nil, "done: " .. tostring(derr) end
+
+    local status = exit:receive()
+    if status == nil then return nil, "exit channel delivered no value" end
+
+    return { code = status.code }
+end
+
+return { main = main }
+`)
+	elapsed := time.Since(start)
+
+	require.Equal(t, 3, luaInt(t, out, "code"))
+	require.Less(t, elapsed, grandchildLifetime/2,
+		"the exit was reported only once the inherited stdout pipe closed")
+}
+
+// The scenario above only means anything if the grandchild really keeps stdout
+// open past the child's own exit, so that draining the pipe would report
+// nothing for as long as the grandchild lives.
+func TestGrandchildKeepsStdoutOpenAfterChildExits(t *testing.T) {
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	cmd := osexec.CommandContext(t.Context(), "sh", "-c", "sleep 5 & exit 3")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	// Process.Wait reaps the child without closing the pipes Cmd created, so
+	// the pipe can still be observed after the child is gone.
+	state, err := cmd.Process.Wait()
+	require.NoError(t, err)
+	require.Equal(t, 3, state.ExitCode())
+
+	read := make(chan error, 1)
+	go func() {
+		_, err := stdout.Read(make([]byte, 1))
+		read <- err
+	}()
+	select {
+	case err := <-read:
+		t.Fatalf("stdout ended with the child instead of with the grandchild: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+	require.NoError(t, stdout.Close())
+}
+
+// Whichever path observes the exit first owns the reap: the child is waited on
+// once, and close() still releases the handle afterwards.
+func TestProcessReapsChildOnceAcrossPaths(t *testing.T) {
+	probe := newReapProbe()
+	p := &Process{handle: probe, started: true}
+
+	require.Equal(t, execapi.ExitStatus{}, p.reap(probe))
+
+	l := setupState()
+	defer l.Close()
+	value.PushTypedUserData(l, p, processTypeName)
+	procClose(l)
+
+	require.True(t, waitFor(t, time.Second, func() bool {
+		return len(probe.sent()) == 1
+	}), "close must still signal the child")
+	require.Equal(t, 1, probe.waits(), "the child must be waited on exactly once")
+}

--- a/runtime/lua/modules/exec/executor.go
+++ b/runtime/lua/modules/exec/executor.go
@@ -160,11 +160,15 @@ func processSecurityMeta(options apiexec.ProcessOptions) attrs.Bag {
 		width, height, _ := options.PTY.Dimensions()
 		terminal["width"], terminal["height"], terminal["term"] = width, height, options.PTY.Term
 	}
+	var processGroup any
+	if options.ProcessGroup != nil {
+		processGroup = *options.ProcessGroup
+	}
 	return attrs.Bag{
 		"work_dir":      options.WorkDir,
 		"env_names":     envNames,
 		"pty":           terminal,
-		"process_group": options.ProcessGroup != nil && *options.ProcessGroup,
+		"process_group": processGroup,
 	}
 }
 

--- a/runtime/lua/modules/exec/executor.go
+++ b/runtime/lua/modules/exec/executor.go
@@ -161,9 +161,10 @@ func processSecurityMeta(options apiexec.ProcessOptions) attrs.Bag {
 		terminal["width"], terminal["height"], terminal["term"] = width, height, options.PTY.Term
 	}
 	return attrs.Bag{
-		"work_dir":  options.WorkDir,
-		"env_names": envNames,
-		"pty":       terminal,
+		"work_dir":      options.WorkDir,
+		"env_names":     envNames,
+		"pty":           terminal,
+		"process_group": options.ProcessGroup != nil && *options.ProcessGroup,
 	}
 }
 

--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -150,7 +150,7 @@ func TestErrorMethods(t *testing.T) {
 }
 
 func TestProcessMethodsRegistered(t *testing.T) {
-	methods := []string{"start", "wait", "done", "signal", "write_stdin", "close_stdin", "stdout_stream", "stderr_stream", "close"}
+	methods := []string{"start", "wait", "done", "signal", "pid", "write_stdin", "close_stdin", "stdout_stream", "stderr_stream", "close"}
 
 	for _, m := range methods {
 		if _, ok := processMethods[m]; !ok {

--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -812,6 +812,20 @@ func TestProcessStartFailureClosesHandle(t *testing.T) {
 	require.Nil(t, process.handle)
 }
 
+type stoppableProcess struct {
+	mockProcess
+	stopped bool
+}
+
+func (p *stoppableProcess) Stop() { p.stopped = true }
+
+func TestProcessCloseReleasesUnstartedNativeCapability(t *testing.T) {
+	handle := &stoppableProcess{}
+	process := NewProcess(context.Background(), handle)
+	process.close(false)
+	require.True(t, handle.stopped)
+}
+
 func (m *mockProcess) Signal(_ int) error {
 	m.signalCalled++
 	return m.signalErr

--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -150,7 +150,7 @@ func TestErrorMethods(t *testing.T) {
 }
 
 func TestProcessMethodsRegistered(t *testing.T) {
-	methods := []string{"start", "wait", "signal", "write_stdin", "close_stdin", "stdout_stream", "stderr_stream", "close"}
+	methods := []string{"start", "wait", "done", "signal", "write_stdin", "close_stdin", "stdout_stream", "stderr_stream", "close"}
 
 	for _, m := range methods {
 		if _, ok := processMethods[m]; !ok {

--- a/runtime/lua/modules/exec/options.go
+++ b/runtime/lua/modules/exec/options.go
@@ -49,6 +49,14 @@ func parseProcessOptions(value lua.LValue) (apiexec.ProcessOptions, error) {
 			return apiexec.ProcessOptions{}, envErr
 		}
 	}
+	if value := table.RawGetString("process_group"); value != lua.LNil {
+		enabled, ok := value.(lua.LBool)
+		if !ok {
+			return apiexec.ProcessOptions{}, fmt.Errorf("process_group must be a boolean")
+		}
+		group := bool(enabled)
+		options.ProcessGroup = &group
+	}
 	if value := table.RawGetString("pty"); value != lua.LNil {
 		pty, ok := value.(*lua.LTable)
 		if !ok {

--- a/runtime/lua/modules/exec/pgroup_test.go
+++ b/runtime/lua/modules/exec/pgroup_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package exec
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	rtresource "github.com/wippyai/runtime/api/runtime/resource"
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	"github.com/wippyai/runtime/service/exec/native"
+	"go.uber.org/zap"
+)
+
+// processTreeCommand prints the pid of a grandchild that only a group-wide
+// signal can reach, then keeps the direct child alive until it is stopped.
+const processTreeCommand = "sh -c 'sleep 300 & echo $!; wait'"
+
+// treeAlive reports whether the pid is still signalable; a reaped process
+// answers ESRCH.
+func treeAlive(pid int) bool { return syscall.Kill(pid, 0) == nil }
+
+// newTreeProcess builds a real native process in its own process group and
+// wraps it in the Lua handle, exactly as executor:exec does.
+func newTreeProcess(ctx context.Context, t *testing.T, group bool) (*Process, io.Reader) {
+	t.Helper()
+	executor := native.NewNativeExecutor(zap.NewNop(), &execapi.NativeExecutorConfig{ProcessGroup: group})
+	handle, err := executor.NewProcess(processTreeCommand, execapi.ProcessOptions{})
+	require.NoError(t, err)
+	return NewProcess(ctx, handle), handle.Stdout()
+}
+
+// startTree drives the Lua start binding and returns the grandchild pid the
+// child reports.
+func startTree(t *testing.T, l *lua.LState, process *Process, stdout io.Reader) int {
+	t.Helper()
+	value.PushTypedUserData(l, process, processTypeName)
+	require.Equal(t, 2, procStart(l))
+	l.SetTop(1)
+
+	pids := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		if scanner.Scan() {
+			pids <- strings.TrimSpace(scanner.Text())
+		}
+		close(pids)
+	}()
+	select {
+	case line, ok := <-pids:
+		require.True(t, ok, "child produced no output")
+		pid, err := strconv.Atoi(line)
+		require.NoErrorf(t, err, "expected a pid on the first output line, got %q", line)
+		t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+		return pid
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the grandchild pid")
+		return 0
+	}
+}
+
+// close() releases the whole tree a harness spawned, not just the command it
+// started: the tool subprocesses are grandchildren of that command.
+func TestCloseReleasesTheProcessGroupTree(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+	grandchild := startTree(t, l, process, stdout)
+	require.True(t, treeAlive(grandchild))
+
+	procClose(l)
+
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !treeAlive(grandchild) }),
+		"grandchild %d survived close() of a process-group child", grandchild)
+}
+
+// The forced close escalates straight to SIGKILL, which must also address the
+// group.
+func TestForcedCloseKillsTheProcessGroupTree(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+	grandchild := startTree(t, l, process, stdout)
+
+	l.Push(lua.LTrue)
+	procClose(l)
+
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !treeAlive(grandchild) }),
+		"grandchild %d survived close(true) of a process-group child", grandchild)
+}
+
+// The cleanup that runs when the owning Lua process exits takes the same path,
+// so it must release the tree too.
+func TestRuntimeCleanupReleasesTheProcessGroupTree(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+	grandchild := startTree(t, l, process, stdout)
+
+	require.NoError(t, store.Close())
+
+	assert.True(t, waitFor(t, 10*time.Second, func() bool { return !treeAlive(grandchild) }),
+		"grandchild %d outlived the owning process", grandchild)
+}
+
+// Without the option the child shares the runtime's group, so only it is
+// signaled. That is the defined behavior for callers that rely on it.
+func TestCloseWithoutProcessGroupLeavesTheGrandchild(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, false)
+	grandchild := startTree(t, l, process, stdout)
+
+	procClose(l)
+
+	assert.True(t, treeAlive(grandchild),
+		"the default close must not reach beyond the direct child")
+}
+
+// pid() is the evidence a caller records for an attempt.
+func TestProcessPidBinding(t *testing.T) {
+	ctx, frame := ctxapi.OpenFrameContext(context.Background())
+	defer ctxapi.ReleaseFrameContext(frame)
+	store := rtresource.NewStore()
+	require.NoError(t, rtresource.SetStore(ctx, store))
+	defer func() { _ = store.Close() }()
+
+	l := setupState()
+	defer l.Close()
+
+	process, stdout := newTreeProcess(ctx, t, true)
+
+	value.PushTypedUserData(l, process, processTypeName)
+	require.Equal(t, 2, procPid(l))
+	require.Equal(t, lua.LNil, l.Get(-2))
+	pidErr, ok := l.Get(-1).(*lua.Error)
+	require.True(t, ok)
+	assert.Contains(t, pidErr.Error(), "process not started")
+	l.SetTop(0)
+
+	grandchild := startTree(t, l, process, stdout)
+
+	require.Equal(t, 2, procPid(l))
+	pid, ok := l.Get(-2).(lua.LInteger)
+	require.True(t, ok, "pid must be an integer")
+	assert.Positive(t, int(pid))
+	assert.NotEqual(t, grandchild, int(pid))
+	l.SetTop(1)
+
+	procClose(l)
+}
+
+func TestParseProcessOptionsProcessGroup(t *testing.T) {
+	l := setupState()
+	defer l.Close()
+
+	table := l.NewTable()
+	table.RawSetString("process_group", lua.LTrue)
+	options, err := parseProcessOptions(table)
+	require.NoError(t, err)
+	require.NotNil(t, options.ProcessGroup)
+	assert.True(t, *options.ProcessGroup)
+	assert.Equal(t, true, processSecurityMeta(options)["process_group"])
+
+	table.RawSetString("process_group", lua.LFalse)
+	options, err = parseProcessOptions(table)
+	require.NoError(t, err)
+	require.NotNil(t, options.ProcessGroup)
+	assert.False(t, *options.ProcessGroup)
+	assert.Equal(t, false, processSecurityMeta(options)["process_group"])
+
+	table.RawSetString("process_group", lua.LString("yes"))
+	_, err = parseProcessOptions(table)
+	require.ErrorContains(t, err, "process_group must be a boolean")
+
+	// An unset option leaves the executor default in force and reports nothing
+	// requested to the policy.
+	empty, err := parseProcessOptions(l.NewTable())
+	require.NoError(t, err)
+	assert.Nil(t, empty.ProcessGroup)
+	assert.Equal(t, false, processSecurityMeta(empty)["process_group"])
+}

--- a/runtime/lua/modules/exec/pgroup_test.go
+++ b/runtime/lua/modules/exec/pgroup_test.go
@@ -213,10 +213,10 @@ func TestParseProcessOptionsProcessGroup(t *testing.T) {
 	_, err = parseProcessOptions(table)
 	require.ErrorContains(t, err, "process_group must be a boolean")
 
-	// An unset option leaves the executor default in force and reports nothing
-	// requested to the policy.
+	// An unset option leaves the executor default in force. Policy metadata
+	// preserves that distinction from an explicit false override.
 	empty, err := parseProcessOptions(l.NewTable())
 	require.NoError(t, err)
 	assert.Nil(t, empty.ProcessGroup)
-	assert.Equal(t, false, processSecurityMeta(empty)["process_group"])
+	assert.Nil(t, processSecurityMeta(empty)["process_group"])
 }

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -125,7 +125,13 @@ func (p *Process) close(force bool) {
 	if cancel != nil {
 		cancel()
 	}
-	if handle == nil || !started {
+	if handle == nil {
+		return
+	}
+	if !started {
+		if stopper, ok := handle.(interface{ Stop() }); ok {
+			stopper.Stop()
+		}
 		return
 	}
 	signal := syscall.SIGTERM
@@ -529,17 +535,17 @@ func procStdout(l *lua.LState) int {
 		return 2
 	}
 
-	reader := handle.Stdout()
-	if reader == nil {
-		l.Push(lua.LNil)
-		l.Push(lua.NewLuaError(l, "stdout not available").WithKind(lua.Internal).WithRetryable(false))
-		return 2
-	}
-
 	table := resource.GetTable(ctx)
 	if table == nil {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, "resource table not available").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	reader := handle.Stdout()
+	if reader == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "stdout not available").WithKind(lua.Internal).WithRetryable(false))
 		return 2
 	}
 
@@ -578,17 +584,17 @@ func procStderr(l *lua.LState) int {
 		return 2
 	}
 
-	reader := handle.Stderr()
-	if reader == nil {
-		l.Push(lua.LNil)
-		l.Push(lua.NewLuaError(l, "stderr not available").WithKind(lua.Internal).WithRetryable(false))
-		return 2
-	}
-
 	table := resource.GetTable(ctx)
 	if table == nil {
 		l.Push(lua.LNil)
 		l.Push(lua.NewLuaError(l, "resource table not available").WithKind(lua.Internal).WithRetryable(false))
+		return 2
+	}
+
+	reader := handle.Stderr()
+	if reader == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "stderr not available").WithKind(lua.Internal).WithRetryable(false))
 		return 2
 	}
 

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -174,6 +174,7 @@ var processMethods = map[string]lua.LGoFunc{
 	"close_stdin":     procCloseStdin,
 	"stdout_stream":   procStdout,
 	"stderr_stream":   procStderr,
+	"pid":             procPid,
 	"close":           procClose,
 	"resize":          procResize,
 	"attach_terminal": procAttachTerminal,
@@ -299,6 +300,45 @@ func procWait(l *lua.LState) int {
 
 	l.Push(yield)
 	return -1
+}
+
+func procPid(l *lua.LState) int {
+	p := checkProcess(l, 1)
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process is closed").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	if !p.started {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process not started: call start() first").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	handle := p.handle
+	p.mu.Unlock()
+
+	identity, ok := handle.(apiexec.ProcessIdentity)
+	if !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process has no host process id").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	pid, err := identity.Pid()
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(wrapExecError(l, err, "read process id", lua.Internal))
+		return 2
+	}
+
+	l.Push(lua.LInteger(pid))
+	l.Push(lua.LNil)
+	return 2
 }
 
 func procSignal(l *lua.LState) int {

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -21,12 +21,66 @@ var errPTYOwnership = errors.New("PTY process is unavailable or already owned")
 type Process struct {
 	handle        apiexec.Process
 	cancelCleanup func()
+	exit          *apiexec.ExitStatus
+	waitErr       error
+	exited        chan struct{}
+	doneChannel   *lua.LUserData
 	stdoutID      uint64
 	stderrID      uint64
 	mu            sync.Mutex
 	started       bool
 	closed        bool
+	reaping       bool
 }
+
+// reap waits on the child exactly once and records how it exited. done(),
+// wait() and close() all funnel through here, so the child is waited on once
+// however many of them are in play, and every caller observes the same exit.
+func (p *Process) reap(handle apiexec.Process) apiexec.ExitStatus {
+	p.mu.Lock()
+	if p.exited == nil {
+		p.exited = make(chan struct{})
+	}
+	exited, owner := p.exited, !p.reaping
+	p.reaping = true
+	p.mu.Unlock()
+
+	if owner {
+		err := handle.Wait()
+		status := apiexec.ClassifyExit(err)
+		p.mu.Lock()
+		p.exit, p.waitErr = &status, err
+		p.mu.Unlock()
+		close(exited)
+	} else {
+		<-exited
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return *p.exit
+}
+
+// reapError reports the untouched error of the single wait, for callers that
+// classify it themselves.
+func (p *Process) reapError(handle apiexec.Process) error {
+	p.reap(handle)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.waitErr
+}
+
+// processReaper routes the wait yield through the wrapper's single reap. A
+// child that done() or close() already reaped still reports its exit instead of
+// failing a second wait.
+type processReaper struct {
+	apiexec.Process
+	proc *Process
+}
+
+func (r *processReaper) AwaitExit() apiexec.ExitStatus { return r.proc.reap(r.Process) }
+
+func (r *processReaper) Wait() error { return r.proc.reapError(r.Process) }
 
 func NewProcess(ctx context.Context, handle apiexec.Process) *Process {
 	p := &Process{
@@ -82,7 +136,7 @@ func (p *Process) close(force bool) {
 	// operation: the child may already have exited, but it must still be waited
 	// on so the OS can reclaim it.
 	_ = handle.Signal(int(signal))
-	go reapReleased(handle, force)
+	go p.reapReleased(handle, force)
 }
 
 // takePTYProcess transfers an unstarted PTY process out of its Lua exec
@@ -137,15 +191,15 @@ const reapGrace = 10 * time.Second
 // Wait closes the stdout and stderr pipes it created. That is inherent to
 // reaping and is the documented consequence of close(): the process is finished
 // with, and its streams along with it.
-func reapReleased(handle apiexec.Process, killed bool) {
-	reapReleasedWithGrace(handle, killed, reapGrace)
+func (p *Process) reapReleased(handle apiexec.Process, killed bool) {
+	p.reapReleasedWithGrace(handle, killed, reapGrace)
 }
 
-func reapReleasedWithGrace(handle apiexec.Process, killed bool, grace time.Duration) {
+func (p *Process) reapReleasedWithGrace(handle apiexec.Process, killed bool, grace time.Duration) {
 	exited := make(chan struct{})
 	go func() {
 		defer close(exited)
-		_ = handle.Wait()
+		p.reap(handle)
 	}()
 
 	if !killed {
@@ -169,6 +223,7 @@ func reapReleasedWithGrace(handle apiexec.Process, killed bool, grace time.Durat
 var processMethods = map[string]lua.LGoFunc{
 	"start":           procStart,
 	"wait":            procWait,
+	"done":            procDone,
 	"signal":          procSignal,
 	"write_stdin":     procWriteStdin,
 	"close_stdin":     procCloseStdin,
@@ -296,7 +351,7 @@ func procWait(l *lua.LState) int {
 	}
 
 	yield := AcquireProcessWaitYield()
-	yield.Process = handle
+	yield.Process = &processReaper{Process: handle, proc: p}
 
 	l.Push(yield)
 	return -1

--- a/runtime/lua/modules/exec/process_exit.go
+++ b/runtime/lua/modules/exec/process_exit.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/api/runtime"
+	apiexec "github.com/wippyai/runtime/api/service/exec"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+)
+
+var processExitID atomic.Uint64
+
+// procDone returns a one-shot channel carrying the child's exit.
+//
+// It is the observation half of wait(): the exit arrives on a channel the
+// caller can select on, and the handle stays open, so a supervisor can keep
+// writing stdin and signaling the child while it waits for the exit. Draining
+// stdout is not a substitute -- a grandchild can hold the pipe open long after
+// the child itself is gone.
+func procDone(l *lua.LState) int {
+	p := checkProcess(l, 1)
+	if p == nil {
+		return 0
+	}
+
+	p.mu.Lock()
+	if existing := p.doneChannel; existing != nil {
+		p.mu.Unlock()
+		l.Push(existing)
+		l.Push(lua.LNil)
+		return 2
+	}
+	if p.closed || p.handle == nil {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process is closed").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	if !p.started {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process not started: call start() first").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	handle := p.handle
+	p.mu.Unlock()
+
+	luaProcess := engine.GetProcess(l)
+	target, hasPID := runtime.GetFramePID(l.Context())
+	router := relay.GetNode(l.Context())
+	if luaProcess == nil || !hasPID || router == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process exit relay unavailable").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	topic := fmt.Sprintf("@exec/process/exit/%d", processExitID.Add(1))
+	ch := engine.NewChannel(1)
+	if err := luaProcess.SubscribeExisting(topic, ch); err != nil {
+		l.Push(lua.LNil)
+		l.Push(wrapExecError(l, err, "subscribe process exit", lua.Internal))
+		return 2
+	}
+	luaProcess.SetTopicHandler(topic, processExitHandler)
+	channel := engine.PushChannel(l, ch)
+	l.Pop(1)
+
+	ctx, cancel := context.WithCancel(l.Context())
+	if !luaProcess.SetSubscriptionCleanup(ch, cancel) {
+		luaProcess.UnsubscribeChannel(ch)
+		cancel()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process exit subscription unavailable").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+
+	p.mu.Lock()
+	p.doneChannel = channel
+	p.mu.Unlock()
+
+	go func() {
+		deliverProcessExit(ctx, router, target, topic, p.reap(handle))
+	}()
+
+	l.Push(channel)
+	l.Push(lua.LNil)
+	return 2
+}
+
+// deliverProcessExit hands the exit to the waiting Lua process. The terminal
+// payload closes the channel behind the single value, so a second receive
+// reports the channel is finished instead of blocking forever.
+func deliverProcessExit(
+	ctx context.Context,
+	router relay.Receiver,
+	target pid.PID,
+	topic string,
+	status apiexec.ExitStatus,
+) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+	pkg := relay.AcquirePackage()
+	pkg.Target = target
+	pkg.AddMessage(topic, payload.New(&status), payload.NewTerminal())
+	if err := router.Send(pkg); err != nil {
+		relay.ReleasePackage(pkg)
+	}
+}
+
+func processExitHandler(
+	_ context.Context,
+	l *lua.LState,
+	_ pid.PID,
+	_ string,
+	payloads []payload.Payload,
+) lua.LValue {
+	if len(payloads) == 0 {
+		return lua.LNil
+	}
+	status, ok := payloads[0].Data().(*apiexec.ExitStatus)
+	if !ok {
+		return lua.LNil
+	}
+
+	exit := l.CreateTable(0, 3)
+	exit.RawSetString("code", lua.LInteger(status.Code))
+	if status.Signal != 0 {
+		exit.RawSetString("signal", lua.LInteger(status.Signal))
+	}
+	if status.Err != nil {
+		exit.RawSetString("error", wrapExecError(l, status.Err, "process exit", lua.Internal))
+	}
+	return exit
+}

--- a/runtime/lua/modules/exec/reap_test.go
+++ b/runtime/lua/modules/exec/reap_test.go
@@ -94,7 +94,7 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
 func TestReapReleasedWaitsOnGracefulStop(t *testing.T) {
 	probe := newReapProbe()
 
-	reapReleased(probe, false)
+	(&Process{}).reapReleased(probe, false)
 
 	if probe.waits() != 1 {
 		t.Fatalf("expected the released process to be waited on once, got %d", probe.waits())
@@ -104,7 +104,7 @@ func TestReapReleasedWaitsOnGracefulStop(t *testing.T) {
 func TestReapReleasedWaitsOnForcedStop(t *testing.T) {
 	probe := newReapProbe()
 
-	reapReleased(probe, true)
+	(&Process{}).reapReleased(probe, true)
 
 	if probe.waits() != 1 {
 		t.Fatalf("expected the killed process to be waited on once, got %d", probe.waits())
@@ -123,7 +123,7 @@ func TestReapReleasedEscalatesToKill(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		reapReleasedWithGrace(probe, false, 10*time.Millisecond)
+		(&Process{}).reapReleasedWithGrace(probe, false, 10*time.Millisecond)
 	}()
 
 	// Let the escalation fire, then release the stand-in child as a real one
@@ -228,7 +228,7 @@ func TestClosedProcessIsNotLeftAsZombie(t *testing.T) {
 	handle := &cmdProcess{cmd: cmd, stdout: stdout}
 
 	_ = handle.Signal(int(syscall.SIGTERM))
-	go reapReleased(handle, false)
+	go (&Process{}).reapReleased(handle, false)
 
 	// A reaped child leaves the process table entirely; an unreaped one lingers
 	// in state Z until the parent exits.

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -81,6 +81,7 @@ Creates a new process with the specified command.
 | work_dir | string | nil | Working directory for the process |
 | env | {[string]: string} | nil | Environment variables as key-value map |
 | pty | PTYOptions | nil | Allocate a pseudo-terminal for the child |
+| process_group | boolean | executor default | Start the child in its own process group so signals reach descendants; unsupported on Windows |
 
 **PTYOptions fields:**
 
@@ -136,6 +137,7 @@ Returned by `executor:exec()`. Represents a process instance.
 | wait | () | integer, error | Waits for process to exit, consumes the handle, yields |
 | done | () | ProcessExitChannel, error | One-shot channel carrying the exit; keeps the handle usable |
 | signal | (sig: integer) | boolean, error | Sends signal to process |
+| pid | () | integer, error | Returns the started child process ID |
 | write_stdin | (data: string) | boolean, error | Writes to process stdin |
 | stdout_stream | () | Stream, error | Returns stdout stream |
 | stderr_stream | () | Stream, error | Returns stderr stream |

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -133,7 +133,8 @@ Returned by `executor:exec()`. Represents a process instance.
 | Method | Signature | Returns | Notes |
 |--------|-----------|---------|-------|
 | start | () | boolean, error | Starts the process |
-| wait | () | integer, error | Waits for process to exit, yields |
+| wait | () | integer, error | Waits for process to exit, consumes the handle, yields |
+| done | () | ProcessExitChannel, error | One-shot channel carrying the exit; keeps the handle usable |
 | signal | (sig: integer) | boolean, error | Sends signal to process |
 | write_stdin | (data: string) | boolean, error | Writes to process stdin |
 | stdout_stream | () | Stream, error | Returns stdout stream |
@@ -180,7 +181,8 @@ Because reaping closes the process's stdout and stderr pipes, its streams are
 finished with once it is closed. Read any output you need before calling this.
 
 After `close()` every method on the process, including `wait()`, reports
-`process closed`. Use `signal()` and `wait()` instead when the exit code matters.
+`process closed`. Use `done()` instead when the exit code matters and the
+handle has to stay usable, or `wait()` when it does not.
 
 **Returns:**
 - Success: `true, nil`
@@ -211,7 +213,22 @@ if err then error(err) end
 
 #### process:wait() → integer, error
 
-Waits for the process to exit and returns the exit code. Automatically closes the process.
+Waits for the process to exit and returns the exit code.
+
+`wait()` consumes the handle. The process is released the moment `wait()` is
+called, before it yields: every other method, `wait()` included, reports
+`process closed` from then on, and the stdout and stderr pipes are closed by
+the reap. Read the output you need first, and use `done()` when the handle must
+stay usable.
+
+A child killed by a signal has no exit code of its own; it is reported as
+`128 + signal`, so `SIGTERM` becomes 143 and `SIGKILL` 137. That is not an
+error: the error return is reserved for a failure to observe the exit at all.
+The signal number itself is on the `done()` value.
+
+`wait()` after `done()` has delivered the exit returns the recorded exit code
+rather than failing. The child is waited on once, whichever of `done()`,
+`wait()` and `close()` gets there first.
 
 **Yields:** until process exits
 
@@ -237,6 +254,60 @@ if err then error(err) end
 if exitCode ~= 0 then
     error("process failed with code " .. exitCode)
 end
+```
+
+#### process:done() → ProcessExitChannel, error
+
+Returns a channel that delivers the child's exit exactly once, then closes.
+Unlike `wait()` it leaves the handle open: `write_stdin()`, `signal()`, the
+streams and `close()` all keep working, so a supervisor can keep driving the
+child while another coroutine waits for it to finish.
+
+Draining stdout is not a substitute for this. A grandchild inherits the pipe
+and can hold it open long after the child itself is gone, so an EOF that never
+arrives says nothing about the exit.
+
+Calling `done()` again returns the same channel. Because the channel closes
+behind the single value, a second `receive()` reports `nil, false` instead of
+blocking.
+
+**The exit value:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| code | integer | Exit code, or `128 + signal` for a child killed by a signal |
+| signal | integer | Signal that killed the child; absent when it exited on its own |
+| error | error | Set only when the exit could not be observed at all |
+
+`done()` reaps the child as soon as it exits, and reaping closes its stdout and
+stderr pipes -- the same consequence `close()` documents. Read output as it
+arrives rather than after the exit.
+
+**Returns:**
+- Success: `channel, nil`
+- Error: `nil, error` - error is structured
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| process closed | errors.INVALID | no |
+| process not started | errors.INVALID | no |
+| process context unavailable | errors.UNAVAILABLE | no |
+
+**Example:**
+
+```lua
+proc:start()
+local exit = assert(proc:done())
+
+coroutine.spawn(function()
+    local status = channel.select{ exit:case_receive() }.value
+    print("child exited with", status.code, status.signal)
+end)
+
+proc:write_stdin("work\n")
+proc:signal(15)
 ```
 
 #### process:signal(sig: integer) → boolean, error
@@ -351,6 +422,15 @@ proc:start()
 proc:wait()
 ```
 
+### ProcessExitChannel
+
+Returned by `process:done()`. A standard channel carrying a single exit value.
+
+| Method | Signature | Returns | Notes |
+|--------|-----------|---------|-------|
+| receive | () | ProcessExit, boolean | Yields until the child exits; `nil, false` once the value has been taken |
+| case_receive | () | case | Case for `channel.select` |
+
 ## Errors
 
 This module returns structured errors. Check kind with `errors.*` constants:
@@ -366,7 +446,7 @@ if err then
 end
 ```
 
-**Possible kinds:** `errors.INVALID`, `errors.INTERNAL`
+**Possible kinds:** `errors.INVALID`, `errors.INTERNAL`, `errors.UNAVAILABLE`
 
 ## Example
 

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -170,15 +170,21 @@ Ordinary pipe-backed processes return an error.
 #### process:close(force?: boolean) → boolean, error
 
 Releases the process. A started child is sent `SIGTERM`, or `SIGKILL` when
-`force` is true, then reaped; an unstarted handle is simply invalidated.
+`force` is true, then reaped; an unstarted handle is simply invalidated. A
+process started with `process_group` is signaled as a group, so its descendants
+go with it. The group outlives the child that leads it, so `close()` still
+reaches the descendants when the child's own exit has already been observed
+through `done()`.
 
 Reaping is what releases the child's entry in the OS process table; without it a
 stopped process lingers as a zombie for the lifetime of the runtime. It happens
 in the background so `close()` does not block, and a child still running after a
 grace period is killed so the reap always completes.
 
-Because reaping closes the process's stdout and stderr pipes, its streams are
-finished with once it is closed. Read any output you need before calling this.
+A stream taken from `stdout_stream()` or `stderr_stream()` outlives the reap:
+the bytes the child wrote before it exited are still readable, and the stream
+ends when the last writer closes the pipe, which may be a descendant rather than
+the child itself.
 
 After `close()` every method on the process, including `wait()`, reports
 `process closed`. Use `done()` instead when the exit code matters and the
@@ -217,9 +223,9 @@ Waits for the process to exit and returns the exit code.
 
 `wait()` consumes the handle. The process is released the moment `wait()` is
 called, before it yields: every other method, `wait()` included, reports
-`process closed` from then on, and the stdout and stderr pipes are closed by
-the reap. Read the output you need first, and use `done()` when the handle must
-stay usable.
+`process closed` from then on. Take the streams you need before calling it, and
+use `done()` when the handle must stay usable; a stream already taken stays
+readable through the exit.
 
 A child killed by a signal has no exit code of its own; it is reported as
 `128 + signal`, so `SIGTERM` becomes 143 and `SIGKILL` 137. That is not an
@@ -279,9 +285,10 @@ blocking.
 | signal | integer | Signal that killed the child; absent when it exited on its own |
 | error | error | Set only when the exit could not be observed at all |
 
-`done()` reaps the child as soon as it exits, and reaping closes its stdout and
-stderr pipes -- the same consequence `close()` documents. Read output as it
-arrives rather than after the exit.
+`done()` reaps the child as soon as it exits, and the streams survive that: what
+the child wrote on its way out is still there to be read once the exit has been
+delivered. The streams end on their own, when the last process holding the pipe
+closes it.
 
 **Returns:**
 - Success: `channel, nil`

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -26,6 +26,7 @@ func init() {
 		OptField("work_dir", typ.String).
 		OptField("env", typ.NewMap(typ.String, typ.String)).
 		OptField("pty", ptyOptionsType).
+		OptField("process_group", typ.Boolean).
 		Build()
 	terminalCompletionType = typ.NewInterface("exec.TerminalCompletionChannel", []typ.Method{
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
@@ -48,6 +49,7 @@ func init() {
 		{Name: "start", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "wait", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "signal", Type: typ.Func().Param("self", typ.Self).Param("sig", typ.Number).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "pid", Type: typ.Func().Param("self", typ.Self).Returns(typ.Integer, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "write_stdin", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "close_stdin", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "stdout_stream", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -39,7 +39,7 @@ func init() {
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.NewOptional(processExitType), typ.Boolean).Build()},
 		{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).
-			Returns(typ.Any).Build()},
+			Returns(engine.ChannelSelectCaseType(typ.Self, processExitType)).Build()},
 	})
 	terminalCompletionType = typ.NewInterface("exec.TerminalCompletionChannel", []typ.Method{
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -11,6 +11,8 @@ import (
 
 var executorType typ.Type
 var processType typ.Type
+var processExitType typ.Type
+var processExitChannelType typ.Type
 var terminalCompletionType typ.Type
 var terminalSessionType typ.Type
 var ptyOptionsType typ.Type
@@ -28,6 +30,17 @@ func init() {
 		OptField("pty", ptyOptionsType).
 		OptField("process_group", typ.Boolean).
 		Build()
+	processExitType = typ.NewRecord().
+		Field("code", typ.Integer).
+		OptField("signal", typ.Integer).
+		OptField("error", typ.LuaError).
+		Build()
+	processExitChannelType = typ.NewInterface("exec.ProcessExitChannel", []typ.Method{
+		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
+			Returns(typ.NewOptional(processExitType), typ.Boolean).Build()},
+		{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).
+			Returns(typ.Any).Build()},
+	})
 	terminalCompletionType = typ.NewInterface("exec.TerminalCompletionChannel", []typ.Method{
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.Boolean, typ.Boolean).Build()},
@@ -48,6 +61,7 @@ func init() {
 	processType = typ.NewInterface("exec.Process", []typ.Method{
 		{Name: "start", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "wait", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "done", Type: typ.Func().Param("self", typ.Self).Returns(processExitChannelType, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "signal", Type: typ.Func().Param("self", typ.Self).Param("sig", typ.Number).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "pid", Type: typ.Func().Param("self", typ.Self).Returns(typ.Integer, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "write_stdin", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
@@ -74,6 +88,8 @@ func ModuleTypes() *io.Manifest {
 
 	m.DefineType("Executor", executorType)
 	m.DefineType("Process", processType)
+	m.DefineType("ProcessExit", processExitType)
+	m.DefineType("ProcessExitChannel", processExitChannelType)
 	m.DefineType("TerminalCompletionChannel", terminalCompletionType)
 	m.DefineType("TerminalSession", terminalSessionType)
 	m.DefineType("PTYOptions", ptyOptionsType)

--- a/service/exec/dispatcher.go
+++ b/service/exec/dispatcher.go
@@ -10,11 +10,6 @@ import (
 	execapi "github.com/wippyai/runtime/api/service/exec"
 )
 
-// exitCoder is an interface for errors that have an exit code.
-type exitCoder interface {
-	ExitCode() int
-}
-
 // Dispatcher handles exec commands.
 type Dispatcher struct{}
 
@@ -42,18 +37,12 @@ func (d *Dispatcher) handleProcessWait(ctx context.Context, cmd dispatcher.Comma
 	waitCmd := cmd.(*execapi.ProcessWaitCmd)
 
 	go func() {
-		err := waitCmd.Process.Wait()
-
-		var exitCode int
-		if err == nil {
-			exitCode = 0
-		} else if ec, ok := err.(exitCoder); ok {
-			exitCode = ec.ExitCode()
-			err = nil
-		}
+		// WaitFor defers to a process that owns its own reap, so a child
+		// already reaped through another path still reports its exit here.
+		status := execapi.WaitFor(waitCmd.Process)
 
 		if ctx.Err() == nil {
-			receiver.CompleteYield(tag, execapi.ProcessWaitResponse{ExitCode: exitCode, Error: err}, nil)
+			receiver.CompleteYield(tag, execapi.ProcessWaitResponse{ExitCode: status.Code, Error: status.Err}, nil)
 		}
 	}()
 

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -244,6 +244,7 @@ func (e *ProcessExecutor) Start() error {
 		width, height, _ := e.pty.Dimensions()
 		master, err := pty.StartWithSize(e.cmd, &pty.Winsize{Cols: uint16(width), Rows: uint16(height)})
 		if err != nil {
+			e.releaseFailedStart()
 			e.stopped.Store(true)
 			if errors.Is(err, pty.ErrUnsupported) {
 				return execapi.ErrPTYUnavailable.WithCause(err)
@@ -255,14 +256,15 @@ func (e *ProcessExecutor) Start() error {
 		e.stderrp = io.NopCloser(strings.NewReader(""))
 	} else {
 		err := e.cmd.Start()
+		if err != nil {
+			e.releaseFailedStart()
+			e.stopped.Store(true)
+			return err
+		}
 		// The child inherited its own descriptors for the write ends; keeping
 		// the executor's copies open would hold the readers past the last real
 		// writer and EOF would never arrive.
 		e.releaseOutputWriters()
-		if err != nil {
-			e.stopped.Store(true)
-			return err
-		}
 	}
 
 	e.pid = e.cmd.Process.Pid
@@ -288,6 +290,24 @@ func (e *ProcessExecutor) releaseOutputWriters() {
 		_ = e.stderrw.Close()
 		e.stderrw = nil
 	}
+}
+
+func (e *ProcessExecutor) releaseFailedStart() {
+	e.releaseOutputWriters()
+	if e.stdinPipe != nil {
+		_ = e.stdinPipe.Close()
+		e.stdinPipe = nil
+	}
+	if e.stdoutp != nil {
+		_ = e.stdoutp.Close()
+		e.stdoutp = nil
+	}
+	if e.stderrp != nil {
+		_ = e.stderrp.Close()
+		e.stderrp = nil
+	}
+	e.stdinClosed = true
+	e.state = terminated
 }
 
 // Pid implements exec.ProcessIdentity. It reports the identifier of the started
@@ -466,8 +486,9 @@ func (e *ProcessExecutor) Stop() {
 	defer e.mu.Unlock()
 
 	if e.pid <= 0 {
+		e.releaseFailedStart()
 		e.closePTY()
-		e.log.Warn("pid is not a positive int", zap.Int("pid", e.pid))
+		e.stopped.Store(true)
 		return
 	}
 

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -24,6 +24,7 @@ import (
 var (
 	_ execapi.ProcessExecutor = (*Executor)(nil)
 	_ execapi.Process         = (*ProcessExecutor)(nil)
+	_ execapi.ProcessIdentity = (*ProcessExecutor)(nil)
 	_ execapi.PTYProcess      = (*ptyProcess)(nil)
 )
 
@@ -39,6 +40,7 @@ type Executor struct {
 	defaultEnv       map[string]string
 	defaultWD        string
 	commandWhitelist []string
+	processGroup     bool
 }
 
 // NewNativeExecutor creates a new native process executor
@@ -48,6 +50,7 @@ func NewNativeExecutor(log *zap.Logger, config *execapi.NativeExecutorConfig) *E
 		defaultEnv:       config.DefaultEnv,
 		defaultWD:        config.DefaultWorkDir,
 		commandWhitelist: config.CommandWhitelist,
+		processGroup:     config.ProcessGroup,
 	}
 }
 
@@ -63,6 +66,13 @@ func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execa
 		if _, _, err := ptyOptions.Dimensions(); err != nil {
 			return nil, err
 		}
+	}
+	processGroup := e.processGroup
+	if options.ProcessGroup != nil {
+		processGroup = *options.ProcessGroup
+	}
+	if processGroup && !processGroupSupported {
+		return nil, execapi.ErrProcessGroupUnsupported
 	}
 	if len(e.commandWhitelist) > 0 {
 		allowed := false
@@ -108,6 +118,7 @@ func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execa
 		WithWorkingDir(workDir),
 		WithEnv(env),
 		WithPTY(ptyOptions),
+		WithProcessGroup(processGroup),
 	)
 	if ptyOptions != nil {
 		return &ptyProcess{ProcessExecutor: process}, nil
@@ -122,23 +133,26 @@ type ptyProcess struct{ *ProcessExecutor }
 
 // ProcessExecutor represents a native process implementation
 type ProcessExecutor struct {
-	stderrp     io.ReadCloser
-	stdoutp     io.ReadCloser
-	stdinPipe   io.WriteCloser
-	cmd         *exec.Cmd
-	log         *zap.Logger
-	envs        map[string]string
-	ptyMaster   *os.File
-	pty         *execapi.PTYOptions
-	wd          string
-	state       string
-	command     string
-	pid         int
-	mu          sync.RWMutex
-	ptyClose    sync.Once
-	stopped     atomic.Bool
-	stdoutOwned bool
-	stdinClosed bool
+<<<<<<< HEAD
+	stderrp      io.ReadCloser
+	stdoutp      io.ReadCloser
+	stdinPipe    io.WriteCloser
+	cmd          *exec.Cmd
+	log          *zap.Logger
+	envs         map[string]string
+	ptyMaster    *os.File
+	pty          *execapi.PTYOptions
+	wd           string
+	state        string
+	command      string
+	pid          int
+	pgid         int
+	mu           sync.RWMutex
+	ptyClose     sync.Once
+	stopped      atomic.Bool
+	stdoutOwned  bool
+	stdinClosed  bool
+	processGroup bool
 }
 
 // NewProcessExecutor creates a new process executor
@@ -185,6 +199,13 @@ func NewProcessExecutor(log *zap.Logger, opts ...Option) *ProcessExecutor {
 		command.Dir = e.wd
 	}
 
+	// A PTY child is started through pty.StartWithAttrs, which replaces
+	// SysProcAttr with a session of its own; setsid already makes that child the
+	// leader of a fresh process group, and adding setpgid on top of it fails.
+	if e.processGroup && e.pty == nil {
+		applyProcessGroup(command)
+	}
+
 	// we can safely skip the error here
 	// because we don't initialize stderrpipe twice or after the process was already started
 	if e.pty == nil {
@@ -229,8 +250,29 @@ func (e *ProcessExecutor) Start() error {
 	}
 
 	e.pid = e.cmd.Process.Pid
+	// Both paths that give the child a group of its own make it the leader:
+	// setpgid with a zero target group, and the PTY path's setsid. The group
+	// identifier is therefore the child pid.
+	if e.processGroup {
+		e.pgid = e.pid
+	}
 	e.state = running
 	return nil
+}
+
+// Pid implements exec.ProcessIdentity. It reports the identifier of the started
+// child so callers can record which OS process an attempt ran as.
+func (e *ProcessExecutor) Pid() (int, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if e.state == notStarted {
+		return 0, ErrProcessNotStarted
+	}
+	if e.pid <= 0 {
+		return 0, ErrInvalidPID
+	}
+	return e.pid, nil
 }
 
 func (p *ptyProcess) Resize(width, height int) error {
@@ -328,6 +370,14 @@ func (e *ProcessExecutor) Signal(sig int) error {
 		return ErrInvalidPID
 	}
 
+	if e.processGroup {
+		if err := signalProcessGroup(e.pgid, syscall.Signal(sig)); err != nil {
+			e.log.Error("error sending signal to process group", zap.Error(err))
+			return err
+		}
+		return nil
+	}
+
 	// we're using os.FindProcess to avoid touching e.cmd
 	pp, err := os.FindProcess(e.pid)
 	if err != nil {
@@ -379,14 +429,18 @@ func (e *ProcessExecutor) Stop() {
 		return
 	}
 
-	pp, err := os.FindProcess(e.pid)
-	if err != nil {
-		e.log.Error("error finding process", zap.Error(err))
-		return
-	}
+	if e.processGroup {
+		_ = signalProcessGroup(e.pgid, syscall.SIGKILL)
+	} else {
+		pp, err := os.FindProcess(e.pid)
+		if err != nil {
+			e.log.Error("error finding process", zap.Error(err))
+			return
+		}
 
-	// kill the process
-	_ = pp.Kill()
+		// kill the process
+		_ = pp.Kill()
+	}
 	// to prevent multiple calls to close()
 	e.pid = 0
 	e.state = terminated

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -133,9 +133,10 @@ type ptyProcess struct{ *ProcessExecutor }
 
 // ProcessExecutor represents a native process implementation
 type ProcessExecutor struct {
-<<<<<<< HEAD
 	stderrp      io.ReadCloser
 	stdoutp      io.ReadCloser
+	stdoutw      *os.File
+	stderrw      *os.File
 	stdinPipe    io.WriteCloser
 	cmd          *exec.Cmd
 	log          *zap.Logger
@@ -152,6 +153,7 @@ type ProcessExecutor struct {
 	stopped      atomic.Bool
 	stdoutOwned  bool
 	stdinClosed  bool
+	stderrOwned  bool
 	processGroup bool
 }
 
@@ -206,19 +208,26 @@ func NewProcessExecutor(log *zap.Logger, opts ...Option) *ProcessExecutor {
 		applyProcessGroup(command)
 	}
 
-	// we can safely skip the error here
-	// because we don't initialize stderrpipe twice or after the process was already started
+	// The output pipes belong to the executor, not to os/exec. Cmd.Wait closes
+	// the pipes StdoutPipe and StderrPipe create, which would discard whatever
+	// the child wrote just before exiting the moment it is reaped, while the
+	// caller still holds the reader. Handing Cmd a plain file leaves the
+	// lifetime here, where the reader's owner decides it.
 	if e.pty == nil {
-		e.stderrp, _ = command.StderrPipe()
-	}
+		if reader, writer, err := os.Pipe(); err == nil {
+			e.stderrp, e.stderrw = reader, writer
+			command.Stderr = writer
+		} else {
+			e.log.Error("error creating stderr pipe", zap.Error(err))
+		}
 
-	// we can safely skip the error here
-	// because we don't initialize stdoutpipe twice or after the process was already started
-	if e.pty == nil {
-		e.stdoutp, _ = command.StdoutPipe()
-	}
+		if reader, writer, err := os.Pipe(); err == nil {
+			e.stdoutp, e.stdoutw = reader, writer
+			command.Stdout = writer
+		} else {
+			e.log.Error("error creating stdout pipe", zap.Error(err))
+		}
 
-	if e.pty == nil {
 		ip, _ := command.StdinPipe()
 		e.stdinPipe = ip
 	}
@@ -244,9 +253,16 @@ func (e *ProcessExecutor) Start() error {
 		e.ptyMaster = master
 		e.stdinPipe, e.stdoutp = master, master
 		e.stderrp = io.NopCloser(strings.NewReader(""))
-	} else if err := e.cmd.Start(); err != nil {
-		e.stopped.Store(true)
-		return err
+	} else {
+		err := e.cmd.Start()
+		// The child inherited its own descriptors for the write ends; keeping
+		// the executor's copies open would hold the readers past the last real
+		// writer and EOF would never arrive.
+		e.releaseOutputWriters()
+		if err != nil {
+			e.stopped.Store(true)
+			return err
+		}
 	}
 
 	e.pid = e.cmd.Process.Pid
@@ -258,6 +274,20 @@ func (e *ProcessExecutor) Start() error {
 	}
 	e.state = running
 	return nil
+}
+
+// releaseOutputWriters closes the executor's copies of the output pipe write
+// ends. The readers then end when the last process writing to them is gone,
+// which is what distinguishes a closed pipe from a finished child.
+func (e *ProcessExecutor) releaseOutputWriters() {
+	if e.stdoutw != nil {
+		_ = e.stdoutw.Close()
+		e.stdoutw = nil
+	}
+	if e.stderrw != nil {
+		_ = e.stderrw.Close()
+		e.stderrw = nil
+	}
 }
 
 // Pid implements exec.ProcessIdentity. It reports the identifier of the started
@@ -355,27 +385,41 @@ func (e *ProcessExecutor) Signal(sig int) error {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if e.state != running {
-		state := e.state
-		if state == terminated {
-			e.log.Debug("process already terminated")
-			return errors.Join(ErrProcessNotRunning, os.ErrProcessDone)
-		}
-		e.log.Error("process is not running", zap.String("state", state))
+	if e.state == notStarted {
+		e.log.Error("process is not running", zap.String("state", e.state))
 		return ErrProcessNotRunning
+	}
+
+	// A process group outlives the child that leads it: the descendants stay in
+	// the group after the leader has been reaped, and the leader's identifier is
+	// not handed to a new process while the group still has members. Addressing
+	// the group therefore stays meaningful once the child's own exit has been
+	// observed, which is when a supervisor most needs it. An empty group answers
+	// ESRCH, and that is the state the caller is told about.
+	if e.processGroup {
+		if e.pgid <= 0 {
+			e.log.Error("pgid is not a positive int", zap.Int("pgid", e.pgid))
+			return ErrInvalidPID
+		}
+		if err := signalProcessGroup(e.pgid, syscall.Signal(sig)); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				e.log.Debug("process group already terminated")
+				return errors.Join(ErrProcessNotRunning, os.ErrProcessDone)
+			}
+			e.log.Error("error sending signal to process group", zap.Error(err))
+			return err
+		}
+		return nil
+	}
+
+	if e.state != running {
+		e.log.Debug("process already terminated")
+		return errors.Join(ErrProcessNotRunning, os.ErrProcessDone)
 	}
 
 	if e.pid <= 0 {
 		e.log.Error("pid is not a positive int", zap.Int("pid", e.pid))
 		return ErrInvalidPID
-	}
-
-	if e.processGroup {
-		if err := signalProcessGroup(e.pgid, syscall.Signal(sig)); err != nil {
-			e.log.Error("error sending signal to process group", zap.Error(err))
-			return err
-		}
-		return nil
 	}
 
 	// we're using os.FindProcess to avoid touching e.cmd
@@ -396,8 +440,11 @@ func (e *ProcessExecutor) Signal(sig int) error {
 
 // Stderr implements exec.Process
 func (e *ProcessExecutor) Stderr() io.ReadCloser {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stderrp != nil {
+		e.stderrOwned = true
+	}
 
 	return e.stderrp
 }
@@ -406,7 +453,7 @@ func (e *ProcessExecutor) Stderr() io.ReadCloser {
 func (e *ProcessExecutor) Stdout() io.ReadCloser {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.ptyMaster != nil && e.stdoutp != nil {
+	if e.stdoutp != nil {
 		e.stdoutOwned = true
 	}
 
@@ -474,11 +521,20 @@ func (e *ProcessExecutor) Wait() error {
 	}
 
 	e.mu.Lock()
-	// A PTY master is not one of os/exec's managed pipes. Wait releases an
-	// unclaimed master; once Stdout hands it to a caller, that reader owns the
-	// final drain and close so the child's last terminal frame is not truncated.
-	if e.ptyMaster != nil && !e.stdoutOwned {
-		e.closePTY()
+	// Wait releases the output nobody asked for. Once Stdout or Stderr hands a
+	// reader to a caller, that reader owns the final drain and close, so the
+	// child's last bytes outlive the reap instead of being thrown away with it.
+	if e.ptyMaster != nil {
+		if !e.stdoutOwned {
+			e.closePTY()
+		}
+	} else {
+		if e.stdoutp != nil && !e.stdoutOwned {
+			_ = e.stdoutp.Close()
+		}
+		if e.stderrp != nil && !e.stderrOwned {
+			_ = e.stderrp.Close()
+		}
 	}
 	e.state = terminated
 	e.mu.Unlock()

--- a/service/exec/native/native_test.go
+++ b/service/exec/native/native_test.go
@@ -613,6 +613,41 @@ func TestExecutor_ReadWithInvalidCommand(t *testing.T) {
 	_ = process.Wait()
 }
 
+func TestExecutorReleasesPipesWhenProcessNeverStarts(t *testing.T) {
+	for _, start := range []bool{false, true} {
+		t.Run(map[bool]string{false: "abandoned", true: "start_failure"}[start], func(t *testing.T) {
+			logger, _ := mocklogger.ZapTestLogger(zap.DebugLevel)
+			executor := NewNativeExecutor(logger, &exec.NativeExecutorConfig{})
+			process, err := executor.NewProcess("wippy-command-that-does-not-exist", exec.ProcessOptions{})
+			require.NoError(t, err)
+			native := process.(*ProcessExecutor)
+			stdout := process.Stdout()
+			stderr := process.Stderr()
+			require.NotNil(t, stdout)
+			require.NotNil(t, stderr)
+
+			if start {
+				require.Error(t, process.Start())
+			} else {
+				native.Stop()
+			}
+
+			_, stdoutErr := stdout.Read(make([]byte, 1))
+			_, stderrErr := stderr.Read(make([]byte, 1))
+			require.Error(t, stdoutErr)
+			require.Error(t, stderrErr)
+			native.mu.RLock()
+			require.Nil(t, native.stdinPipe)
+			require.Nil(t, native.stdoutp)
+			require.Nil(t, native.stderrp)
+			require.Equal(t, terminated, native.state)
+			require.True(t, native.stdinClosed)
+			native.mu.RUnlock()
+			require.True(t, native.stopped.Load())
+		})
+	}
+}
+
 func TestExecutor_WriteStdin(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/service/exec/native/options.go
+++ b/service/exec/native/options.go
@@ -31,3 +31,9 @@ func WithCmd(cmd string) Option {
 func WithPTY(options *execapi.PTYOptions) Option {
 	return func(e *ProcessExecutor) { e.pty = options }
 }
+
+// WithProcessGroup starts the process in a process group of its own so signals
+// addressed to it reach its descendants.
+func WithProcessGroup(enabled bool) Option {
+	return func(e *ProcessExecutor) { e.processGroup = enabled }
+}

--- a/service/exec/native/pgroup_test.go
+++ b/service/exec/native/pgroup_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package native
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/service/exec"
+	"go.uber.org/zap"
+)
+
+// treeCommand prints the pid of a grandchild that outlives a signal sent to the
+// direct child alone, then keeps the child alive until it is stopped.
+const treeCommand = "sh -c 'sleep 300 & echo $!; wait'"
+
+// readPID takes the first line the child writes and reads it as a pid.
+func readPID(t *testing.T, reader io.Reader) int {
+	t.Helper()
+	lines := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(reader)
+		if scanner.Scan() {
+			lines <- strings.TrimSpace(scanner.Text())
+		}
+		close(lines)
+	}()
+	select {
+	case line, ok := <-lines:
+		require.True(t, ok, "child produced no output")
+		pid, err := strconv.Atoi(line)
+		require.NoErrorf(t, err, "expected a pid on the first output line, got %q", line)
+		return pid
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the grandchild pid")
+		return 0
+	}
+}
+
+// alive reports whether the pid can still be signaled. A pid that has been
+// reaped answers ESRCH.
+func alive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func waitGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !alive(pid) {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return !alive(pid)
+}
+
+// A signal sent to a process started with its own process group reaches every
+// descendant that has not left the group, which is the whole point of the
+// option: a harness spawns its tools as grandchildren.
+func TestProcessGroupSignalReachesGrandchild(t *testing.T) {
+	enabled := true
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(treeCommand, exec.ProcessOptions{ProcessGroup: &enabled})
+	require.NoError(t, err)
+
+	stdout := process.Stdout()
+	require.NoError(t, process.Start())
+	grandchild := readPID(t, stdout)
+	require.True(t, alive(grandchild), "grandchild should be running")
+
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+
+	assert.True(t, waitGone(grandchild, 5*time.Second),
+		"grandchild %d survived a signal sent to the process group", grandchild)
+}
+
+// The default keeps the child in the runtime's own group, where a group signal
+// would reach the runtime itself. Only the direct child is signaled.
+func TestWithoutProcessGroupOnlyTheDirectChildIsSignaled(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(treeCommand, exec.ProcessOptions{})
+	require.NoError(t, err)
+
+	stdout := process.Stdout()
+	require.NoError(t, process.Start())
+	grandchild := readPID(t, stdout)
+	t.Cleanup(func() { _ = syscall.Kill(grandchild, syscall.SIGKILL) })
+
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+
+	assert.True(t, alive(grandchild),
+		"a signal to the direct child must not reach the grandchild by default")
+}
+
+// close(force) escalation and the runtime's owner-exit cleanup both go through
+// Signal, so SIGTERM must address the group as well.
+func TestProcessGroupTerminationReachesGrandchild(t *testing.T) {
+	enabled := true
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(
+		// The trap is set after the grandchild starts: a disposition of SIG_IGN
+		// is inherited, so an earlier trap would make the grandchild ignore TERM
+		// as well and the test would prove nothing.
+		"sh -c 'sleep 300 & echo $!; trap \"\" TERM; wait'",
+		exec.ProcessOptions{ProcessGroup: &enabled},
+	)
+	require.NoError(t, err)
+
+	stdout := process.Stdout()
+	require.NoError(t, process.Start())
+	grandchild := readPID(t, stdout)
+	t.Cleanup(func() { _ = syscall.Kill(grandchild, syscall.SIGKILL) })
+
+	// The child ignores TERM; the grandchild does not, so the group delivery is
+	// what is observed here.
+	require.NoError(t, process.Signal(int(syscall.SIGTERM)))
+	assert.True(t, waitGone(grandchild, 5*time.Second),
+		"grandchild %d survived SIGTERM sent to the process group", grandchild)
+
+	// The child's own wait returns once the grandchild is gone, so it exits too.
+	_ = process.Wait()
+}
+
+// A PTY child is already a session leader of its own group. Requesting a
+// process group there must not add a conflicting setpgid that fails the start.
+func TestProcessGroupWithPTYStartsAndSignalsTheSession(t *testing.T) {
+	enabled := true
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess(treeCommand, exec.ProcessOptions{
+		PTY:          &exec.PTYOptions{Width: 80, Height: 24},
+		ProcessGroup: &enabled,
+	})
+	require.NoError(t, err)
+
+	// A PTY child has no pipes: the master exists only once the process starts,
+	// and the caller that acquires it owns its close.
+	require.NoError(t, process.Start())
+	stdout := process.Stdout()
+	require.NotNil(t, stdout)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	grandchild := readPID(t, stdout)
+	t.Cleanup(func() { _ = syscall.Kill(grandchild, syscall.SIGKILL) })
+
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+
+	assert.True(t, waitGone(grandchild, 5*time.Second),
+		"grandchild %d survived a signal sent to the PTY session group", grandchild)
+}
+
+// The executor default applies when the command says nothing, and an explicit
+// per-command value wins in both directions.
+func TestProcessGroupExecutorDefaultAndPerCommandOverride(t *testing.T) {
+	enabled, disabled := true, false
+	tests := []struct {
+		option      *bool
+		name        string
+		configured  bool
+		wantEnabled bool
+	}{
+		{name: "default off", configured: false, option: nil, wantEnabled: false},
+		{name: "default on", configured: true, option: nil, wantEnabled: true},
+		{name: "command enables", configured: false, option: &enabled, wantEnabled: true},
+		{name: "command disables", configured: true, option: &disabled, wantEnabled: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{ProcessGroup: test.configured})
+			process, err := executor.NewProcess("true", exec.ProcessOptions{ProcessGroup: test.option})
+			require.NoError(t, err)
+
+			native, ok := process.(*ProcessExecutor)
+			require.True(t, ok)
+			assert.Equal(t, test.wantEnabled, native.processGroup)
+			if test.wantEnabled {
+				require.NotNil(t, native.cmd.SysProcAttr)
+				assert.True(t, native.cmd.SysProcAttr.Setpgid)
+			} else if native.cmd.SysProcAttr != nil {
+				assert.False(t, native.cmd.SysProcAttr.Setpgid)
+			}
+		})
+	}
+}
+
+// The pid is the evidence a caller records for an attempt, so it is readable
+// only once there is a child to identify.
+func TestProcessPidRequiresAStartedChild(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess("sh -c 'exit 0'", exec.ProcessOptions{})
+	require.NoError(t, err)
+
+	identity, ok := process.(exec.ProcessIdentity)
+	require.True(t, ok, "native processes expose their pid")
+
+	_, err = identity.Pid()
+	require.ErrorIs(t, err, ErrProcessNotStarted)
+
+	require.NoError(t, process.Start())
+	pid, err := identity.Pid()
+	require.NoError(t, err)
+	assert.Positive(t, pid)
+	assert.Equal(t, process.(*ProcessExecutor).cmd.Process.Pid, pid)
+
+	require.NoError(t, process.Wait())
+}

--- a/service/exec/native/pgroup_unix.go
+++ b/service/exec/native/pgroup_unix.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package native
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// processGroupSupported reports whether this platform can start a child in its
+// own process group.
+const processGroupSupported = true
+
+// applyProcessGroup makes the child the leader of a new process group. Every
+// process it spawns inherits that group unless it deliberately leaves it, so a
+// signal addressed to the group reaches the whole tree.
+func applyProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// signalProcessGroup delivers sig to every member of the group led by pgid.
+func signalProcessGroup(pgid int, sig syscall.Signal) error {
+	return syscall.Kill(-pgid, sig)
+}

--- a/service/exec/native/pgroup_windows.go
+++ b/service/exec/native/pgroup_windows.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package native
+
+import (
+	"os/exec"
+	"syscall"
+
+	execapi "github.com/wippyai/runtime/api/service/exec"
+)
+
+// processGroupSupported reports whether this platform can start a child in its
+// own process group. Windows groups a process tree with a Job Object, which
+// this executor does not yet create, so the option is refused rather than
+// accepted and ignored.
+const processGroupSupported = false
+
+func applyProcessGroup(_ *exec.Cmd) {}
+
+func signalProcessGroup(_ int, _ syscall.Signal) error {
+	return execapi.ErrProcessGroupUnsupported
+}


### PR DESCRIPTION
## Summary

- add `process_group` as a native-executor default and per-process override so signals, `close()`, and owner cleanup can terminate a child process tree
- add `proc:pid()` and a reusable one-shot `proc:done()` exit channel without consuming the process handle
- centralize exit classification and ensure `wait()`, `done()`, and `close()` share one reap result
- preserve caller-owned stdout/stderr through reaping and release all native pipes on failed start or abandoned unstarted processes
- reject process groups on unsupported platforms instead of silently ignoring the option

## Lifecycle coverage

The regression suite covers exit before subscription, signal/completion races, descendants retaining output pipes, output drain after exit, graceful and forced group cleanup, owner-exit cleanup, repeated `done()`, `wait()` after `done()`, failed start, unstarted cleanup, PTY behavior, executor defaults and per-command overrides, and platform-specific exit classification.

## Verification

- uncached race tests for `api/service/exec`, `service/exec/...`, and `runtime/lua/modules/exec`
- downstream terminal, boot-component, and stream tests
- `go vet`
- golangci-lint v2.13.2: 0 issues
- Windows amd64 build of the affected packages
- `go mod verify`
- `git diff --check`
