### PR TITLE
feat(exec): close_stdin ends a child's stdin after writes

### DIFF
--- a/api/service/exec/api.go
+++ b/api/service/exec/api.go
@@ -101,6 +101,14 @@ type PTYProcess interface {
 	Resize(width, height int) error
 }
 
+// StdinCloser is the capability of a process whose stdin can be closed
+// after the caller wrote everything, so a child that reads until end of
+// file sees it. Closing is idempotent; later writes fail. A PTY-backed
+// process has no separate stdin to close.
+type StdinCloser interface {
+	CloseStdin() error
+}
+
 // WaitCanceler is an optional lifecycle capability for remote executors whose
 // Wait operation can otherwise outlive an abandoned proxy or runtime process.
 type WaitCanceler interface {

--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -150,7 +150,7 @@ func TestErrorMethods(t *testing.T) {
 }
 
 func TestProcessMethodsRegistered(t *testing.T) {
-	methods := []string{"start", "wait", "signal", "write_stdin", "stdout_stream", "stderr_stream", "close"}
+	methods := []string{"start", "wait", "signal", "write_stdin", "close_stdin", "stdout_stream", "stderr_stream", "close"}
 
 	for _, m := range methods {
 		if _, ok := processMethods[m]; !ok {

--- a/runtime/lua/modules/exec/process.go
+++ b/runtime/lua/modules/exec/process.go
@@ -171,6 +171,7 @@ var processMethods = map[string]lua.LGoFunc{
 	"wait":            procWait,
 	"signal":          procSignal,
 	"write_stdin":     procWriteStdin,
+	"close_stdin":     procCloseStdin,
 	"stdout_stream":   procStdout,
 	"stderr_stream":   procStderr,
 	"close":           procClose,
@@ -326,6 +327,47 @@ func procSignal(l *lua.LState) int {
 	if err != nil {
 		l.Push(lua.LNil)
 		l.Push(wrapExecError(l, err, "send signal", lua.Internal))
+		return 2
+	}
+
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}
+
+// procCloseStdin ends the child's stdin after the caller wrote everything,
+// so a child that reads until end of file proceeds. Idempotent; a process
+// without the capability, such as a PTY-backed one, reports why.
+func procCloseStdin(l *lua.LState) int {
+	p := checkProcess(l, 1)
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process is closed").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	if !p.started {
+		p.mu.Unlock()
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process not started: call start() first").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	handle := p.handle
+	p.mu.Unlock()
+
+	closer, ok := handle.(apiexec.StdinCloser)
+	if !ok {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "this process cannot close stdin").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	if err := closer.CloseStdin(); err != nil {
+		l.Push(lua.LNil)
+		l.Push(wrapExecError(l, err, "close stdin", lua.Internal))
 		return 2
 	}
 

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -48,6 +48,7 @@ func init() {
 		{Name: "wait", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "signal", Type: typ.Func().Param("self", typ.Self).Param("sig", typ.Number).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "write_stdin", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "close_stdin", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "stdout_stream", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "stderr_stream", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "close", Type: typ.Func().Param("self", typ.Self).OptParam("force", typ.Boolean).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},

--- a/service/exec/docker/docker.go
+++ b/service/exec/docker/docker.go
@@ -176,6 +176,7 @@ func (e *Executor) Close() error {
 type Process struct {
 	waitCtx         context.Context
 	stdinWriter     io.WriteCloser
+	stdinCloser     interface{ CloseWrite() error }
 	stderrReader    io.ReadCloser
 	stdoutReader    io.ReadCloser
 	tmpfs           map[string]string
@@ -310,6 +311,7 @@ func (p *Process) Start() error {
 	stdoutPipeR, stdoutPipeW := io.Pipe()
 	stderrPipeR, stderrPipeW := io.Pipe()
 	p.stdinWriter = attachResp.Conn
+	p.stdinCloser = &attachResp
 	p.stdoutReader = stdoutPipeR
 	p.stderrReader = stderrPipeR
 	p.started = true
@@ -381,6 +383,26 @@ func (p *Process) Signal(sig int) error {
 
 	p.log.Debug("signal sent", zap.String("id", containerID), zap.String("signal", sigName))
 	return nil
+}
+
+// CloseStdin implements exec.StdinCloser by half-closing the attached
+// connection, which the container sees as end of file on its stdin.
+func (p *Process) CloseStdin() error {
+	p.mu.RLock()
+	if !p.started {
+		p.mu.RUnlock()
+		return ErrContainerNotStarted
+	}
+	if p.stopped {
+		p.mu.RUnlock()
+		return ErrContainerStopped
+	}
+	closer := p.stdinCloser
+	p.mu.RUnlock()
+	if closer == nil {
+		return ErrStdinNotAvailable
+	}
+	return closer.CloseWrite()
 }
 
 // WriteStdin writes data to the container's stdin

--- a/service/exec/native/errors.go
+++ b/service/exec/native/errors.go
@@ -13,6 +13,8 @@ var (
 	ErrProcessNotRunning = apierror.New(apierror.Invalid, "process is not running").WithRetryable(apierror.False)
 	ErrProcessNotStarted = apierror.New(apierror.Invalid, "process not started").WithRetryable(apierror.False)
 	ErrInvalidPID        = apierror.New(apierror.Invalid, "pid is not a positive int, process is possibly not running").WithRetryable(apierror.False)
+	ErrStdinClosed       = apierror.New(apierror.Invalid, "stdin is closed").WithRetryable(apierror.False)
+	ErrStdinPTY          = apierror.New(apierror.Invalid, "a PTY process has no separate stdin to close").WithRetryable(apierror.False)
 )
 
 func NewCommandNotAllowedError(cmd string) apierror.Error {

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -138,6 +138,7 @@ type ProcessExecutor struct {
 	ptyClose    sync.Once
 	stopped     atomic.Bool
 	stdoutOwned bool
+	stdinClosed bool
 }
 
 // NewProcessExecutor creates a new process executor
@@ -259,6 +260,10 @@ func (e *ProcessExecutor) WriteStdin(data []byte) error {
 		e.log.Error("process is not running", zap.String("state", state))
 		return ErrProcessNotRunning
 	}
+	if e.stdinClosed {
+		e.mu.RUnlock()
+		return ErrStdinClosed
+	}
 	stdin := e.stdinPipe
 	e.mu.RUnlock()
 
@@ -276,6 +281,28 @@ func (e *ProcessExecutor) WriteStdin(data []byte) error {
 	e.log.Debug("written to stdin", zap.Int("bytes", n))
 
 	return nil
+}
+
+// CloseStdin implements exec.StdinCloser: it ends the child's stdin so a
+// reader that waits for end of file proceeds. The PTY master is the
+// child's terminal, not a separate stdin, and stays open.
+func (e *ProcessExecutor) CloseStdin() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state != running {
+		return ErrProcessNotRunning
+	}
+	if e.pty != nil {
+		return ErrStdinPTY
+	}
+	if e.stdinClosed {
+		return nil
+	}
+	e.stdinClosed = true
+	if e.stdinPipe == nil {
+		return nil
+	}
+	return e.stdinPipe.Close()
 }
 
 // Signal implements exec.Process

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -215,6 +215,9 @@ func (e *ProcessExecutor) Start() error {
 		master, err := pty.StartWithSize(e.cmd, &pty.Winsize{Cols: uint16(width), Rows: uint16(height)})
 		if err != nil {
 			e.stopped.Store(true)
+			if errors.Is(err, pty.ErrUnsupported) {
+				return execapi.ErrPTYUnavailable.WithCause(err)
+			}
 			return err
 		}
 		e.ptyMaster = master

--- a/service/exec/native/native_pty_unix_test.go
+++ b/service/exec/native/native_pty_unix_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build unix
+
+package native
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/service/exec"
+	"go.uber.org/zap"
+)
+
+func TestPTYProcessRefusesCloseStdin(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess("cat", exec.ProcessOptions{PTY: &exec.PTYOptions{Width: 80, Height: 24}})
+	require.NoError(t, err)
+	require.NoError(t, process.Start())
+	closer, ok := process.(exec.StdinCloser)
+	require.True(t, ok)
+	require.ErrorIs(t, closer.CloseStdin(), ErrStdinPTY)
+	require.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
+}

--- a/service/exec/native/native_pty_windows_test.go
+++ b/service/exec/native/native_pty_windows_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package native
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/service/exec"
+	"go.uber.org/zap"
+)
+
+func TestPTYProcessStartReportsUnavailable(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess("cmd /c exit 0", exec.ProcessOptions{PTY: &exec.PTYOptions{Width: 80, Height: 24}})
+	require.NoError(t, err)
+	require.ErrorIs(t, process.Start(), exec.ErrPTYUnavailable)
+}

--- a/service/exec/native/native_test.go
+++ b/service/exec/native/native_test.go
@@ -12,7 +12,6 @@ import (
 	osexec "os/exec"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -709,18 +708,6 @@ func TestExecutor_CloseStdin(t *testing.T) {
 	assert.NoError(t, readErr)
 	assert.Equal(t, "until end of file", string(output))
 	assert.NoError(t, process.Wait())
-}
-
-func TestPTYProcessRefusesCloseStdin(t *testing.T) {
-	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
-	process, err := executor.NewProcess("cat", exec.ProcessOptions{PTY: &exec.PTYOptions{Width: 80, Height: 24}})
-	assert.NoError(t, err)
-	assert.NoError(t, process.Start())
-	closer, ok := process.(exec.StdinCloser)
-	assert.True(t, ok)
-	assert.ErrorIs(t, closer.CloseStdin(), ErrStdinPTY)
-	assert.NoError(t, process.Signal(int(syscall.SIGKILL)))
-	_ = process.Wait()
 }
 
 func TestNativeExecutor_Config(t *testing.T) {

--- a/service/exec/native/native_test.go
+++ b/service/exec/native/native_test.go
@@ -12,6 +12,7 @@ import (
 	osexec "os/exec"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -689,6 +690,37 @@ func TestExecutor_WriteStdin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecutor_CloseStdin(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess("cat", exec.ProcessOptions{})
+	assert.NoError(t, err)
+	closer, ok := process.(exec.StdinCloser)
+	assert.True(t, ok)
+	assert.ErrorIs(t, closer.CloseStdin(), ErrProcessNotRunning)
+	assert.NoError(t, process.Start())
+	stdout := process.Stdout()
+	assert.NoError(t, process.WriteStdin([]byte("until end of file")))
+	assert.NoError(t, closer.CloseStdin())
+	assert.NoError(t, closer.CloseStdin())
+	assert.ErrorIs(t, process.WriteStdin([]byte("late")), ErrStdinClosed)
+	output, readErr := io.ReadAll(stdout)
+	assert.NoError(t, readErr)
+	assert.Equal(t, "until end of file", string(output))
+	assert.NoError(t, process.Wait())
+}
+
+func TestPTYProcessRefusesCloseStdin(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	process, err := executor.NewProcess("cat", exec.ProcessOptions{PTY: &exec.PTYOptions{Width: 80, Height: 24}})
+	assert.NoError(t, err)
+	assert.NoError(t, process.Start())
+	closer, ok := process.(exec.StdinCloser)
+	assert.True(t, ok)
+	assert.ErrorIs(t, closer.CloseStdin(), ErrStdinPTY)
+	assert.NoError(t, process.Signal(int(syscall.SIGKILL)))
+	_ = process.Wait()
 }
 
 func TestNativeExecutor_Config(t *testing.T) {


### PR DESCRIPTION
A child that reads stdin until end of file (for example `codex exec -` reading its prompt from stdin) never proceeds while the runtime keeps the write side open; the Lua exec process had no way to close it.

- `api/service/exec`: optional `StdinCloser` capability.
- native executor: `CloseStdin` closes the stdin pipe once; later `WriteStdin` returns `ErrStdinClosed`; PTY processes refuse with `ErrStdinPTY` because the master is the terminal.
- docker executor: half-closes the attached connection.
- Lua `exec` process: `close_stdin()`; a process without the capability reports it as unavailable.
- Tests: native `cat` reads to EOF after close, write after close refused, PTY refusal; method registration.

Found while proving the Codex authentication path in Bee: the admitted launch writes the brief to stdin and Codex 0.153 waits for EOF.