### PR TITLE
Retain automatic cluster listeners through startup and cleanup

### DIFF
--- a/boot/components/system/cluster.example.yaml
+++ b/boot/components/system/cluster.example.yaml
@@ -9,6 +9,13 @@
 # list to enumerate and no "new vs existing" state to flip by hand.
 #
 # Three topologies are shown below; use one.
+#
+# For several instances on one machine, membership.bind_port: 0 and
+# internode.bind_port: 0 ask the OS for available ports. The internode listener
+# stays bound while its port is published in membership metadata; startup never
+# releases a probe socket and tries to reclaim it. Read LocalNode().Addr and its
+# internode_port metadata after Start succeeds to obtain actual endpoints.
+# Discovery and peer authorization remain the application's responsibility.
 
 # ---------------------------------------------------------------------------
 # 1. Single node (development). Cluster enabled with no peers: the one node

--- a/boot/components/system/cluster.go
+++ b/boot/components/system/cluster.go
@@ -73,25 +73,6 @@ func internodeAdvertiseEndpoint(clusterCfg boot.Config, bindPort int) (string, i
 	return addr, configuredPort, nil
 }
 
-// discoverInternodePort starts a throwaway connection manager just long
-// enough to learn the actual listen port (AutoPort picks an ephemeral one),
-// then stops it. The discovered port is pinned on the real manager's config
-// so it binds the same port across restarts, and is advertised in node
-// metadata before the real manager starts.
-func discoverInternodePort(cfg internode.ManagerConfig, coll metricsapi.Collector) (int, error) {
-	tmp := internode.NewConnectionManager(cfg, coll)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	if err := tmp.Start(ctx, func(clusterapi.NodeID, []byte) {}); err != nil {
-		return 0, NewConnectionManagerPreStartError(err)
-	}
-	port := tmp.GetListenPort()
-	if err := tmp.Stop(); err != nil {
-		return 0, NewConnectionManagerStopError(err)
-	}
-	return port, nil
-}
-
 // clusterHealthScoreCeiling is the maximum memberlist health score
 // (where 0 = healthy) at which the activity-based liveness check still
 // reports healthy. Memberlist scores 1 or 2 commonly during chaos
@@ -130,6 +111,24 @@ func Cluster() boot.Component {
 	var internodeSvc *internode.Service
 	var connMgr internode.ConnectionManager
 	var logger *zap.Logger
+	var advertiseConfig boot.Config
+	var internodeActive, membershipActive bool
+	// Boot lifecycle calls are serialized. Clear each ownership flag before
+	// cleanup so failed Start followed by Loader.Shutdown cannot stop it twice.
+	stopServices := func() {
+		if internodeActive {
+			internodeActive = false
+			if err := internodeSvc.Stop(); err != nil {
+				logger.Error("failed to stop internode service", zap.Error(err))
+			}
+		}
+		if membershipActive {
+			membershipActive = false
+			if err := membershipSvc.Stop(); err != nil {
+				logger.Error("failed to stop membership service", zap.Error(err))
+			}
+		}
+	}
 
 	return boot.New(boot.P{
 		Name:      ClusterName,
@@ -247,19 +246,11 @@ func Cluster() boot.Component {
 				return ok
 			}
 
-			// Discover the actual internode port (AutoPort picks an
-			// ephemeral one) before the real start, since it's advertised in
-			// node metadata. Pin it so the real manager binds the same port
-			// across restarts.
-			actualPort, err := discoverInternodePort(connManagerCfg, metricsapi.GetCollector(ctx))
-			if err != nil {
-				return ctx, err
-			}
-			connManagerCfg.BindPort = actualPort
-			connManagerCfg.AutoPort = false
 			connMgr = internode.NewConnectionManager(connManagerCfg, metricsapi.GetCollector(ctx))
-
-			advertiseAddr, advertisePort, err := internodeAdvertiseEndpoint(clusterCfg, actualPort)
+			advertiseConfig = clusterCfg
+			// Validate overrides now; resolve an automatic port from the live
+			// listener during Start, before membership can advertise it.
+			_, _, err = internodeAdvertiseEndpoint(clusterCfg, 1)
 			if err != nil {
 				return ctx, err
 			}
@@ -281,17 +272,10 @@ func Cluster() boot.Component {
 				internode.MetadataSurfaceProtocol: "1",
 				internode.MetadataSurfaceGraphics: "1",
 				"role":                            "wippy",
-				internode.MetadataPort:            strconv.Itoa(actualPort),
 				internode.MetadataPublicKey:       base64.RawStdEncoding.EncodeToString(publicKey),
 				"raft_eligible":                   strconv.FormatBool(raftEligible),
 				"raft_priority":                   strconv.Itoa(clusterCfg.GetInt(ClusterRaftPriority, 100)),
 				"failure_domain":                  clusterCfg.GetString(ClusterFailureDomain, ""),
-			}
-			if advertiseAddr != "" {
-				// v2 metadata is additive: old peers ignore it and keep using
-				// internode_port plus the memberlist address.
-				nodeMeta[internode.MetadataAdvertiseAddr] = advertiseAddr
-				nodeMeta[internode.MetadataAdvertisePort] = strconv.Itoa(advertisePort)
 			}
 
 			// Create membership service config
@@ -405,7 +389,6 @@ func Cluster() boot.Component {
 
 			logger.Info("cluster initialized",
 				zap.String("node_name", nodeName),
-				zap.Int("internode_port", actualPort),
 				zap.Int("membership_port", memberCfg.BindPort),
 				zap.Strings("join_addrs", joinAddrs),
 			)
@@ -413,17 +396,34 @@ func Cluster() boot.Component {
 			return ctx, nil
 		},
 		Start: func(ctx context.Context) error {
-			if membershipSvc != nil {
-				logger.Info("starting cluster membership service")
-				if err := membershipSvc.Start(ctx); err != nil {
-					return NewMembershipStartError(err)
-				}
+			if internodeActive || membershipActive {
+				return fmt.Errorf("cluster component already started")
 			}
-
 			if internodeSvc != nil {
-				logger.Info("starting cluster internode service")
 				if err := internodeSvc.Start(ctx); err != nil {
 					return NewInternodeStartError(err)
+				}
+				internodeActive = true
+				actualPort := connMgr.GetListenPort()
+				addr, port, err := internodeAdvertiseEndpoint(advertiseConfig, actualPort)
+				if err != nil {
+					stopServices()
+					return err
+				}
+				meta := map[string]string{internode.MetadataPort: strconv.Itoa(actualPort)}
+				if addr != "" {
+					meta[internode.MetadataAdvertiseAddr] = addr
+					meta[internode.MetadataAdvertisePort] = strconv.Itoa(port)
+				}
+				membershipSvc.UpdateMeta(meta)
+			}
+			if membershipSvc != nil {
+				logger.Info("starting cluster membership service")
+				// Membership can acquire sockets before reporting a join error.
+				membershipActive = true
+				if err := membershipSvc.Start(ctx); err != nil {
+					stopServices()
+					return NewMembershipStartError(err)
 				}
 			}
 
@@ -463,20 +463,7 @@ func Cluster() boot.Component {
 			return nil
 		},
 		Stop: func(_ context.Context) error {
-			if internodeSvc != nil {
-				logger.Info("stopping cluster internode service")
-				if err := internodeSvc.Stop(); err != nil {
-					logger.Error("failed to stop internode service", zap.Error(err))
-				}
-			}
-
-			if membershipSvc != nil {
-				logger.Info("stopping cluster membership service")
-				if err := membershipSvc.Stop(); err != nil {
-					logger.Error("failed to stop membership service", zap.Error(err))
-				}
-			}
-
+			stopServices()
 			return nil
 		},
 	})

--- a/boot/components/system/cluster_listener_test.go
+++ b/boot/components/system/cluster_listener_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package system
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+	clusterapi "github.com/wippyai/runtime/api/cluster"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/event"
+	logsapi "github.com/wippyai/runtime/api/logs"
+	metricsapi "github.com/wippyai/runtime/api/metrics"
+	payloadapi "github.com/wippyai/runtime/api/payload"
+	relayapi "github.com/wippyai/runtime/api/relay"
+	metricscfg "github.com/wippyai/runtime/api/service/metrics"
+	"github.com/wippyai/runtime/cluster/internode"
+	"github.com/wippyai/runtime/service/metrics"
+	"github.com/wippyai/runtime/system/eventbus"
+	"github.com/wippyai/runtime/system/payload"
+	"github.com/wippyai/runtime/system/relay"
+	"go.uber.org/zap"
+)
+
+func TestClusterBootPublishesOnlyRetainedListener(t *testing.T) {
+	t.Run("normal_shutdown", func(t *testing.T) { checkClusterBootListener(t, false) })
+	t.Run("failed_join_shutdown", func(t *testing.T) { checkClusterBootListener(t, true) })
+}
+
+func checkClusterBootListener(t *testing.T, failJoin bool) {
+	t.Helper()
+	pub, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	secret := make([]byte, 32)
+	_, err = rand.Read(secret)
+	require.NoError(t, err)
+	settings := map[string]any{
+		"enabled": true, ClusterNodeName: "listener-proof", "raft.enabled": false,
+		"membership.bind_addr": "127.0.0.1", "membership.bind_port": 0,
+		ClusterMembershipSecret: base64.StdEncoding.EncodeToString(secret),
+		"internode.bind_addr":   "127.0.0.1", "internode.bind_port": 0,
+		"internode.auto_port":                        true,
+		"internode.identity_key":                     base64.RawStdEncoding.EncodeToString(key),
+		"internode.trusted_peer_keys.listener-proof": base64.RawStdEncoding.EncodeToString(pub),
+	}
+	if failJoin {
+		settings[ClusterMembershipJoin] = "127.0.0.1:1"
+	}
+	cfg := boot.NewConfig(boot.WithSection("cluster", settings))
+	base, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx := ctxapi.WithAppContext(base, ctxapi.NewAppContext())
+	ctx = boot.WithConfig(ctx, cfg)
+	ctx = logsapi.WithLogger(ctx, zap.NewNop())
+	ctx = event.WithBus(ctx, eventbus.NewBus())
+	ctx = payloadapi.WithTranscoder(ctx, payload.NewTranscoder())
+	relayNode := relay.NewNode("listener-proof")
+	ctx = relayapi.WithNode(ctx, relayNode)
+	ctx = relayapi.WithRouter(ctx, relay.NewRouter(relayNode, nil))
+	collector := metrics.NewCollector(metricscfg.Config{})
+	defer collector.Close()
+	ctx = metricsapi.WithCollector(ctx, collector)
+	component := Cluster()
+	ctx, err = component.Load(ctx)
+	require.NoError(t, err)
+	membership := clusterapi.GetMembership(ctx)
+	require.NotNil(t, membership)
+	require.Empty(t, membership.LocalNode().Meta[internode.MetadataPort], "Load cannot advertise a temporary probe")
+	stop := component.(boot.Stopper)
+	defer stop.Stop(ctx)
+	startErr := component.(boot.Starter).Start(ctx)
+	if failJoin {
+		require.Error(t, startErr)
+	} else {
+		require.NoError(t, startErr)
+	}
+	node := membership.LocalNode()
+	port, err := strconv.Atoi(node.Meta[internode.MetadataPort])
+	require.NoError(t, err)
+	require.Positive(t, port)
+	endpoint := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	if !failJoin {
+		probe, err := net.Listen("tcp", endpoint)
+		if probe != nil {
+			_ = probe.Close()
+		}
+		require.Error(t, err, "advertised endpoint must remain reserved")
+	}
+	require.NoError(t, stop.Stop(ctx))
+	probe, err := net.Listen("tcp", endpoint)
+	require.NoError(t, err, "shutdown must release the retained socket")
+	require.NoError(t, probe.Close())
+}

--- a/boot/components/system/cluster_listener_test.go
+++ b/boot/components/system/cluster_listener_test.go
@@ -88,14 +88,14 @@ func checkClusterBootListener(t *testing.T, failJoin bool) {
 	require.Positive(t, port)
 	endpoint := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 	if !failJoin {
-		probe, err := net.Listen("tcp", endpoint)
+		probe, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", endpoint)
 		if probe != nil {
 			_ = probe.Close()
 		}
 		require.Error(t, err, "advertised endpoint must remain reserved")
 	}
 	require.NoError(t, stop.Stop(ctx))
-	probe, err := net.Listen("tcp", endpoint)
+	probe, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", endpoint)
 	require.NoError(t, err, "shutdown must release the retained socket")
 	require.NoError(t, probe.Close())
 }

--- a/cluster/internode/automatic_port_test.go
+++ b/cluster/internode/automatic_port_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"go.uber.org/zap"
+)
+
+func TestZeroPortReportsRetainedEndpoint(t *testing.T) {
+	for _, automatic := range []bool{false, true} {
+		t.Run(strconv.FormatBool(automatic), func(t *testing.T) {
+			cfg := insecureManagerConfig()
+			cfg.Logger = zap.NewNop()
+			cfg.BindAddr, cfg.BindPort, cfg.AutoPort = "127.0.0.1", 0, automatic
+			manager := NewConnectionManager(cfg, nil)
+			require.NoError(t, manager.Start(context.Background(), func(cluster.NodeID, []byte) {}))
+			defer manager.Stop()
+			port := manager.GetListenPort()
+			require.Positive(t, port)
+			listener, err := net.Listen("tcp", net.JoinHostPort(cfg.BindAddr, strconv.Itoa(port)))
+			if listener != nil {
+				_ = listener.Close()
+			}
+			require.Error(t, err)
+		})
+	}
+}

--- a/cluster/internode/automatic_port_test.go
+++ b/cluster/internode/automatic_port_test.go
@@ -24,7 +24,7 @@ func TestZeroPortReportsRetainedEndpoint(t *testing.T) {
 			defer manager.Stop()
 			port := manager.GetListenPort()
 			require.Positive(t, port)
-			listener, err := net.Listen("tcp", net.JoinHostPort(cfg.BindAddr, strconv.Itoa(port)))
+			listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", net.JoinHostPort(cfg.BindAddr, strconv.Itoa(port)))
 			if listener != nil {
 				_ = listener.Close()
 			}

--- a/cluster/internode/endpoint_update_test.go
+++ b/cluster/internode/endpoint_update_test.go
@@ -9,7 +9,25 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wippyai/runtime/api/cluster"
 	"github.com/wippyai/runtime/api/event"
+	"go.uber.org/zap"
 )
+
+func TestConnectedPeerRetainsUpdatedEndpointForRetry(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	m.AddManagedNode("peer")
+	defer m.RemoveManagedNode("peer")
+	m.nodeStates.UpdateNodeAddress("peer", "127.0.0.1", 9100)
+	m.nodeStates.SetNodeConnection("peer", nil, StateConnected)
+	m.EnsureConnection("peer", "127.0.0.2", 9200)
+	addr, port, ok := m.nodeStates.GetNodeAddress("peer")
+	require.True(t, ok)
+	require.Equal(t, "127.0.0.2", addr)
+	require.Equal(t, 9200, port)
+	_, state := m.nodeStates.GetNodeConnection("peer")
+	require.Equal(t, StateConnected, state)
+}
 
 func TestServiceMembershipUpdateRefreshesManagedEndpoint(t *testing.T) {
 	service, manager, _, bus, ctx, cancel := setupService(t)

--- a/cluster/internode/endpoint_update_test.go
+++ b/cluster/internode/endpoint_update_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"github.com/wippyai/runtime/api/event"
+)
+
+func TestServiceMembershipUpdateRefreshesManagedEndpoint(t *testing.T) {
+	service, manager, _, bus, ctx, cancel := setupService(t)
+	defer cancel()
+	require.NoError(t, service.Start(ctx))
+	defer service.Stop()
+	manager.AddManagedNode("peer")
+	bus.Send(ctx, event.Event{
+		System: cluster.System, Kind: cluster.NodeUpdated, Path: "node.updated",
+		Data: cluster.NodeEvent{Node: cluster.NodeInfo{
+			ID: "peer", Addr: "127.0.0.1:7946",
+			Meta: cluster.NodeMeta{MetadataPort: "9100"},
+		}},
+	})
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		for _, call := range manager.ensuredConns {
+			if call == (ensureConnCall{nodeID: "peer", addr: "127.0.0.1", port: 9100}) {
+				return true
+			}
+		}
+		return false
+	}, time.Second, time.Millisecond)
+}
+
+func TestServiceMembershipUpdateDoesNotReadmitDepartedPeer(t *testing.T) {
+	service, manager, _, _, ctx, cancel := setupService(t)
+	defer cancel()
+	require.NoError(t, service.Start(ctx))
+	defer service.Stop()
+	manager.AddManagedNode("departed")
+	manager.RemoveManagedNode("departed")
+	service.handleMembershipEvent(event.Event{
+		Kind: cluster.NodeUpdated,
+		Data: cluster.NodeEvent{Node: cluster.NodeInfo{
+			ID: "departed", Addr: "127.0.0.1:7946",
+			Meta: cluster.NodeMeta{MetadataPort: "9100"},
+		}},
+	})
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	require.False(t, manager.managedNodes["departed"])
+	for _, call := range manager.ensuredConns {
+		require.NotEqual(t, "departed", call.nodeID)
+	}
+}

--- a/cluster/internode/internode.go
+++ b/cluster/internode/internode.go
@@ -39,6 +39,8 @@ type PackageCallback func(*relay.Package) error
 
 type Service struct {
 	ctx              context.Context
+	cancel           context.CancelFunc
+	localNodeID      cluster.NodeID
 	logger           *zap.Logger
 	connMan          ConnectionManager
 	codec            cluster.MessageCodec
@@ -67,7 +69,9 @@ func NewService(
 }
 
 func (s *Service) Start(ctx context.Context) error {
+	ctx, s.cancel = context.WithCancel(ctx)
 	s.ctx = ctx
+	s.localNodeID = s.membership.LocalNode().ID
 	s.logger.Info("Starting inter-node service...")
 
 	onMessage := func(nodeID cluster.NodeID, data []byte) {
@@ -98,11 +102,13 @@ func (s *Service) Start(ctx context.Context) error {
 	}
 
 	if err := s.connMan.Start(ctx, onMessage); err != nil {
+		s.cancel()
 		return NewStartConnectionManagerError(err)
 	}
 
 	sub, err := eventbus.NewSubscriber(ctx, s.bus, cluster.System, "node.(joined|left)", s.handleMembershipEvent)
 	if err != nil {
+		s.cancel()
 		_ = s.connMan.Stop()
 		return NewSubscribeMembershipError(err)
 	}
@@ -110,7 +116,7 @@ func (s *Service) Start(ctx context.Context) error {
 
 	// Process nodes that are already in the cluster at startup.
 	for _, nodeInfo := range s.membership.Nodes() {
-		if nodeInfo.ID != s.membership.LocalNode().ID {
+		if nodeInfo.ID != s.localNodeID {
 			s.logger.Info("Processing pre-existing cluster member", zap.String("node_id", nodeInfo.ID))
 			s.connMan.AddManagedNode(nodeInfo.ID)
 			s.connectToNode(nodeInfo)
@@ -141,7 +147,7 @@ func (s *Service) orphanSweepLoop(ctx context.Context) {
 		case <-t.C:
 			members := s.membership.Nodes()
 			known := make(map[cluster.NodeID]struct{}, len(members)+1)
-			known[s.membership.LocalNode().ID] = struct{}{}
+			known[s.localNodeID] = struct{}{}
 			for _, n := range members {
 				known[n.ID] = struct{}{}
 			}
@@ -155,6 +161,9 @@ func (s *Service) orphanSweepLoop(ctx context.Context) {
 
 func (s *Service) Stop() error {
 	s.logger.Info("Stopping inter-node service...")
+	if s.cancel != nil {
+		s.cancel()
+	}
 	if s.subscriber != nil {
 		s.subscriber.Close()
 	}
@@ -265,7 +274,7 @@ func (s *Service) handleMembershipEvent(e event.Event) {
 		return
 	}
 	nodeInfo := nodeEvent.Node
-	if nodeInfo.ID == s.membership.LocalNode().ID {
+	if nodeInfo.ID == s.localNodeID {
 		return
 	}
 

--- a/cluster/internode/internode.go
+++ b/cluster/internode/internode.go
@@ -40,7 +40,6 @@ type PackageCallback func(*relay.Package) error
 type Service struct {
 	ctx              context.Context
 	cancel           context.CancelFunc
-	localNodeID      cluster.NodeID
 	logger           *zap.Logger
 	connMan          ConnectionManager
 	codec            cluster.MessageCodec
@@ -48,6 +47,7 @@ type Service struct {
 	bus              event.Bus
 	membership       cluster.Membership
 	subscriber       *eventbus.Subscriber
+	localNodeID      cluster.NodeID
 }
 
 func NewService(

--- a/cluster/internode/internode.go
+++ b/cluster/internode/internode.go
@@ -106,7 +106,7 @@ func (s *Service) Start(ctx context.Context) error {
 		return NewStartConnectionManagerError(err)
 	}
 
-	sub, err := eventbus.NewSubscriber(ctx, s.bus, cluster.System, "node.(joined|left)", s.handleMembershipEvent)
+	sub, err := eventbus.NewSubscriber(ctx, s.bus, cluster.System, "node.(joined|left|updated)", s.handleMembershipEvent)
 	if err != nil {
 		s.cancel()
 		_ = s.connMan.Stop()
@@ -284,6 +284,10 @@ func (s *Service) handleMembershipEvent(e event.Event) {
 			zap.String("node_id", nodeInfo.ID))
 		s.connMan.AddManagedNode(nodeInfo.ID)
 		s.connectToNode(nodeInfo)
+	case cluster.NodeUpdated:
+		if s.connMan.IsManaged(nodeInfo.ID) {
+			s.connectToNode(nodeInfo)
+		}
 	case cluster.NodeLeft:
 		s.logger.Info("Node left cluster, cleaning up state and connection",
 			zap.String("node_id", nodeInfo.ID))

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -353,6 +353,7 @@ func (m *manager) EnsureConnection(nodeID cluster.NodeID, addr string, port int)
 		return
 	}
 
+	m.nodeStates.UpdateNodeAddress(nodeID, addr, port)
 	_, currentState := m.nodeStates.GetNodeConnection(nodeID)
 	if currentState == StateConnected {
 		return
@@ -362,7 +363,6 @@ func (m *manager) EnsureConnection(nodeID cluster.NodeID, addr string, port int)
 		return
 	}
 
-	m.nodeStates.UpdateNodeAddress(nodeID, addr, port)
 	m.sendCommand(nodeID, nodeCommand{
 		Type: cmdConnect,
 		Data: connectData{Addr: addr, Port: port},

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -824,23 +825,30 @@ func (m *manager) startListener() (net.Listener, int, error) {
 	if m.config.AutoPort {
 		return m.tryPortRange()
 	}
-	addr := fmt.Sprintf("%s:%d", m.config.BindAddr, m.config.BindPort)
+	addr := net.JoinHostPort(m.config.BindAddr, strconv.Itoa(m.config.BindPort))
 	listener, err := m.listen(addr)
-	return listener, m.config.BindPort, err
+	if err != nil {
+		return nil, 0, err
+	}
+	return listener, listener.Addr().(*net.TCPAddr).Port, nil
 }
 
 func (m *manager) tryPortRange() (net.Listener, int, error) {
 	startPort := m.config.BindPort
 	if startPort == 0 {
-		startPort = DefaultPortRangeStart
+		listener, err := m.listen(net.JoinHostPort(m.config.BindAddr, "0"))
+		if err != nil {
+			return nil, 0, err
+		}
+		return listener, listener.Addr().(*net.TCPAddr).Port, nil
 	}
 	for port := startPort; port <= DefaultPortRangeEnd; port++ {
-		addr := fmt.Sprintf("%s:%d", m.config.BindAddr, port)
+		addr := net.JoinHostPort(m.config.BindAddr, strconv.Itoa(port))
 		if listener, err := m.listen(addr); err == nil {
 			return listener, port, nil
 		}
 	}
-	addr := fmt.Sprintf("%s:0", m.config.BindAddr)
+	addr := net.JoinHostPort(m.config.BindAddr, "0")
 	listener, err := m.listen(addr)
 	if err != nil {
 		return nil, 0, err

--- a/cluster/stack.go
+++ b/cluster/stack.go
@@ -85,8 +85,8 @@ type StackConfig struct {
 	MembershipProbeInterval       time.Duration
 	MembershipProbeTimeout        time.Duration
 	MembershipTCPTimeout          time.Duration
-	MembershipBindPort            int
-	InternodeBindPort             int
+	MembershipBindPort            int // zero asks the OS for a TCP/UDP gossip port
+	InternodeBindPort             int // zero asks the OS for an internode TCP port
 	MembershipSuspicionMult       int
 	InternodeAutoPort             bool
 }
@@ -137,8 +137,8 @@ func AssembleStack(cfg StackConfig) (*Stack, error) {
 	node := relay.NewNode(cfg.NodeName)
 	codec := internode.NewMessageCodec(cfg.Transcoder)
 
-	// Pre-start a temporary connection manager to discover the actual
-	// internode port (especially under AutoPort). Mirrors the boot flow.
+	// Bind during Start and publish the retained listener's actual endpoint
+	// before joining membership. Construction must not reserve network ports.
 	mgrCfg := internode.DefaultManagerConfig()
 	mgrCfg.LocalNodeID = cfg.NodeName
 	mgrCfg.BindAddr = stringOr(cfg.InternodeBindAddr, "0.0.0.0")
@@ -171,36 +171,20 @@ func AssembleStack(cfg StackConfig) (*Stack, error) {
 		return ok
 	}
 
-	tempMgr := internode.NewConnectionManager(mgrCfg, cfg.Collector)
-	tempCtx, tempCancel := context.WithCancel(context.Background())
-	if err := tempMgr.Start(tempCtx, func(_ clusterapi.NodeID, _ []byte) {}); err != nil {
-		tempCancel()
-		return nil, fmt.Errorf("cluster: pre-start connection manager: %w", err)
-	}
-	actualPort := tempMgr.GetListenPort()
-	if err := tempMgr.Stop(); err != nil {
-		tempCancel()
-		return nil, fmt.Errorf("cluster: stop pre-start connection manager: %w", err)
-	}
-	tempCancel()
-
-	// Pin the discovered port for the real manager.
-	mgrCfg.BindPort = actualPort
-	mgrCfg.AutoPort = false
 	connMgr := internode.NewConnectionManager(mgrCfg, cfg.Collector)
 
-	// Augment meta with the discovered port.
+	// Copy caller metadata and publish the identity. Start adds the retained
+	// listener port before membership begins advertising.
 	meta := clusterapi.NodeMeta{}
 	for k, v := range cfg.Meta {
 		meta[k] = v
 	}
-	meta[internode.MetadataPort] = strconv.Itoa(actualPort)
 	meta[internode.MetadataPublicKey] = base64.RawStdEncoding.EncodeToString(publicKey)
 
 	memCfg := membership.Config{
 		NodeName:            cfg.NodeName,
 		BindAddr:            stringOr(cfg.MembershipBindAddr, "0.0.0.0"),
-		BindPort:            intOr(cfg.MembershipBindPort, 7946),
+		BindPort:            cfg.MembershipBindPort,
 		JoinAddrs:           cfg.JoinAddrs,
 		SecretKey:           secretKey,
 		AdvertiseIP:         cfg.MembershipAdvertise,
@@ -253,8 +237,7 @@ func AssembleStack(cfg StackConfig) (*Stack, error) {
 	}, nil
 }
 
-// Start brings up membership and internode. Order matches the boot path:
-// membership first (so internode has a peer set ready), then internode.
+// Start retains the internode listener before advertising it through membership.
 func (s *Stack) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -262,17 +245,19 @@ func (s *Stack) Start(ctx context.Context) error {
 		return fmt.Errorf("cluster: stack already started")
 	}
 
+	if err := s.Internode.Start(ctx); err != nil {
+		return fmt.Errorf("cluster: start internode: %w", err)
+	}
+	s.Membership.UpdateMeta(map[string]string{
+		internode.MetadataPort: strconv.Itoa(s.ConnMgr.GetListenPort()),
+	})
 	if err := s.Membership.Start(ctx); err != nil {
 		// memberlist.Create binds the gossip port BEFORE attempting Join,
 		// so a Join failure leaks the port even though Start returned an
 		// error. Tear membership down so a caller-side retry can re-bind.
 		_ = s.Membership.Stop()
+		_ = s.Internode.Stop()
 		return fmt.Errorf("cluster: start membership: %w", err)
-	}
-	if err := s.Internode.Start(ctx); err != nil {
-		// Best effort: tear membership down so we don't leak a half-up stack.
-		_ = s.Membership.Stop()
-		return fmt.Errorf("cluster: start internode: %w", err)
 	}
 	s.started = true
 	return nil
@@ -301,13 +286,6 @@ func (s *Stack) Stop() error {
 
 func stringOr(v, def string) string {
 	if v == "" {
-		return def
-	}
-	return v
-}
-
-func intOr(v, def int) int {
-	if v == 0 {
 		return def
 	}
 	return v

--- a/cluster/stack_ports_test.go
+++ b/cluster/stack_ports_test.go
@@ -27,7 +27,7 @@ import (
 // Every advertised internode endpoint must remain owned by its listener.
 func TestConcurrentAutomaticPorts(t *testing.T) {
 	const count = 20
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
 	defer cancel()
 	collector := metrics.NewCollector(metricscfg.Config{})
 	defer collector.Close()
@@ -140,11 +140,11 @@ func TestConcurrentAutomaticPorts(t *testing.T) {
 			}
 		}
 	}()
-	// A missed leave requires dead-node detection, the 30s reclaim delay,
-	// and anti-entropy before the same name can move to a new address.
+	// A missed leave can require a full probe round (~20s), suspicion (~23s),
+	// the 30s reclaim delay, and anti-entropy before the address can change.
 	require.Eventually(t, func() bool {
 		return len(restarted.ConnMgr.ConnectedNodes()) == count-1
-	}, 60*time.Second, 50*time.Millisecond, "same identity must rejoin at a new endpoint")
+	}, 2*time.Minute, 50*time.Millisecond, "same identity must rejoin at a new endpoint")
 	joined = true
 }
 

--- a/cluster/stack_ports_test.go
+++ b/cluster/stack_ports_test.go
@@ -140,9 +140,11 @@ func TestConcurrentAutomaticPorts(t *testing.T) {
 			}
 		}
 	}()
+	// A missed leave requires dead-node detection, the 30s reclaim delay,
+	// and anti-entropy before the same name can move to a new address.
 	require.Eventually(t, func() bool {
 		return len(restarted.ConnMgr.ConnectedNodes()) == count-1
-	}, 15*time.Second, 50*time.Millisecond, "same identity must rejoin at a new endpoint")
+	}, 60*time.Second, 50*time.Millisecond, "same identity must rejoin at a new endpoint")
 	joined = true
 }
 

--- a/cluster/stack_ports_test.go
+++ b/cluster/stack_ports_test.go
@@ -27,7 +27,7 @@ import (
 // Every advertised internode endpoint must remain owned by its listener.
 func TestConcurrentAutomaticPorts(t *testing.T) {
 	const count = 20
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	collector := metrics.NewCollector(metricscfg.Config{})
 	defer collector.Close()

--- a/cluster/stack_ports_test.go
+++ b/cluster/stack_ports_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cluster
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metricscfg "github.com/wippyai/runtime/api/service/metrics"
+	"github.com/wippyai/runtime/cluster/internode"
+	"github.com/wippyai/runtime/service/metrics"
+	"github.com/wippyai/runtime/system/eventbus"
+	"github.com/wippyai/runtime/system/payload"
+	"go.uber.org/zap"
+)
+
+// Real authenticated stacks share one address without assigning any port.
+// Every advertised internode endpoint must remain owned by its listener.
+func TestConcurrentAutomaticPorts(t *testing.T) {
+	const count = 20
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	collector := metrics.NewCollector(metricscfg.Config{})
+	defer collector.Close()
+	keys := make([]ed25519.PrivateKey, count)
+	trusted := make(map[string]string, count)
+	for i := range keys {
+		pub, key, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		keys[i] = key
+		trusted[fmt.Sprintf("project-%d", i)] = base64.RawStdEncoding.EncodeToString(pub)
+	}
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+	stacks := make([]*Stack, count)
+	defer func() {
+		var stopping sync.WaitGroup
+		for _, stack := range stacks {
+			if stack != nil {
+				stopping.Go(func() { _ = stack.Stop() })
+			}
+		}
+		stopping.Wait()
+	}()
+	config := func(i int) StackConfig {
+		return StackConfig{
+			NodeName: fmt.Sprintf("project-%d", i), Logger: zap.NewNop(),
+			Bus: eventbus.NewBus(), Collector: collector, Transcoder: payload.NewTranscoder(),
+			MembershipBindAddr: "127.0.0.1", InternodeBindAddr: "127.0.0.1",
+			MembershipBindPort: 0, InternodeBindPort: 0, InternodeAutoPort: true,
+			SecretKey:                base64.StdEncoding.EncodeToString(secret),
+			InternodeIdentityKey:     base64.RawStdEncoding.EncodeToString(keys[i]),
+			InternodeTrustedPeerKeys: trusted,
+		}
+	}
+	stacks[0], err = AssembleStack(config(0))
+	require.NoError(t, err)
+	require.Zero(t, stacks[0].ConnMgr.GetListenPort(), "construction must not bind")
+	require.NoError(t, stacks[0].Start(ctx))
+	seed := stacks[0].Membership.LocalNode().Addr
+	errors := make(chan error, count-1)
+	var starting sync.WaitGroup
+	for i := 1; i < count; i++ {
+		starting.Go(func() {
+			cfg := config(i)
+			cfg.JoinAddrs = []string{seed}
+			stack, err := AssembleStack(cfg)
+			if err == nil {
+				stacks[i] = stack
+				err = stack.Start(ctx)
+			}
+			errors <- err
+		})
+	}
+	starting.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+	ports := make(map[int]bool)
+	for _, stack := range stacks {
+		port := stack.ConnMgr.GetListenPort()
+		require.Positive(t, port)
+		require.False(t, ports[port], "duplicate listener port")
+		ports[port] = true
+		require.Equal(t, strconv.Itoa(port), stack.Membership.LocalNode().Meta[internode.MetadataPort])
+		listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if listener != nil {
+			_ = listener.Close()
+		}
+		require.Error(t, err, "advertised listener must remain bound")
+	}
+	require.Eventually(t, func() bool {
+		for _, stack := range stacks {
+			if len(stack.ConnMgr.ConnectedNodes()) != count-1 {
+				return false
+			}
+		}
+		return true
+	}, 20*time.Second, 50*time.Millisecond, "all authenticated mesh connections must form")
+
+	// A new execution keeps its logical name and key, but must not depend on
+	// its previous endpoint being available after shutdown.
+	oldPort := stacks[count-1].ConnMgr.GetListenPort()
+	require.NoError(t, stacks[count-1].Stop())
+	occupied, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(oldPort)))
+	require.NoError(t, err)
+	defer occupied.Close()
+	cfg := config(count - 1)
+	cfg.JoinAddrs = []string{seed}
+	restarted, err := AssembleStack(cfg)
+	require.NoError(t, err)
+	stacks[count-1] = restarted
+	require.NoError(t, restarted.Start(ctx))
+	require.NotEqual(t, oldPort, restarted.ConnMgr.GetListenPort())
+	joined := false
+	defer func() {
+		if !joined {
+			for _, stack := range stacks {
+				t.Logf("node=%s members=%v connected=%v", stack.Membership.LocalNode().ID, stack.Membership.Nodes(), stack.ConnMgr.ConnectedNodes())
+			}
+		}
+	}()
+	require.Eventually(t, func() bool {
+		return len(restarted.ConnMgr.ConnectedNodes()) == count-1
+	}, 15*time.Second, 50*time.Millisecond, "same identity must rejoin at a new endpoint")
+	joined = true
+}
+
+func TestFailedJoinReleasesAutomaticPorts(t *testing.T) {
+	collector := metrics.NewCollector(metricscfg.Config{})
+	defer collector.Close()
+	pub, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	secret := make([]byte, 32)
+	_, err = rand.Read(secret)
+	require.NoError(t, err)
+	stack, err := AssembleStack(StackConfig{
+		NodeName: "failed-join", Logger: zap.NewNop(), Bus: eventbus.NewBus(),
+		Transcoder: payload.NewTranscoder(), Collector: collector,
+		MembershipBindAddr: "127.0.0.1", InternodeBindAddr: "127.0.0.1",
+		JoinAddrs:                []string{"127.0.0.1:1"},
+		SecretKey:                base64.StdEncoding.EncodeToString(secret),
+		InternodeIdentityKey:     base64.RawStdEncoding.EncodeToString(key),
+		InternodeTrustedPeerKeys: map[string]string{"failed-join": base64.RawStdEncoding.EncodeToString(pub)},
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	require.Error(t, stack.Start(ctx))
+	port := stack.ConnMgr.GetListenPort()
+	require.Positive(t, port, "internode must have started before the failed join")
+	for _, address := range []string{
+		net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), stack.Membership.LocalNode().Addr,
+	} {
+		listener, err := net.Listen("tcp", address)
+		require.NoError(t, err, "failed startup must release %s", address)
+		require.NoError(t, listener.Close())
+	}
+	packet, err := net.ListenPacket("udp", stack.Membership.LocalNode().Addr)
+	require.NoError(t, err, "failed startup must release gossip UDP")
+	require.NoError(t, packet.Close())
+	require.NoError(t, stack.Stop())
+}

--- a/cluster/stack_ports_test.go
+++ b/cluster/stack_ports_test.go
@@ -52,6 +52,15 @@ func TestConcurrentAutomaticPorts(t *testing.T) {
 		}
 		stopping.Wait()
 	}()
+	defer func() {
+		if t.Failed() {
+			for _, stack := range stacks {
+				if stack != nil {
+					t.Logf("node=%s members=%d connected=%v", stack.Membership.LocalNode().ID, len(stack.Membership.Nodes()), stack.ConnMgr.ConnectedNodes())
+				}
+			}
+		}
+	}()
 	config := func(i int) StackConfig {
 		return StackConfig{
 			NodeName: fmt.Sprintf("project-%d", i), Logger: zap.NewNop(),

--- a/cluster/stack_ports_test.go
+++ b/cluster/stack_ports_test.go
@@ -94,7 +94,7 @@ func TestConcurrentAutomaticPorts(t *testing.T) {
 		require.False(t, ports[port], "duplicate listener port")
 		ports[port] = true
 		require.Equal(t, strconv.Itoa(port), stack.Membership.LocalNode().Meta[internode.MetadataPort])
-		listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
 		if listener != nil {
 			_ = listener.Close()
 		}
@@ -113,7 +113,7 @@ func TestConcurrentAutomaticPorts(t *testing.T) {
 	// its previous endpoint being available after shutdown.
 	oldPort := stacks[count-1].ConnMgr.GetListenPort()
 	require.NoError(t, stacks[count-1].Stop())
-	occupied, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(oldPort)))
+	occupied, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(oldPort)))
 	require.NoError(t, err)
 	defer occupied.Close()
 	cfg := config(count - 1)
@@ -163,11 +163,11 @@ func TestFailedJoinReleasesAutomaticPorts(t *testing.T) {
 	for _, address := range []string{
 		net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), stack.Membership.LocalNode().Addr,
 	} {
-		listener, err := net.Listen("tcp", address)
+		listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", address)
 		require.NoError(t, err, "failed startup must release %s", address)
 		require.NoError(t, listener.Close())
 	}
-	packet, err := net.ListenPacket("udp", stack.Membership.LocalNode().Addr)
+	packet, err := (&net.ListenConfig{}).ListenPacket(t.Context(), "udp", stack.Membership.LocalNode().Addr)
 	require.NoError(t, err, "failed startup must release gossip UDP")
 	require.NoError(t, packet.Close())
 	require.NoError(t, stack.Stop())

--- a/runtime/wasm/engine/process_cpu_termination_test.go
+++ b/runtime/wasm/engine/process_cpu_termination_test.go
@@ -298,18 +298,18 @@ func testSchedulerDedicatedWorkerOccupiedUntilTermination(t *testing.T) {
 		t.Fatalf("freshMod.Compile: %v", err)
 	}
 
-	var cpuReleased atomic.Bool
+	cpuReleased := make(chan struct{})
 	cpuProc := NewActorProcess(
 		NewProcess(cpuMod, "", wasmapi.WASIConfig{}, wasmapi.LimitsConfig{}, nil),
 		actor.DefaultLimits(),
-		func() { cpuReleased.Store(true) },
+		func() { close(cpuReleased) },
 	)
 
-	var freshReleased atomic.Bool
+	freshReleased := make(chan struct{})
 	freshProc := NewActorProcess(
 		NewProcess(freshMod, "", wasmapi.WASIConfig{}, wasmapi.LimitsConfig{}, nil),
 		actor.DefaultLimits(),
-		func() { freshReleased.Store(true) },
+		func() { close(freshReleased) },
 	)
 
 	cpuCompletedCh := make(chan *runtime.Result, 1)
@@ -401,13 +401,17 @@ func testSchedulerDedicatedWorkerOccupiedUntilTermination(t *testing.T) {
 		t.Fatal("Scheduler: timed out waiting for fresh actor completion result")
 	}
 
-	// 6. Assert resources were released upon termination
-	if !cpuReleased.Load() {
-		t.Fatal("Scheduler: expected CPU actor resources to be released upon termination")
+	// Completion notifications precede process Close; wait for both releases.
+	select {
+	case <-cpuReleased:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Scheduler: timed out waiting for CPU actor resource release")
 	}
 
-	if !freshReleased.Load() {
-		t.Fatal("Scheduler: fresh actor resources were not released")
+	select {
+	case <-freshReleased:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Scheduler: timed out waiting for fresh actor resource release")
 	}
 
 	// 7. Verify process is evicted from scheduler lookup


### PR DESCRIPTION
## Summary

Retain the real internode listener from startup through shutdown. Remove the temporary bind/close/rebind probe, publish the live listener's actual port before joining membership, and release acquired TCP/UDP listeners after failed startup.

- Zero ports request OS-assigned listeners; configured nonzero ports retain the existing selection behavior.
- Construction does not reserve ports. Compiled stacks now use automatic gossip ports when `MembershipBindPort` is zero.
- Stop the internode sweep with its service context.
- Process membership endpoint updates only for managed peers, without re-admitting departed peers.
- Retain changed endpoints even while connected so subsequent retries use the current address.
- Preserve the merged #673 generation protections, #707 socket-first TLS teardown, #706 surface adapter, and #710 cancellable admission.

No new public API or production membership timing changes.

## Verification

- Twenty uninstrumented race repetitions of the authenticated 20-node startup/restart test passed in 463.435s. The restarted node keeps its logical identity/key and changes its endpoint while the old internode port is occupied.
- Full race suites pass on the final rebased tree: `./cluster/... ./boot/components/system/... ./system/relay`.
- Pinned golangci-lint on those packages: 0 issues.
- Deterministic regressions cover forwarding membership updates, refusing departed-peer re-admission, and retaining a connected peer's updated endpoint; the endpoint-retention regression failed before the fix.
- Listener tests cover boot startup/shutdown, zero ports with both automatic modes, and cleanup after failed membership join.
- Linux CI exposed an existing WASM fixture race: scheduler completion is notified before process resource release. The fixture now waits for its release callbacks; no runtime scheduling behavior changed. Twenty focused race repetitions, the engine/scheduler suites in CI short mode, and pinned engine lint pass.

The restart assertion allows two minutes because a missed leave can require a full probe round, suspicion confirmation, the existing 30-second dead-name reclaim delay, and anti-entropy. Earlier 15/60-second assertions could expire before that sequence completes; the enclosing test context now covers it as well. Production defaults are unchanged.

#709 and #712 remain dependent PRs and must preserve these changes when rebased.
