### PR TITLE
Preserve command cancellation and clean up failed runtime startup

### DIFF
--- a/api/boot/boot.go
+++ b/api/boot/boot.go
@@ -28,7 +28,8 @@ type (
 
 	// Stopper is implemented by components that need graceful shutdown.
 	Stopper interface {
-		// Stop gracefully shuts down the service.
+		// Stop releases resources acquired by Load and Start. Shutdown can run
+		// after a later component fails to load, before Start was ever called.
 		Stop(ctx context.Context) error
 	}
 )

--- a/boot/infrastructure.go
+++ b/boot/infrastructure.go
@@ -4,6 +4,7 @@ package boot
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -54,9 +55,22 @@ func getPeerManager(ctx context.Context) *relay.PeerManager {
 // The logger is wrapped with event streaming capabilities, allowing runtime control
 // of log propagation and streaming to the event bus.
 func NewBootstrapContext(logger *zap.Logger, cfg boot.Config) (context.Context, error) {
+	return NewBootstrapContextWithParent(context.Background(), logger, cfg)
+}
+
+// NewBootstrapContextWithParent preserves the caller's cancellation, deadline
+// and values while installing a fresh application context. Native application
+// runners must use it so their owner lifetime reaches runtime components.
+func NewBootstrapContextWithParent(parent context.Context, logger *zap.Logger, cfg boot.Config) (context.Context, error) {
+	if parent == nil {
+		return nil, fmt.Errorf("bootstrap parent context is required")
+	}
+	if err := parent.Err(); err != nil {
+		return nil, err
+	}
 	// Create AppContext and attach config
 	appCtx := contextapi.NewAppContext()
-	ctx := contextapi.WithAppContext(context.Background(), appCtx)
+	ctx := contextapi.WithAppContext(parent, appCtx)
 	ctx = moduleapi.WithSourceRegistry(ctx, moduleapi.NewSourceRegistry())
 	if cfg != nil {
 		ctx = boot.WithConfig(ctx, cfg)

--- a/boot/infrastructure_parent_test.go
+++ b/boot/infrastructure_parent_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MPL-2.0
+package boot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	bootapi "github.com/wippyai/runtime/api/boot"
+	"go.uber.org/zap"
+)
+
+func TestBootstrapContextPreservesParentLifetime(t *testing.T) {
+	type testKey struct{}
+	deadline := time.Now().Add(time.Minute)
+	parent, cancel := context.WithDeadline(context.WithValue(context.Background(), testKey{}, "parent"), deadline)
+	defer cancel()
+	ctx, err := NewBootstrapContextWithParent(parent, zap.NewNop(), bootapi.NewConfig())
+	require.NoError(t, err)
+	require.Equal(t, "parent", ctx.Value(testKey{}))
+	actual, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.Equal(t, deadline, actual)
+	cancel()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestBootstrapContextRejectsUnavailableParent(t *testing.T) {
+	_, err := NewBootstrapContextWithParent(nil, zap.NewNop(), nil)
+	require.Error(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = NewBootstrapContextWithParent(ctx, zap.NewNop(), nil)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/cmd/wippy/cmd/run.go
+++ b/cmd/wippy/cmd/run.go
@@ -34,7 +34,6 @@ import (
 	"github.com/wippyai/runtime/cmd/internal/banner"
 	"github.com/wippyai/runtime/cmd/internal/bootconfig"
 	"github.com/wippyai/runtime/cmd/internal/entries"
-	"github.com/wippyai/runtime/cmd/internal/shutdown"
 	embedpkg "github.com/wippyai/runtime/service/fs/embed"
 	terminalservice "github.com/wippyai/runtime/service/terminal"
 	securitysys "github.com/wippyai/runtime/system/security"
@@ -146,7 +145,7 @@ func commandHost(cmd *cobra.Command) string {
 	return host
 }
 
-func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
+func runWithUseCase(cmd *cobra.Command, args []string, useCase string) (result error) {
 	memLimit := initMemoryLimit()
 
 	execSpec := ""
@@ -223,7 +222,13 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 		return err
 	}
 
-	ctx, err := bootpkg.NewBootstrapContext(logger, cfg)
+	parent := context.Background()
+	if cmd != nil {
+		parent = cmd.Context()
+	}
+	parent, cancelRuntime := context.WithCancel(parent)
+	defer cancelRuntime()
+	ctx, err := bootpkg.NewBootstrapContextWithParent(parent, logger, cfg)
 	if err != nil {
 		logger.Error("failed to initialize bootstrap context", zap.Error(err))
 		return NewInitializeBootstrapContextError(err)
@@ -259,15 +264,27 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 		return NewCreateLoaderError(err)
 	}
 
-	ctx, err = loader.Load(ctx)
+	runtimeShutdown := &runShutdown{}
+	var sigChan chan os.Signal
+	defer func() {
+		runtimeShutdown.deferCleanup(ctx, &result, loader, logger, silentLogs)
+		if sigChan != nil {
+			signal.Stop(sigChan)
+		}
+	}()
+
+	loadedContext, loadError := loader.Load(ctx)
+	if loadedContext != nil {
+		ctx = loadedContext
+	}
+	err = loadError
 	if err != nil {
 		logger.Error("load failed", zap.Error(err))
 		return NewLoadComponentsError(err)
 	}
 	logger.Info("components loaded successfully")
 
-	sigChan := setupSupervisorSignalChannel(ctx)
-	defer signal.Stop(sigChan)
+	sigChan = setupSupervisorSignalChannel(ctx)
 
 	err = loader.Start(ctx)
 	if err != nil {
@@ -317,15 +334,8 @@ func runWithUseCase(cmd *cobra.Command, args []string, useCase string) error {
 		}
 	}
 
-	waitForShutdownSignal(sigChan, logger, nil)
-
-	exitCode := shutdown.Perform(ctx, loader, logger, silentLogs)
-	if exitCode != 0 {
-		_ = logger.Sync()
-		os.Exit(exitCode)
-	}
-
-	return nil
+	waitForShutdownSignal(ctx, sigChan, logger, nil)
+	return ctx.Err()
 }
 
 // loadRuntimeConfig resolves the effective runtime configuration for run-like
@@ -1044,17 +1054,26 @@ func setupSupervisorSignalChannel(ctx context.Context) chan os.Signal {
 
 // waitForShutdownSignal handles first-signal graceful shutdown and second-signal
 // forced process termination.
-func waitForShutdownSignal(sigChan chan os.Signal, logger *zap.Logger, onFirstSignal func()) {
-	sig := <-sigChan
+func waitForShutdownSignal(ctx context.Context, sigChan chan os.Signal, logger *zap.Logger, onFirstSignal func()) {
+	var sig os.Signal
+	select {
+	case <-ctx.Done():
+		return
+	case sig = <-sigChan:
+	}
 	logger.Info("received shutdown signal", zap.String("signal", sig.String()))
 	if onFirstSignal != nil {
 		onFirstSignal()
 	}
 
 	go func() {
-		<-sigChan
-		logger.Error("force exit")
-		os.Exit(1)
+		select {
+		case <-ctx.Done():
+			return
+		case <-sigChan:
+			logger.Error("force exit")
+			os.Exit(1)
+		}
 	}()
 
 	if !silentLogs {

--- a/cmd/wippy/cmd/run_load_cleanup_test.go
+++ b/cmd/wippy/cmd/run_load_cleanup_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+	"go.uber.org/zap"
+)
+
+func TestPackBootstrapFailureStopsPreviouslyLoadedComponents(t *testing.T) {
+	directory := t.TempDir()
+	config := filepath.Join(directory, "wippy.yaml")
+	require.NoError(t, os.WriteFile(config, []byte("version: \"1.0\"\n"), 0600))
+	setTestConfigFiles(t, config)
+	previous := nativeOptions
+	t.Cleanup(func() { nativeOptions = previous })
+	loaded, stopped := 0, 0
+	failure := errors.New("injected component load failure")
+	nativeOptions = &ExecuteOptions{
+		LockFile: filepath.Join(directory, "wippy.lock"),
+		Components: []boot.Component{
+			boot.New(boot.P{Name: "cleanup-proof-owner", Load: func(ctx context.Context) (context.Context, error) {
+				loaded++
+				return ctx, nil
+			}, Stop: func(ctx context.Context) error {
+				require.NoError(t, ctx.Err(), "cleanup receives its own live context")
+				stopped++
+				return nil
+			}}),
+			boot.New(boot.P{Name: "cleanup-proof-failure", DependsOn: []string{"cleanup-proof-owner"}, Load: func(ctx context.Context) (context.Context, error) {
+				return ctx, failure
+			}}),
+		},
+	}
+	loadedContext, loader, logger, registry, err := bootstrapPackRuntime(nil, zap.NewNop())
+	require.ErrorContains(t, err, failure.Error())
+	require.Nil(t, loadedContext)
+	require.Nil(t, loader)
+	require.Nil(t, logger)
+	require.Nil(t, registry)
+	require.Equal(t, 1, loaded)
+	require.Equal(t, 1, stopped, "failed bootstrap must release prior component ownership")
+}

--- a/cmd/wippy/cmd/run_pack.go
+++ b/cmd/wippy/cmd/run_pack.go
@@ -25,7 +25,6 @@ import (
 	"github.com/wippyai/runtime/boot/deps/lock"
 	"github.com/wippyai/runtime/cmd/internal/banner"
 	"github.com/wippyai/runtime/cmd/internal/entries"
-	"github.com/wippyai/runtime/cmd/internal/shutdown"
 	"github.com/wippyai/wapp"
 	"go.uber.org/zap"
 )
@@ -554,7 +553,7 @@ func getCacheDir() string {
 }
 
 // runFromPackFile executes runtime from one .wapp file.
-func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase string) error {
+func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase string) (result error) {
 	memLimit := initMemoryLimit()
 
 	banner.Print(silentLogs)
@@ -580,6 +579,10 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase
 		return err
 	}
 	defer embedReg.Close()
+	runtimeShutdown := &runShutdown{}
+	defer func() {
+		runtimeShutdown.deferCleanup(ctx, &result, loader, runLogger, silentLogs)
+	}()
 
 	mainModule, _, err := moduleIdentityFromPackFile(packFile)
 	if err != nil {
@@ -599,11 +602,11 @@ func runFromPackFile(cmd *cobra.Command, packFile string, args []string, useCase
 	}
 	entries.ConfigureSourceLoader(ctx, sourcePaths, runLogger)
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule, commandHost(cmd))
+	return runPackEntriesWithShutdown(ctx, loader, runLogger, packEntries, args, useCase, mainModule, commandHost(cmd), runtimeShutdown)
 }
 
 // runFromPackFiles executes runtime from multiple already resolved .wapp files.
-func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, useCase string) error {
+func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, useCase string) (result error) {
 	memLimit := initMemoryLimit()
 
 	banner.Print(silentLogs)
@@ -629,6 +632,10 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, use
 		return err
 	}
 	defer embedReg.Close()
+	runtimeShutdown := &runShutdown{}
+	defer func() {
+		runtimeShutdown.deferCleanup(ctx, &result, loader, runLogger, silentLogs)
+	}()
 
 	mainModule := ""
 	if len(packFiles) > 0 {
@@ -652,7 +659,7 @@ func runFromPackFiles(cmd *cobra.Command, packFiles []string, args []string, use
 	}
 	entries.ConfigureSourceLoader(ctx, sourcePaths, runLogger)
 
-	return runPackEntries(ctx, loader, runLogger, packEntries, args, useCase, mainModule, commandHost(cmd))
+	return runPackEntriesWithShutdown(ctx, loader, runLogger, packEntries, args, useCase, mainModule, commandHost(cmd), runtimeShutdown)
 }
 
 func packSourcePaths(packFiles []string, rootModule string) ([]lock.ModuleLoadPath, error) {
@@ -684,11 +691,28 @@ func runPackEntries(
 	mainModule string,
 	hostID string,
 ) error {
+	return runPackEntriesWithShutdown(ctx, loader, logger, packEntries, args, useCase, mainModule, hostID, &runShutdown{})
+}
+
+func runPackEntriesWithShutdown(
+	ctx context.Context,
+	loader *bootpkg.Loader,
+	logger *zap.Logger,
+	packEntries []registry.Entry,
+	args []string,
+	useCase string,
+	mainModule string,
+	hostID string,
+	runtimeShutdown *runShutdown,
+) (result error) {
 	sigChan := setupSupervisorSignalChannel(ctx)
 	defer signal.Stop(sigChan)
 
 	appCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	defer func() {
+		runtimeShutdown.deferCleanup(ctx, &result, loader, logger, silentLogs)
+	}()
 
 	if err := loader.Start(appCtx); err != nil {
 		logger.Error("start failed", zap.Error(err))
@@ -729,15 +753,8 @@ func runPackEntries(
 		}
 	}
 
-	waitForShutdownSignal(sigChan, logger, nil)
-
-	exitCode := shutdown.Perform(ctx, loader, logger, silentLogs)
-	if exitCode != 0 {
-		_ = logger.Sync()
-		os.Exit(exitCode)
-	}
-
-	return nil
+	waitForShutdownSignal(appCtx, sigChan, logger, nil)
+	return appCtx.Err()
 }
 
 func moduleIdentityFromPackFile(packFile string) (moduleName string, moduleVersion string, err error) {

--- a/cmd/wippy/cmd/run_pack_bootstrap.go
+++ b/cmd/wippy/cmd/run_pack_bootstrap.go
@@ -30,7 +30,11 @@ func bootstrapPackRuntimeWithDefaults(cmd *cobra.Command, baseLogger *zap.Logger
 		return nil, nil, nil, nil, err
 	}
 
-	ctx, err := bootpkg.NewBootstrapContext(baseLogger, cfg)
+	parent := context.Background()
+	if cmd != nil {
+		parent = cmd.Context()
+	}
+	ctx, err := bootpkg.NewBootstrapContextWithParent(parent, baseLogger, cfg)
 	if err != nil {
 		baseLogger.Error("failed to initialize bootstrap context", zap.Error(err))
 		return nil, nil, nil, nil, NewInitializeBootstrapContextError(err)
@@ -60,9 +64,16 @@ func bootstrapPackRuntimeWithDefaults(cmd *cobra.Command, baseLogger *zap.Logger
 		return nil, nil, nil, nil, NewCreateLoaderError(err)
 	}
 
-	ctx, err = loader.Load(ctx)
+	loadedContext, loadError := loader.Load(ctx)
+	if loadedContext != nil {
+		ctx = loadedContext
+	}
+	err = loadError
 	if err != nil {
 		logger.Error("load failed", zap.Error(err))
+		// Successful earlier Load calls already own resources even though a
+		// later component failed. Release them before dropping the context.
+		(&runShutdown{}).perform(ctx, loader, logger, silentLogs)
 		embedReg.Close()
 		return nil, nil, nil, nil, NewLoadComponentsError(err)
 	}

--- a/cmd/wippy/cmd/run_pack_shutdown_test.go
+++ b/cmd/wippy/cmd/run_pack_shutdown_test.go
@@ -139,7 +139,7 @@ func TestWaitForShutdownSignal_InvokesOnFirstSignalOnlyWhenSet(t *testing.T) {
 		sigChan <- syscall.SIGTERM
 
 		called := make(chan struct{}, 1)
-		waitForShutdownSignal(sigChan, zap.NewNop(), func() { called <- struct{}{} })
+		waitForShutdownSignal(t.Context(), sigChan, zap.NewNop(), func() { called <- struct{}{} })
 
 		select {
 		case <-called:
@@ -152,7 +152,7 @@ func TestWaitForShutdownSignal_InvokesOnFirstSignalOnlyWhenSet(t *testing.T) {
 		sigChan := make(chan os.Signal, 1)
 		sigChan <- syscall.SIGTERM
 
-		waitForShutdownSignal(sigChan, zap.NewNop(), nil)
+		waitForShutdownSignal(t.Context(), sigChan, zap.NewNop(), nil)
 	})
 }
 
@@ -183,4 +183,19 @@ func waitForServiceStatus(t *testing.T, sup *supervisorpkg.Supervisor, serviceID
 	}
 
 	t.Fatalf("timeout waiting for service %q to reach status %q", serviceID, status)
+}
+
+func TestWaitForShutdownSignalAcceptsParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		waitForShutdownSignal(ctx, make(chan os.Signal, 1), zap.NewNop(), func() { t.Error("cancellation reported an OS signal") })
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown waiter ignored parent cancellation")
+	}
 }

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -37,15 +37,12 @@ func TestRunPackEntries_InvalidRequirementFailsNormalizationPipeline(t *testing.
 
 	setTestConfigFiles(t, cfgPath)
 
-	ctx, loader, logger, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
+	ctx, loader, _, embedReg, err := bootstrapPackRuntime(nil, zap.NewNop())
 	if err != nil {
 		t.Fatalf("bootstrap pack runtime: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = embedReg.Close()
-	})
-	t.Cleanup(func() {
-		_ = shutdown.Perform(ctx, loader, logger, true)
 	})
 
 	packEntries := []regapi.Entry{

--- a/cmd/wippy/cmd/run_pack_test.go
+++ b/cmd/wippy/cmd/run_pack_test.go
@@ -1454,7 +1454,6 @@ func TestRunPackEntries_ExplicitHostDoesNotFallBack(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer embedReg.Close()
-	defer shutdown.Perform(ctx, loader, logger, true)
 	entries := []regapi.Entry{{
 		ID: regapi.NewID("test", "runner"), Kind: "process.lua",
 		Meta: map[string]any{"command": map[string]any{"name": "probe"}},

--- a/cmd/wippy/cmd/run_shutdown.go
+++ b/cmd/wippy/cmd/run_shutdown.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	bootpkg "github.com/wippyai/runtime/boot"
+	"github.com/wippyai/runtime/cmd/internal/shutdown"
+	"go.uber.org/zap"
+)
+
+// runShutdown owns the lifetime of one loaded command runtime. Pack loading
+// has an outer phase that can fail before runPackEntries is called, so the
+// same one-shot owner is shared by both phases. A deferred cleanup must also
+// be safe when the normal path has already performed it.
+type runShutdown struct {
+	once     sync.Once
+	exitCode int
+}
+
+func (s *runShutdown) perform(ctx context.Context, loader *bootpkg.Loader, logger *zap.Logger, silent bool) int {
+	s.once.Do(func() {
+		s.exitCode = shutdown.Perform(ctx, loader, logger, silent)
+	})
+	return s.exitCode
+}
+
+func (s *runShutdown) deferCleanup(ctx context.Context, result *error, loader *bootpkg.Loader, logger *zap.Logger, silent bool) {
+	exitCode := s.perform(ctx, loader, logger, silent)
+	// Preserve an existing startup/launch/cancellation error. A programmatic
+	// exit code is only actionable when the runtime itself otherwise completed
+	// successfully, matching the old explicit-shutdown path.
+	if *result == nil && exitCode != 0 {
+		_ = logger.Sync()
+		os.Exit(exitCode)
+	}
+}

--- a/service/store/dispatcher.go
+++ b/service/store/dispatcher.go
@@ -54,6 +54,10 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 
 // Stop shuts down the dispatcher and drains pending jobs.
 func (d *Dispatcher) Stop(_ context.Context) error {
+	// Load can succeed even when boot never reaches Start.
+	if d.cancel == nil {
+		return nil
+	}
 	d.stopOnce.Do(func() {
 		d.admitMu.Lock()
 		d.stopped = true

--- a/service/websocket/dispatcher.go
+++ b/service/websocket/dispatcher.go
@@ -82,6 +82,11 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 
 // Stop shuts down the dispatcher and drains pending jobs.
 func (d *Dispatcher) Stop(_ context.Context) error {
+	// Load constructs this dispatcher before the boot Start phase. A later
+	// component can fail to load, so cleanup must tolerate no worker pool.
+	if d.cancel == nil {
+		return nil
+	}
 	d.cancel()
 	close(d.jobs)
 	d.wg.Wait()

--- a/service/websocket/dispatcher_lifecycle_test.go
+++ b/service/websocket/dispatcher_lifecycle_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package websocket
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDispatcherStopBeforeStart(t *testing.T) {
+	// Boot must clean up successfully loaded components even if a later Load
+	// fails before the Start phase reaches this dispatcher.
+	d := NewDispatcher()
+	if err := d.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/system/eventbus/dispatcher.go
+++ b/system/eventbus/dispatcher.go
@@ -65,6 +65,10 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 
 // Stop unsubscribes and stops the routing loop.
 func (d *Dispatcher) Stop(ctx context.Context) error {
+	// Load can succeed even when boot never reaches Start.
+	if d.cancel == nil {
+		return nil
+	}
 	d.cancel()
 	d.bus.Unsubscribe(ctx, d.subID)
 	close(d.eventC)

--- a/system/security/dispatcher.go
+++ b/system/security/dispatcher.go
@@ -49,6 +49,10 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 
 // Stop shuts down the dispatcher and drains pending jobs.
 func (d *Dispatcher) Stop(_ context.Context) error {
+	// A later component may fail to load before any worker pool starts.
+	if d.cancel == nil {
+		return nil
+	}
 	d.cancel()
 	close(d.jobs)
 	d.wg.Wait()


### PR DESCRIPTION
## Summary

- preserve the Cobra command context through runtime bootstrap so cancellation, deadlines, and caller values reach loaded components
- keep the latest successful load context when a later component fails
- give each command runtime one cleanup owner shared across pack bootstrap, start, launch, cancellation, and normal shutdown paths
- clean already-loaded components after load/start failures and make affected dispatchers tolerate cleanup before `Start`

The change reuses the existing loader and shutdown pipeline. It adds one parent-aware bootstrap entry point and one command-local one-shot cleanup owner; no runtime protocol or configuration surface is introduced.

## Regression coverage

Tests cover parent cancellation/value/deadline propagation, partial-load cleanup, pre-start dispatcher cleanup, pack-start failure, normal shutdown, cancellation without a signal, and prevention of duplicate shutdown.

## Verification

- uncached race tests for boot, command runtime, store/WebSocket dispatchers, event bus, and security dispatcher
- `go vet`
- golangci-lint v2.13.2: 0 issues
- Windows amd64 build of affected packages
- `go mod verify`
- `git diff --check`
