### PR TITLE
feat(fs): read-only directory volumes (readonly option)

### DIFF
--- a/api/fs/errors.go
+++ b/api/fs/errors.go
@@ -2,11 +2,14 @@
 
 package fs
 
-import "errors"
+import (
+	"errors"
+	"syscall"
+)
 
 var (
 	ErrClosed           = errors.New("filesystem is closed")
 	ErrPermissionDenied = errors.New("permission denied")
-	ErrReadOnly         = errors.New("filesystem is read-only")
+	ErrReadOnly         = error(syscall.EROFS)
 	ErrInvalidFileMode  = errors.New("invalid file mode: contains bits outside of fs.ModePerm")
 )

--- a/api/fs/errors.go
+++ b/api/fs/errors.go
@@ -7,5 +7,6 @@ import "errors"
 var (
 	ErrClosed           = errors.New("filesystem is closed")
 	ErrPermissionDenied = errors.New("permission denied")
+	ErrReadOnly         = errors.New("filesystem is read-only")
 	ErrInvalidFileMode  = errors.New("invalid file mode: contains bits outside of fs.ModePerm")
 )

--- a/api/fs/errors_test.go
+++ b/api/fs/errors_test.go
@@ -3,6 +3,7 @@
 package fs
 
 import (
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,10 @@ func TestSentinelErrors(t *testing.T) {
 
 	t.Run("ErrPermissionDenied", func(t *testing.T) {
 		assert.Equal(t, "permission denied", ErrPermissionDenied.Error())
+	})
+
+	t.Run("ErrReadOnly", func(t *testing.T) {
+		assert.ErrorIs(t, ErrReadOnly, syscall.EROFS)
 	})
 
 	t.Run("ErrInvalidFileMode", func(t *testing.T) {

--- a/api/fs/readonly.go
+++ b/api/fs/readonly.go
@@ -3,6 +3,7 @@
 package fs
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"time"
@@ -11,28 +12,37 @@ import (
 var _ FS = (*ReadOnlyFS)(nil)
 
 // ReadOnlyFS adapts an fs.ReadDirFS to the FS interface.
-// All write operations return fs.ErrPermission.
+// All write operations return ErrReadOnly.
 type ReadOnlyFS struct {
-	fs.ReadDirFS
+	fsys fs.ReadDirFS
 }
 
 // NewReadOnlyFS creates a read-only filesystem adapter.
 func NewReadOnlyFS(fsys fs.ReadDirFS) *ReadOnlyFS {
-	return &ReadOnlyFS{ReadDirFS: fsys}
+	return &ReadOnlyFS{fsys: fsys}
+}
+
+// Open opens a file for reading.
+func (r *ReadOnlyFS) Open(name string) (fs.File, error) {
+	file, err := r.fsys.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &readOnlyFile{File: file}, nil
 }
 
 // OpenFile implements WriteFS.OpenFile for read-only access.
-// Returns fs.ErrPermission for write modes.
+// Returns ErrReadOnly for write modes.
 func (r *ReadOnlyFS) OpenFile(name string, flag int, _ fs.FileMode) (File, error) {
 	if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
 		return nil, &fs.PathError{
 			Op:   "open",
 			Path: name,
-			Err:  fs.ErrPermission,
+			Err:  ErrReadOnly,
 		}
 	}
 
-	file, err := r.Open(name)
+	file, err := r.fsys.Open(name)
 	if err != nil {
 		return nil, err
 	}
@@ -41,28 +51,33 @@ func (r *ReadOnlyFS) OpenFile(name string, flag int, _ fs.FileMode) (File, error
 }
 
 // Remove implements WriteFS.Remove.
-// Always returns fs.ErrPermission.
+// Always returns ErrReadOnly.
 func (r *ReadOnlyFS) Remove(name string) error {
 	return &fs.PathError{
 		Op:   "remove",
 		Path: name,
-		Err:  fs.ErrPermission,
+		Err:  ErrReadOnly,
 	}
 }
 
 // Mkdir implements WriteFS.Mkdir.
-// Always returns fs.ErrPermission.
+// Always returns ErrReadOnly.
 func (r *ReadOnlyFS) Mkdir(name string, _ fs.FileMode) error {
 	return &fs.PathError{
 		Op:   "mkdir",
 		Path: name,
-		Err:  fs.ErrPermission,
+		Err:  ErrReadOnly,
 	}
+}
+
+// ReadDir reads a directory.
+func (r *ReadOnlyFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return r.fsys.ReadDir(name)
 }
 
 // Stat implements ReadFS.Stat.
 func (r *ReadOnlyFS) Stat(name string) (fs.FileInfo, error) {
-	if statFS, ok := r.ReadDirFS.(fs.StatFS); ok {
+	if statFS, ok := r.fsys.(fs.StatFS); ok {
 		return statFS.Stat(name)
 	}
 	file, err := r.Open(name)
@@ -79,40 +94,48 @@ func (r *ReadOnlyFS) Lstat(name string) (fs.FileInfo, error) {
 	type lstater interface {
 		Lstat(name string) (fs.FileInfo, error)
 	}
-	if ls, ok := r.ReadDirFS.(lstater); ok {
+	if ls, ok := r.fsys.(lstater); ok {
 		return ls.Lstat(name)
 	}
 	return r.Stat(name)
 }
 
 // Rename implements WriteFS.Rename.
-// Always returns fs.ErrPermission.
+// Always returns ErrReadOnly.
 func (r *ReadOnlyFS) Rename(oldname, _ string) error {
 	return &fs.PathError{
 		Op:   "rename",
 		Path: oldname,
-		Err:  fs.ErrPermission,
+		Err:  ErrReadOnly,
 	}
 }
 
 // Truncate implements WriteFS.Truncate.
-// Always returns fs.ErrPermission.
+// Always returns ErrReadOnly.
 func (r *ReadOnlyFS) Truncate(name string, _ int64) error {
 	return &fs.PathError{
 		Op:   "truncate",
 		Path: name,
-		Err:  fs.ErrPermission,
+		Err:  ErrReadOnly,
 	}
 }
 
 // Chtimes implements WriteFS.Chtimes.
-// Always returns fs.ErrPermission.
+// Always returns ErrReadOnly.
 func (r *ReadOnlyFS) Chtimes(name string, _, _ time.Time) error {
 	return &fs.PathError{
 		Op:   "chtimes",
 		Path: name,
-		Err:  fs.ErrPermission,
+		Err:  ErrReadOnly,
 	}
+}
+
+// Close closes the underlying filesystem when it owns resources.
+func (r *ReadOnlyFS) Close() error {
+	if closer, ok := r.fsys.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
 }
 
 // readOnlyFile wraps an fs.File to block write operations.
@@ -120,17 +143,30 @@ type readOnlyFile struct {
 	fs.File
 }
 
-// Write returns fs.ErrPermission.
+// Write returns ErrReadOnly.
 func (f *readOnlyFile) Write([]byte) (int, error) {
-	return 0, fs.ErrPermission
+	return 0, ErrReadOnly
 }
 
-// Seek returns fs.ErrPermission (not supported on read-only files).
-func (f *readOnlyFile) Seek(int64, int) (int64, error) {
-	return 0, fs.ErrPermission
+// Seek changes the read offset.
+func (f *readOnlyFile) Seek(offset int64, whence int) (int64, error) {
+	seeker, ok := f.File.(io.Seeker)
+	if !ok {
+		return 0, fs.ErrInvalid
+	}
+	return seeker.Seek(offset, whence)
 }
 
 // Sync is a no-op for read-only files.
 func (f *readOnlyFile) Sync() error {
 	return nil
+}
+
+// ReadDir reads directory entries.
+func (f *readOnlyFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	dir, ok := f.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, fs.ErrInvalid
+	}
+	return dir.ReadDir(n)
 }

--- a/api/fs/readonly_test.go
+++ b/api/fs/readonly_test.go
@@ -5,12 +5,33 @@ package fs
 import (
 	"errors"
 	"io"
-	"io/fs"
+	iofs "io/fs"
 	"os"
+	"reflect"
 	"testing"
 	"testing/fstest"
 	"time"
 )
+
+type basicFile struct {
+	file iofs.File
+}
+
+func (f *basicFile) Read(p []byte) (int, error)   { return f.file.Read(p) }
+func (f *basicFile) Close() error                 { return f.file.Close() }
+func (f *basicFile) Stat() (iofs.FileInfo, error) { return f.file.Stat() }
+
+type basicFS struct {
+	iofs.ReadDirFS
+}
+
+func (f basicFS) Open(name string) (iofs.File, error) {
+	file, err := f.ReadDirFS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &basicFile{file: file}, nil
+}
 
 func TestReadOnlyFS_Open(t *testing.T) {
 	testFS := fstest.MapFS{
@@ -73,6 +94,16 @@ func TestReadOnlyFS_Open(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReadOnlyFS_DoesNotExposeUnderlyingFilesystem(t *testing.T) {
+	typeOfReadOnlyFS := reflect.TypeOf(ReadOnlyFS{})
+	for index := 0; index < typeOfReadOnlyFS.NumField(); index++ {
+		field := typeOfReadOnlyFS.Field(index)
+		if field.IsExported() {
+			t.Fatalf("ReadOnlyFS exposes field %q", field.Name)
+		}
 	}
 }
 
@@ -206,8 +237,8 @@ func TestReadOnlyFS_OpenFile(t *testing.T) {
 		if err == nil {
 			t.Error("OpenFile() with O_WRONLY should fail")
 		}
-		if !errors.Is(err, fs.ErrPermission) {
-			t.Errorf("Expected fs.ErrPermission, got %v", err)
+		if !errors.Is(err, ErrReadOnly) {
+			t.Errorf("Expected ErrReadOnly, got %v", err)
 		}
 	})
 
@@ -253,18 +284,18 @@ func TestReadOnlyFS_FileOperations(t *testing.T) {
 		if err == nil {
 			t.Error("Write() should fail on read-only file")
 		}
-		if !errors.Is(err, fs.ErrPermission) {
-			t.Errorf("Expected fs.ErrPermission, got %v", err)
+		if !errors.Is(err, ErrReadOnly) {
+			t.Errorf("Expected ErrReadOnly, got %v", err)
 		}
 	})
 
-	t.Run("Seek fails", func(t *testing.T) {
-		_, err := file.Seek(0, 0)
-		if err == nil {
-			t.Error("Seek() should fail on read-only file")
+	t.Run("Seek succeeds", func(t *testing.T) {
+		position, err := file.Seek(3, io.SeekStart)
+		if err != nil {
+			t.Fatalf("Seek() error = %v", err)
 		}
-		if !errors.Is(err, fs.ErrPermission) {
-			t.Errorf("Expected fs.ErrPermission, got %v", err)
+		if position != 3 {
+			t.Fatalf("Seek() position = %d, want 3", position)
 		}
 	})
 
@@ -276,6 +307,28 @@ func TestReadOnlyFS_FileOperations(t *testing.T) {
 	})
 }
 
+func TestReadOnlyFS_UnsupportedOptionalFileOperations(t *testing.T) {
+	readOnlyFS := NewReadOnlyFS(basicFS{ReadDirFS: fstest.MapFS{
+		"file.txt": {Data: []byte("data")},
+	}})
+	file, err := readOnlyFS.OpenFile("file.txt", os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if _, err := file.Seek(0, io.SeekStart); !errors.Is(err, iofs.ErrInvalid) {
+		t.Fatalf("Seek() error = %v, want fs.ErrInvalid", err)
+	}
+	directoryFile, ok := file.(iofs.ReadDirFile)
+	if !ok {
+		t.Fatal("OpenFile() result does not implement fs.ReadDirFile")
+	}
+	if _, err := directoryFile.ReadDir(-1); !errors.Is(err, iofs.ErrInvalid) {
+		t.Fatalf("ReadDir() error = %v, want fs.ErrInvalid", err)
+	}
+}
+
 func TestReadOnlyFS_UnsupportedOperations(t *testing.T) {
 	testFS := fstest.MapFS{}
 	readOnlyFS := NewReadOnlyFS(testFS)
@@ -285,8 +338,8 @@ func TestReadOnlyFS_UnsupportedOperations(t *testing.T) {
 		if err == nil {
 			t.Error("Remove() should fail")
 		}
-		if !errors.Is(err, fs.ErrPermission) {
-			t.Errorf("Expected fs.ErrPermission, got %v", err)
+		if !errors.Is(err, ErrReadOnly) {
+			t.Errorf("Expected ErrReadOnly, got %v", err)
 		}
 	})
 
@@ -295,8 +348,8 @@ func TestReadOnlyFS_UnsupportedOperations(t *testing.T) {
 		if err == nil {
 			t.Error("Mkdir() should fail")
 		}
-		if !errors.Is(err, fs.ErrPermission) {
-			t.Errorf("Expected fs.ErrPermission, got %v", err)
+		if !errors.Is(err, ErrReadOnly) {
+			t.Errorf("Expected ErrReadOnly, got %v", err)
 		}
 	})
 }

--- a/api/service/fs/directory/config.go
+++ b/api/service/fs/directory/config.go
@@ -21,6 +21,10 @@ type Config struct {
 	Base       string `json:"base"`
 	parsedMode fs.FileMode
 	AutoInit   bool `json:"auto_init"`
+	// ReadOnly refuses every mutation at the filesystem boundary, whatever
+	// the mode says: no writable open, creation, truncation, removal,
+	// rename, directory creation or metadata change goes through.
+	ReadOnly bool `json:"readonly"`
 }
 
 const (
@@ -46,6 +50,10 @@ func (c *Config) Validate() error {
 
 	if c.Base != "" && c.Base != BaseProject && c.Base != BaseModule {
 		return NewInvalidBaseError(c.Base)
+	}
+
+	if c.ReadOnly && c.AutoInit {
+		return ErrReadOnlyAutoInit
 	}
 
 	if c.Mode != "" {

--- a/api/service/fs/directory/config_test.go
+++ b/api/service/fs/directory/config_test.go
@@ -53,6 +53,7 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 			config: Config{
 				Directory: "/usr/share",
 				Mode:      "0444",
+				ReadOnly:  true,
 			},
 			wantErr: false,
 		},
@@ -75,6 +76,7 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 			assert.Equal(t, tt.config.Mode, decoded.Mode)
 			assert.Equal(t, tt.config.Type, decoded.Type)
 			assert.Equal(t, tt.config.Base, decoded.Base)
+			assert.Equal(t, tt.config.ReadOnly, decoded.ReadOnly)
 		})
 	}
 }

--- a/api/service/fs/directory/config_test.go
+++ b/api/service/fs/directory/config_test.go
@@ -79,6 +79,16 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 	}
 }
 
+func TestConfig_ReadOnly(t *testing.T) {
+	decoded := Config{}
+	require.NoError(t, json.Unmarshal([]byte(`{"directory": "/var/data", "readonly": true}`), &decoded))
+	assert.True(t, decoded.ReadOnly)
+	require.NoError(t, decoded.Validate())
+
+	conflict := Config{Directory: "/var/data", ReadOnly: true, AutoInit: true}
+	assert.ErrorIs(t, conflict.Validate(), ErrReadOnlyAutoInit)
+}
+
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/api/service/fs/directory/errors.go
+++ b/api/service/fs/directory/errors.go
@@ -10,6 +10,9 @@ import (
 // ErrEmptyDirectoryPath indicates a missing directory path.
 var ErrEmptyDirectoryPath = apierror.New(apierror.Invalid, "directory path is required").WithRetryable(apierror.False)
 
+// ErrReadOnlyAutoInit indicates a read-only volume asked to create its own root.
+var ErrReadOnlyAutoInit = apierror.New(apierror.Invalid, "a read-only directory cannot auto_init").WithRetryable(apierror.False)
+
 // NewInvalidModeFormatError reports invalid file mode formatting.
 func NewInvalidModeFormatError(cause error) apierror.Error {
 	return apierror.New(apierror.Invalid, "invalid file mode format").WithCause(cause).WithRetryable(apierror.False)

--- a/runtime/lua/modules/fs/file.go
+++ b/runtime/lua/modules/fs/file.go
@@ -173,7 +173,7 @@ func fileRead(l *lua.LState) int {
 			return 2
 		}
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "read failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "read failed", lua.Internal))
 		return 2
 	}
 
@@ -197,7 +197,7 @@ func fileWrite(l *lua.LState) int {
 	_, err := f.Write([]byte(data))
 	if err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "write failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "write failed", lua.Internal))
 		return 2
 	}
 
@@ -231,7 +231,7 @@ func fileSeek(l *lua.LState) int {
 	pos, err := f.Seek(offset, w)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "seek failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "seek failed", lua.Internal))
 		return 2
 	}
 
@@ -248,7 +248,7 @@ func fileClose(l *lua.LState) int {
 	err := f.Close()
 	if err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "close failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "close failed", lua.Internal))
 		return 2
 	}
 	l.Push(lua.LTrue)
@@ -264,7 +264,7 @@ func fileStat(l *lua.LState) int {
 	info, err := f.Stat()
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "stat failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "stat failed", lua.Internal))
 		return 2
 	}
 	l.Push(pushFileInfo(l, info))
@@ -280,7 +280,7 @@ func fileSync(l *lua.LState) int {
 	err := f.Sync()
 	if err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "sync failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "sync failed", lua.Internal))
 		return 2
 	}
 	l.Push(lua.LTrue)

--- a/runtime/lua/modules/fs/fs.go
+++ b/runtime/lua/modules/fs/fs.go
@@ -3,8 +3,10 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"os"
 	"path"
 	"strings"
@@ -18,6 +20,16 @@ import (
 type FS struct {
 	fs  fsapi.FS
 	cwd string
+}
+
+func wrapFilesystemError(l *lua.LState, err error, message string, fallback lua.Kind) *lua.Error {
+	kind := fallback
+	if errors.Is(err, fsapi.ErrReadOnly) ||
+		errors.Is(err, fsapi.ErrPermissionDenied) ||
+		errors.Is(err, iofs.ErrPermission) {
+		kind = lua.PermissionDenied
+	}
+	return lua.WrapErrorWithLua(l, err, message).WithKind(kind)
 }
 
 // dirIterator is a userdata-based iterator for directory entries
@@ -96,7 +108,7 @@ func fsChdir(l *lua.LState) int {
 	info, err := fs.fs.Stat(target)
 	if err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "failed to stat directory").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "failed to stat directory", lua.NotFound))
 		return 2
 	}
 	if !info.IsDir() {
@@ -168,7 +180,7 @@ func fsOpen(l *lua.LState) int {
 	file, err := fs.fs.OpenFile(resolved, flag, 0644)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "failed to open file").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "failed to open file", lua.NotFound))
 		return 2
 	}
 
@@ -197,7 +209,7 @@ func fsStat(l *lua.LState) int {
 	info, err := fs.fs.Stat(resolved)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "stat failed").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "stat failed", lua.NotFound))
 		return 2
 	}
 	l.Push(pushFileInfo(l, info))
@@ -230,7 +242,7 @@ func fsMkdir(l *lua.LState) int {
 	}
 	if err := fs.fs.Mkdir(resolved, 0755); err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "mkdir failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "mkdir failed", lua.Internal))
 		return 2
 	}
 	l.Push(lua.LTrue)
@@ -266,7 +278,7 @@ func fsRemove(l *lua.LState) int {
 	}
 	if err := fs.fs.Remove(resolved); err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "remove failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "remove failed", lua.Internal))
 		return 2
 	}
 	l.Push(lua.LTrue)
@@ -294,7 +306,7 @@ func fsReaddir(l *lua.LState) int {
 	info, err := fs.fs.Stat(resolved)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "failed to stat directory").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "failed to stat directory", lua.NotFound))
 		return 2
 	}
 	if !info.IsDir() {
@@ -305,7 +317,7 @@ func fsReaddir(l *lua.LState) int {
 	entries, err := fs.fs.ReadDir(resolved)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "readdir failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "readdir failed", lua.Internal))
 		return 2
 	}
 
@@ -380,7 +392,7 @@ func fsIsdir(l *lua.LState) int {
 	info, err := fs.fs.Stat(resolved)
 	if err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "stat failed").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "stat failed", lua.NotFound))
 		return 2
 	}
 	l.Push(lua.LBool(info.IsDir()))
@@ -408,7 +420,7 @@ func fsReadfile(l *lua.LState) int {
 	file, err := fs.fs.OpenFile(resolved, os.O_RDONLY, 0)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "failed to open file").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "failed to open file", lua.NotFound))
 		return 2
 	}
 	defer func() { _ = file.Close() }()
@@ -416,7 +428,7 @@ func fsReadfile(l *lua.LState) int {
 	data, err := io.ReadAll(file)
 	if err != nil {
 		l.Push(lua.LNil)
-		l.Push(lua.WrapErrorWithLua(l, err, "failed to read file").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "failed to read file", lua.Internal))
 		return 2
 	}
 
@@ -466,7 +478,7 @@ func fsWritefile(l *lua.LState) int {
 	dstFile, err := fs.fs.OpenFile(resolved, flag, 0644)
 	if err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "failed to open destination").WithKind(lua.NotFound))
+		l.Push(wrapFilesystemError(l, err, "failed to open destination", lua.NotFound))
 		return 2
 	}
 	defer func() { _ = dstFile.Close() }()
@@ -499,7 +511,7 @@ func fsWritefile(l *lua.LState) int {
 
 	if _, err := io.Copy(dstFile, reader); err != nil {
 		l.Push(lua.LFalse)
-		l.Push(lua.WrapErrorWithLua(l, err, "copy failed").WithKind(lua.Internal))
+		l.Push(wrapFilesystemError(l, err, "copy failed", lua.Internal))
 		return 2
 	}
 

--- a/runtime/lua/modules/fs/fs_test.go
+++ b/runtime/lua/modules/fs/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	ctxapi "github.com/wippyai/runtime/api/context"
+	fsapi "github.com/wippyai/runtime/api/fs"
 	"github.com/wippyai/runtime/api/runtime/resource"
 	"github.com/wippyai/runtime/runtime/lua/modules/stream"
 	"github.com/wippyai/runtime/service/fs/directory"
@@ -255,6 +256,68 @@ func TestFSStructuredErrors(t *testing.T) {
 				luaErr := requireLuaError(t, l.Get(-1))
 				assert.Equal(t, tt.checkKind, string(luaErr.Kind()), "error kind should match")
 			}
+		})
+	}
+}
+
+func TestFSReadOnlyErrorsArePermissionDenied(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(tmpDir+"/file.txt", []byte("data"), 0600))
+	base, err := directory.NewFS(tmpDir, 0755, false)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, base.Close()) }()
+	filesystem := NewFS(fsapi.NewReadOnlyFS(base), "")
+
+	tests := []struct {
+		fn    func(*lua.LState) int
+		setup func(*lua.LState)
+		name  string
+	}{
+		{
+			name: "open",
+			fn:   fsOpen,
+			setup: func(l *lua.LState) {
+				l.SetContext(t.Context())
+				l.Push(lua.LString("file.txt"))
+				l.Push(lua.LString("w"))
+			},
+		},
+		{
+			name: "mkdir",
+			fn:   fsMkdir,
+			setup: func(l *lua.LState) {
+				l.Push(lua.LString("newdir"))
+			},
+		},
+		{
+			name: "remove",
+			fn:   fsRemove,
+			setup: func(l *lua.LState) {
+				l.Push(lua.LString("file.txt"))
+			},
+		},
+		{
+			name: "writefile",
+			fn:   fsWritefile,
+			setup: func(l *lua.LState) {
+				l.Push(lua.LString("file.txt"))
+				l.Push(lua.LString("changed"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := lua.NewState()
+			defer l.Close()
+			ud := l.NewUserData()
+			ud.Value = filesystem
+			l.Push(ud)
+			tt.setup(l)
+			require.Equal(t, 2, tt.fn(l))
+			luaErr := requireLuaError(t, l.Get(-1))
+			assert.Equal(t, lua.PermissionDenied, luaErr.Kind())
+			assert.Contains(t, luaErr.Error(), fsapi.ErrReadOnly.Error())
 		})
 	}
 }

--- a/runtime/wasm/engine/process_wasi_test.go
+++ b/runtime/wasm/engine/process_wasi_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ctxapi "github.com/wippyai/runtime/api/context"
 	envapi "github.com/wippyai/runtime/api/env"
 	fsapi "github.com/wippyai/runtime/api/fs"
@@ -70,6 +72,13 @@ func (r *testFSRegistry) GetFS(name string) (fsapi.FS, bool) {
 	fs, ok := r.entries[name]
 	return fs, ok
 }
+
+type testHostPathFS struct {
+	fsapi.FS
+	root string
+}
+
+func (f *testHostPathFS) RootPath() string { return f.root }
 
 func TestResolveWASICallConfig_Empty(t *testing.T) {
 	p := &Process{}
@@ -144,6 +153,52 @@ func TestResolveWASICallConfig_ResolvesEnvAndMounts(t *testing.T) {
 	if cfg.Mounts[0].Filesystem != mockFS {
 		t.Fatal("cfg.Mounts[0].Filesystem does not match expected FS instance")
 	}
+}
+
+func TestResolveWASICallConfig_ReadOnlyFilesystemHidesHostPath(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	secapi.SetStrictMode(ctx, false)
+	base := &testHostPathFS{
+		FS:   fsapi.NewReadOnlyFS(fstest.MapFS{}),
+		root: t.TempDir(),
+	}
+	readOnly := fsapi.NewReadOnlyFS(base)
+	p := &Process{
+		wasi: wasmapi.WASIConfig{Mounts: []wasmapi.WASIMountConfig{{
+			FS:       registry.ParseID("app.fs:data"),
+			Guest:    "/data",
+			ReadOnly: false,
+		}}},
+		fsReg: &testFSRegistry{entries: map[string]fsapi.FS{"app.fs:data": readOnly}},
+	}
+
+	cfg, err := p.resolveWASICallConfig(ctx)
+	require.NoError(t, err)
+	require.Len(t, cfg.Mounts, 1)
+	assert.Empty(t, cfg.Mounts[0].Host)
+	assert.Same(t, readOnly, cfg.Mounts[0].Filesystem)
+}
+
+func TestResolveWASICallConfig_WritableFilesystemUsesHostPath(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	secapi.SetStrictMode(ctx, false)
+	hostPath := t.TempDir()
+	writable := &testHostPathFS{
+		FS:   fsapi.NewReadOnlyFS(fstest.MapFS{}),
+		root: hostPath,
+	}
+	p := &Process{
+		wasi: wasmapi.WASIConfig{Mounts: []wasmapi.WASIMountConfig{{
+			FS:    registry.ParseID("app.fs:data"),
+			Guest: "/data",
+		}}},
+		fsReg: &testFSRegistry{entries: map[string]fsapi.FS{"app.fs:data": writable}},
+	}
+
+	cfg, err := p.resolveWASICallConfig(ctx)
+	require.NoError(t, err)
+	require.Len(t, cfg.Mounts, 1)
+	assert.Equal(t, hostPath, cfg.Mounts[0].Host)
 }
 
 func TestResolveWASICallConfig_RequiredEnvMissing(t *testing.T) {

--- a/runtime/wasm/host/wippy/hosts/filesystem/types_test.go
+++ b/runtime/wasm/host/wippy/hosts/filesystem/types_test.go
@@ -187,3 +187,10 @@ func TestR11RenameRejectsReadonlyDestination(t *testing.T) {
 		t.Fatalf("source missing after rejected rename: %v", statErr)
 	}
 }
+
+func TestMapOSErrorReadOnly(t *testing.T) {
+	got := mapOSError(&fs.PathError{Op: "open", Path: "item", Err: fsapi.ErrReadOnly})
+	if got == nil || got.Code != ErrorReadOnly {
+		t.Fatalf("mapOSError() = %#v, want read-only", got)
+	}
+}

--- a/service/fs/directory/factory.go
+++ b/service/fs/directory/factory.go
@@ -13,6 +13,7 @@ type CreateFSConfig struct {
 	DirPath  string
 	Mode     fs.FileMode
 	AutoInit bool
+	ReadOnly bool
 }
 
 // FactoryAPI defines the interface for creating filesystem instances.
@@ -31,5 +32,8 @@ func NewFactory() *Factory {
 
 // CreateFS creates a new directory filesystem.
 func (f *Factory) CreateFS(cfg CreateFSConfig) (fsapi.FS, error) {
+	if cfg.ReadOnly {
+		return NewReadOnlyFS(cfg.DirPath, cfg.Mode)
+	}
 	return NewFS(cfg.DirPath, cfg.Mode, cfg.AutoInit)
 }

--- a/service/fs/directory/factory.go
+++ b/service/fs/directory/factory.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 
 	fsapi "github.com/wippyai/runtime/api/fs"
+	dirapi "github.com/wippyai/runtime/api/service/fs/directory"
 )
 
 // CreateFSConfig is a config for CreateFS.
@@ -32,8 +33,16 @@ func NewFactory() *Factory {
 
 // CreateFS creates a new directory filesystem.
 func (f *Factory) CreateFS(cfg CreateFSConfig) (fsapi.FS, error) {
-	if cfg.ReadOnly {
-		return NewReadOnlyFS(cfg.DirPath, cfg.Mode)
+	if cfg.ReadOnly && cfg.AutoInit {
+		return nil, dirapi.ErrReadOnlyAutoInit
 	}
-	return NewFS(cfg.DirPath, cfg.Mode, cfg.AutoInit)
+
+	filesystem, err := NewFS(cfg.DirPath, cfg.Mode, cfg.AutoInit)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.ReadOnly {
+		return fsapi.NewReadOnlyFS(filesystem), nil
+	}
+	return filesystem, nil
 }

--- a/service/fs/directory/fs.go
+++ b/service/fs/directory/fs.go
@@ -26,16 +26,10 @@ const (
 
 // FS implements both ReadFS and WriteFS interfaces.
 type FS struct {
-	root     *os.Root
-	dirPath  string // original path for error messages
-	mode     fs.FileMode
-	readOnly bool
-	closed   atomic.Bool
-}
-
-// ReadOnly reports whether every mutation is refused at the boundary.
-func (d *FS) ReadOnly() bool {
-	return d.readOnly
+	root    *os.Root
+	dirPath string // original path for error messages
+	mode    fs.FileMode
+	closed  atomic.Bool
 }
 
 // RootPath returns the absolute host path backing this filesystem.
@@ -46,18 +40,6 @@ func (d *FS) RootPath() string {
 // NewFS creates a new FS instance. It automatically adds execute bits
 // if the read bits are set but the execute bits are missing.
 func NewFS(dirPath string, mode fs.FileMode, autoInit bool) (*FS, error) {
-	return newFS(dirPath, mode, autoInit, false)
-}
-
-// NewReadOnlyFS creates an FS that refuses every mutation at the boundary:
-// writable or creating opens, truncation, removal, rename, directory
-// creation and metadata changes fail with ErrReadOnly whatever the mode
-// says, and handles it hands out are read-only. It never creates its root.
-func NewReadOnlyFS(dirPath string, mode fs.FileMode) (*FS, error) {
-	return newFS(dirPath, mode, false, true)
-}
-
-func newFS(dirPath string, mode fs.FileMode, autoInit bool, readOnly bool) (*FS, error) {
 	absPath, err := filepath.Abs(dirPath)
 	if err != nil {
 		return nil, systemfs.NewInvalidPathError(err)
@@ -80,10 +62,9 @@ func newFS(dirPath string, mode fs.FileMode, autoInit bool, readOnly bool) (*FS,
 	}
 
 	return &FS{
-		root:     root,
-		dirPath:  absPath,
-		mode:     mode,
-		readOnly: readOnly,
+		root:    root,
+		dirPath: absPath,
+		mode:    mode,
 	}, nil
 }
 
@@ -108,14 +89,6 @@ func (d *FS) checkPermissions(op, displayPath string, check permCheck) error {
 			Op:   op,
 			Path: displayPath,
 			Err:  fsapi.ErrClosed,
-		}
-	}
-
-	if d.readOnly && check&permWrite != 0 {
-		return &fs.PathError{
-			Op:   op,
-			Path: displayPath,
-			Err:  fsapi.ErrReadOnly,
 		}
 	}
 

--- a/service/fs/directory/fs.go
+++ b/service/fs/directory/fs.go
@@ -26,10 +26,16 @@ const (
 
 // FS implements both ReadFS and WriteFS interfaces.
 type FS struct {
-	root    *os.Root
-	dirPath string // original path for error messages
-	mode    fs.FileMode
-	closed  atomic.Bool
+	root     *os.Root
+	dirPath  string // original path for error messages
+	mode     fs.FileMode
+	readOnly bool
+	closed   atomic.Bool
+}
+
+// ReadOnly reports whether every mutation is refused at the boundary.
+func (d *FS) ReadOnly() bool {
+	return d.readOnly
 }
 
 // RootPath returns the absolute host path backing this filesystem.
@@ -40,6 +46,18 @@ func (d *FS) RootPath() string {
 // NewFS creates a new FS instance. It automatically adds execute bits
 // if the read bits are set but the execute bits are missing.
 func NewFS(dirPath string, mode fs.FileMode, autoInit bool) (*FS, error) {
+	return newFS(dirPath, mode, autoInit, false)
+}
+
+// NewReadOnlyFS creates an FS that refuses every mutation at the boundary:
+// writable or creating opens, truncation, removal, rename, directory
+// creation and metadata changes fail with ErrReadOnly whatever the mode
+// says, and handles it hands out are read-only. It never creates its root.
+func NewReadOnlyFS(dirPath string, mode fs.FileMode) (*FS, error) {
+	return newFS(dirPath, mode, false, true)
+}
+
+func newFS(dirPath string, mode fs.FileMode, autoInit bool, readOnly bool) (*FS, error) {
 	absPath, err := filepath.Abs(dirPath)
 	if err != nil {
 		return nil, systemfs.NewInvalidPathError(err)
@@ -62,9 +80,10 @@ func NewFS(dirPath string, mode fs.FileMode, autoInit bool) (*FS, error) {
 	}
 
 	return &FS{
-		root:    root,
-		dirPath: absPath,
-		mode:    mode,
+		root:     root,
+		dirPath:  absPath,
+		mode:     mode,
+		readOnly: readOnly,
 	}, nil
 }
 
@@ -89,6 +108,14 @@ func (d *FS) checkPermissions(op, displayPath string, check permCheck) error {
 			Op:   op,
 			Path: displayPath,
 			Err:  fsapi.ErrClosed,
+		}
+	}
+
+	if d.readOnly && check&permWrite != 0 {
+		return &fs.PathError{
+			Op:   op,
+			Path: displayPath,
+			Err:  fsapi.ErrReadOnly,
 		}
 	}
 
@@ -163,8 +190,9 @@ func (d *FS) OpenFile(name string, flag int, perm fs.FileMode) (fsapi.File, erro
 		}
 	}
 
-	// Check permissions based on flags.
-	if flag&(os.O_WRONLY|os.O_RDWR) != 0 {
+	// Check permissions based on flags. Creating, truncating or appending
+	// mutates as much as writing does.
+	if flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_APPEND) != 0 {
 		if err := d.checkPermissions("open", displayName, permWrite); err != nil {
 			return nil, err
 		}

--- a/service/fs/directory/manager.go
+++ b/service/fs/directory/manager.go
@@ -146,6 +146,7 @@ func (m *Manager) registerFSLocked(ctx context.Context, entry registry.Entry, cf
 		DirPath:  dirPath,
 		Mode:     cfg.GetMode(),
 		AutoInit: cfg.AutoInit,
+		ReadOnly: cfg.ReadOnly,
 	})
 	if err != nil {
 		m.log.Error("failed to create filesystem instance",

--- a/service/fs/directory/manager_test.go
+++ b/service/fs/directory/manager_test.go
@@ -632,6 +632,35 @@ func TestManager_AddResolvesModuleRelativePathWhenBaseOmitted(t *testing.T) {
 	assert.Equal(t, filepath.Join(moduleRoot, "public"), factory.Configs[0].DirPath)
 }
 
+func TestManager_PropagatesReadOnlyAcrossAddAndUpdate(t *testing.T) {
+	ctx := ctxapi.NewRootContext()
+	factory := NewMockFactory(&MockFS{}, nil)
+	manager := NewDirectoryManager(eventbus.NewBus(), &MockTranscoder{}, factory, zap.NewNop())
+	entry := registry.Entry{
+		ID:   registry.NewID("app.fs", "data"),
+		Kind: dirapi.Kind,
+		Data: NewMockPayload(&dirapi.Config{
+			Directory: "/tmp/data",
+			Mode:      "0755",
+			ReadOnly:  true,
+		}),
+	}
+
+	require.NoError(t, manager.Add(ctx, entry))
+	require.Len(t, factory.Configs, 1)
+	assert.True(t, factory.Configs[0].ReadOnly)
+
+	entry.Data = NewMockPayload(&dirapi.Config{
+		Directory: "/tmp/data",
+		Mode:      "0755",
+		ReadOnly:  false,
+	})
+	require.NoError(t, manager.Update(ctx, entry))
+	require.Len(t, factory.Configs, 2)
+	assert.False(t, factory.Configs[1].ReadOnly)
+	require.NoError(t, manager.Delete(ctx, entry))
+}
+
 // Add test for factory error handling
 func TestManager_FactoryError(t *testing.T) {
 	ctx := ctxapi.NewRootContext()

--- a/service/fs/directory/readonly_test.go
+++ b/service/fs/directory/readonly_test.go
@@ -13,71 +13,99 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fsapi "github.com/wippyai/runtime/api/fs"
+	dirapi "github.com/wippyai/runtime/api/service/fs/directory"
 	"github.com/wippyai/runtime/tests/tempfiles"
 )
 
 func requireReadOnly(t *testing.T, err error) {
 	t.Helper()
 	require.Error(t, err)
-	var pathErr *iofs.PathError
-	require.ErrorAs(t, err, &pathErr)
-	assert.ErrorIs(t, pathErr.Err, fsapi.ErrReadOnly)
+	assert.ErrorIs(t, err, fsapi.ErrReadOnly)
 }
 
-func TestFS_ReadOnlyVolume(t *testing.T) {
+func TestFactory_ReadOnlyVolume(t *testing.T) {
 	root, cleanup := tempfiles.TempDirWithFiles(t, "readonly_test", map[string]string{
 		"file1.txt":      "content1",
 		"dir1/file2.txt": "content2",
 	})
 	defer cleanup()
 
-	// The mode grants everything; read-only refuses mutations regardless.
-	fs, err := NewReadOnlyFS(root, 0755)
+	filesystem, err := NewFactory().CreateFS(CreateFSConfig{
+		DirPath:  root,
+		Mode:     0755,
+		ReadOnly: true,
+	})
 	require.NoError(t, err)
-	defer func() { require.NoError(t, fs.Close()) }()
-	assert.True(t, fs.ReadOnly())
+	defer func() { require.NoError(t, filesystem.(io.Closer).Close()) }()
+	_, exposesHostPath := filesystem.(fsapi.HostPathFS)
+	assert.False(t, exposesHostPath)
 
-	// Reads, stats and listings work, including chunked reads for streaming.
-	f, err := fs.Open("file1.txt")
+	file, err := filesystem.Open("file1.txt")
 	require.NoError(t, err)
 	buf := make([]byte, 3)
-	n, err := f.Read(buf)
+	n, err := file.Read(buf)
 	require.NoError(t, err)
 	assert.Equal(t, "con", string(buf[:n]))
-	rest, err := io.ReadAll(f)
-	require.NoError(t, err)
-	assert.Equal(t, "tent1", string(rest))
-	require.NoError(t, f.Close())
+	_, exposesChmod := file.(interface{ Chmod(os.FileMode) error })
+	assert.False(t, exposesChmod)
+	writer, exposesWrite := file.(io.Writer)
+	require.True(t, exposesWrite)
+	_, err = writer.Write([]byte("x"))
+	requireReadOnly(t, err)
+	require.NoError(t, file.Close())
 
-	info, err := fs.Stat("dir1/file2.txt")
+	info, err := filesystem.Stat("dir1/file2.txt")
 	require.NoError(t, err)
 	assert.Equal(t, int64(8), info.Size())
-	_, err = fs.Lstat("file1.txt")
+	_, err = filesystem.Lstat("file1.txt")
 	require.NoError(t, err)
-	entries, err := fs.ReadDir("dir1")
+	entries, err := filesystem.ReadDir("dir1")
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
-
-	rf, err := fs.OpenFile("file1.txt", os.O_RDONLY, 0)
+	directoryFile, err := filesystem.Open("dir1")
 	require.NoError(t, err)
-	_, err = rf.Write([]byte("x"))
-	assert.Error(t, err, "a handle from a read-only volume never writes")
-	require.NoError(t, rf.Close())
+	readDirectory, ok := directoryFile.(iofs.ReadDirFile)
+	require.True(t, ok)
+	entries, err = readDirectory.ReadDir(-1)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	require.NoError(t, directoryFile.Close())
 
-	// Every mutation is refused at the boundary.
-	for _, flag := range []int{os.O_WRONLY, os.O_RDWR, os.O_RDONLY | os.O_CREATE, os.O_RDONLY | os.O_TRUNC, os.O_RDONLY | os.O_APPEND} {
-		_, err = fs.OpenFile("file1.txt", flag, 0644)
-		requireReadOnly(t, err)
-	}
-	_, err = fs.OpenFile("created.txt", os.O_CREATE|os.O_WRONLY, 0644)
+	readFile, err := filesystem.OpenFile("file1.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	_, err = readFile.Seek(3, io.SeekStart)
+	require.NoError(t, err)
+	rest, err := io.ReadAll(readFile)
+	require.NoError(t, err)
+	assert.Equal(t, "tent1", string(rest))
+	_, exposesChmod = readFile.(interface{ Chmod(os.FileMode) error })
+	assert.False(t, exposesChmod)
+	_, err = readFile.Write([]byte("x"))
 	requireReadOnly(t, err)
-	requireReadOnly(t, fs.Remove("file1.txt"))
-	requireReadOnly(t, fs.Mkdir("newdir", 0755))
-	requireReadOnly(t, fs.Rename("file1.txt", "moved.txt"))
-	requireReadOnly(t, fs.Truncate("file1.txt", 0))
-	requireReadOnly(t, fs.Chtimes("file1.txt", time.Now(), time.Now()))
+	require.NoError(t, readFile.Close())
 
-	// Nothing changed on disk.
+	for _, flag := range []int{
+		os.O_WRONLY,
+		os.O_RDWR,
+		os.O_RDONLY | os.O_CREATE,
+		os.O_RDONLY | os.O_TRUNC,
+		os.O_RDONLY | os.O_APPEND,
+		os.O_WRONLY | os.O_CREATE | os.O_EXCL,
+	} {
+		_, err = filesystem.OpenFile("file1.txt", flag, 0644)
+		requireReadOnly(t, err)
+		var pathErr *iofs.PathError
+		require.ErrorAs(t, err, &pathErr)
+		assert.Equal(t, "open", pathErr.Op)
+	}
+	_, err = filesystem.OpenFile("created.txt", os.O_CREATE|os.O_WRONLY, 0644)
+	requireReadOnly(t, err)
+	requireReadOnly(t, filesystem.Remove("file1.txt"))
+	requireReadOnly(t, filesystem.Mkdir("newdir", 0755))
+	requireReadOnly(t, filesystem.Rename("file1.txt", "moved.txt"))
+	requireReadOnly(t, filesystem.Truncate("file1.txt", 0))
+	requireReadOnly(t, filesystem.Chtimes("file1.txt", time.Now(), time.Now()))
+
 	content, err := os.ReadFile(filepath.Join(root, "file1.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "content1", string(content))
@@ -87,31 +115,43 @@ func TestFS_ReadOnlyVolume(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestFS_ReadOnlyVolume_NeverCreatesRoot(t *testing.T) {
+func TestFactory_ReadOnlyNeverCreatesRoot(t *testing.T) {
 	root, cleanup := tempfiles.TempDirWithFiles(t, "readonly_root", map[string]string{})
 	defer cleanup()
-	_, err := NewReadOnlyFS(filepath.Join(root, "absent"), 0755)
+	absent := filepath.Join(root, "absent")
+
+	_, err := NewFactory().CreateFS(CreateFSConfig{DirPath: absent, Mode: 0755, ReadOnly: true})
 	require.Error(t, err)
+	_, statErr := os.Stat(absent)
+	assert.True(t, os.IsNotExist(statErr))
 }
 
-func TestFactory_CreateFS_ReadOnly(t *testing.T) {
-	root, cleanup := tempfiles.TempDirWithFiles(t, "readonly_factory", map[string]string{"file.txt": "x"})
-	defer cleanup()
-	created, err := NewFactory().CreateFS(CreateFSConfig{DirPath: root, Mode: 0755, ReadOnly: true})
+func TestFactory_RejectsReadOnlyAutoInit(t *testing.T) {
+	_, err := NewFactory().CreateFS(CreateFSConfig{
+		DirPath:  filepath.Join(t.TempDir(), "absent"),
+		Mode:     0755,
+		AutoInit: true,
+		ReadOnly: true,
+	})
+	assert.ErrorIs(t, err, dirapi.ErrReadOnlyAutoInit)
+}
+
+func TestFactory_WritableVolumeRetainsHostPath(t *testing.T) {
+	filesystem, err := NewFactory().CreateFS(CreateFSConfig{DirPath: t.TempDir(), Mode: 0755})
 	require.NoError(t, err)
-	readOnly, ok := created.(*FS)
-	require.True(t, ok)
-	defer func() { _ = readOnly.Close() }()
-	assert.True(t, readOnly.ReadOnly())
-	_, err = created.OpenFile("file.txt", os.O_WRONLY, 0644)
-	requireReadOnly(t, err)
-	writable, err := NewFactory().CreateFS(CreateFSConfig{DirPath: root, Mode: 0755})
+	defer func() { require.NoError(t, filesystem.(io.Closer).Close()) }()
+	_, exposesHostPath := filesystem.(fsapi.HostPathFS)
+	assert.True(t, exposesHostPath)
+}
+
+func TestFactory_ReadOnlyCloseClosesDirectory(t *testing.T) {
+	filesystem, err := NewFactory().CreateFS(CreateFSConfig{
+		DirPath:  t.TempDir(),
+		Mode:     0755,
+		ReadOnly: true,
+	})
 	require.NoError(t, err)
-	writableFS, ok := writable.(*FS)
-	require.True(t, ok)
-	defer func() { _ = writableFS.Close() }()
-	assert.False(t, writableFS.ReadOnly())
-	wf, err := writable.OpenFile("file.txt", os.O_WRONLY|os.O_TRUNC, 0644)
-	require.NoError(t, err)
-	require.NoError(t, wf.Close())
+	require.NoError(t, filesystem.(io.Closer).Close())
+	_, err = filesystem.Open(".")
+	assert.ErrorIs(t, err, fsapi.ErrClosed)
 }

--- a/service/fs/directory/readonly_test.go
+++ b/service/fs/directory/readonly_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package directory
+
+import (
+	"io"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fsapi "github.com/wippyai/runtime/api/fs"
+	"github.com/wippyai/runtime/tests/tempfiles"
+)
+
+func requireReadOnly(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var pathErr *iofs.PathError
+	require.ErrorAs(t, err, &pathErr)
+	assert.ErrorIs(t, pathErr.Err, fsapi.ErrReadOnly)
+}
+
+func TestFS_ReadOnlyVolume(t *testing.T) {
+	root, cleanup := tempfiles.TempDirWithFiles(t, "readonly_test", map[string]string{
+		"file1.txt":      "content1",
+		"dir1/file2.txt": "content2",
+	})
+	defer cleanup()
+
+	// The mode grants everything; read-only refuses mutations regardless.
+	fs, err := NewReadOnlyFS(root, 0755)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, fs.Close()) }()
+	assert.True(t, fs.ReadOnly())
+
+	// Reads, stats and listings work, including chunked reads for streaming.
+	f, err := fs.Open("file1.txt")
+	require.NoError(t, err)
+	buf := make([]byte, 3)
+	n, err := f.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "con", string(buf[:n]))
+	rest, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, "tent1", string(rest))
+	require.NoError(t, f.Close())
+
+	info, err := fs.Stat("dir1/file2.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), info.Size())
+	_, err = fs.Lstat("file1.txt")
+	require.NoError(t, err)
+	entries, err := fs.ReadDir("dir1")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+
+	rf, err := fs.OpenFile("file1.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	_, err = rf.Write([]byte("x"))
+	assert.Error(t, err, "a handle from a read-only volume never writes")
+	require.NoError(t, rf.Close())
+
+	// Every mutation is refused at the boundary.
+	for _, flag := range []int{os.O_WRONLY, os.O_RDWR, os.O_RDONLY | os.O_CREATE, os.O_RDONLY | os.O_TRUNC, os.O_RDONLY | os.O_APPEND} {
+		_, err = fs.OpenFile("file1.txt", flag, 0644)
+		requireReadOnly(t, err)
+	}
+	_, err = fs.OpenFile("created.txt", os.O_CREATE|os.O_WRONLY, 0644)
+	requireReadOnly(t, err)
+	requireReadOnly(t, fs.Remove("file1.txt"))
+	requireReadOnly(t, fs.Mkdir("newdir", 0755))
+	requireReadOnly(t, fs.Rename("file1.txt", "moved.txt"))
+	requireReadOnly(t, fs.Truncate("file1.txt", 0))
+	requireReadOnly(t, fs.Chtimes("file1.txt", time.Now(), time.Now()))
+
+	// Nothing changed on disk.
+	content, err := os.ReadFile(filepath.Join(root, "file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "content1", string(content))
+	_, err = os.Stat(filepath.Join(root, "created.txt"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(root, "newdir"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFS_ReadOnlyVolume_NeverCreatesRoot(t *testing.T) {
+	root, cleanup := tempfiles.TempDirWithFiles(t, "readonly_root", map[string]string{})
+	defer cleanup()
+	_, err := NewReadOnlyFS(filepath.Join(root, "absent"), 0755)
+	require.Error(t, err)
+}
+
+func TestFactory_CreateFS_ReadOnly(t *testing.T) {
+	root, cleanup := tempfiles.TempDirWithFiles(t, "readonly_factory", map[string]string{"file.txt": "x"})
+	defer cleanup()
+	created, err := NewFactory().CreateFS(CreateFSConfig{DirPath: root, Mode: 0755, ReadOnly: true})
+	require.NoError(t, err)
+	readOnly, ok := created.(*FS)
+	require.True(t, ok)
+	defer func() { _ = readOnly.Close() }()
+	assert.True(t, readOnly.ReadOnly())
+	_, err = created.OpenFile("file.txt", os.O_WRONLY, 0644)
+	requireReadOnly(t, err)
+	writable, err := NewFactory().CreateFS(CreateFSConfig{DirPath: root, Mode: 0755})
+	require.NoError(t, err)
+	writableFS, ok := writable.(*FS)
+	require.True(t, ok)
+	defer func() { _ = writableFS.Close() }()
+	assert.False(t, writableFS.ReadOnly())
+	wf, err := writable.OpenFile("file.txt", os.O_WRONLY|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	require.NoError(t, wf.Close())
+}


### PR DESCRIPTION
Adds `readonly: true` to `fs.directory`.

Read-only volumes:
- allow reads, stat, lstat, directory iteration, and seeking;
- reject writable/create/truncate/append opens and all filesystem mutations with `fsapi.ErrReadOnly` (`EROFS`);
- reject `readonly: true` with `auto_init: true`;
- never create a missing root;
- hide the backing host path and concrete `os.File` mutators, including from WASI mounts;
- surface denied Lua operations as `PermissionDenied` and WASI operations as `ErrorReadOnly`.

The directory factory composes the shared `fsapi.ReadOnlyFS` adapter, keeping one enforcement path. Writable directory volumes retain the host-path mount path and existing behavior.

Regression coverage includes config round trips and validation, manager add/update propagation, factory lifecycle and close behavior, every mutation operation and open-flag family, on-disk immutability, handle confinement, safe optional operations, Lua error kinds, WASI host-path selection, Linux race tests, and Windows compilation.