### PR TITLE
feat(app): isolate explicit client launch from owner execution

### DIFF
--- a/cmd/app/launch.go
+++ b/cmd/app/launch.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wippyai/runtime/api/boot"
+)
+
+// ErrBusy means another invocation owns the selected application state.
+// It says nothing about the owner's identity, readiness or ability to accept clients.
+var ErrBusy = errors.New("application state is owned")
+
+// Launch runs an application-specific invocation before owner state is opened.
+// It may run a client without calling runOwner. The callback owns discovery,
+// authentication and admission; the runner never attaches or retries for it.
+// Update, runtime tooling and --base bypass this callback.
+// runOwner is single-use, synchronous, and invalid after Launch returns.
+type Launch func(ctx context.Context, request LaunchRequest, runOwner func(OwnerOptions) error) error
+
+// LaunchRequest identifies the ordinary invocation. StateDir is already resolved
+// from --state-dir or the executable's default and cannot be redirected by runOwner.
+type LaunchRequest struct {
+	Name      string
+	Module    string
+	Directory string
+	StateDir  string
+	Command   string
+	Arguments []string
+}
+
+// OwnerOptions selects the application command and preparation for one owner run.
+// Empty Command and nil Arguments retain the invocation values. Prepare runs
+// under exclusive state ownership, before deployment or application stores open.
+type OwnerOptions struct {
+	Prepare   func(context.Context) (OwnerResources, error)
+	Command   string
+	Arguments []string
+}
+
+// OwnerResources lives inside the owner's exclusive lifetime. Close runs after
+// runtime shutdown and before unlocking, even when preparation or startup fails.
+// Config cannot redirect registry history. Deadline optionally bounds execution.
+type OwnerResources struct {
+	Config   boot.Config
+	Close    func() error
+	Deadline time.Time
+}
+
+func launch(ctx context.Context, callback Launch, request LaunchRequest, run func(context.Context, OwnerOptions) error) (result error) {
+	ctx, cancel := context.WithCancel(ctx)
+	var mu sync.Mutex
+	var running sync.WaitGroup
+	var started, closed, active bool
+	defer func() {
+		mu.Lock()
+		closed = true
+		if active {
+			result = errors.Join(result, fmt.Errorf("application launch returned before owner runner completed"))
+		}
+		mu.Unlock()
+		cancel()
+		running.Wait()
+	}()
+	return callback(ctx, request, func(options OwnerOptions) error {
+		mu.Lock()
+		if closed || started {
+			mu.Unlock()
+			return fmt.Errorf("application owner runner is single-use and valid only during launch")
+		}
+		started = true
+		active = true
+		running.Add(1)
+		mu.Unlock()
+		defer func() {
+			mu.Lock()
+			active = false
+			mu.Unlock()
+			running.Done()
+		}()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return run(ctx, options)
+	})
+}
+
+func launchOverrides(config boot.Config, historyPath string) boot.Config {
+	sections := make(map[string]map[string]any)
+	if config != nil {
+		for _, key := range config.Keys() {
+			section, name, ok := strings.Cut(key, boot.ConfigSep)
+			if !ok {
+				continue
+			}
+			if sections[section] == nil {
+				sections[section] = make(map[string]any)
+			}
+			value, found := config.Get(key)
+			if found {
+				sections[section][name] = value
+			}
+		}
+	}
+	if sections["registry"] == nil {
+		sections["registry"] = make(map[string]any)
+	}
+	sections["registry"]["enable_history"] = true
+	sections["registry"]["history_type"] = "sqlite"
+	sections["registry"]["history_path"] = historyPath
+	options := make([]boot.ConfigOption, 0, len(sections))
+	for section, values := range sections {
+		options = append(options, boot.WithSection(section, values))
+	}
+	return boot.NewConfig(options...)
+}

--- a/cmd/app/launch_test.go
+++ b/cmd/app/launch_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+)
+
+func launchOptions(callback Launch) Options {
+	return Options{Name: "launch-test", Command: "desktop", Mode: "base", Launch: callback}
+}
+
+func TestClientLaunchDoesNotOpenOwnerState(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "absent")
+	options := launchOptions(func(_ context.Context, request LaunchRequest, _ func(OwnerOptions) error) error {
+		require.Equal(t, state, request.StateDir)
+		require.Equal(t, []string{"terminal", "two words"}, request.Arguments)
+		require.NotEmpty(t, request.Directory)
+		return nil
+	})
+	options.DataEnv = map[string]string{"INVALID NAME": "../outside"}
+	require.NoError(t, Run(t.Context(), options, []string{"--state-dir", state, "run", "terminal", "two words"}))
+	require.NoDirExists(t, state)
+}
+
+func TestBusyOwnerCanSelectClientWithoutOpeningStores(t *testing.T) {
+	state := t.TempDir()
+	unlock, err := lockApplication(state)
+	require.NoError(t, err)
+	defer unlock()
+	require.NoError(t, os.WriteFile(filepath.Join(state, "active.json"), []byte("invalid"), 0o600))
+	called, prepared := false, false
+	options := launchOptions(func(_ context.Context, _ LaunchRequest, run func(OwnerOptions) error) error {
+		err := run(OwnerOptions{Prepare: func(context.Context) (OwnerResources, error) {
+			prepared = true
+			return OwnerResources{}, nil
+		}})
+		require.ErrorIs(t, err, ErrBusy)
+		called = true
+		return nil
+	})
+	options.DataEnv = map[string]string{"INVALID NAME": "../outside"}
+	require.NoError(t, Run(t.Context(), options, []string{"--state-dir", state}))
+	require.True(t, called)
+	require.False(t, prepared)
+	require.NoDirExists(t, filepath.Join(state, "deployment"))
+}
+
+func TestLockIOErrorIsNotBusy(t *testing.T) {
+	state := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(state, ".application.lock"), 0o700))
+	options := launchOptions(func(_ context.Context, _ LaunchRequest, run func(OwnerOptions) error) error {
+		err := run(OwnerOptions{})
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrBusy)
+		return err
+	})
+	require.Error(t, Run(t.Context(), options, []string{"--state-dir", state}))
+}
+
+func TestOwnerPreparationClosesUnderLockOnFailure(t *testing.T) {
+	for _, failPrepare := range []bool{false, true} {
+		t.Run(map[bool]string{false: "seed_failure", true: "preparation_failure"}[failPrepare], func(t *testing.T) {
+			state := t.TempDir()
+			failure, cleanup := errors.New("prepare failed"), errors.New("cleanup failed")
+			closes := 0
+			options := launchOptions(func(_ context.Context, _ LaunchRequest, run func(OwnerOptions) error) error {
+				return run(OwnerOptions{Prepare: func(context.Context) (OwnerResources, error) {
+					resources := OwnerResources{Close: func() error {
+						closes++
+						_, err := lockApplication(state)
+						require.ErrorIs(t, err, errLockBusy)
+						return cleanup
+					}}
+					if failPrepare {
+						return resources, failure
+					}
+					return resources, nil
+				}})
+			})
+			err := Run(t.Context(), options, []string{"--state-dir", state})
+			require.ErrorIs(t, err, cleanup)
+			if failPrepare {
+				require.ErrorIs(t, err, failure)
+			}
+			require.Equal(t, 1, closes)
+			unlock, err := lockApplication(state)
+			require.NoError(t, err)
+			unlock()
+		})
+	}
+}
+
+func TestLaunchBypassedForReservedOperations(t *testing.T) {
+	for _, args := range [][]string{{"runtime", "lint"}, {"update"}, {"--base"}} {
+		options := launchOptions(func(context.Context, LaunchRequest, func(OwnerOptions) error) error {
+			t.Fatal("reserved operation invoked application launch")
+			return nil
+		})
+		err := Run(t.Context(), options, append([]string{"--state-dir", t.TempDir()}, args...))
+		require.Error(t, err, "empty bundle must reject the standard owner path")
+	}
+}
+
+func TestLaunchOwnerRunnerSingleUseAndScoped(t *testing.T) {
+	var escaped func(OwnerOptions) error
+	var calls int
+	err := launch(t.Context(), func(_ context.Context, _ LaunchRequest, run func(OwnerOptions) error) error {
+		escaped = run
+		require.NoError(t, run(OwnerOptions{}))
+		require.ErrorContains(t, run(OwnerOptions{}), "single-use")
+		return nil
+	}, LaunchRequest{}, func(context.Context, OwnerOptions) error { calls++; return nil })
+	require.NoError(t, err)
+	require.ErrorContains(t, escaped(OwnerOptions{}), "single-use")
+	require.Equal(t, 1, calls)
+}
+
+func TestLaunchReturnCancelsAndJoinsOwner(t *testing.T) {
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	var goroutine sync.WaitGroup
+	err := launch(t.Context(), func(_ context.Context, _ LaunchRequest, run func(OwnerOptions) error) error {
+		goroutine.Go(func() { _ = run(OwnerOptions{}) })
+		<-started
+		return nil
+	}, LaunchRequest{}, func(ctx context.Context, _ OwnerOptions) error {
+		close(started)
+		<-ctx.Done()
+		close(stopped)
+		return ctx.Err()
+	})
+	require.ErrorContains(t, err, "before owner runner completed")
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("launch returned before owner cleanup")
+	}
+	goroutine.Wait()
+}
+
+func TestExpiredOwnerDoesNotOpenDeployment(t *testing.T) {
+	state := t.TempDir()
+	closes := 0
+	options := launchOptions(func(_ context.Context, _ LaunchRequest, run func(OwnerOptions) error) error {
+		return run(OwnerOptions{Prepare: func(context.Context) (OwnerResources, error) {
+			return OwnerResources{Deadline: time.Now().Add(-time.Second), Close: func() error { closes++; return nil }}, nil
+		}})
+	})
+	require.ErrorIs(t, Run(t.Context(), options, []string{"--state-dir", state}), context.DeadlineExceeded)
+	require.Equal(t, 1, closes)
+	require.NoDirExists(t, filepath.Join(state, "deployment"))
+}
+
+func TestOwnerConfigCannotRedirectHistory(t *testing.T) {
+	config := launchOverrides(boot.NewConfig(boot.WithSection("registry", map[string]any{
+		"enable_history": false, "history_type": "other", "history_path": "elsewhere",
+	}), boot.WithSection("cluster", map[string]any{"enabled": true})), "selected/registry.db")
+	require.Equal(t, "selected/registry.db", config.GetString("registry.history_path", ""))
+	require.Equal(t, "sqlite", config.GetString("registry.history_type", ""))
+	require.True(t, config.GetBool("registry.enable_history", false))
+	require.True(t, config.GetBool("cluster.enabled", false))
+}

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/wippyai/runtime/api/boot"
 	"github.com/wippyai/runtime/cmd/wippy/cmd"
@@ -98,10 +100,10 @@ func Run(ctx context.Context, options Options, args []string) error {
 }
 
 func runApplication(ctx context.Context, options Options, stateDir string, base bool, command string, remaining []string, owner OwnerOptions) (result error) {
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := ctx.Err(); err != nil {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return err
 	}
 	unlock, err := lockApplication(stateDir)
@@ -190,12 +192,20 @@ func runApplication(ctx context.Context, options Options, stateDir string, base 
 }
 
 func configureDataEnvironment(state string, variables map[string]string) error {
-	for name, relative := range variables {
-		if !environmentName.MatchString(name) || !filepath.IsLocal(relative) {
+	names := make([]string, 0, len(variables))
+	for name := range variables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		relative := variables[name]
+		if !environmentName.MatchString(name) || !filepath.IsLocal(relative) || strings.ContainsRune(relative, 0) {
 			return fmt.Errorf("invalid application data environment binding %q", name)
 		}
+	}
+	for _, name := range names {
 		if _, exists := os.LookupEnv(name); !exists {
-			if err := os.Setenv(name, filepath.Join(state, relative)); err != nil {
+			if err := os.Setenv(name, filepath.Join(state, variables[name])); err != nil {
 				return err
 			}
 		}

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 // DataEnv maps application-owned environment variables to paths within StateDir.
 // Existing environment values remain explicit user overrides.
 type Options struct {
+	Launch     Launch
 	DataEnv    map[string]string
 	Components []boot.Component
 	Name       string
@@ -34,6 +36,12 @@ var environmentName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
 // arguments follow `run`; `runtime` exposes the Wippy CLI, including
 // Hub authentication, update and source inspection commands.
 func Run(ctx context.Context, options Options, args []string) error {
+	if ctx == nil {
+		return fmt.Errorf("application context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if !applicationName.MatchString(options.Name) {
 		return fmt.Errorf("invalid application name")
 	}
@@ -62,23 +70,79 @@ func Run(ctx context.Context, options Options, args []string) error {
 	if err != nil {
 		return err
 	}
+	remaining := append([]string(nil), flags.Args()...)
+	ordinary := !*base && (len(remaining) == 0 || (remaining[0] != "runtime" && remaining[0] != "update"))
+	if options.Launch != nil && ordinary {
+		if len(remaining) > 0 && remaining[0] == "run" {
+			remaining = remaining[1:]
+		}
+		directory, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		request := LaunchRequest{Name: options.Name, Module: options.Bundle.Root, StateDir: stateDir,
+			Directory: directory, Command: *command, Arguments: append([]string(nil), remaining...)}
+		return launch(ctx, options.Launch, request, func(ctx context.Context, owner OwnerOptions) error {
+			selected := *command
+			if owner.Command != "" {
+				selected = owner.Command
+			}
+			arguments := remaining
+			if owner.Arguments != nil {
+				arguments = owner.Arguments
+			}
+			return runApplication(ctx, options, stateDir, false, selected, append([]string{"run"}, arguments...), owner)
+		})
+	}
+	return runApplication(ctx, options, stateDir, *base, *command, remaining, OwnerOptions{})
+}
+
+func runApplication(ctx context.Context, options Options, stateDir string, base bool, command string, remaining []string, owner OwnerOptions) (result error) {
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	unlock, err := lockApplication(stateDir)
+	if err != nil {
+		if errors.Is(err, errLockBusy) {
+			return fmt.Errorf("%w: %w", ErrBusy, err)
+		}
+		return err
+	}
+	defer unlock()
+	var overrides boot.Config
+	if owner.Prepare != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		resources, err := owner.Prepare(ctx)
+		if resources.Close != nil {
+			defer func() { result = errors.Join(result, resources.Close()) }()
+		}
+		if err != nil {
+			return err
+		}
+		if !resources.Deadline.IsZero() {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithDeadline(ctx, resources.Deadline)
+			defer cancel()
+		}
+		overrides = resources.Config
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if err := configureDataEnvironment(stateDir, options.DataEnv); err != nil {
 		return err
 	}
-	unlock, err := lockApplication(stateDir)
-	if err != nil {
-		return err
-	}
-	defer unlock()
 	deployment, err := selectedDeployment(stateDir)
 	if err != nil {
 		return err
 	}
 	historyPath := filepath.Join(stateDir, "registry.db")
-	if *base {
+	if base {
 		if options.Mode != "base" {
 			return fmt.Errorf("bootstrap applications do not expose a base deployment")
 		}
@@ -91,16 +155,15 @@ func Run(ctx context.Context, options Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	remaining := flags.Args()
 	if len(remaining) > 0 && remaining[0] == "update" {
-		if *base {
+		if base {
 			return fmt.Errorf("base recovery cannot be updated")
 		}
 		return updateDeployment(ctx, options, stateDir, deployment, remaining[1:], runChild)
 	}
-	runtimeArgs := []string{"run", "--silent", "--", *command}
+	runtimeArgs := []string{"run", "--silent", "--", command}
 	if len(remaining) > 0 && remaining[0] == "runtime" {
-		if *base {
+		if base {
 			return fmt.Errorf("base recovery only runs the embedded application")
 		}
 		runtimeArgs = remaining[1:]
@@ -122,11 +185,7 @@ func Run(ctx context.Context, options Options, args []string) error {
 		LockFile:    lockPath,
 		ConfigFiles: configFiles,
 		Components:  options.Components,
-		Overrides: boot.NewConfig(boot.WithSection("registry", map[string]any{
-			"enable_history": true,
-			"history_type":   "sqlite",
-			"history_path":   historyPath,
-		})),
+		Overrides:   launchOverrides(overrides, historyPath),
 	})
 }
 

--- a/cmd/app/run_validation_test.go
+++ b/cmd/app/run_validation_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInvalidDataEnvironmentDoesNotApplyOtherBindings(t *testing.T) {
+	const name = "WIPPY_APP_TEST_VALID_BINDING"
+	t.Setenv(name, "")
+	if err := os.Unsetenv(name); err != nil {
+		t.Fatal(err)
+	}
+	for _, invalid := range []string{"../outside", "", "data\x00file"} {
+		err := configureDataEnvironment(t.TempDir(), map[string]string{
+			name: "data", "WIPPY_APP_TEST_Z_INVALID_BINDING": invalid,
+		})
+		if err == nil {
+			t.Fatalf("accepted invalid path %q", invalid)
+		}
+		if _, found := os.LookupEnv(name); found {
+			t.Fatal("invalid configuration partially changed the environment")
+		}
+	}
+}
+
+func TestDataEnvironmentPreservesExplicitEmptyOverride(t *testing.T) {
+	const name = "WIPPY_APP_TEST_EMPTY_OVERRIDE"
+	t.Setenv(name, "")
+	if err := configureDataEnvironment(t.TempDir(), map[string]string{name: "data"}); err != nil {
+		t.Fatal(err)
+	}
+	if value, found := os.LookupEnv(name); !found || value != "" {
+		t.Fatalf("explicit override changed: %q, %v", value, found)
+	}
+}
+
+func TestCanceledOwnerDoesNotCreateStateDirectory(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	state := filepath.Join(t.TempDir(), "not-created")
+	err := runApplication(ctx, Options{}, state, false, "", nil, OwnerOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation, got %v", err)
+	}
+	if _, err := os.Stat(state); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canceled invocation created state: %v", err)
+	}
+}


### PR DESCRIPTION
## Purpose

Let a Builder-produced executable select an application-specific client or owner invocation without changing ordinary Wippy runtime semantics.

## Design

- All implementation and contracts live in `cmd/app`, following #727. No `api/application`, public statelock package, Lua API, or boot-component discovery is added.
- `Options.Launch` is an explicit native callback. It can run a client directly or call the one-shot, scoped owner runner. The application owns discovery, authentication, admission and attachment errors.
- The owner runner alone acquires application-state ownership, prepares native owner resources, opens deployment/history, executes the existing runtime command, and cleans up before unlocking.
- Actual contention returns `app.ErrBusy`; filesystem errors are not contention. No automatic attachment, retry, or owner fallback occurs.
- Recovery, update and runtime tooling bypass the callback. Explicit state selection and registry-history ownership remain fixed.
- An escaped/repeated owner runner is rejected. Returning while it is active cancels and joins it and reports a lifecycle error.

#726's embedded-baseline selection is a separate application option, not a launch result. Builder and Bee need corresponding explicit wiring; the former implicit `PrepareLaunch` component integration is intentionally removed. Do not merge until those integration checks are complete.

## Validation

- `go test -race ./cmd/app -count=10` passes.
- Pinned golangci-lint on `./cmd/app/...`: zero issues.
- Windows amd64 non-CGO application test binary cross-compiles (not executed on Windows).
- Tests cover client-only state isolation, busy-owner routing without store access, lock I/O errors, preparation/seed failure cleanup under ownership, reserved operation bypass, expired owner credentials, fixed registry history, and runner lifetime enforcement.
- No changes outside `cmd/app`; no docs or README files added to the repository.
