### PR TITLE
Expose native surface transport with owned receiver lifetime

### DIFF
--- a/boot/components/system/tty_mesh.go
+++ b/boot/components/system/tty_mesh.go
@@ -4,7 +4,6 @@ package system
 
 import (
 	"context"
-	"errors"
 
 	"github.com/wippyai/runtime/api/boot"
 	clusterapi "github.com/wippyai/runtime/api/cluster"
@@ -35,48 +34,11 @@ func TTYMesh() boot.Component {
 			if !ok || node == nil {
 				return nil, ttyapi.ErrServiceUnavailable
 			}
-			return ctx, service.SetMesh(node.ID(), surfaceMesh{cm: cm, membership: clusterapi.GetMembership(ctx)})
+			transport, err := internode.NewSurfaceTransport(cm, clusterapi.GetMembership(ctx))
+			if err != nil {
+				return nil, err
+			}
+			return ctx, service.SetMesh(node.ID(), transport)
 		},
 	})
-}
-
-type surfaceMesh struct {
-	cm         internode.ConnectionManager
-	membership clusterapi.Membership
-}
-
-func (t surfaceMesh) Send(peer string, data []byte) error {
-	err := t.cm.SendToNode(peer, data, internode.ClassSurface)
-	if errors.Is(err, internode.ErrQueueFull) {
-		return ttyapi.ErrMeshBusy
-	}
-	return err
-}
-func (t surfaceMesh) Receive(fn func(string, []byte)) error {
-	if !t.cm.RegisterClassReceiver(internode.ClassSurface, fn) {
-		return errors.New("terminal mesh receiver already registered")
-	}
-	return nil
-}
-
-func (t surfaceMesh) CheckPeer(peer string) error {
-	if t.membership != nil {
-		for _, node := range t.membership.Nodes() {
-			if node.ID == peer && node.Meta[internode.MetadataSurfaceProtocol] == "1" {
-				return nil
-			}
-		}
-	}
-	return ttyapi.ErrServiceUnavailable
-}
-
-func (t surfaceMesh) SupportsGraphics(peer string) bool {
-	if t.membership != nil {
-		for _, node := range t.membership.Nodes() {
-			if node.ID == peer {
-				return node.Meta[internode.MetadataSurfaceProtocol] == "1" && node.Meta[internode.MetadataSurfaceGraphics] == "1"
-			}
-		}
-	}
-	return false
 }

--- a/cluster/internode/surface_transport.go
+++ b/cluster/internode/surface_transport.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"errors"
+
+	clusterapi "github.com/wippyai/runtime/api/cluster"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+// NewSurfaceTransport shares the native surface protocol with compiled hosts
+// that assemble a mesh without the full boot graph. It opens no listener and
+// registers its class receiver only when the TTY service calls Receive. The host
+// must close its TTY service before stopping the supplied connection manager.
+// Receiver registration is exclusive for the manager's lifetime.
+func NewSurfaceTransport(manager ConnectionManager, membership clusterapi.Membership) (ttyapi.MeshTransport, error) {
+	if manager == nil || membership == nil {
+		return nil, ttyapi.ErrServiceUnavailable
+	}
+	return surfaceTransport{cm: manager, membership: membership}, nil
+}
+
+type surfaceTransport struct {
+	cm         ConnectionManager
+	membership clusterapi.Membership
+}
+
+func (t surfaceTransport) Send(peer string, data []byte) error {
+	return t.cm.SendToNode(peer, data, ClassSurface)
+}
+func (t surfaceTransport) Receive(fn func(string, []byte)) error {
+	if !t.cm.RegisterClassReceiver(ClassSurface, fn) {
+		return errors.New("terminal mesh receiver already registered")
+	}
+	return nil
+}
+
+func (t surfaceTransport) CheckPeer(peer string) error {
+	if t.membership != nil {
+		for _, node := range t.membership.Nodes() {
+			if node.ID == peer && node.Meta[MetadataSurfaceProtocol] == "1" {
+				return nil
+			}
+		}
+	}
+	return ttyapi.ErrServiceUnavailable
+}

--- a/cluster/internode/surface_transport.go
+++ b/cluster/internode/surface_transport.go
@@ -4,6 +4,7 @@ package internode
 
 import (
 	"errors"
+	"sync"
 
 	clusterapi "github.com/wippyai/runtime/api/cluster"
 	ttyapi "github.com/wippyai/runtime/api/tty"
@@ -13,30 +14,60 @@ import (
 // that assemble a mesh without the full boot graph. It opens no listener and
 // registers its class receiver only when the TTY service calls Receive. The host
 // must close its TTY service before stopping the supplied connection manager.
-// Receiver registration is exclusive for the manager's lifetime.
+// Each adapter owns at most one registration lifetime. Receive(nil) releases
+// only its own successful registration and permanently retires that adapter.
+// A replacement service constructs a fresh adapter. The host must not manipulate
+// ClassSurface registration directly while an adapter owns it. Release does not
+// drain callbacks already dispatched; the TTY service fences them during close.
 func NewSurfaceTransport(manager ConnectionManager, membership clusterapi.Membership) (ttyapi.MeshTransport, error) {
 	if manager == nil || membership == nil {
 		return nil, ttyapi.ErrServiceUnavailable
 	}
-	return surfaceTransport{cm: manager, membership: membership}, nil
+	return &surfaceTransport{cm: manager, membership: membership}, nil
 }
 
 type surfaceTransport struct {
 	cm         ConnectionManager
 	membership clusterapi.Membership
+	mu         sync.Mutex
+	claimed    bool
+	retired    bool
 }
 
-func (t surfaceTransport) Send(peer string, data []byte) error {
-	return t.cm.SendToNode(peer, data, ClassSurface)
+func (t *surfaceTransport) Send(peer string, data []byte) error {
+	err := t.cm.SendToNode(peer, data, ClassSurface)
+	if errors.Is(err, ErrQueueFull) {
+		return ttyapi.ErrMeshBusy
+	}
+	return err
 }
-func (t surfaceTransport) Receive(fn func(string, []byte)) error {
-	if !t.cm.RegisterClassReceiver(ClassSurface, fn) {
+func (t *surfaceTransport) Receive(fn func(string, []byte)) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if fn == nil {
+		if t.retired {
+			return nil
+		}
+		if t.claimed {
+			if !t.cm.RegisterClassReceiver(ClassSurface, nil) {
+				return errors.New("terminal mesh receiver release failed")
+			}
+			t.claimed = false
+		}
+		t.retired = true
+		return nil
+	}
+	if t.retired {
+		return ttyapi.ErrServiceUnavailable
+	}
+	if t.claimed || !t.cm.RegisterClassReceiver(ClassSurface, fn) {
 		return errors.New("terminal mesh receiver already registered")
 	}
+	t.claimed = true
 	return nil
 }
 
-func (t surfaceTransport) CheckPeer(peer string) error {
+func (t *surfaceTransport) CheckPeer(peer string) error {
 	if t.membership != nil {
 		for _, node := range t.membership.Nodes() {
 			if node.ID == peer && node.Meta[MetadataSurfaceProtocol] == "1" {
@@ -45,4 +76,15 @@ func (t surfaceTransport) CheckPeer(peer string) error {
 		}
 	}
 	return ttyapi.ErrServiceUnavailable
+}
+
+func (t *surfaceTransport) SupportsGraphics(peer string) bool {
+	if t.membership != nil {
+		for _, node := range t.membership.Nodes() {
+			if node.ID == peer {
+				return node.Meta[MetadataSurfaceProtocol] == "1" && node.Meta[MetadataSurfaceGraphics] == "1"
+			}
+		}
+	}
+	return false
 }

--- a/cluster/internode/surface_transport_test.go
+++ b/cluster/internode/surface_transport_test.go
@@ -24,7 +24,7 @@ func TestSurfaceMeshChecksPeerProtocolBeforeAttach(t *testing.T) {
 	require.NoError(t, transport.CheckPeer("new"))
 	require.ErrorIs(t, transport.CheckPeer("old"), ttyapi.ErrServiceUnavailable)
 	require.ErrorIs(t, transport.CheckPeer("absent"), ttyapi.ErrServiceUnavailable)
-	require.ErrorIs(t, (surfaceTransport{}).CheckPeer("new"), ttyapi.ErrServiceUnavailable)
+	require.ErrorIs(t, (&surfaceTransport{}).CheckPeer("new"), ttyapi.ErrServiceUnavailable)
 }
 
 func TestSurfaceTransportRequiresHostOwnedMesh(t *testing.T) {
@@ -34,10 +34,10 @@ func TestSurfaceTransportRequiresHostOwnedMesh(t *testing.T) {
 }
 
 func TestSurfaceGraphicsCapabilityIsAdditive(t *testing.T) {
-	transport := surfaceMesh{membership: surfaceMembership{
-		{ID: "text", Meta: clusterapi.NodeMeta{internode.MetadataSurfaceProtocol: "1"}},
-		{ID: "images", Meta: clusterapi.NodeMeta{internode.MetadataSurfaceProtocol: "1", internode.MetadataSurfaceGraphics: "1"}},
-		{ID: "wrong", Meta: clusterapi.NodeMeta{internode.MetadataSurfaceProtocol: "2", internode.MetadataSurfaceGraphics: "1"}},
+	transport := surfaceTransport{membership: surfaceMembership{
+		{ID: "text", Meta: clusterapi.NodeMeta{MetadataSurfaceProtocol: "1"}},
+		{ID: "images", Meta: clusterapi.NodeMeta{MetadataSurfaceProtocol: "1", MetadataSurfaceGraphics: "1"}},
+		{ID: "wrong", Meta: clusterapi.NodeMeta{MetadataSurfaceProtocol: "2", MetadataSurfaceGraphics: "1"}},
 	}}
 	require.NoError(t, transport.CheckPeer("text"))
 	require.NoError(t, transport.CheckPeer("images"))
@@ -45,4 +45,39 @@ func TestSurfaceGraphicsCapabilityIsAdditive(t *testing.T) {
 	require.True(t, transport.SupportsGraphics("images"))
 	require.False(t, transport.SupportsGraphics("wrong"))
 	require.False(t, transport.SupportsGraphics("absent"))
+}
+
+func TestSurfaceTransportReleaseOwnsOnlyItsSuccessfulRegistration(t *testing.T) {
+	manager := &manager{}
+	membership := surfaceMembership{}
+	first, err := NewSurfaceTransport(manager, membership)
+	require.NoError(t, err)
+	second, err := NewSurfaceTransport(manager, membership)
+	require.NoError(t, err)
+	calls := 0
+	require.NoError(t, first.Receive(func(string, []byte) { calls++ }))
+	require.Error(t, second.Receive(func(string, []byte) { t.Error("failed receiver invoked") }))
+	require.NoError(t, second.Receive(nil), "failed admission cleanup must not clear the first owner")
+	receive := manager.lookupClassReceiver(ClassSurface)
+	require.NotNil(t, receive)
+	receive("peer", nil)
+	require.Equal(t, 1, calls)
+	require.NoError(t, first.Receive(nil))
+	replacement, err := NewSurfaceTransport(manager, membership)
+	require.NoError(t, err)
+	require.NoError(t, replacement.Receive(func(string, []byte) { calls += 10 }))
+	require.NoError(t, first.Receive(nil), "retired cleanup must not clear its replacement")
+	completed := make(chan error, 16)
+	for range 16 {
+		go func() { completed <- first.Receive(nil) }()
+	}
+	for range 16 {
+		require.NoError(t, <-completed)
+	}
+	receive = manager.lookupClassReceiver(ClassSurface)
+	require.NotNil(t, receive)
+	receive("peer", nil)
+	require.Equal(t, 11, calls)
+	require.Error(t, first.Receive(func(string, []byte) {}), "retired adapter cannot claim a new lifetime")
+	require.NoError(t, replacement.Receive(nil))
 }

--- a/cluster/internode/surface_transport_test.go
+++ b/cluster/internode/surface_transport_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-package system
+package internode
 
 import (
 	"testing"
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	clusterapi "github.com/wippyai/runtime/api/cluster"
 	ttyapi "github.com/wippyai/runtime/api/tty"
-	"github.com/wippyai/runtime/cluster/internode"
 )
 
 type surfaceMembership []clusterapi.NodeInfo
@@ -18,14 +17,20 @@ func (surfaceMembership) LocalNode() clusterapi.NodeInfo { return clusterapi.Nod
 func (surfaceMembership) UpdateMeta(map[string]string)   {}
 
 func TestSurfaceMeshChecksPeerProtocolBeforeAttach(t *testing.T) {
-	transport := surfaceMesh{membership: surfaceMembership{
+	transport := surfaceTransport{membership: surfaceMembership{
 		{ID: "old"},
-		{ID: "new", Meta: clusterapi.NodeMeta{internode.MetadataSurfaceProtocol: "1"}},
+		{ID: "new", Meta: clusterapi.NodeMeta{MetadataSurfaceProtocol: "1"}},
 	}}
 	require.NoError(t, transport.CheckPeer("new"))
 	require.ErrorIs(t, transport.CheckPeer("old"), ttyapi.ErrServiceUnavailable)
 	require.ErrorIs(t, transport.CheckPeer("absent"), ttyapi.ErrServiceUnavailable)
-	require.ErrorIs(t, (surfaceMesh{}).CheckPeer("new"), ttyapi.ErrServiceUnavailable)
+	require.ErrorIs(t, (surfaceTransport{}).CheckPeer("new"), ttyapi.ErrServiceUnavailable)
+}
+
+func TestSurfaceTransportRequiresHostOwnedMesh(t *testing.T) {
+	transport, err := NewSurfaceTransport(nil, surfaceMembership{})
+	require.Nil(t, transport)
+	require.ErrorIs(t, err, ttyapi.ErrServiceUnavailable)
 }
 
 func TestSurfaceGraphicsCapabilityIsAdditive(t *testing.T) {


### PR DESCRIPTION
Native clients need to attach the existing TTY mesh service to their connection manager without loading the full boot graph. Expose the existing adapter through NewSurfaceTransport and use it in normal boot as well.

Each adapter releases only its own successful receiver registration. Failed duplicate registration and repeated cleanup cannot remove a replacement receiver. The extracted adapter preserves protocol checks, graphics capability negotiation, and the ErrQueueFull-to-ErrMeshBusy mapping already on main. It opens no listener and leaves TTY admission checks in the existing service.

Validated on current main: internode, boot, and TTY race suites pass; pinned lint reports zero issues. Receiver lifetime and graphics capability tests are retained in the internode package.
