### PR TITLE
Prevent blocking terminal reads from starving control commands

### DIFF
--- a/service/terminal/tty/dispatcher.go
+++ b/service/terminal/tty/dispatcher.go
@@ -18,12 +18,14 @@ var (
 	errNoTerminalContext = errors.New("no terminal context")
 	errNoRawController   = errors.New("raw terminal control unavailable")
 	errNoInputController = errors.New("input controller unavailable")
+	errDispatcherBusy    = errors.New("terminal command queue capacity exceeded")
+	errDispatcherStarted = errors.New("terminal dispatcher already started")
 )
 
 // Option configures a Dispatcher.
 type Option func(*Dispatcher)
 
-// WithWorkers sets the number of worker goroutines.
+// WithWorkers sets the worker count for each of the read and control lanes.
 func WithWorkers(n int) Option {
 	return func(d *Dispatcher) {
 		if n > 0 {
@@ -32,16 +34,19 @@ func WithWorkers(n int) Option {
 	}
 }
 
-// Dispatcher handles terminal I/O commands via an async worker pool.
+// Dispatcher isolates blocking stream reads from terminal control commands.
+// Each lane has a bounded queue and the configured worker count.
 type Dispatcher struct {
-	ctx        context.Context
-	jobs       chan job
-	cancel     context.CancelFunc
-	asyncSlots chan struct{}
-	wg         sync.WaitGroup
-	workers    int
-	asyncMu    sync.Mutex
-	stopping   bool
+	ctx         context.Context
+	reads       chan job
+	jobs        chan job
+	cancel      context.CancelFunc
+	asyncSlots  chan struct{}
+	wg          sync.WaitGroup
+	workers     int
+	asyncMu     sync.Mutex
+	lifecycleMu sync.Mutex
+	stopping    bool
 }
 
 type job struct {
@@ -51,7 +56,7 @@ type job struct {
 	tag      uint64
 }
 
-// NewDispatcher creates a terminal I/O dispatcher with default 1 worker.
+// NewDispatcher creates a terminal I/O dispatcher with one worker per lane.
 func NewDispatcher(opts ...Option) *Dispatcher {
 	d := &Dispatcher{workers: 1, asyncSlots: make(chan struct{}, 128)}
 	for _, opt := range opts {
@@ -62,51 +67,99 @@ func NewDispatcher(opts ...Option) *Dispatcher {
 
 // Start initializes the worker pool.
 func (d *Dispatcher) Start(ctx context.Context) error {
+	d.lifecycleMu.Lock()
+	defer d.lifecycleMu.Unlock()
+	d.asyncMu.Lock()
+	defer d.asyncMu.Unlock()
+	if d.jobs != nil {
+		return errDispatcherStarted
+	}
+	d.stopping = false
 	d.ctx, d.cancel = context.WithCancel(ctx)
 	d.jobs = make(chan job, d.workers*2)
+	d.reads = make(chan job, d.workers*2)
 	for i := 0; i < d.workers; i++ {
-		d.wg.Add(1)
-		go d.worker()
+		d.wg.Add(2)
+		go d.worker(d.jobs)
+		go d.worker(d.reads)
 	}
 	return nil
 }
 
 // Stop shuts down the dispatcher and drains pending jobs.
 func (d *Dispatcher) Stop(_ context.Context) error {
+	d.lifecycleMu.Lock()
+	defer d.lifecycleMu.Unlock()
 	d.asyncMu.Lock()
 	d.stopping = true
-	d.asyncMu.Unlock()
-	if d.cancel != nil {
-		d.cancel()
+	cancel := d.cancel
+	jobs, reads := d.jobs, d.reads
+	d.cancel = nil
+	d.ctx = nil
+	d.jobs, d.reads = nil, nil
+	if jobs != nil {
+		close(jobs)
+		close(reads)
 	}
-	if d.jobs != nil {
-		close(d.jobs)
+	d.asyncMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 	d.wg.Wait()
-	d.jobs = nil
-	d.cancel = nil
 	return nil
 }
 
-func (d *Dispatcher) worker() {
+func (d *Dispatcher) worker(jobs <-chan job) {
 	defer d.wg.Done()
-	for j := range d.jobs {
+	for j := range jobs {
 		d.execute(j)
 	}
 }
 
-func (d *Dispatcher) submit(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) {
+func (d *Dispatcher) submit(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
 	j := job{ctx: ctx, cmd: cmd, tag: tag, receiver: receiver}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d.asyncMu.Lock()
 	if d.jobs == nil {
+		stopping := d.stopping
+		d.asyncMu.Unlock()
+		if stopping {
+			return ttyapi.ErrServiceUnavailable
+		}
 		d.execute(j)
-		return
+		return nil
+	}
+	if d.stopping {
+		d.asyncMu.Unlock()
+		return ttyapi.ErrServiceUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		d.asyncMu.Unlock()
+		return err
+	}
+	if err := d.ctx.Err(); err != nil {
+		d.asyncMu.Unlock()
+		return err
 	}
 
+	queue := d.jobs
+	switch cmd.(type) {
+	case ttyapi.ReadCmd, ttyapi.ReadLineCmd:
+		queue = d.reads
+	}
 	select {
-	case d.jobs <- j:
+	case queue <- j:
+		d.asyncMu.Unlock()
+		return nil
 	case <-d.ctx.Done():
+		err := d.ctx.Err()
+		d.asyncMu.Unlock()
+		return err
 	default:
-		d.execute(j)
+		d.asyncMu.Unlock()
+		return errDispatcherBusy
 	}
 }
 
@@ -245,8 +298,7 @@ func trimLine(line string) string {
 }
 
 func (d *Dispatcher) handle(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) error {
-	d.submit(ctx, cmd, tag, receiver)
-	return nil
+	return d.submit(ctx, cmd, tag, receiver)
 }
 
 // RegisterAll registers all terminal I/O handlers.
@@ -280,14 +332,15 @@ func (d *Dispatcher) handleViewportIO(ctx context.Context, command dispatcher.Co
 		return ttyapi.ErrMeshBusy
 	}
 	d.wg.Add(1)
+	lifecycleCtx := d.ctx
 	d.asyncMu.Unlock()
 	go func() {
 		defer d.wg.Done()
 		defer func() { <-d.asyncSlots }()
 		runCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		if d.ctx != nil {
-			stop := context.AfterFunc(d.ctx, cancel)
+		if lifecycleCtx != nil {
+			stop := context.AfterFunc(lifecycleCtx, cancel)
 			defer stop()
 		}
 		var result any

--- a/service/terminal/tty/read_isolation_test.go
+++ b/service/terminal/tty/read_isolation_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MPL-2.0
+package tty
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/service/terminal"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+type isolationReceiver struct{ done chan error }
+
+func (r isolationReceiver) CompleteYield(_ uint64, _ any, err error) { r.done <- err }
+
+type blockingRead struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func (r *blockingRead) Read([]byte) (int, error) {
+	r.enteredOnce.Do(func() { close(r.entered) })
+	<-r.release
+	return 0, io.EOF
+}
+
+func (r *blockingRead) unblock() { r.releaseOnce.Do(func() { close(r.release) }) }
+
+func TestBlockedReadDoesNotPreventAnotherTerminalStarting(t *testing.T) {
+	d := NewDispatcher()
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	blocked := &blockingRead{entered: make(chan struct{}), release: make(chan struct{})}
+	defer func() { blocked.unblock(); _ = d.Stop(context.Background()) }()
+	readCtx := ctxapi.NewRootContext()
+	readCtx, _ = ctxapi.OpenFrameContext(readCtx)
+	_ = terminal.WithTerminalContext(readCtx, terminal.NewTerminalContext(blocked, nil, nil))
+	readResult := isolationReceiver{make(chan error, 1)}
+	if err := d.handle(readCtx, ttyapi.ReadLineCmd{}, 1, readResult); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-blocked.entered:
+	case <-time.After(time.Second):
+		t.Fatal("read did not start")
+	}
+	controlCtx := ctxapi.NewRootContext()
+	controlCtx, _ = ctxapi.OpenFrameContext(controlCtx)
+	tc := terminal.NewTerminalContext(nil, nil, nil)
+	tc.Input = &stubInputController{}
+	_ = terminal.WithTerminalContext(controlCtx, tc)
+	started := isolationReceiver{make(chan error, 1)}
+	if err := d.handle(controlCtx, ttyapi.StartInputCmd{}, 2, started); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-started.done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked stdin prevented unrelated terminal startup")
+	}
+}
+
+func TestReadQueueSaturationReturnsBusy(t *testing.T) {
+	d := NewDispatcher()
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	blocked := &blockingRead{entered: make(chan struct{}), release: make(chan struct{})}
+	defer func() { blocked.unblock(); _ = d.Stop(context.Background()) }()
+	readCtx := ctxapi.NewRootContext()
+	readCtx, _ = ctxapi.OpenFrameContext(readCtx)
+	_ = terminal.WithTerminalContext(readCtx, terminal.NewTerminalContext(blocked, nil, nil))
+
+	if err := d.handle(readCtx, ttyapi.ReadLineCmd{}, 1, isolationReceiver{make(chan error, 1)}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-blocked.entered:
+	case <-time.After(time.Second):
+		t.Fatal("read did not start")
+	}
+	for tag := uint64(2); tag <= 3; tag++ {
+		if err := d.handle(readCtx, ttyapi.ReadLineCmd{}, tag, isolationReceiver{make(chan error, 1)}); err != nil {
+			t.Fatalf("queued read %d failed: %v", tag, err)
+		}
+	}
+	busyResult := make(chan error, 1)
+	go func() {
+		busyResult <- d.handle(readCtx, ttyapi.ReadLineCmd{}, 4, isolationReceiver{make(chan error, 1)})
+	}()
+	select {
+	case err := <-busyResult:
+		if !errors.Is(err, errDispatcherBusy) {
+			t.Fatalf("expected saturated read queue to return dispatcher busy, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("saturated read submission blocked the caller")
+	}
+}
+
+func TestSubmitAndStopSerializeQueueClosure(t *testing.T) {
+	d := NewDispatcher()
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	blocked := &blockingRead{entered: make(chan struct{}), release: make(chan struct{})}
+	defer func() { blocked.unblock(); _ = d.Stop(context.Background()) }()
+	readCtx := ctxapi.NewRootContext()
+	readCtx, _ = ctxapi.OpenFrameContext(readCtx)
+	_ = terminal.WithTerminalContext(readCtx, terminal.NewTerminalContext(blocked, nil, nil))
+	if err := d.handle(readCtx, ttyapi.ReadLineCmd{}, 1, isolationReceiver{make(chan error, 1)}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-blocked.entered:
+	case <-time.After(time.Second):
+		t.Fatal("read did not start")
+	}
+
+	panics := make(chan any, 1)
+	var submitters sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		submitters.Add(1)
+		go func() {
+			defer submitters.Done()
+			for tag := uint64(2); tag < 34; tag++ {
+				func() {
+					defer func() {
+						if recovered := recover(); recovered != nil {
+							select {
+							case panics <- recovered:
+							default:
+							}
+						}
+					}()
+					_ = d.handle(readCtx, ttyapi.ReadLineCmd{}, tag, isolationReceiver{make(chan error, 1)})
+				}()
+			}
+		}()
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- d.Stop(context.Background()) }()
+	blocked.unblock()
+	submitters.Wait()
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher stop did not complete")
+	}
+	select {
+	case recovered := <-panics:
+		t.Fatalf("submit raced Stop with panic: %v", recovered)
+	default:
+	}
+}


### PR DESCRIPTION
A blocking stream read could occupy the only terminal dispatcher worker and prevent unrelated control commands from starting another terminal.

This change gives blocking reads and control commands separate bounded worker queues. Saturated admission returns a clear error, and submission is serialized with shutdown so a queue cannot close under a caller. Duplicate starts are rejected and restart remains supported.

Regression coverage includes blocked-read isolation, bounded admission, and concurrent submission with shutdown.

Validation on the current main replay: focused race tests pass; the concurrency matrix passes 100 times; repository-pinned lint and vet pass; Windows compilation and diff checks pass.