### PR TITLE
feat(hash): streaming hasher (hash.new with update, sum, reset)

### DIFF
--- a/runtime/lua/modules/hash/module.go
+++ b/runtime/lua/modules/hash/module.go
@@ -21,14 +21,14 @@ import (
 // Module is the hash module definition.
 var Module = &luaapi.ModuleDef{
 	Name:        "hash",
-	Description: "Cryptographic hash functions, HMAC, and PBKDF2",
+	Description: "Cryptographic hash functions, streaming hashers, HMAC, and PBKDF2",
 	Class:       []string{luaapi.ClassEncoding, luaapi.ClassSecurity, luaapi.ClassDeterministic},
 	Build:       buildModule,
 	Types:       ModuleTypes,
 }
 
 func buildModule() (*lua.LTable, []luaapi.YieldType) {
-	mod := lua.CreateTable(0, 11)
+	mod := lua.CreateTable(0, 12)
 	mod.RawSetString("md5", lua.LGoFunc(hashMD5))
 	mod.RawSetString("sha1", lua.LGoFunc(hashSHA1))
 	mod.RawSetString("sha256", lua.LGoFunc(hashSHA256))
@@ -40,6 +40,7 @@ func buildModule() (*lua.LTable, []luaapi.YieldType) {
 	mod.RawSetString("hmac_sha1", lua.LGoFunc(hmacSHA1))
 	mod.RawSetString("hmac_md5", lua.LGoFunc(hmacMD5))
 	mod.RawSetString("pbkdf2", lua.LGoFunc(pbkdf2Derive))
+	mod.RawSetString("new", lua.LGoFunc(hashNew))
 	mod.Immutable = true
 	return mod, nil
 }

--- a/runtime/lua/modules/hash/module_test.go
+++ b/runtime/lua/modules/hash/module_test.go
@@ -25,7 +25,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	modTbl := mod.(*lua.LTable)
-	funcs := []string{"md5", "sha1", "sha256", "sha512", "fnv32", "fnv64", "hmac_sha256", "hmac_sha512", "hmac_sha1", "hmac_md5", "pbkdf2"}
+	funcs := []string{"md5", "sha1", "sha256", "sha512", "fnv32", "fnv64", "hmac_sha256", "hmac_sha512", "hmac_sha1", "hmac_md5", "pbkdf2", "new"}
 	for _, fn := range funcs {
 		if modTbl.RawGetString(fn).Type() != lua.LTFunction {
 			t.Errorf("%s function not registered", fn)

--- a/runtime/lua/modules/hash/spec.md
+++ b/runtime/lua/modules/hash/spec.md
@@ -2,7 +2,7 @@
 
 # hash
 
-Cryptographic hash functions, HMAC, and PBKDF2. Encoding, security, deterministic.
+Cryptographic hash functions, streaming hashers, HMAC, and PBKDF2. Encoding, security, deterministic.
 
 ## Loading
 
@@ -273,4 +273,52 @@ print(type(fnv))  -- "number"
 
 -- All hash functions are deterministic
 assert(hash.md5("test") == hash.md5("test"))
+```
+
+### new(algorithm: string) → Hasher, error
+
+Creates a streaming hasher, so input too large to hold in one string (a file read in chunks) digests exactly as the one-shot function would.
+
+| Param | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| algorithm | string | yes | - | `md5`, `sha1`, `sha256` or `sha512` |
+
+**Returns:**
+- Success: `Hasher`
+- Error: `nil, error` - structured error
+
+**Errors (structured):**
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| algorithm not a string | errors.INVALID | no |
+| unsupported algorithm | errors.INVALID | no |
+
+## Hasher
+
+### update(data: string) → boolean, error
+
+Appends data to the running hash.
+
+| Condition | Kind | Retryable |
+|-----------|------|-----------|
+| data not a string | errors.INVALID | no |
+
+### sum(raw?: boolean) → string, error
+
+Returns the digest of everything appended so far (hex, or raw bytes when `raw` is true) and keeps the state, so more data may follow.
+
+### reset()
+
+Discards everything appended so far.
+
+```lua
+local hasher = hash.new("sha256")
+local file = vol:open("large.bin", "r")
+while true do
+  local chunk, err = file:read(65536)
+  if not chunk then break end
+  hasher:update(chunk)
+end
+local digest = hasher:sum()
 ```

--- a/runtime/lua/modules/hash/spec.md
+++ b/runtime/lua/modules/hash/spec.md
@@ -2,7 +2,7 @@
 
 # hash
 
-Cryptographic hash functions, streaming hashers, HMAC, and PBKDF2. Encoding, security, deterministic.
+Cryptographic hash functions, HMAC, and PBKDF2. Encoding, security, deterministic.
 
 ## Loading
 
@@ -273,52 +273,4 @@ print(type(fnv))  -- "number"
 
 -- All hash functions are deterministic
 assert(hash.md5("test") == hash.md5("test"))
-```
-
-### new(algorithm: string) → Hasher, error
-
-Creates a streaming hasher, so input too large to hold in one string (a file read in chunks) digests exactly as the one-shot function would.
-
-| Param | Type | Required | Default | Notes |
-|-------|------|----------|---------|-------|
-| algorithm | string | yes | - | `md5`, `sha1`, `sha256` or `sha512` |
-
-**Returns:**
-- Success: `Hasher`
-- Error: `nil, error` - structured error
-
-**Errors (structured):**
-
-| Condition | Kind | Retryable |
-|-----------|------|-----------|
-| algorithm not a string | errors.INVALID | no |
-| unsupported algorithm | errors.INVALID | no |
-
-## Hasher
-
-### update(data: string) → boolean, error
-
-Appends data to the running hash.
-
-| Condition | Kind | Retryable |
-|-----------|------|-----------|
-| data not a string | errors.INVALID | no |
-
-### sum(raw?: boolean) → string, error
-
-Returns the digest of everything appended so far (hex, or raw bytes when `raw` is true) and keeps the state, so more data may follow.
-
-### reset()
-
-Discards everything appended so far.
-
-```lua
-local hasher = hash.new("sha256")
-local file = vol:open("large.bin", "r")
-while true do
-  local chunk, err = file:read(65536)
-  if not chunk then break end
-  hasher:update(chunk)
-end
-local digest = hasher:sum()
 ```

--- a/runtime/lua/modules/hash/stream.go
+++ b/runtime/lua/modules/hash/stream.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hash
+
+import (
+	"crypto/md5"  //nolint:gosec
+	"crypto/sha1" //nolint:gosec
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+const hasherTypeName = "hash.Hasher"
+
+// hasher accumulates input across calls so that data too large to hold in
+// one string, such as a file read in chunks, digests the same as one-shot.
+type hasher struct {
+	algorithm string
+	h         hash.Hash
+}
+
+var hasherMetatable *lua.LTable
+
+func init() {
+	hasherMetatable = value.RegisterTypeMethods(nil, hasherTypeName,
+		map[string]lua.LGoFunc{"__tostring": hasherToString},
+		map[string]lua.LGoFunc{
+			"update": hasherUpdate,
+			"sum":    hasherSum,
+			"reset":  hasherReset,
+		})
+}
+
+func newHashFunc(algorithm string) (func() hash.Hash, bool) {
+	switch algorithm {
+	case "md5":
+		return md5.New, true //nolint:gosec
+	case "sha1":
+		return sha1.New, true //nolint:gosec
+	case "sha256":
+		return sha256.New, true
+	case "sha512":
+		return sha512.New, true
+	default:
+		return nil, false
+	}
+}
+
+// hashNew creates a streaming hasher: hash.new(algorithm) -> Hasher, error
+func hashNew(l *lua.LState) int {
+	if l.Get(1).Type() != lua.LTString {
+		return invalidError(l, "algorithm must be a string")
+	}
+	algorithm := l.ToString(1)
+	constructor, ok := newHashFunc(algorithm)
+	if !ok {
+		return invalidError(l, fmt.Sprintf("unsupported hash function: %s", algorithm))
+	}
+	value.PushUserData(l, &hasher{algorithm: algorithm, h: constructor()}, hasherMetatable)
+	l.Push(lua.LNil)
+	return 2
+}
+
+func checkHasher(l *lua.LState, n int) *hasher {
+	ud := l.CheckUserData(n)
+	h, ok := ud.Value.(*hasher)
+	if !ok {
+		l.ArgError(n, "hasher expected")
+		return nil
+	}
+	return h
+}
+
+func hasherToString(l *lua.LState) int {
+	h := checkHasher(l, 1)
+	if h == nil {
+		return 0
+	}
+	l.Push(lua.LString("hash.Hasher(" + h.algorithm + ")"))
+	return 1
+}
+
+// hasherUpdate appends data: hasher:update(data) -> boolean, error
+func hasherUpdate(l *lua.LState) int {
+	h := checkHasher(l, 1)
+	if h == nil {
+		return 0
+	}
+	if l.Get(2).Type() != lua.LTString {
+		l.Push(lua.LFalse)
+		l.Push(lua.NewLuaError(l, "data must be a string").WithKind(lua.Invalid).WithRetryable(false))
+		return 2
+	}
+	h.h.Write([]byte(l.ToString(2)))
+	l.Push(lua.LTrue)
+	l.Push(lua.LNil)
+	return 2
+}
+
+// hasherSum returns the digest of everything appended so far without
+// resetting the state: hasher:sum(raw?) -> string, error
+func hasherSum(l *lua.LState) int {
+	h := checkHasher(l, 1)
+	if h == nil {
+		return 0
+	}
+	raw := l.GetTop() >= 2 && l.ToBool(2)
+	result := h.h.Sum(nil)
+	if raw {
+		l.Push(lua.LString(result))
+	} else {
+		l.Push(lua.LString(hex.EncodeToString(result)))
+	}
+	l.Push(lua.LNil)
+	return 2
+}
+
+// hasherReset discards everything appended so far: hasher:reset()
+func hasherReset(l *lua.LState) int {
+	h := checkHasher(l, 1)
+	if h == nil {
+		return 0
+	}
+	h.h.Reset()
+	return 0
+}

--- a/runtime/lua/modules/hash/stream.go
+++ b/runtime/lua/modules/hash/stream.go
@@ -20,8 +20,8 @@ const hasherTypeName = "hash.Hasher"
 // hasher accumulates input across calls so that data too large to hold in
 // one string, such as a file read in chunks, digests the same as one-shot.
 type hasher struct {
-	algorithm string
 	h         hash.Hash
+	algorithm string
 }
 
 var hasherMetatable *lua.LTable
@@ -39,9 +39,9 @@ func init() {
 func newHashFunc(algorithm string) (func() hash.Hash, bool) {
 	switch algorithm {
 	case "md5":
-		return md5.New, true //nolint:gosec
+		return md5.New, true
 	case "sha1":
-		return sha1.New, true //nolint:gosec
+		return sha1.New, true
 	case "sha256":
 		return sha256.New, true
 	case "sha512":

--- a/runtime/lua/modules/hash/stream_test.go
+++ b/runtime/lua/modules/hash/stream_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hash
+
+import (
+	"testing"
+
+	lua "github.com/wippyai/go-lua"
+)
+
+func newStreamState(t *testing.T) *lua.LState {
+	t.Helper()
+	l := lua.NewState()
+	tbl, _ := Module.Build()
+	l.SetGlobal(Module.Name, tbl)
+	return l
+}
+
+func TestStreamMatchesOneShot(t *testing.T) {
+	l := newStreamState(t)
+	defer l.Close()
+	err := l.DoString(`
+		for _, algorithm in ipairs({"md5", "sha1", "sha256", "sha512"}) do
+			local hasher, err = hash.new(algorithm)
+			if err ~= nil then error(algorithm .. ": " .. tostring(err)) end
+			assert(hasher:update("hel"))
+			assert(hasher:update(""))
+			assert(hasher:update("lo"))
+			local streamed = hasher:sum()
+			local whole = hash[algorithm]("hello")
+			if streamed ~= whole then error(algorithm .. " stream " .. streamed .. " differs from one-shot " .. whole) end
+			local raw = hasher:sum(true)
+			if #raw * 2 ~= #whole then error(algorithm .. " raw length") end
+			assert(hasher:update("!"))
+			if hasher:sum() ~= hash[algorithm]("hello!") then error(algorithm .. " sum did not keep the state") end
+			hasher:reset()
+			if hasher:sum() ~= hash[algorithm]("") then error(algorithm .. " reset did not clear the state") end
+		end
+	`)
+	if err != nil {
+		t.Fatalf("stream test failed: %v", err)
+	}
+}
+
+func TestStreamErrors(t *testing.T) {
+	l := newStreamState(t)
+	defer l.Close()
+	err := l.DoString(`
+		local hasher, err = hash.new("crc32")
+		if hasher ~= nil or err == nil then error("unsupported algorithm accepted") end
+		local _, kind_err = hash.new(42)
+		if kind_err == nil then error("non-string algorithm accepted") end
+		local sha = assert(hash.new("sha256"))
+		local ok, update_err = sha:update(7)
+		if ok or update_err == nil then error("non-string data accepted") end
+		if tostring(sha) ~= "hash.Hasher(sha256)" then error("tostring: " .. tostring(sha)) end
+	`)
+	if err != nil {
+		t.Fatalf("stream error test failed: %v", err)
+	}
+}
+
+func TestStreamLargeInput(t *testing.T) {
+	l := newStreamState(t)
+	defer l.Close()
+	err := l.DoString(`
+		local chunk = string.rep("x", 65536)
+		local hasher = assert(hash.new("sha256"))
+		for _ = 1, 64 do assert(hasher:update(chunk)) end
+		if hasher:sum() ~= hash.sha256(string.rep(chunk, 64)) then error("large stream differs from one-shot") end
+	`)
+	if err != nil {
+		t.Fatalf("large stream test failed: %v", err)
+	}
+}

--- a/runtime/lua/modules/hash/types.go
+++ b/runtime/lua/modules/hash/types.go
@@ -23,6 +23,15 @@ func ModuleTypes() *io.Manifest {
 	// pbkdf2 function type: (password: string, salt: string, iterations: number, key_length: number, algo?: string): string, Error?
 	pbkdf2Fn := typ.Func().Param("password", typ.String).Param("salt", typ.String).Param("iterations", typ.Number).Param("key_length", typ.Number).OptParam("algo", typ.String).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()
 
+	// streaming hasher: hash.new(algorithm: string): Hasher, Error?
+	hasherType := typ.NewInterface("hash.Hasher", []typ.Method{
+		{Name: "update", Type: typ.Func().Param("self", typ.Self).Param("data", typ.String).Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "sum", Type: typ.Func().Param("self", typ.Self).OptParam("raw", typ.Boolean).Returns(typ.String, typ.NewOptional(typ.LuaError)).Build()},
+		{Name: "reset", Type: typ.Func().Param("self", typ.Self).Build()},
+	})
+	m.DefineType("Hasher", hasherType)
+	newFn := typ.Func().Param("algorithm", typ.String).Returns(hasherType, typ.NewOptional(typ.LuaError)).Build()
+
 	moduleType := typ.NewInterface("hash", []typ.Method{
 		{Name: "md5", Type: hashFn},
 		{Name: "sha1", Type: hashFn},
@@ -35,6 +44,7 @@ func ModuleTypes() *io.Manifest {
 		{Name: "hmac_sha1", Type: hmacFn},
 		{Name: "hmac_md5", Type: hmacFn},
 		{Name: "pbkdf2", Type: pbkdf2Fn},
+		{Name: "new", Type: newFn},
 	})
 
 	m.SetExport(moduleType)


### PR DESCRIPTION
Adds `hash.new(algorithm)` returning a `hash.Hasher` userdata with `update(data)`, `sum(raw?)`, and `reset()`. Chunked input produces the same digest as the one-shot helpers without retaining the full payload in one Lua string.

Supported algorithms: MD5, SHA-1, SHA-256, and SHA-512. `sum` does not reset the state, so callers can continue updating. Invalid algorithms and non-string input return structured `INVALID` errors. The Lua type manifest exposes the new API.

Regression coverage verifies every supported algorithm, empty chunks, raw and hexadecimal output, non-destructive sums, continued updates, reset, invalid inputs, and a 4 MiB chunked payload. Focused normal and race tests pass, and hosted lint, CodeQL, Linux, Windows, native-app, and integration gates are green.

This enables host-side streaming measurement of large executable payloads before launch.