### PR TITLE
Honor explicit command hosts when launching packs

### DIFF
--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -137,15 +137,23 @@ func runTest(cmd *cobra.Command, args []string) error {
 	return runWithUseCase(cmd, args, "test")
 }
 
+// commandHost applies the operator's selection equally to source and pack launches.
+func commandHost(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	host, _ := cmd.Flags().GetString("host")
+	return host
+}
+
 func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 	memLimit := initMemoryLimit()
 
 	execSpec := ""
-	execHost := ""
+	execHost := commandHost(cmd)
 	registryURL := ""
 	if cmd != nil {
 		execSpec, _ = cmd.Flags().GetString("exec")
-		execHost, _ = cmd.Flags().GetString("host")
 		registryURL, _ = cmd.Flags().GetString("registry")
 	}
 

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -599,7 +599,7 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase
 	}
 	entries.ConfigureSourceLoader(ctx, sourcePaths, runLogger)
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule, commandHost(cmd))
 }
 
 // runFromPackFiles executes runtime from multiple already resolved .wapp files.
@@ -652,7 +652,7 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, use
 	}
 	entries.ConfigureSourceLoader(ctx, sourcePaths, runLogger)
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule)
+	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule, commandHost(cmd))
 }
 
 func packSourcePaths(packFiles []string, rootModule string) ([]lock.ModuleLoadPath, error) {
@@ -682,6 +682,7 @@ func runPackEntries(
 	args []string,
 	useCase string,
 	mainModule string,
+	hostID string,
 ) error {
 	sigChan := setupSupervisorSignalChannel(ctx)
 	defer signal.Stop(sigChan)
@@ -716,7 +717,7 @@ func runPackEntries(
 
 	if entryID != "" {
 		execCtx, stopExecSignals := newExecSignalContext(appCtx)
-		execErr := launchExecProcess(execCtx, logger, entryID, "", args)
+		execErr := launchExecProcess(execCtx, logger, entryID, hostID, args)
 		interrupted := execWasInterrupted(execCtx, appCtx, execErr)
 		stopExecSignals()
 		if execErr != nil && !interrupted {

--- a/cmd/wippy/cmd/run_pack_shutdown_test.go
+++ b/cmd/wippy/cmd/run_pack_shutdown_test.go
@@ -74,7 +74,7 @@ func TestRunPackEntries_GracefulShutdownStopsRunningService(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runPackEntries(ctx, loader, baseLogger, nil, nil, defaultUseCase, "")
+		done <- runPackEntries(ctx, loader, baseLogger, nil, nil, defaultUseCase, "", "")
 	}()
 
 	waitForLogMessage(t, logs, "supervisor started")

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -68,7 +68,7 @@ func TestRunPackEntries_InvalidRequirementFailsNormalizationPipeline(t *testing.
 		},
 	}
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, defaultUseCase, "")
+	err = runPackEntries(ctx, loader, zap.NewNop(), packEntries, []string{"missing"}, defaultUseCase, "", "")
 	if err == nil {
 		t.Fatal("expected normalization pipeline error")
 	}
@@ -101,7 +101,7 @@ func TestRunPackEntries_NoEntrypointRunsAsServer(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, defaultUseCase, "")
+		done <- runPackEntries(ctx, loader, zap.NewNop(), nil, nil, defaultUseCase, "", "")
 	}()
 
 	select {
@@ -139,7 +139,7 @@ func TestRunPackEntries_TestModeWithoutTestEntrypointErrors(t *testing.T) {
 		_ = embedReg.Close()
 	})
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, "test", "")
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, nil, "test", "", "")
 	if err == nil {
 		t.Fatal("expected an error when there is no test entrypoint")
 	}
@@ -165,7 +165,7 @@ func TestRunPackEntries_RunModeUnknownCommandErrors(t *testing.T) {
 		_ = embedReg.Close()
 	})
 
-	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, defaultUseCase, "")
+	err = runPackEntries(ctx, loader, zap.NewNop(), nil, []string{"nope"}, defaultUseCase, "", "")
 	if err == nil {
 		t.Fatal("expected an error for an unknown command")
 	}
@@ -1442,4 +1442,29 @@ type failingPackRegistry struct {
 
 func (f failingPackRegistry) Register(_ string, _ *wapp.Reader, _ *os.File) error {
 	return f.err
+}
+
+// Explicit host selection must reach execution even when there is no terminal
+// host to auto-detect. A missing selected host must never silently fall back.
+func TestRunPackEntries_ExplicitHostDoesNotFallBack(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "wippy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	setTestConfigFiles(t, cfgPath)
+	ctx, loader, logger, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer embedReg.Close()
+	defer shutdown.Perform(ctx, loader, logger, true)
+	entries := []regapi.Entry{{
+		ID: regapi.NewID("test", "runner"), Kind: "process.lua",
+		Meta: map[string]any{"command": map[string]any{"name": "probe"}},
+		Data: payload.New(map[string]any{"source": "return {main = function() return 0 end}", "method": "main"}),
+	}}
+	err = runPackEntries(ctx, loader, logger, entries, []string{"probe"}, defaultUseCase, "", "test:chosen-host")
+	if err == nil || !strings.Contains(err.Error(), "test:chosen-host") {
+		t.Fatalf("expected selected host failure, got %v", err)
+	}
 }


### PR DESCRIPTION
Packed applications ignored the explicit --host selection and always attempted terminal-host discovery, so headless pack launches behaved differently from source launches.

This change carries the selected host through both single-pack and multi-pack paths into command execution. An omitted host retains discovery; an invalid explicit host fails visibly instead of silently falling back.

The current-main replay contains only the four implementation and regression files. Unrelated fixture and surface-assertion commits were removed.

Validation: the pack regression suite passes under the race detector; repository-pinned scoped lint, vet, and diff checks pass. The integration regression boots the pack runtime and proves a selected missing host is reported.