### PR TITLE
Abort internode TLS without waiting for peer close notification

### DIFF
--- a/cluster/internode/connection.go
+++ b/cluster/internode/connection.go
@@ -256,7 +256,8 @@ func (c *NodeConnection) Run(handler func(class Class, msg []byte)) *ConnectionE
 	}
 }
 
-// Close terminates the connection gracefully and cancels all ongoing operations.
+// Close aborts the session transport and cancels all ongoing operations.
+// It does not drain queued frames or wait for a TLS close notification.
 func (c *NodeConnection) Close() {
 	if c.closed.CompareAndSwap(false, true) {
 		c.lifecycleMu.Lock()
@@ -264,7 +265,7 @@ func (c *NodeConnection) Close() {
 			c.cancel()
 		}
 		c.lifecycleMu.Unlock()
-		_ = c.conn.Close()
+		abortConnection(c.conn)
 	}
 }
 

--- a/cluster/internode/connection_abort.go
+++ b/cluster/internode/connection_abort.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// abortConnection releases a failed or retired session without requiring peer
+// cooperation. Internode teardown is not an application delivery receipt: queued
+// and in-flight work is resolved by the session lifecycle. Close the TLS socket
+// first so close_notify cannot hold shutdown or handshake rejection open.
+func abortConnection(conn net.Conn) {
+	if secured, ok := conn.(*tls.Conn); ok {
+		_ = secured.NetConn().Close()
+	}
+	_ = conn.Close()
+}

--- a/cluster/internode/connection_tls_close_test.go
+++ b/cluster/internode/connection_tls_close_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func idleTLSPair(t *testing.T) (*tls.Conn, *tls.Conn) {
+	t.Helper()
+	one, two := managerTestTLSConfigs(t)
+	clientConfig, err := loadTLSConfig(one)
+	require.NoError(t, err)
+	serverConfig, err := loadTLSConfig(two)
+	require.NoError(t, err)
+	clientConfig.ServerName = "127.0.0.1"
+	serverRaw, clientRaw := net.Pipe()
+	t.Cleanup(func() { _ = serverRaw.Close(); _ = clientRaw.Close() })
+	client := tls.Client(clientRaw, clientConfig)
+	server := tls.Server(serverRaw, serverConfig)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	serverHandshake := make(chan error, 1)
+	go func() { serverHandshake <- server.HandshakeContext(ctx) }()
+	require.NoError(t, client.HandshakeContext(ctx))
+	require.NoError(t, <-serverHandshake)
+	require.True(t, client.ConnectionState().HandshakeComplete)
+	require.NotEmpty(t, server.ConnectionState().VerifiedChains, "server must authenticate the client")
+
+	return client, server
+}
+
+func TestNodeConnectionTLSCloseWithoutPeerRead(t *testing.T) {
+	client, _ := idleTLSPair(t)
+
+	// The authenticated peer deliberately performs no more reads. Closing the
+	// runtime session must release its transport without waiting for close_notify.
+	node := newNodeConnection(client, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
+	done := make(chan struct{})
+	go func() { node.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		// Release and join the goroutine even when checking the unfixed version.
+		_ = client.NetConn().Close()
+		<-done
+		t.Fatal("runtime TLS shutdown waited for an idle peer to read close_notify")
+	}
+	node.Close() // repeated shutdown is safe
+}
+
+func TestClientHandshakeRejectionDoesNotWaitForTLSCloseNotify(t *testing.T) {
+	client, server := idleTLSPair(t)
+	peerDone := make(chan error, 1)
+	go func() {
+		_, err := readPrefixedBytes(server, maxNodeIDLength)
+		if err == nil {
+			err = writePrefixedBytes(server, []byte("unexpected-peer"))
+		}
+		peerDone <- err
+		// No further read: the peer has supplied an invalid identity.
+	}()
+	done := make(chan error, 1)
+	go func() {
+		_, err := PerformClientHandshake(client, DefaultNodeConnectionConfig(), zap.NewNop(), "self", "expected-peer")
+		done <- err
+	}()
+	require.NoError(t, <-peerDone)
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "node ID mismatch")
+	case <-time.After(time.Second):
+		_ = client.NetConn().Close()
+		<-done
+		t.Fatal("handshake rejection waited for peer to read close_notify")
+	}
+}

--- a/cluster/internode/handshake.go
+++ b/cluster/internode/handshake.go
@@ -228,7 +228,7 @@ func performAuthenticatedServerHandshake(conn net.Conn, config NodeConnectionCon
 // On success, ownership of the connection is transferred to the returned NodeConnection.
 func PerformClientHandshake(conn net.Conn, config NodeConnectionConfig, logger *zap.Logger, selfID, expectedRemoteNodeID cluster.NodeID) (*NodeConnection, error) {
 	if err := conn.SetDeadline(time.Now().Add(config.HandshakeTimeout)); err != nil {
-		_ = conn.Close()
+		abortConnection(conn)
 		return nil, &ConnectionError{Reason: ExitNetworkError, Err: NewSetDeadlineError(err)}
 	}
 
@@ -247,7 +247,7 @@ func PerformClientHandshake(conn net.Conn, config NodeConnectionConfig, logger *
 		}
 	}
 	if err != nil {
-		_ = conn.Close()
+		abortConnection(conn)
 		return nil, &ConnectionError{Reason: ExitProtocolError, Err: err}
 	}
 
@@ -258,7 +258,7 @@ func PerformClientHandshake(conn net.Conn, config NodeConnectionConfig, logger *
 // PerformServerHandshake executes the server side of the handshake protocol.
 func PerformServerHandshake(conn net.Conn, config NodeConnectionConfig, logger *zap.Logger, selfID cluster.NodeID) (*NodeConnection, error) {
 	if err := conn.SetDeadline(time.Now().Add(config.HandshakeTimeout)); err != nil {
-		_ = conn.Close()
+		abortConnection(conn)
 		return nil, &ConnectionError{Reason: ExitNetworkError, Err: NewSetDeadlineError(err)}
 	}
 
@@ -275,7 +275,7 @@ func PerformServerHandshake(conn net.Conn, config NodeConnectionConfig, logger *
 		}
 	}
 	if err != nil {
-		_ = conn.Close()
+		abortConnection(conn)
 		return nil, &ConnectionError{Reason: ExitProtocolError, Err: err}
 	}
 

--- a/cluster/internode/manager_tls_test.go
+++ b/cluster/internode/manager_tls_test.go
@@ -61,7 +61,6 @@ func TestManagerTLSSetupFailureDoesNotFallBackToPlaintext(t *testing.T) {
 	config.Logger = zap.NewNop()
 	config.TLS = ManagerTLSConfig{Enabled: true, CertFile: filepath.Join(t.TempDir(), "missing.pem")}
 	m := NewConnectionManager(config, nil).(*manager)
-	require.True(t, m.ProtectsPayloads())
 	require.Error(t, m.Start(t.Context(), func(cluster.NodeID, []byte) { t.Error("unexpected delivery") }))
 	require.Nil(t, m.listener)
 	require.NoError(t, m.Stop())

--- a/cluster/internode/manager_tls_test.go
+++ b/cluster/internode/manager_tls_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"go.uber.org/zap"
+)
+
+func managerTestTLSConfigs(t *testing.T) (ManagerTLSConfig, ManagerTLSConfig) {
+	t.Helper()
+	rootPublic, rootPrivate, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	now := time.Now()
+	root := &x509.Certificate{
+		SerialNumber: big.NewInt(1), NotBefore: now.Add(-time.Minute), NotAfter: now.Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, root, root, rootPublic, rootPrivate)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600))
+	leaf := func(name string, serial int64) ManagerTLSConfig {
+		public, private, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		certificate := &x509.Certificate{
+			SerialNumber: big.NewInt(serial), NotBefore: now.Add(-time.Minute), NotAfter: now.Add(time.Hour),
+			KeyUsage:    x509.KeyUsageDigitalSignature,
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+			IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, certificate, root, public, rootPrivate)
+		require.NoError(t, err)
+		key, err := x509.MarshalPKCS8PrivateKey(private)
+		require.NoError(t, err)
+		cfg := ManagerTLSConfig{Enabled: true, CAFile: caPath, CertFile: filepath.Join(dir, name+".pem"), KeyFile: filepath.Join(dir, name+".key")}
+		require.NoError(t, os.WriteFile(cfg.CertFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600))
+		require.NoError(t, os.WriteFile(cfg.KeyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), 0600))
+		return cfg
+	}
+	return leaf("one", 2), leaf("two", 3)
+}
+
+func TestManagerTLSSetupFailureDoesNotFallBackToPlaintext(t *testing.T) {
+	config := insecureManagerConfig()
+	config.LocalNodeID = "test"
+	config.BindAddr = "127.0.0.1"
+	config.Logger = zap.NewNop()
+	config.TLS = ManagerTLSConfig{Enabled: true, CertFile: filepath.Join(t.TempDir(), "missing.pem")}
+	m := NewConnectionManager(config, nil).(*manager)
+	require.True(t, m.ProtectsPayloads())
+	require.Error(t, m.Start(t.Context(), func(cluster.NodeID, []byte) { t.Error("unexpected delivery") }))
+	require.Nil(t, m.listener)
+	require.NoError(t, m.Stop())
+}


### PR DESCRIPTION
Closing an internode TLS connection can block while an idle peer stops reading close notifications, delaying session shutdown or handshake rejection.

Close the underlying socket before the TLS wrapper during session teardown and failed handshakes. Plain connections retain their existing close behavior and TLS verification remains unchanged.

Tests use mutually authenticated TLS with a peer that stops reading, covering session shutdown and invalid-identity rejection. Invalid TLS configuration also fails without plaintext fallback. The full internode race suite and pinned lint pass on current main, including the merged peer-generation lifecycle fixes.
