### PR TITLE
Carry cancellation through native relay queue admission

### DIFF
--- a/cluster/internode/context_admission_test.go
+++ b/cluster/internode/context_admission_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wippyai/runtime/api/relay"
+	systemrelay "github.com/wippyai/runtime/system/relay"
+	"go.uber.org/zap"
+)
+
+func TestContextQueueCancellationDoesNotEnqueueWork(t *testing.T) {
+	states := setupStateManager()
+	states.CreateNodeState("peer")
+	state := states.GetNodeState("peer")
+	state.queueMu.Lock()
+	blockedCtx, cancelBlocked := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- states.QueueMessageClassContext(blockedCtx, "peer", []byte("busy"), ClassRaftRPC) }()
+	require.Eventually(t, func() bool { return state.queueMu.waiting.Load() != nil }, time.Second, time.Millisecond)
+	cancelBlocked()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("queue acquisition did not cancel")
+	}
+	state.queueMu.Unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := states.QueueMessageClassContext(ctx, "peer", []byte("canceled"), ClassRaftRPC); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled admission: %v", err)
+	}
+	if got := drainAllData(states, "peer"); len(got) != 0 {
+		t.Fatalf("rejected messages entered queue: %q", got)
+	}
+	if err := states.QueueMessageClassContext(context.Background(), "peer", []byte("accepted"), ClassRaftRPC); err != nil {
+		t.Fatal(err)
+	}
+	got := drainAllData(states, "peer")
+	if len(got) != 1 || string(got[0]) != "accepted" {
+		t.Fatalf("accepted data: %q", got)
+	}
+}
+
+func TestContextManagerDoesNotHideUnmanagedDestination(t *testing.T) {
+	m := &manager{nodeStates: setupStateManager()}
+	if err := m.SendToNodeContext(context.Background(), "missing", []byte("request"), ClassRaftRPC); !errors.Is(err, ErrNodeNotManaged) {
+		t.Fatalf("unmanaged send reported admission: %v", err)
+	}
+}
+
+func TestInternodeContextFailureLeavesPackageWithCaller(t *testing.T) {
+	for _, failure := range []string{"canceled", "unmanaged", "encode"} {
+		t.Run(failure, func(t *testing.T) {
+			states := setupStateManager()
+			if failure != "unmanaged" {
+				states.CreateNodeState("peer")
+			}
+			m := &manager{nodeStates: states}
+			codec := &mockCodec{}
+			if failure == "encode" {
+				codec.encodeError = errors.New("encode failed")
+			}
+			service := NewService(zap.NewNop(), m, codec, nil, nil, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if failure == "canceled" {
+				cancel()
+			}
+
+			pkg := relay.NewServicePackage("local", "host", "peer", "remote", "request")
+			if err := service.SendContext(ctx, pkg); err == nil {
+				t.Fatal("expected failed admission")
+			}
+			if pkg.Target.Node != "peer" || pkg.Target.Host != "remote" || len(pkg.Messages) != 1 {
+				t.Fatal("failed admission consumed caller-owned package")
+			}
+			relay.ReleasePackage(pkg)
+		})
+	}
+}
+
+func TestInternodeContextSuccessQueuesBeforeTransferringOwnership(t *testing.T) {
+	states := setupStateManager()
+	states.CreateNodeState("peer")
+	service := NewService(zap.NewNop(), &manager{nodeStates: states}, &mockCodec{encoded: []byte("encoded-request")}, nil, nil, nil)
+	router := systemrelay.NewRouter(systemrelay.NewNode("local"), service)
+	pkg := relay.NewServicePackage("local", "host", "peer", "remote", "request")
+	if err := router.SendContext(context.Background(), pkg); err != nil {
+		relay.ReleasePackage(pkg)
+		t.Fatal(err)
+	}
+	// The package has transferred: inspect only the independently queued bytes.
+	got := drainAllData(states, "peer")
+	if len(got) != 1 || string(got[0]) != "encoded-request" {
+		t.Fatalf("successful admission lost data: %q", got)
+	}
+}
+
+func TestContextQueueWaitsForContentionThenAdmitsOnce(t *testing.T) {
+	states := setupStateManager()
+	states.CreateNodeState("peer")
+	state := states.GetNodeState("peer")
+	state.queueMu.Lock()
+	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { done <- states.QueueMessageClassContext(ctx, "peer", []byte("once"), ClassRaftRPC) }()
+	require.Eventually(t, func() bool { return state.queueMu.waiting.Load() != nil }, time.Second, time.Millisecond)
+	state.queueMu.Unlock()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("queue unlock did not wake sender")
+	}
+	require.Equal(t, [][]byte{[]byte("once")}, drainAllData(states, "peer"))
+}

--- a/cluster/internode/context_admission_test.go
+++ b/cluster/internode/context_admission_test.go
@@ -56,6 +56,53 @@ func TestContextManagerDoesNotHideUnmanagedDestination(t *testing.T) {
 	}
 }
 
+func TestContextQueueManagerShutdownCancelsAdmission(t *testing.T) {
+	states := setupStateManager()
+	states.CreateNodeState("peer")
+	state := states.GetNodeState("peer")
+	state.queueMu.Lock()
+	defer state.queueMu.Unlock()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	m := &manager{ctx: ctx, nodeStates: states}
+	caller, cancelCaller := context.WithCancel(t.Context())
+	defer cancelCaller()
+	done := make(chan error, 1)
+	go func() { done <- m.SendToNodeContext(caller, "peer", []byte("rejected"), ClassRaftRPC) }()
+	require.Eventually(t, func() bool { return state.queueMu.waiting.Load() != nil }, time.Second, time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("manager shutdown did not cancel queue admission")
+	}
+	require.Zero(t, state.queues[ClassRaftRPC].len())
+}
+
+func TestContextQueueRejectsReplacedPeerGeneration(t *testing.T) {
+	states := setupStateManager()
+	states.CreateNodeState("peer")
+	state := states.GetNodeState("peer")
+	state.queueMu.Lock()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- states.QueueMessageClassContext(ctx, "peer", []byte("old"), ClassRaftRPC) }()
+	require.Eventually(t, func() bool { return state.queueMu.waiting.Load() != nil }, time.Second, time.Millisecond)
+	require.Same(t, state, states.detachNodeState("peer"))
+	states.CreateNodeState("peer")
+	state.queueMu.Unlock()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, ErrNodeNotManaged)
+	case <-time.After(time.Second):
+		t.Fatal("queue admission did not finish after peer replacement")
+	}
+	require.Zero(t, state.queues[ClassRaftRPC].len())
+	require.Empty(t, drainAllData(states, "peer"))
+}
+
 func TestInternodeContextFailureLeavesPackageWithCaller(t *testing.T) {
 	for _, failure := range []string{"canceled", "unmanaged", "encode"} {
 		t.Run(failure, func(t *testing.T) {

--- a/cluster/internode/internode.go
+++ b/cluster/internode/internode.go
@@ -4,6 +4,7 @@ package internode
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 	"strings"
@@ -159,6 +160,59 @@ func (s *Service) Stop() error {
 	}
 	return s.connMan.Stop()
 }
+
+var ErrContextQueueUnsupported = errors.New("internode: connection manager does not support cancellable queue admission")
+
+// SendContext transfers package ownership only on successful queue admission.
+// Cancellation stops waiting to admit; it cannot recall an accepted message.
+func (s *Service) SendContext(ctx context.Context, pkg *relay.Package) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if pkg == nil {
+		return errors.New("internode: nil package")
+	}
+	sender, ok := s.connMan.(ContextConnectionManager)
+	if !ok {
+		return ErrContextQueueUnsupported
+	}
+	data, err := s.codec.Encode(pkg)
+	if err != nil {
+		return NewEncodePackageError(pkg.Target.Node, err)
+	}
+	var topic string
+	if len(pkg.Messages) > 0 {
+		topic = pkg.Messages[0].Topic
+	}
+	// Discovery consumers may run before the transport subscriber. Wait for
+	// its registration without recreating state from a membership snapshot.
+	if !s.connMan.IsManaged(pkg.Target.Node) && s.membership != nil {
+		for _, member := range s.membership.Nodes() {
+			if member.ID != pkg.Target.Node {
+				continue
+			}
+			if waiter, ok := s.connMan.(interface {
+				WaitManaged(context.Context, cluster.NodeID) error
+			}); ok {
+				if err := waiter.WaitManaged(ctx, pkg.Target.Node); err != nil {
+					return err
+				}
+			}
+			break
+		}
+	}
+	// Queue admission still checks the state: a departure may race the wait.
+	if err := sender.SendToNodeContext(ctx, pkg.Target.Node, data, ClassForTopic(topic)); err != nil {
+		return err
+	}
+	relay.ReleasePackage(pkg)
+	return nil
+}
+
+var _ relay.ContextSender = (*Service)(nil)
 
 func (s *Service) Send(pkg *relay.Package) error {
 	data, err := s.codec.Encode(pkg)

--- a/cluster/internode/managed_wait.go
+++ b/cluster/internode/managed_wait.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+
+	"github.com/wippyai/runtime/api/cluster"
+)
+
+// WaitManaged waits for registration without creating a peer or connecting it.
+// Registration is not a delivery guarantee; admission must recheck peer state.
+// The caller bounds the wait. Manager shutdown also wakes it.
+func (m *manager) WaitManaged(ctx context.Context, nodeID cluster.NodeID) error {
+	var stopped <-chan struct{}
+	if m.ctx != nil {
+		stopped = m.ctx.Done()
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if m.ctx != nil {
+			if err := m.ctx.Err(); err != nil {
+				return err
+			}
+		}
+		// Subscribe before reading state so a concurrent join cannot be missed.
+		m.managedMu.Lock()
+		if m.managedChanged == nil {
+			m.managedChanged = make(chan struct{})
+		}
+		changed := m.managedChanged
+		m.managedMu.Unlock()
+		if m.IsManaged(nodeID) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-stopped:
+			return m.ctx.Err()
+		case <-changed:
+		}
+	}
+}
+
+func (m *manager) notifyManagedChange() {
+	m.managedMu.Lock()
+	if m.managedChanged != nil {
+		close(m.managedChanged)
+		m.managedChanged = nil
+	}
+	m.managedMu.Unlock()
+}

--- a/cluster/internode/managed_wait_test.go
+++ b/cluster/internode/managed_wait_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"github.com/wippyai/runtime/api/relay"
+	"go.uber.org/zap"
+)
+
+func TestContextSendWaitsForDiscoveredPeerRegistration(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	membership := &mockMembership{nodes: []cluster.NodeInfo{{ID: "peer"}}}
+	service := NewService(zap.NewNop(), m, &mockCodec{encoded: []byte("once")}, nil, nil, membership)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	pkg := relay.NewServicePackage("local", "host", "peer", "remote", "request")
+	done := make(chan error, 1)
+	go func() { done <- service.SendContext(ctx, pkg) }()
+	select {
+	case err := <-done:
+		t.Fatalf("send returned before transport registration: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	// Simulate the transport subscriber running after a discovery consumer.
+	m.AddManagedNode("peer")
+	require.NoError(t, <-done)
+	require.Equal(t, [][]byte{[]byte("once")}, drainAllData(m.nodeStates, "peer"))
+	m.RemoveManagedNode("peer")
+}
+
+func TestContextSendDiscoveryWaitPreservesCallerOwnership(t *testing.T) {
+	for _, stop := range []bool{false, true} {
+		t.Run(map[bool]string{false: "cancel", true: "shutdown"}[stop], func(t *testing.T) {
+			cfg := insecureManagerConfig()
+			cfg.Logger = zap.NewNop()
+			m := NewConnectionManager(cfg, nil).(*manager)
+			m.ctx, m.cancel = context.WithCancel(t.Context())
+			defer m.cancel()
+			service := NewService(zap.NewNop(), m, &mockCodec{}, nil, nil, &mockMembership{nodes: []cluster.NodeInfo{{ID: "peer"}}})
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			pkg := relay.NewServicePackage("local", "host", "peer", "remote", "request")
+			defer relay.ReleasePackage(pkg)
+			done := make(chan error, 1)
+			go func() { done <- service.SendContext(ctx, pkg) }()
+			require.Eventually(t, func() bool {
+				m.managedMu.Lock()
+				defer m.managedMu.Unlock()
+				return m.managedChanged != nil
+			}, time.Second, time.Millisecond)
+			if stop {
+				m.cancel()
+			} else {
+				cancel()
+			}
+			select {
+			case err := <-done:
+				require.ErrorIs(t, err, context.Canceled)
+			case <-time.After(time.Second):
+				t.Fatal("discovery wait did not cancel")
+			}
+			require.Equal(t, cluster.NodeID("peer"), pkg.Target.Node)
+			require.False(t, m.IsManaged("peer"), "send must not resurrect peer state")
+		})
+	}
+}
+
+func TestContextSendUnknownPeerDoesNotWaitOrCreateState(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	service := NewService(zap.NewNop(), m, &mockCodec{}, nil, nil, &mockMembership{})
+	pkg := relay.NewServicePackage("local", "host", "unknown", "remote", "request")
+	defer relay.ReleasePackage(pkg)
+	require.ErrorIs(t, service.SendContext(t.Context(), pkg), ErrNodeNotManaged)
+	require.False(t, m.IsManaged("unknown"))
+}
+
+func TestManagedWaitCannotResurrectDepartedPeer(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	m.AddManagedNode("departed")
+	m.RemoveManagedNode("departed")
+	// Membership can still contain the departed peer; only its subscriber may
+	// restore transport state. The send must expire without creating it.
+	service := NewService(zap.NewNop(), m, &mockCodec{}, nil, nil, &mockMembership{nodes: []cluster.NodeInfo{{ID: "departed"}}})
+	pkg := relay.NewServicePackage("local", "host", "departed", "remote", "request")
+	defer relay.ReleasePackage(pkg)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, service.SendContext(ctx, pkg), context.DeadlineExceeded)
+	require.False(t, m.IsManaged("departed"))
+}
+
+func TestManagedWaitConcurrentRegistrationDoesNotLoseWakeups(t *testing.T) {
+	cfg := insecureManagerConfig()
+	cfg.Logger = zap.NewNop()
+	m := NewConnectionManager(cfg, nil).(*manager)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	const peers = 100
+	ready := make(chan struct{})
+	done := make(chan error, peers)
+	for i := range peers {
+		node := fmt.Sprintf("peer-%d", i)
+		go func() { <-ready; done <- m.WaitManaged(ctx, node) }()
+	}
+	close(ready)
+	for i := range peers {
+		m.AddManagedNode(fmt.Sprintf("peer-%d", i))
+	}
+	for range peers {
+		require.NoError(t, <-done)
+	}
+	for i := range peers {
+		m.RemoveManagedNode(fmt.Sprintf("peer-%d", i))
+	}
+}

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -205,7 +205,6 @@ type ConnectionManager interface {
 }
 
 type manager struct {
-	managedMu      sync.Mutex
 	managedChanged chan struct{}
 	ctx            context.Context
 	listener       net.Listener
@@ -224,6 +223,7 @@ type manager struct {
 	actualPort     int
 	controlLoopsMu sync.Mutex
 	registerMu     sync.Mutex
+	managedMu      sync.Mutex
 }
 
 func NewConnectionManager(config ManagerConfig, coll metrics.Collector) ConnectionManager {

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -311,10 +311,18 @@ type ContextConnectionManager interface {
 }
 
 func (m *manager) SendToNodeContext(ctx context.Context, nodeID cluster.NodeID, data []byte, class Class) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if m.ctx != nil {
 		if err := m.ctx.Err(); err != nil {
 			return err
 		}
+		admissionCtx, cancel := context.WithCancel(ctx)
+		stop := context.AfterFunc(m.ctx, cancel)
+		defer stop()
+		defer cancel()
+		ctx = admissionCtx
 	}
 	// Unlike legacy best-effort SendToNode, never report success for an
 	// unmanaged destination. The caller must know admission did not occur.

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -205,14 +205,16 @@ type ConnectionManager interface {
 }
 
 type manager struct {
-	ctx          context.Context
-	listener     net.Listener
-	cancel       context.CancelFunc
-	logger       *zap.Logger
-	onMessage    func(cluster.NodeID, []byte)
-	tlsConfig    *tls.Config
-	nodeStates   *NodeStateManager
-	controlLoops map[cluster.NodeID]*nodeControlLoop
+	managedMu      sync.Mutex
+	managedChanged chan struct{}
+	ctx            context.Context
+	listener       net.Listener
+	cancel         context.CancelFunc
+	logger         *zap.Logger
+	onMessage      func(cluster.NodeID, []byte)
+	tlsConfig      *tls.Config
+	nodeStates     *NodeStateManager
+	controlLoops   map[cluster.NodeID]*nodeControlLoop
 	// classReceivers is accessed on every inbound frame (lookupClassReceiver
 	// runs in the read hot path). Registrations happen only at boot, so we
 	// keep the array behind an atomic.Pointer snapshot.
@@ -302,6 +304,23 @@ func (m *manager) Stop() error {
 	return nil
 }
 
+// ContextConnectionManager is optional transactional queue admission. Error
+// means data was not retained; success does not guarantee remote delivery.
+type ContextConnectionManager interface {
+	SendToNodeContext(context.Context, cluster.NodeID, []byte, Class) error
+}
+
+func (m *manager) SendToNodeContext(ctx context.Context, nodeID cluster.NodeID, data []byte, class Class) error {
+	if m.ctx != nil {
+		if err := m.ctx.Err(); err != nil {
+			return err
+		}
+	}
+	// Unlike legacy best-effort SendToNode, never report success for an
+	// unmanaged destination. The caller must know admission did not occur.
+	return m.nodeStates.QueueMessageClassContext(ctx, nodeID, data, class)
+}
+
 func (m *manager) SendToNode(nodeID cluster.NodeID, data []byte, class Class) error {
 	err := m.nodeStates.QueueMessageClass(nodeID, data, class)
 	if err != nil {
@@ -350,6 +369,7 @@ func (m *manager) ConnectedNodes() []cluster.NodeID {
 }
 
 func (m *manager) AddManagedNode(nodeID cluster.NodeID) {
+	defer m.notifyManagedChange()
 	// Serialize membership and inbound admission with state detachment.
 	m.controlLoopsMu.Lock()
 	defer m.controlLoopsMu.Unlock()

--- a/cluster/internode/queue_mutex.go
+++ b/cluster/internode/queue_mutex.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// queueMutex keeps ordinary queue operations on the standard mutex path.
+// Context senders subscribe only when contended; unlock wakes them without
+// polling, a helper goroutine, or treating mutex contention as queue capacity.
+type queueMutex struct {
+	waiting atomic.Pointer[queueWait]
+	mu      sync.Mutex
+}
+type queueWait struct{ changed chan struct{} }
+
+func (m *queueMutex) Lock() { m.mu.Lock() }
+func (m *queueMutex) Unlock() {
+	m.mu.Unlock()
+	if waiter := m.waiting.Load(); waiter != nil && m.waiting.CompareAndSwap(waiter, nil) {
+		close(waiter.changed)
+	}
+}
+func (m *queueMutex) subscribe() <-chan struct{} {
+	for {
+		if waiter := m.waiting.Load(); waiter != nil {
+			return waiter.changed
+		}
+		waiter := &queueWait{changed: make(chan struct{})}
+		if m.waiting.CompareAndSwap(nil, waiter) {
+			return waiter.changed
+		}
+	}
+}
+func (m *queueMutex) LockContext(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if m.mu.TryLock() {
+			break
+		}
+		changed := m.subscribe()
+		if m.mu.TryLock() {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		m.Unlock()
+		return err
+	}
+	return nil
+}

--- a/cluster/internode/state_manager.go
+++ b/cluster/internode/state_manager.go
@@ -3,6 +3,7 @@
 package internode
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -36,7 +37,7 @@ type NodeState struct {
 	surfaceTurn   bool            // guarded by queueMu; fair turns between application classes
 	state         ConnectionState
 	stateMu       sync.RWMutex
-	queueMu       sync.Mutex
+	queueMu       queueMutex
 }
 
 // classQueue is a FIFO of pending messages for one Class.
@@ -240,6 +241,21 @@ func (nsm *NodeStateManager) GetNodeState(nodeID cluster.NodeID) *NodeState {
 // Returns ErrNodeNotManaged if no state exists for nodeID.
 // Returns ErrQueueFull for gossip or surface traffic when full.
 func (nsm *NodeStateManager) QueueMessageClass(nodeID cluster.NodeID, data []byte, class Class) error {
+	return nsm.queueMessageClass(context.Background(), nodeID, data, class, false)
+}
+
+// QueueMessageClassContext cancels queue-lock admission, not accepted delivery.
+func (nsm *NodeStateManager) QueueMessageClassContext(ctx context.Context, nodeID cluster.NodeID, data []byte, class Class) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return nsm.queueMessageClass(ctx, nodeID, data, class, true)
+}
+
+func (nsm *NodeStateManager) queueMessageClass(ctx context.Context, nodeID cluster.NodeID, data []byte, class Class, cancellable bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	state := nsm.GetNodeState(nodeID)
 	if state == nil {
 		return ErrNodeNotManaged
@@ -254,7 +270,17 @@ func (nsm *NodeStateManager) QueueMessageClass(nodeID cluster.NodeID, data []byt
 	if class == ClassSurface && len(data) > MaxSurfaceFrameSize {
 		return NewMessageSizeExceedsMaxError(len(data), MaxSurfaceFrameSize)
 	}
-	state.queueMu.Lock()
+	if cancellable {
+		if err := state.queueMu.LockContext(ctx); err != nil {
+			return err
+		}
+	} else {
+		state.queueMu.Lock()
+	}
+	if nsm.GetNodeState(nodeID) != state {
+		state.queueMu.Unlock()
+		return ErrNodeNotManaged
+	}
 	q := state.queues[class]
 	var rejected bool
 	switch class {

--- a/cluster/internode/state_manager.go
+++ b/cluster/internode/state_manager.go
@@ -32,12 +32,12 @@ type NodeState struct {
 	queues        [numClasses]*classQueue
 	messageNotify chan struct{}
 	connection    *NodeConnection
+	queueMu       queueMutex
 	address       nodeAddress
 	lastDepth     [numClasses]int // last queue depth emitted to telemetry; guarded by queueMu
 	surfaceTurn   bool            // guarded by queueMu; fair turns between application classes
 	state         ConnectionState
 	stateMu       sync.RWMutex
-	queueMu       queueMutex
 }
 
 // classQueue is a FIFO of pending messages for one Class.

--- a/system/relay/router.go
+++ b/system/relay/router.go
@@ -3,6 +3,7 @@
 package relay
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
@@ -66,27 +67,49 @@ func (r *Router) SetInternode(receiver api.Receiver) {
 // Send routes the package to the appropriate destination.
 // Routing priority: local node → peer nodes → internode fallback.
 func (r *Router) Send(pkg *api.Package) error {
+	receiver, err := r.receiverFor(pkg)
+	if err != nil {
+		return err
+	}
+	return receiver.Send(pkg)
+}
+
+// SendContext preserves routing precedence while requiring a cancellable
+// receiver. It never detaches a legacy Send in a goroutine. On error the caller
+// still owns the package; a successful send transfers it to the receiver.
+func (r *Router) SendContext(ctx context.Context, pkg *api.Package) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	receiver, err := r.receiverFor(pkg)
+	if err != nil {
+		return err
+	}
+	if sender, ok := receiver.(api.ContextSender); ok {
+		return sender.SendContext(ctx, pkg)
+	}
+	return NewContextUnsupportedError(pkg.Target.Host, pkg.Target.Node)
+}
+
+func (r *Router) receiverFor(pkg *api.Package) (api.Receiver, error) {
 	if pkg == nil {
-		return NewNilPackageError()
+		return nil, NewNilPackageError()
 	}
-
-	// Route to local node if target node is empty or matches the local node's ID.
 	if pkg.Target.Node == "" || pkg.Target.Node == r.localNode.ID() {
-		return r.localNode.Send(pkg)
+		return r.localNode, nil
 	}
-
-	// Check if it's for a registered peer node.
 	if receiver, ok := r.peers.Load(pkg.Target.Node); ok {
 		if rec, ok := receiver.(api.Receiver); ok {
-			return rec.Send(pkg)
+			return rec, nil
 		}
 	}
-
-	// Fallback to internode for unknown nodes. Lock-free hot-path read:
-	// atomic.Pointer.Load is a single MOV on every message send.
 	if p := r.internode.Load(); p != nil {
-		return (*p).Send(pkg)
+		return *p, nil
 	}
-
-	return NewNodeNotFoundError(pkg.Target.Node)
+	return nil, NewNodeNotFoundError(pkg.Target.Node)
 }
+
+var _ api.ContextSender = (*Router)(nil)

--- a/system/relay/router_context_test.go
+++ b/system/relay/router_context_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package relay_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wippyai/runtime/api/pid"
+	api "github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/system/relay"
+)
+
+type contextRoute struct {
+	entered chan context.Context
+}
+
+func (*contextRoute) Send(*api.Package) error { panic("legacy send must not be called") }
+func (r *contextRoute) SendContext(ctx context.Context, _ *api.Package) error {
+	r.entered <- ctx
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type contextRouteNode struct {
+	*mockNode
+	*contextRoute
+}
+
+func (n *contextRouteNode) Send(pkg *api.Package) error { return n.contextRoute.Send(pkg) }
+
+func TestRouterContextCancellationAcrossRoutes(t *testing.T) {
+	for _, target := range []string{"", "local", "peer", "remote"} {
+		t.Run(target, func(t *testing.T) {
+			localReceiver := &contextRoute{entered: make(chan context.Context, 1)}
+			peerReceiver := &contextRoute{entered: make(chan context.Context, 1)}
+			remoteReceiver := &contextRoute{entered: make(chan context.Context, 1)}
+			local := &contextRouteNode{mockNode: &mockNode{id: "local"}, contextRoute: localReceiver}
+			r := relay.NewRouter(local, remoteReceiver)
+			if err := r.RegisterPeer("peer", peerReceiver); err != nil {
+				t.Fatal(err)
+			}
+			pkg := &api.Package{Target: pid.PID{Node: target, Host: "worker"}}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- r.SendContext(ctx, pkg) }()
+			var received context.Context
+			var selected string
+			select {
+			case received = <-localReceiver.entered:
+				selected = "local"
+			case received = <-peerReceiver.entered:
+				selected = "peer"
+			case received = <-remoteReceiver.entered:
+				selected = "remote"
+			}
+			expected := target
+			if expected == "" {
+				expected = "local"
+			}
+			if selected != expected {
+				t.Fatalf("route = %s, want %s", selected, expected)
+			}
+			if received != ctx {
+				t.Fatal("router did not propagate caller context")
+			}
+			cancel()
+			if err := <-done; !errors.Is(err, context.Canceled) {
+				t.Fatalf("delivery cancellation: %v", err)
+			}
+			if pkg.Target.Host != "worker" {
+				t.Fatal("failed delivery consumed caller package")
+			}
+		})
+	}
+}
+
+func TestRouterContextRejectsLegacyDestinations(t *testing.T) {
+	for _, target := range []string{"local", "peer", "remote"} {
+		t.Run(target, func(t *testing.T) {
+			local := &mockNode{id: "local"}
+			legacy := &mockReceiver{}
+			r := relay.NewRouter(local, legacy)
+			if err := r.RegisterPeer("peer", legacy); err != nil {
+				t.Fatal(err)
+			}
+			pkg := &api.Package{Target: pid.PID{Node: target, Host: "worker"}}
+			if err := r.SendContext(context.Background(), pkg); !errors.Is(err, relay.ErrContextUnsupported) {
+				t.Fatalf("legacy delivery did not fail explicitly: %v", err)
+			}
+			if local.sendCalled != 0 || legacy.sendCalled != 0 {
+				t.Fatal("cancellable path invoked legacy receiver")
+			}
+			// The historical API still supports that same receiver.
+			if err := r.Send(pkg); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestRouterCanceledContextDoesNotDeliver(t *testing.T) {
+	receiver := &contextRoute{entered: make(chan context.Context, 1)}
+	r := relay.NewRouter(&mockNode{id: "local"}, receiver)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pkg := &api.Package{Target: pid.PID{Node: "remote", Host: "worker"}}
+	if err := r.SendContext(ctx, pkg); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled delivery: %v", err)
+	}
+	select {
+	case <-receiver.entered:
+		t.Fatal("already canceled call entered receiver")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

Carry caller cancellation through the existing relay route into internode queue admission. Bee's native mesh actor uses this path; legacy Send remains unchanged.

- Preserve local, registered-peer, then internode routing precedence. Unsupported context receivers fail explicitly.
- Wait for transport registration only for a discovered peer, without creating or resurrecting managed state.
- Keep package ownership with the caller on rejection; successful admission transfers ownership, not a remote-delivery guarantee.
- Cancel pending admission on caller cancellation or manager shutdown, and reject a peer generation replaced while waiting.
- Preserve #673's lifecycle serialization and generation protections when rebasing onto current main.

No Lua API, application configuration, or new transport is introduced. Encoding remains synchronous and is not preemptible; cancellation cannot recall an accepted message.

## Validation

- `go test -race ./cluster/internode ./system/relay` passes.
- Pinned golangci-lint passes on both changed packages: 0 issues.
- Added shutdown regression fails before the fix and passes afterward. Coverage also includes queue contention, cancellation without later enqueue, replaced peers, discovery/registration ordering, ownership, and routing precedence.
