### PR TITLE
Expose typed terminal input without an actor scheduler

### DIFF
--- a/service/terminal/input.go
+++ b/service/terminal/input.go
@@ -30,7 +30,6 @@ type InputReader struct {
 	stopDone     chan struct{}
 	stopErr      error
 	done         chan struct{}
-	doneClosed   bool
 	err          error
 	stdin        *os.File
 	wg           sync.WaitGroup
@@ -39,6 +38,7 @@ type InputReader struct {
 	stopping     bool
 	mouseEnabled bool
 	pasteEnabled bool
+	doneClosed   bool
 }
 
 // NewEventInputReader creates an InputReader that delivers events to the given sink

--- a/service/terminal/input.go
+++ b/service/terminal/input.go
@@ -9,9 +9,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/charmbracelet/x/input"
 	"github.com/charmbracelet/x/term"
-	"github.com/muesli/cancelreader"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/relay"
@@ -25,7 +23,7 @@ type InputReader struct {
 	emitter      *inputEmitter
 	raw          *RawManager
 	sink         func(tty.Event)
-	reader       *input.Reader
+	reader       terminalInputReader
 	cancel       context.CancelFunc
 	stopDone     chan struct{}
 	stopErr      error
@@ -135,8 +133,7 @@ func (r *InputReader) Start() error {
 		return errors.New("stdin is required")
 	}
 
-	termType := os.Getenv("TERM")
-	reader, err := input.NewReader(r.stdin, termType, 0)
+	reader, err := newTerminalInputReader(r.stdin, os.Getenv("TERM"))
 	if err != nil {
 		_ = r.raw.Disable()
 		return err
@@ -315,7 +312,7 @@ func (r *InputReader) screenSize() (int, int, error) {
 	return term.GetSize(r.stdin.Fd())
 }
 
-func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader, session <-chan struct{}) {
+func (r *InputReader) readLoop(ctx context.Context, reader terminalInputReader, session <-chan struct{}) {
 	var readErr error
 	defer func() {
 		r.wg.Done()
@@ -324,32 +321,7 @@ func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader, sessio
 		}
 	}()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		events, err := reader.ReadEvents()
-		for _, ev := range events {
-			ttyEv := ConvertInputEvent(ev)
-			if ttyEv != nil {
-				r.sendEvent(ttyEv)
-			}
-		}
-
-		if err != nil {
-			r.mu.Lock()
-			stopping := r.stopping
-			r.mu.Unlock()
-			if stopping || ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, cancelreader.ErrCanceled) {
-				return
-			}
-			readErr = err
-			return
-		}
-	}
+	readErr = streamTerminalInput(ctx, reader, r.sendEvent)
 }
 
 func (r *InputReader) emitResize() {

--- a/service/terminal/input.go
+++ b/service/terminal/input.go
@@ -11,25 +11,28 @@ import (
 
 	"github.com/charmbracelet/x/input"
 	"github.com/charmbracelet/x/term"
+	"github.com/muesli/cancelreader"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/relay"
-	ttyapi "github.com/wippyai/runtime/api/tty"
+	tty "github.com/wippyai/runtime/api/tty"
 	"github.com/wippyai/runtime/system/scheduler/actor"
 )
 
-// InputReader reads terminal input and delivers parsed events via the scheduler.
+// InputReader reads terminal input and delivers parsed events to a sink.
 type InputReader struct {
 	output       io.Writer
 	emitter      *inputEmitter
 	raw          *RawManager
-	scheduler    *actor.Scheduler
+	sink         func(tty.Event)
 	reader       *input.Reader
 	cancel       context.CancelFunc
 	stopDone     chan struct{}
 	stopErr      error
+	done         chan struct{}
+	doneClosed   bool
+	err          error
 	stdin        *os.File
-	targetPID    pid.PID
 	wg           sync.WaitGroup
 	mu           sync.Mutex
 	started      bool
@@ -38,18 +41,67 @@ type InputReader struct {
 	pasteEnabled bool
 }
 
-// NewInputReader creates an InputReader that delivers events to the given process.
-func NewInputReader(stdin *os.File, output io.Writer, raw *RawManager, scheduler *actor.Scheduler, targetPID pid.PID) *InputReader {
+// NewEventInputReader creates an InputReader that delivers events to the given sink
+// without requiring an actor scheduler or PID routing.
+//
+// Start acquires terminal resources. A nil raw manager is created from stdin;
+// nil output and sink discard their respective values.
+//
+// The sink is called serially and must return promptly. It must not call back
+// into the reader or wait for network acknowledgments. Network consumers should
+// enqueue events with bounded capacity and handle overflow outside the callback.
+func NewEventInputReader(stdin *os.File, output io.Writer, raw *RawManager, sink func(tty.Event)) *InputReader {
 	if output == nil {
 		output = io.Discard
 	}
-	return &InputReader{
-		stdin:     stdin,
-		output:    output,
-		raw:       raw,
-		scheduler: scheduler,
-		targetPID: targetPID,
+	if sink == nil {
+		sink = func(tty.Event) {}
 	}
+	if raw == nil && stdin != nil {
+		raw = NewRawManager(stdin)
+	}
+	return &InputReader{
+		stdin:  stdin,
+		output: output,
+		raw:    raw,
+		sink:   sink,
+		done:   make(chan struct{}),
+	}
+}
+
+// NewInputReader creates an InputReader that delivers events to the given process
+// via the actor scheduler. It is implemented as an adapter to NewEventInputReader.
+func NewInputReader(stdin *os.File, output io.Writer, raw *RawManager, scheduler *actor.Scheduler, targetPID pid.PID) *InputReader {
+	return NewEventInputReader(stdin, output, raw, func(ev tty.Event) {
+		if scheduler == nil {
+			return
+		}
+		pkg := relay.AcquirePackage()
+		pkg.Target = targetPID
+		evCopy := ev
+		pkg.AddMessage(relay.Topic(TopicTTYEvents), payload.New(&evCopy))
+		if err := scheduler.Send(pkg); err != nil {
+			relay.ReleasePackage(pkg)
+		}
+	})
+}
+
+// Done returns a completion channel that is closed when the reader terminates
+// (via Stop, EOF, or a read error) for the current active Start session.
+func (r *InputReader) Done() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
+// Err returns the error that caused the reader to terminate, if any.
+// It returns io.EOF if the input stream reached EOF, or a non-nil error if
+// a reader error occurred. If the reader was stopped cleanly or is still running,
+// Err returns nil.
+func (r *InputReader) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
 }
 
 // Start enables raw mode and spawns the read loop and SIGWINCH goroutine.
@@ -61,9 +113,26 @@ func (r *InputReader) Start() error {
 		return errors.New("input reader already started")
 	}
 	r.stopErr = nil
+	if r.doneClosed || r.done == nil {
+		r.done = make(chan struct{})
+		r.doneClosed = false
+	}
+	r.err = nil
 
+	if r.raw == nil {
+		if r.stdin != nil {
+			r.raw = NewRawManager(r.stdin)
+		} else {
+			return errors.New("terminal raw manager is required")
+		}
+	}
 	if err := r.raw.Enable(); err != nil {
 		return err
+	}
+
+	if r.stdin == nil {
+		_ = r.raw.Disable()
+		return errors.New("stdin is required")
 	}
 
 	termType := os.Getenv("TERM")
@@ -76,13 +145,19 @@ func (r *InputReader) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 	r.reader = reader
-	r.emitter = newInputEmitter(r.sendNow)
+	r.emitter = newInputEmitter(r.deliverToSink)
 	r.started = true
 	pasteSequence := []byte("\033[?2004h")
 	if n, err := r.output.Write(pasteSequence); err != nil || n != len(pasteSequence) {
 		r.started = false
 		cancel()
+		r.cancel = nil
 		_ = reader.Close()
+		r.reader = nil
+		if r.emitter != nil {
+			r.emitter.stop()
+			r.emitter = nil
+		}
 		_ = r.raw.Disable()
 		if err == nil {
 			err = io.ErrShortWrite
@@ -102,7 +177,7 @@ func (r *InputReader) Start() error {
 	}
 
 	r.wg.Add(2)
-	go r.readLoop(ctx, reader)
+	go r.readLoop(ctx, reader, r.done)
 	go r.sigwinchLoop(ctx)
 
 	return nil
@@ -110,7 +185,19 @@ func (r *InputReader) Start() error {
 
 // Stop cancels the read loop, waits for goroutines, and restores the terminal.
 func (r *InputReader) Stop() error {
+	return r.stopWithCause(nil, nil)
+}
+
+func (r *InputReader) stopWithCause(cause error, session <-chan struct{}) error {
 	r.mu.Lock()
+	// A completed reader may finish after Stop and a subsequent Start.
+	if session != nil && session != r.done {
+		r.mu.Unlock()
+		return nil
+	}
+	if cause != nil && r.err == nil {
+		r.err = cause
+	}
 	if r.stopping {
 		done := r.stopDone
 		r.mu.Unlock()
@@ -121,24 +208,30 @@ func (r *InputReader) Stop() error {
 		return err
 	}
 	if !r.started {
+		err := r.stopErr
 		r.mu.Unlock()
-		return nil
+		return err
 	}
 
 	r.started = false
 	r.stopping = true
 	r.stopDone = make(chan struct{})
-	if r.emitter != nil {
-		r.emitter.stop()
-	}
-	if r.cancel != nil {
-		r.cancel()
-		r.cancel = nil
-	}
-	if r.reader != nil {
-		r.reader.Cancel()
-	}
+
+	emitter := r.emitter
+	cancel := r.cancel
+	r.cancel = nil
+	reader := r.reader
 	r.mu.Unlock()
+
+	if emitter != nil {
+		emitter.stop()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if reader != nil {
+		reader.Cancel()
+	}
 
 	r.wg.Wait()
 
@@ -147,6 +240,7 @@ func (r *InputReader) Stop() error {
 		_ = r.reader.Close()
 		r.reader = nil
 	}
+	r.emitter = nil
 
 	// Disable mouse tracking if it was enabled
 	if r.mouseEnabled {
@@ -163,8 +257,25 @@ func (r *InputReader) Stop() error {
 		}
 		r.pasteEnabled = false
 	}
+	var rawErr error
+	if r.raw != nil {
+		rawErr = r.raw.Disable()
+	}
 	r.stopping = false
-	r.stopErr = errors.Join(pasteErr, r.raw.Disable())
+	r.stopErr = errors.Join(pasteErr, rawErr)
+	if r.stopErr != nil {
+		if r.err == nil {
+			r.err = r.stopErr
+		} else {
+			r.err = errors.Join(r.err, r.stopErr)
+		}
+	}
+	if !r.doneClosed {
+		r.doneClosed = true
+		if r.done != nil {
+			close(r.done)
+		}
+	}
 	close(r.stopDone)
 	r.stopDone = nil
 	err := r.stopErr
@@ -198,11 +309,20 @@ func (r *InputReader) ScreenSize() (int, int, error) {
 }
 
 func (r *InputReader) screenSize() (int, int, error) {
+	if r.stdin == nil {
+		return 0, 0, errors.New("stdin is nil")
+	}
 	return term.GetSize(r.stdin.Fd())
 }
 
-func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader) {
-	defer r.wg.Done()
+func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader, session <-chan struct{}) {
+	var readErr error
+	defer func() {
+		r.wg.Done()
+		if readErr != nil {
+			_ = r.stopWithCause(readErr, session)
+		}
+	}()
 
 	for {
 		select {
@@ -212,23 +332,22 @@ func (r *InputReader) readLoop(ctx context.Context, reader *input.Reader) {
 		}
 
 		events, err := reader.ReadEvents()
-		if err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
-				return
-			}
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				continue
-			}
-		}
-
 		for _, ev := range events {
 			ttyEv := ConvertInputEvent(ev)
 			if ttyEv != nil {
 				r.sendEvent(ttyEv)
 			}
+		}
+
+		if err != nil {
+			r.mu.Lock()
+			stopping := r.stopping
+			r.mu.Unlock()
+			if stopping || ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, cancelreader.ErrCanceled) {
+				return
+			}
+			readErr = err
+			return
 		}
 	}
 }
@@ -253,13 +372,13 @@ func (r *InputReader) sendEvent(ev *TTYEvent) {
 	}
 }
 
-func (r *InputReader) sendNow(ev *TTYEvent) {
-	pkg := relay.AcquirePackage()
-	pkg.Target = r.targetPID
-	pkg.AddMessage(relay.Topic(TopicTTYEvents), payload.New(ev))
-	if err := r.scheduler.Send(pkg); err != nil {
-		relay.ReleasePackage(pkg)
+func (r *InputReader) deliverToSink(ev *TTYEvent) {
+	if ev == nil {
+		return
+	}
+	if r.sink != nil {
+		r.sink(*ev)
 	}
 }
 
-var _ ttyapi.InputController = (*InputReader)(nil)
+var _ tty.InputController = (*InputReader)(nil)

--- a/service/terminal/input_eof_test.go
+++ b/service/terminal/input_eof_test.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+// SPDX-License-Identifier: MPL-2.0
+package terminal
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	tty "github.com/wippyai/runtime/api/tty"
+)
+
+func TestPhysicalReaderPeerCloseCompletesCleanup(t *testing.T) {
+	master, slave, err := pty.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer master.Close()
+	defer slave.Close()
+	if err := pty.Setsize(slave, &pty.Winsize{Rows: 24, Cols: 80}); err != nil {
+		t.Fatal(err)
+	}
+	events := make(chan tty.Event, 4)
+	raw := NewRawManager(slave)
+	reader := NewEventInputReader(slave, io.Discard, raw, func(event tty.Event) {
+		select {
+		case events <- event:
+		default:
+		}
+	})
+	if err := reader.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Stop()
+	select {
+	case event := <-events:
+		if event.Type != "start" {
+			t.Fatalf("first event: %#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("missing start event")
+	}
+	master.Close()
+	select {
+	case <-reader.Done():
+	case <-time.After(time.Second):
+		t.Fatal("peer close did not finish reader cleanup")
+	}
+	if reader.Err() == nil {
+		t.Fatal("peer close not reported")
+	}
+	if raw.Enabled() {
+		t.Fatal("reader completion left raw mode owned")
+	}
+}

--- a/service/terminal/input_event.go
+++ b/service/terminal/input_event.go
@@ -3,6 +3,7 @@
 package terminal
 
 import (
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/input"
 	ttyapi "github.com/wippyai/runtime/api/tty"
@@ -88,6 +89,35 @@ func ConvertInputEvent(ev input.Event) *TTYEvent {
 	}
 }
 
+// convertUVInputEvent adapts ultraviolet's streaming decoder events to the
+// established terminal event contract.
+func convertUVInputEvent(ev uv.Event) *TTYEvent {
+	switch e := ev.(type) {
+	case uv.KeyPressEvent:
+		return convertUVKeyEvent(uv.Key(e), "press")
+	case uv.KeyReleaseEvent:
+		return convertUVKeyEvent(uv.Key(e), "release")
+	case uv.MouseClickEvent:
+		return convertUVMouseEvent(uv.Mouse(e), "press")
+	case uv.MouseReleaseEvent:
+		return convertUVMouseEvent(uv.Mouse(e), "release")
+	case uv.MouseMotionEvent:
+		return convertUVMouseEvent(uv.Mouse(e), "motion")
+	case uv.MouseWheelEvent:
+		return convertUVMouseEvent(uv.Mouse(e), "wheel")
+	case uv.WindowSizeEvent:
+		return &TTYEvent{Type: "resize", Width: e.Width, Height: e.Height}
+	case uv.FocusEvent:
+		return &TTYEvent{Type: "focus", Focused: true}
+	case uv.BlurEvent:
+		return &TTYEvent{Type: "focus", Focused: false}
+	case uv.PasteEvent:
+		return &TTYEvent{Type: "paste", Paste: e.Content}
+	default:
+		return nil
+	}
+}
+
 func convertKeyEvent(k input.Key, action string) *TTYEvent {
 	ev := &TTYEvent{
 		Type:   "key",
@@ -130,5 +160,108 @@ func convertMouseEvent(m input.Mouse, action string) *TTYEvent {
 		Alt:   m.Mod.Contains(input.ModAlt),
 		Ctrl:  m.Mod.Contains(input.ModCtrl),
 		Shift: m.Mod.Contains(input.ModShift),
+	}
+}
+
+func convertUVKeyEvent(k uv.Key, action string) *TTYEvent {
+	ev := &TTYEvent{
+		Type:   "key",
+		Action: action,
+		Alt:    k.Mod.Contains(uv.ModAlt),
+		Ctrl:   k.Mod.Contains(uv.ModCtrl),
+		Shift:  k.Mod.Contains(uv.ModShift),
+	}
+
+	if name := uvKeyTypeName(k.Code); name != "" {
+		ev.KeyType = name
+		ev.Key = name
+	} else if k.Text != "" {
+		ev.KeyType = "runes"
+		ev.Key = k.Text
+	} else if k.Code > 0 && k.Code < uv.KeyExtended {
+		ev.KeyType = "runes"
+		ev.Key = string(k.Code)
+	} else {
+		ev.KeyType = "unknown"
+		ev.Key = k.Keystroke()
+	}
+	return ev
+}
+
+func uvKeyTypeName(code rune) string {
+	switch code {
+	case uv.KeyEnter:
+		return "enter"
+	case uv.KeyTab:
+		return "tab"
+	case uv.KeyBackspace:
+		return "backspace"
+	case uv.KeyEscape:
+		return "esc"
+	case uv.KeySpace:
+		return "space"
+	case uv.KeyUp:
+		return "up"
+	case uv.KeyDown:
+		return "down"
+	case uv.KeyLeft:
+		return "left"
+	case uv.KeyRight:
+		return "right"
+	case uv.KeyHome:
+		return "home"
+	case uv.KeyEnd:
+		return "end"
+	case uv.KeyPgUp:
+		return "pgup"
+	case uv.KeyPgDown:
+		return "pgdown"
+	case uv.KeyInsert:
+		return "insert"
+	case uv.KeyDelete:
+		return "delete"
+	case uv.KeyF1:
+		return "f1"
+	case uv.KeyF2:
+		return "f2"
+	case uv.KeyF3:
+		return "f3"
+	case uv.KeyF4:
+		return "f4"
+	case uv.KeyF5:
+		return "f5"
+	case uv.KeyF6:
+		return "f6"
+	case uv.KeyF7:
+		return "f7"
+	case uv.KeyF8:
+		return "f8"
+	case uv.KeyF9:
+		return "f9"
+	case uv.KeyF10:
+		return "f10"
+	case uv.KeyF11:
+		return "f11"
+	case uv.KeyF12:
+		return "f12"
+	default:
+		return ""
+	}
+}
+
+func convertUVMouseEvent(m uv.Mouse, action string) *TTYEvent {
+	btn := "none"
+	if name, ok := mouseButtonName[m.Button]; ok {
+		btn = name
+	}
+	return &TTYEvent{
+		Type:   "mouse",
+		Action: action,
+		Button: btn,
+		X:      m.X + 1,
+		Y:      m.Y + 1,
+		Alt:    m.Mod.Contains(uv.ModAlt),
+		Ctrl:   m.Mod.Contains(uv.ModCtrl),
+		Shift:  m.Mod.Contains(uv.ModShift),
 	}
 }

--- a/service/terminal/input_event_test.go
+++ b/service/terminal/input_event_test.go
@@ -5,11 +5,45 @@ package terminal
 import (
 	"testing"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/input"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConvertUVInputEventPreservesNavigationAndKittyModifiers(t *testing.T) {
+	navigation := convertUVInputEvent(uv.KeyPressEvent(uv.Key{Code: uv.KeyPgDown, Mod: uv.ModCtrl | uv.ModAlt}))
+	require.NotNil(t, navigation)
+	assert.Equal(t, "key", navigation.Type)
+	assert.Equal(t, "pgdown", navigation.Key)
+	assert.Equal(t, "pgdown", navigation.KeyType)
+	assert.True(t, navigation.Ctrl)
+	assert.True(t, navigation.Alt)
+
+	kittyControl := convertUVInputEvent(uv.KeyReleaseEvent(uv.Key{
+		Code:     'a',
+		BaseCode: 'a',
+		Mod:      uv.ModCtrl,
+	}))
+	require.NotNil(t, kittyControl)
+	assert.Equal(t, "release", kittyControl.Action)
+	assert.Equal(t, "a", kittyControl.Key)
+	assert.Equal(t, "runes", kittyControl.KeyType)
+	assert.True(t, kittyControl.Ctrl)
+
+	kittyText := convertUVInputEvent(uv.KeyPressEvent(uv.Key{
+		Code:        'é',
+		BaseCode:    'e',
+		ShiftedCode: 'É',
+		Text:        "é",
+		Mod:         uv.ModShift,
+	}))
+	require.NotNil(t, kittyText)
+	assert.Equal(t, "é", kittyText.Key)
+	assert.Equal(t, "runes", kittyText.KeyType)
+	assert.True(t, kittyText.Shift)
+}
 
 func TestConvertInputEvent_KeyPress_Runes(t *testing.T) {
 	ev := input.KeyPressEvent(input.Key{

--- a/service/terminal/input_framing.go
+++ b/service/terminal/input_framing.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package terminal
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+const terminalInputReadSize = 4 * 1024
+const maxUnframedTerminalInput = 64 * 1024
+
+// ErrInputFrameTooLarge reports an incomplete terminal sequence that exceeded
+// the physical reader's retained-input budget.
+var ErrInputFrameTooLarge = errors.New("terminal input framing limit exceeded")
+
+// framedTerminalInput keeps the streaming decoder's retained input bounded.
+// A complete event releases at most one decoder read. Ultraviolet may have one
+// 4 KiB read queued behind that event, so an unterminated CSI or bracketed
+// paste retains at most the 64 KiB budget plus one decoder read.
+type framedTerminalInput struct {
+	reader io.Reader
+	err    error
+
+	mu       sync.Mutex
+	retained int
+}
+
+func newFramedTerminalInput(reader io.Reader) *framedTerminalInput {
+	return &framedTerminalInput{reader: &deferInputReadError{reader: reader}}
+}
+
+func (r *framedTerminalInput) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	remaining := maxUnframedTerminalInput - r.retained
+	if remaining <= 0 {
+		r.err = ErrInputFrameTooLarge
+		r.mu.Unlock()
+		return 0, ErrInputFrameTooLarge
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	r.mu.Unlock()
+
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.mu.Lock()
+		r.retained += n
+		r.mu.Unlock()
+	}
+	if err != nil {
+		r.mu.Lock()
+		r.err = err
+		r.mu.Unlock()
+	}
+	return n, err
+}
+
+func (r *framedTerminalInput) acknowledgeEvent() {
+	r.mu.Lock()
+	r.retained -= min(r.retained, terminalInputReadSize)
+	r.mu.Unlock()
+}
+
+func (r *framedTerminalInput) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+// deferInputReadError makes a legal (n > 0, err != nil) read visible to the
+// streaming decoder before reporting the terminal error on its next read.
+type deferInputReadError struct {
+	reader io.Reader
+	err    error
+}
+
+func (r *deferInputReadError) Read(p []byte) (int, error) {
+	if r.err != nil {
+		err := r.err
+		r.err = nil
+		return 0, err
+	}
+	n, err := r.reader.Read(p)
+	if n > 0 && err != nil {
+		r.err = err
+		return n, nil
+	}
+	return n, err
+}

--- a/service/terminal/input_framing.go
+++ b/service/terminal/input_framing.go
@@ -60,7 +60,9 @@ func (r *framedTerminalInput) Read(p []byte) (int, error) {
 
 func (r *framedTerminalInput) acknowledgeEvent() {
 	r.mu.Lock()
-	r.retained -= min(r.retained, terminalInputReadSize)
+	// The completed event may span many reads. Only bytes trailing it in the
+	// decoder's current read can still be incomplete.
+	r.retained = min(r.retained, terminalInputReadSize)
 	r.mu.Unlock()
 }
 

--- a/service/terminal/input_generation_test.go
+++ b/service/terminal/input_generation_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+package terminal
+
+import (
+	"io"
+	"testing"
+)
+
+func TestRetiredInputCleanupCannotStopRestartedSession(t *testing.T) {
+	reader := NewEventInputReader(nil, io.Discard, nil, nil)
+	retired := reader.Done()
+	// Stop has completed and Start has published a new session before the old
+	// read loop's deferred cleanup runs after its WaitGroup decrement.
+	reader.done = make(chan struct{})
+	reader.started = true
+	active := reader.Done()
+	if err := reader.stopWithCause(io.EOF, retired); err != nil {
+		t.Fatal(err)
+	}
+	if !reader.started {
+		t.Fatal("retired cleanup stopped new reader")
+	}
+	if err := reader.Err(); err != nil {
+		t.Fatalf("retired error contaminated new reader: %v", err)
+	}
+	select {
+	case <-active:
+		t.Fatal("retired cleanup closed active completion")
+	default:
+	}
+}

--- a/service/terminal/input_sink_test.go
+++ b/service/terminal/input_sink_test.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: MPL-2.0
+//go:build !windows
+
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/input"
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	tty "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/system/scheduler/actor"
+)
+
+func TestNewEventInputReader_ConstructorAndDefaults(t *testing.T) {
+	// Defaults when nil values passed
+	reader := NewEventInputReader(nil, nil, nil, nil)
+	require.NotNil(t, reader)
+	require.NotNil(t, reader.output)
+	require.NotNil(t, reader.sink)
+	require.NotNil(t, reader.Done())
+	require.NoError(t, reader.Err())
+
+	// Non-nil stdin should initialize default RawManager if raw was nil
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+	defer w.Close()
+
+	readerWithStdin := NewEventInputReader(r, nil, nil, nil)
+	require.NotNil(t, readerWithStdin.raw)
+}
+
+func TestNewEventInputReader_DirectSinkDelivery(t *testing.T) {
+	var delivered []tty.Event
+	var mu sync.Mutex
+
+	sink := func(ev tty.Event) {
+		mu.Lock()
+		delivered = append(delivered, ev)
+		mu.Unlock()
+	}
+
+	reader := NewEventInputReader(nil, io.Discard, nil, sink)
+	reader.emitter = newInputEmitter(reader.deliverToSink)
+
+	reader.sendEvent(&tty.Event{
+		Type:   "key",
+		Key:    "a",
+		Action: "press",
+	})
+	reader.sendEvent(&tty.Event{
+		Type:   "mouse",
+		Action: "press",
+		X:      10,
+		Y:      20,
+	})
+
+	mu.Lock()
+	require.Len(t, delivered, 2)
+	assert.Equal(t, "key", delivered[0].Type)
+	assert.Equal(t, "a", delivered[0].Key)
+	assert.Equal(t, "mouse", delivered[1].Type)
+	assert.Equal(t, 10, delivered[1].X)
+	assert.Equal(t, 20, delivered[1].Y)
+	mu.Unlock()
+}
+
+func TestNewInputReader_SchedulerAdapterCompatibility(t *testing.T) {
+	targetPID := pid.PID{Host: "node1", UniqID: "proc123"}
+	registry := &mockCommandRegistry{}
+	sched := actor.NewScheduler(registry, actor.WithWorkers(1))
+	sched.Start()
+	defer sched.Stop(context.Background())
+
+	adapterReader := NewInputReader(nil, io.Discard, nil, sched, targetPID)
+	require.NotNil(t, adapterReader.sink)
+
+	testEvent := tty.Event{Type: "key", Key: "enter"}
+	// Calling sink sends via sched.Send(pkg); does not panic even if proc not found
+	require.NotPanics(t, func() {
+		adapterReader.sink(testEvent)
+	})
+
+	// Test nil scheduler does not panic
+	nilSchedReader := NewInputReader(nil, io.Discard, nil, nil, targetPID)
+	require.NotPanics(t, func() {
+		nilSchedReader.sink(testEvent)
+	})
+}
+
+func TestInputReader_PTY_StartStopLifecycle_DoneAndErr(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	defer master.Close()
+	defer slave.Close()
+
+	var events []tty.Event
+	var mu sync.Mutex
+	sink := func(ev tty.Event) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}
+
+	var output bytes.Buffer
+	raw := NewRawManager(slave)
+	reader := NewEventInputReader(slave, &output, raw, sink)
+
+	doneCh := reader.Done()
+	require.NotNil(t, doneCh)
+
+	select {
+	case <-doneCh:
+		t.Fatal("Done() must not be closed before Start()")
+	default:
+	}
+
+	require.NoError(t, reader.Start())
+	require.True(t, raw.Enabled())
+
+	// Initial start event should be emitted
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) >= 1 && events[0].Type == "start"
+	}, time.Second, 10*time.Millisecond)
+
+	// Clean stop
+	require.NoError(t, reader.Stop())
+	require.False(t, raw.Enabled())
+
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("Done() did not close after Stop()")
+	}
+
+	require.NoError(t, reader.Err())
+
+	// Stop is idempotent
+	require.NoError(t, reader.Stop())
+	require.NoError(t, reader.Err())
+}
+
+func TestInputReader_PTY_EOF_TeardownAndNotification(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	defer slave.Close()
+
+	var events []tty.Event
+	var mu sync.Mutex
+	sink := func(ev tty.Event) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}
+
+	var output bytes.Buffer
+	raw := NewRawManager(slave)
+	reader := NewEventInputReader(slave, &output, raw, sink)
+
+	require.NoError(t, reader.Start())
+	require.True(t, raw.Enabled())
+
+	// Write input to master and close it to trigger EOF on slave
+	_, err = master.Write([]byte("x"))
+	require.NoError(t, err)
+	time.Sleep(20 * time.Millisecond)
+
+	// Close master to cause EOF on slave
+	require.NoError(t, master.Close())
+
+	// Reader should detect EOF, clean up terminal, and close Done() without hanging
+	select {
+	case <-reader.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for Done() on EOF")
+	}
+
+	// Preserve the actual platform read error (EOF or a PTY I/O error).
+	require.Error(t, reader.Err())
+
+	// Raw mode should be disabled automatically
+	require.False(t, raw.Enabled())
+
+	// A closed PTY may also fail terminal restoration. Preserve that failure
+	// through Err rather than requiring successful I/O on the closed peer.
+	if stopErr := reader.Stop(); stopErr != nil {
+		require.ErrorIs(t, reader.Err(), stopErr)
+	}
+}
+
+func TestInputReader_PTY_RestartLifecycle(t *testing.T) {
+	master1, slave1, err := pty.Open()
+	require.NoError(t, err)
+	defer master1.Close()
+	defer slave1.Close()
+
+	var events []tty.Event
+	var mu sync.Mutex
+	sink := func(ev tty.Event) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	}
+
+	raw1 := NewRawManager(slave1)
+	reader := NewEventInputReader(slave1, io.Discard, raw1, sink)
+
+	// Session 1
+	require.NoError(t, reader.Start())
+	done1 := reader.Done()
+	require.NoError(t, reader.Stop())
+
+	select {
+	case <-done1:
+	case <-time.After(time.Second):
+		t.Fatal("done1 did not close")
+	}
+	require.NoError(t, reader.Err())
+
+	// Session 2 (restart on new pty)
+	master2, slave2, err := pty.Open()
+	require.NoError(t, err)
+	defer master2.Close()
+	defer slave2.Close()
+
+	reader.stdin = slave2
+	reader.raw = NewRawManager(slave2)
+
+	require.NoError(t, reader.Start())
+	done2 := reader.Done()
+	require.NotEqual(t, done1, done2, "Done() must return a fresh channel on restart")
+
+	select {
+	case <-done2:
+		t.Fatal("done2 must be open while active")
+	default:
+	}
+	require.NoError(t, reader.Err())
+
+	require.NoError(t, reader.Stop())
+
+	select {
+	case <-done2:
+	case <-time.After(time.Second):
+		t.Fatal("done2 did not close after Stop()")
+	}
+	require.NoError(t, reader.Err())
+}
+
+func TestInputReader_ConcurrentStopCallers_ActiveStart(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	defer master.Close()
+	defer slave.Close()
+
+	raw := NewRawManager(slave)
+	reader := NewEventInputReader(slave, io.Discard, raw, func(tty.Event) {})
+
+	require.NoError(t, reader.Start())
+	doneCh := reader.Done()
+
+	const concurrency = 10
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+
+	wg.Add(concurrency)
+	for i := range concurrency {
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = reader.Stop()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "Stop caller %d failed", i)
+	}
+
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("Done() did not close")
+	}
+	require.False(t, raw.Enabled())
+}
+
+func TestInputReader_StartFailureCleanup(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	defer master.Close()
+	defer slave.Close()
+
+	failure := errors.New("write failure")
+	raw := NewRawManager(slave)
+	reader := NewEventInputReader(slave, &failingWriter{err: failure}, raw, nil)
+	defer reader.Stop()
+
+	// Fail after raw mode and the cancelable input reader have been acquired.
+	require.ErrorIs(t, reader.Start(), failure)
+	require.False(t, raw.Enabled())
+	require.False(t, reader.started)
+	require.False(t, reader.stopping)
+	require.Nil(t, reader.cancel)
+	require.Nil(t, reader.reader)
+	require.Nil(t, reader.emitter)
+
+	// The failed start must not poison a later attempt on the same terminal.
+	reader.output = io.Discard
+	require.NoError(t, reader.Start())
+	require.NoError(t, reader.Stop())
+	require.False(t, raw.Enabled())
+}
+
+type mockErrorReader struct {
+	err error
+}
+
+func (m *mockErrorReader) Read(p []byte) (int, error) {
+	return 0, m.err
+}
+
+func TestInputReader_PermanentReadError_TerminatesWithoutSpinning(t *testing.T) {
+	expectedErr := errors.New("permanent I/O device error")
+	errReader := &mockErrorReader{err: expectedErr}
+
+	inputRd, err := input.NewReader(errReader, "xterm", 0)
+	require.NoError(t, err)
+
+	reader := NewEventInputReader(nil, io.Discard, nil, func(tty.Event) {})
+	reader.started = true
+	reader.done = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader.cancel = cancel
+	reader.reader = inputRd
+	reader.emitter = newInputEmitter(reader.deliverToSink)
+
+	reader.wg.Add(1)
+	go reader.readLoop(ctx, inputRd, reader.done)
+
+	// Must terminate promptly and close Done without spinning
+	select {
+	case <-reader.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("readLoop spun on permanent read error rather than terminating promptly")
+	}
+
+	require.ErrorIs(t, reader.Err(), expectedErr)
+}

--- a/service/terminal/input_sink_test.go
+++ b/service/terminal/input_sink_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -75,6 +76,225 @@ func TestNewEventInputReader_DirectSinkDelivery(t *testing.T) {
 	assert.Equal(t, 20, delivered[1].Y)
 	mu.Unlock()
 }
+
+func TestInputReaderFramesFragmentedWheelBurstBeforeFollowingKey(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = master.Close()
+		_ = slave.Close()
+	})
+	require.NoError(t, pty.Setsize(slave, &pty.Winsize{Rows: 24, Cols: 80}))
+
+	events := make(chan tty.Event, 64)
+	reader := NewEventInputReader(slave, io.Discard, NewRawManager(slave), func(event tty.Event) {
+		events <- event
+	})
+	require.NoError(t, reader.Start())
+	t.Cleanup(func() { require.NoError(t, reader.Stop()) })
+
+	// The burst is deliberately larger than x/input's 256-byte read buffer,
+	// leaving one SGR sequence split across reads. Trackpads commonly produce
+	// this shape; a wheel produces the identical SGR records individually.
+	var burst strings.Builder
+	for range 12 {
+		burst.WriteString("\x1b[<64;5;5M")
+	}
+	for range 40 {
+		burst.WriteString("\x1b[<65;5;5M")
+	}
+	_, err = io.WriteString(master, burst.String()+"z")
+	require.NoError(t, err)
+
+	var received []tty.Event
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case event := <-events:
+				if event.Type != "start" {
+					received = append(received, event)
+				}
+			default:
+				return len(received) >= 53
+			}
+		}
+	}, time.Second, time.Millisecond)
+
+	var wheelUp, wheelDown int
+	var keys []string
+	for _, event := range received {
+		switch event.Type {
+		case "mouse":
+			require.Equal(t, "wheel", event.Action)
+			switch event.Button {
+			case "wheel_up":
+				wheelUp++
+			case "wheel_down":
+				wheelDown++
+			default:
+				t.Fatalf("unexpected mouse button %q", event.Button)
+			}
+		case "key":
+			keys = append(keys, event.Key)
+		default:
+			t.Fatalf("unexpected event %#v", event)
+		}
+	}
+	require.Equal(t, 12, wheelUp)
+	require.Equal(t, 40, wheelDown)
+	require.Equal(t, []string{"z"}, keys)
+}
+
+func TestInputReaderPreservesEscapeTimeoutAndFragmentedNavigation(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = master.Close()
+		_ = slave.Close()
+	})
+	events := make(chan tty.Event, 4)
+	reader := NewEventInputReader(slave, io.Discard, NewRawManager(slave), func(event tty.Event) {
+		if event.Type == "key" {
+			events <- event
+		}
+	})
+	require.NoError(t, reader.Start())
+	t.Cleanup(func() { require.NoError(t, reader.Stop()) })
+
+	_, err = master.Write([]byte("\x1b"))
+	require.NoError(t, err)
+	select {
+	case event := <-events:
+		require.Equal(t, "esc", event.KeyType)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("standalone escape did not honor the decoder timeout")
+	}
+
+	_, err = master.Write([]byte("\x1b["))
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond)
+	_, err = master.Write([]byte("A"))
+	require.NoError(t, err)
+	select {
+	case event := <-events:
+		require.Equal(t, "up", event.KeyType)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("fragmented navigation sequence was not decoded")
+	}
+}
+
+func TestInputReaderStopDrainsPartialEscape(t *testing.T) {
+	master, slave, err := pty.Open()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = master.Close()
+		_ = slave.Close()
+	})
+	reader := NewEventInputReader(slave, io.Discard, NewRawManager(slave), func(tty.Event) {})
+	require.NoError(t, reader.Start())
+	_, err = master.Write([]byte("\x1b["))
+	require.NoError(t, err)
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- reader.Stop() }()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop blocked while the decoder held a partial escape")
+	}
+}
+
+func TestInputReaderDeliversDataReturnedWithEOF(t *testing.T) {
+	input := &eofWithDataReader{data: []byte("z")}
+	events := make(chan tty.Event, 1)
+	reader := NewEventInputReader(nil, io.Discard, nil, func(event tty.Event) { events <- event })
+	reader.started = true
+	reader.reader = input
+	reader.emitter = newInputEmitter(reader.deliverToSink)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	reader.wg.Add(1)
+	go reader.readLoop(ctx, input, reader.Done())
+
+	select {
+	case event := <-events:
+		require.Equal(t, "key", event.Type)
+		require.Equal(t, "z", event.Key)
+	case <-time.After(time.Second):
+		t.Fatal("data returned with EOF was not delivered")
+	}
+	select {
+	case <-reader.Done():
+	case <-time.After(time.Second):
+		t.Fatal("reader did not complete after EOF")
+	}
+	require.ErrorIs(t, reader.Err(), io.EOF)
+}
+
+func TestInputReaderBoundsUnterminatedBracketedPaste(t *testing.T) {
+	// Thousands of already-decoded keys make the event acknowledgements drain
+	// the preceding read. The unterminated paste that follows must still reach
+	// the framing limit instead of growing indefinitely.
+	input := &unterminatedPasteReader{prefix: []byte(strings.Repeat("z", terminalInputReadSize-6) + "\x1b[200~")}
+	reader := NewEventInputReader(nil, io.Discard, nil, func(tty.Event) {})
+	reader.started = true
+	reader.reader = input
+	reader.emitter = newInputEmitter(reader.deliverToSink)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	reader.wg.Add(1)
+	go reader.readLoop(ctx, input, reader.Done())
+
+	select {
+	case <-reader.Done():
+	case <-time.After(time.Second):
+		t.Fatal("unterminated paste did not reach the frame limit")
+	}
+	require.ErrorIs(t, reader.Err(), ErrInputFrameTooLarge)
+}
+
+type eofWithDataReader struct {
+	data   []byte
+	offset int
+}
+
+func (r *eofWithDataReader) Read(p []byte) (int, error) {
+	if r.offset == len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.offset:])
+	r.offset += n
+	if r.offset == len(r.data) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *eofWithDataReader) Cancel() bool { return true }
+
+func (r *eofWithDataReader) Close() error { return nil }
+
+type unterminatedPasteReader struct {
+	prefix []byte
+	offset int
+}
+
+func (r *unterminatedPasteReader) Read(p []byte) (int, error) {
+	if r.offset < len(r.prefix) {
+		n := copy(p, r.prefix[r.offset:])
+		r.offset += n
+		return n, nil
+	}
+	for index := range p {
+		p[index] = 'x'
+	}
+	return len(p), nil
+}
+
+func (r *unterminatedPasteReader) Cancel() bool { return true }
+
+func (r *unterminatedPasteReader) Close() error { return nil }
 
 func TestNewInputReader_SchedulerAdapterCompatibility(t *testing.T) {
 	targetPID := pid.PID{Host: "node1", UniqID: "proc123"}

--- a/service/terminal/input_sink_test.go
+++ b/service/terminal/input_sink_test.go
@@ -254,6 +254,20 @@ func TestInputReaderBoundsUnterminatedBracketedPaste(t *testing.T) {
 	require.ErrorIs(t, reader.Err(), ErrInputFrameTooLarge)
 }
 
+func TestTerminalInputReleasesCompletedLargePasteBudget(t *testing.T) {
+	first := strings.Repeat("a", 56*1024)
+	second := strings.Repeat("b", 12*1024)
+	input := &eofWithDataReader{data: []byte("\x1b[200~" + first + "\x1b[201~\x1b[200~" + second + "\x1b[201~")}
+	var got []string
+	err := streamTerminalInput(context.Background(), input, func(event *TTYEvent) {
+		if event != nil && event.Type == "paste" {
+			got = append(got, event.Paste)
+		}
+	})
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, []string{first, second}, got)
+}
+
 type eofWithDataReader struct {
 	data   []byte
 	offset int

--- a/service/terminal/input_stream.go
+++ b/service/terminal/input_stream.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package terminal
+
+import "io"
+
+// terminalInputReader is the cancellable native input source owned by an
+// InputReader session.
+type terminalInputReader interface {
+	io.Reader
+	Cancel() bool
+	Close() error
+}
+
+type inputEventSink func(*TTYEvent)

--- a/service/terminal/input_stream_other.go
+++ b/service/terminal/input_stream_other.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+//go:build !windows
+
+package terminal
+
+import (
+	"context"
+	"os"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func newTerminalInputReader(stdin *os.File, _ string) (terminalInputReader, error) {
+	return uv.NewCancelReader(stdin)
+}
+
+func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink inputEventSink) error {
+	framed := newFramedTerminalInput(reader)
+	terminalReader := uv.NewTerminalReader(framed, os.Getenv("TERM"))
+	events := make(chan uv.Event)
+	streamDone := make(chan error, 1)
+	go func() { streamDone <- terminalReader.StreamEvents(ctx, events) }()
+
+	// StreamEvents sends synchronously. Keep receiving after cancellation so its
+	// final flush cannot strand the decoder while Stop waits for this loop.
+	contextDone := ctx.Done()
+	stopping := false
+	for {
+		select {
+		case event := <-events:
+			framed.acknowledgeEvent()
+			if !stopping {
+				sink(convertUVInputEvent(event))
+			}
+		case err := <-streamDone:
+			if stopping || ctx.Err() != nil {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			return framed.Err()
+		case <-contextDone:
+			stopping = true
+			contextDone = nil
+		}
+	}
+}

--- a/service/terminal/input_stream_other.go
+++ b/service/terminal/input_stream_other.go
@@ -27,7 +27,11 @@ func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink i
 	stopping := false
 	for {
 		select {
-		case event := <-events:
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
 			framed.acknowledgeEvent()
 			if !stopping {
 				sink(convertUVInputEvent(event))

--- a/service/terminal/input_stream_windows.go
+++ b/service/terminal/input_stream_windows.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+//go:build windows
+
+package terminal
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/charmbracelet/x/input"
+	"github.com/muesli/cancelreader"
+)
+
+// Keep the established x/input Console API reader on Windows. Ultraviolet's
+// Windows stream selects native console records through an unexported concrete
+// reader type, which a bounded io.Reader wrapper would hide.
+func newTerminalInputReader(stdin *os.File, termType string) (terminalInputReader, error) {
+	return input.NewReader(stdin, termType, 0)
+}
+
+func streamTerminalInput(ctx context.Context, reader terminalInputReader, sink inputEventSink) error {
+	legacy, ok := reader.(*input.Reader)
+	if !ok {
+		return errors.New("windows terminal input reader is not x/input")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		events, err := legacy.ReadEvents()
+		for _, event := range events {
+			sink(ConvertInputEvent(event))
+		}
+		if err == nil {
+			continue
+		}
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, cancelreader.ErrCanceled) {
+			return nil
+		}
+		return err
+	}
+}


### PR DESCRIPTION
Compiled terminal clients need parsed input without creating a scheduler-owned process solely to receive keystrokes, plus a completion signal when the terminal disconnects. The former Unix reader parsed each read independently, so terminal sequences split at a buffer boundary could be corrupted.

This change exposes NewEventInputReader with serial typed callbacks while preserving NewInputReader as the scheduler adapter. Each session reports Done and Err, late cleanup cannot stop a restarted reader, and Stop restores terminal modes while serializing cleanup.

Unix input now uses the existing streaming decoder with a bounded incomplete-frame budget. The polished replay removes unrelated test commits, correctly releases accounting for completed multi-read events, and handles decoder-channel closure without spinning. Windows retains the established Console API reader.

Validation: the terminal service suite passes under race; framing and shutdown regressions pass repeatedly; repository-pinned scoped lint, vet, Windows compilation, and diff checks pass. Coverage includes fragmented mouse and navigation sequences, UTF-8 and paste input, EOF with data, framing bounds, restart generations, cancellation, and consecutive large valid pastes.