### PR TITLE
Preserve native peer and connection evidence through Lua messages

### DIFF
--- a/api/relay/pool.go
+++ b/api/relay/pool.go
@@ -62,6 +62,7 @@ func ReleasePackage(p *Package) {
 	for _, msg := range p.Messages {
 		ReleaseMessage(msg)
 	}
+	p.Ingress = IngressIdentity{}
 	p.Source = pid.PID{}
 	p.Target = pid.PID{}
 	p.Messages = p.Messages[:0]

--- a/api/relay/pubsub_test.go
+++ b/api/relay/pubsub_test.go
@@ -23,12 +23,14 @@ func TestPackage_Pool(t *testing.T) {
 		require.NotNil(t, p)
 		require.NotNil(t, p.Messages)
 
+		p.Ingress = IngressIdentity{Node: "peer", Authenticated: true, IntegrityProtected: true, ConnectionClosed: make(chan struct{})}
 		p.Source = pid.PID{Host: "host1", UniqID: "proc1"}
 		p.Target = pid.PID{Host: "host2", UniqID: "proc2"}
 		p.Messages = append(p.Messages, &Message{Topic: "test"})
 
 		ReleasePackage(p)
 
+		assert.Equal(t, IngressIdentity{}, p.Ingress)
 		assert.Empty(t, p.Source.Host)
 		assert.Empty(t, p.Target.Host)
 		assert.Empty(t, p.Messages)

--- a/api/relay/relay.go
+++ b/api/relay/relay.go
@@ -73,8 +73,26 @@ type (
 		MaxItems int
 	}
 
+	// IngressIdentity records the immediate network peer observed by the local
+	// transport. It is never serialized and does not authenticate Package.Source
+	// or a transitive origin. Authenticated describes the peer handshake, not
+	// payload integrity on plaintext transport. Local packages have a zero identity. Go receivers
+	// may rely on it only within the trusted local runtime transport boundary.
+	IngressIdentity struct {
+		// ConnectionClosed is the locally observed lifetime of the exact ingress
+		// connection. Nil means the transport does not provide this capability.
+		ConnectionClosed <-chan struct{}
+		Node             pid.NodeID
+		Authenticated    bool
+		// IntegrityProtected reports transport protection of frame contents.
+		// It does not by itself authenticate Node; consumers requiring both
+		// guarantees must check both flags and authorize the immediate peer.
+		IntegrityProtected bool
+	}
+
 	// Package combines source, target and messages for delivery.
 	Package struct {
+		Ingress  IngressIdentity `json:"-" codec:"-"`
 		Source   pid.PID
 		Target   pid.PID
 		Messages []*Message

--- a/cluster/internode/connection.go
+++ b/cluster/internode/connection.go
@@ -139,6 +139,7 @@ func DefaultNodeConnectionConfig() NodeConnectionConfig {
 // via bindDrain) so there is a single queue and a single goroutine wakeup
 // per frame on the send path.
 type NodeConnection struct {
+	closedSignal  chan struct{} // guarded by lifecycleMu
 	conn          net.Conn
 	logger        *zap.Logger
 	cancel        context.CancelFunc
@@ -262,6 +263,13 @@ func (c *NodeConnection) Close() {
 		c.lifecycleMu.Lock()
 		if c.cancel != nil {
 			c.cancel()
+		}
+		if c.closedSignal != nil {
+			select {
+			case <-c.closedSignal:
+			default:
+				close(c.closedSignal)
+			}
 		}
 		c.lifecycleMu.Unlock()
 		_ = c.conn.Close()
@@ -458,4 +466,19 @@ func readFrame(r io.Reader, maxMessageSize uint32) (Class, []byte, error) {
 
 	// It was a large message allocated on its own.
 	return class, msg, nil
+}
+
+// Closed observes loss of this exact connection, not gossip departure or later
+// reconnection to the same peer. Subscription after Close is already signaled.
+// No channel is allocated for connections whose lifecycle nobody observes.
+func (c *NodeConnection) Closed() <-chan struct{} {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	if c.closedSignal == nil {
+		c.closedSignal = make(chan struct{})
+		if c.closed.Load() {
+			close(c.closedSignal)
+		}
+	}
+	return c.closedSignal
 }

--- a/cluster/internode/connection.go
+++ b/cluster/internode/connection.go
@@ -197,6 +197,12 @@ func (c *NodeConnection) bindDrain(notify <-chan struct{}, drain func(int) []Out
 // ExitCleanShutdown and Run returns the writer's error.
 func (c *NodeConnection) Run(handler func(class Class, msg []byte)) *ConnectionError {
 	c.lifecycleMu.Lock()
+	// Close may win before the monitor goroutine starts. Do not publish a
+	// fresh writer context after the one-shot Close has already completed.
+	if c.closed.Load() {
+		c.lifecycleMu.Unlock()
+		return &ConnectionError{Reason: ExitCleanShutdown, Err: ErrCleanShutdown}
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
 	c.lifecycleMu.Unlock()

--- a/cluster/internode/connection_lifetime_test.go
+++ b/cluster/internode/connection_lifetime_test.go
@@ -5,7 +5,6 @@ package internode
 import (
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -40,28 +39,5 @@ func TestConnectionClosedBeforeFirstSubscriber(t *testing.T) {
 	case <-connection.Closed():
 	default:
 		t.Fatal("late subscription missed closure")
-	}
-}
-
-func TestConnectionRunAfterCloseReturns(t *testing.T) {
-	a, b := newMockConnPair()
-	defer b.Close()
-	connection := newNodeConnection(a, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
-	connection.Close()
-	done := make(chan *ConnectionError, 1)
-	go func() { done <- connection.Run(func(Class, []byte) {}) }()
-	select {
-	case err := <-done:
-		require.Equal(t, ExitCleanShutdown, err.Reason)
-	case <-time.After(time.Second):
-		// Release the leaked writer on the unfixed implementation so the
-		// regression itself does not leave a background goroutine behind.
-		connection.lifecycleMu.Lock()
-		if connection.cancel != nil {
-			connection.cancel()
-		}
-		connection.lifecycleMu.Unlock()
-		<-done
-		t.Fatal("Run created an uncanceled writer after Close")
 	}
 }

--- a/cluster/internode/connection_lifetime_test.go
+++ b/cluster/internode/connection_lifetime_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestConnectionClosureObservationSurvivesSubscriptionRaces(t *testing.T) {
+	a, b := newMockConnPair()
+	defer b.Close()
+	connection := newNodeConnection(a, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
+	signal := connection.Closed()
+	require.Equal(t, signal, connection.Closed())
+	var joined sync.WaitGroup
+	for range 100 {
+		joined.Go(func() { <-connection.Closed() })
+	}
+	connection.Close()
+	joined.Wait()
+	select {
+	case <-signal:
+	default:
+		t.Fatal("connection closure was not signaled")
+	}
+	require.Equal(t, signal, connection.Closed(), "late subscribers must observe the same closed lifetime")
+	connection.Close()
+}
+func TestConnectionClosedBeforeFirstSubscriber(t *testing.T) {
+	a, b := newMockConnPair()
+	defer b.Close()
+	connection := newNodeConnection(a, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
+	connection.Close()
+	select {
+	case <-connection.Closed():
+	default:
+		t.Fatal("late subscription missed closure")
+	}
+}
+
+func TestConnectionRunAfterCloseReturns(t *testing.T) {
+	a, b := newMockConnPair()
+	defer b.Close()
+	connection := newNodeConnection(a, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
+	connection.Close()
+	done := make(chan *ConnectionError, 1)
+	go func() { done <- connection.Run(func(Class, []byte) {}) }()
+	select {
+	case err := <-done:
+		require.Equal(t, ExitCleanShutdown, err.Reason)
+	case <-time.After(time.Second):
+		// Release the leaked writer on the unfixed implementation so the
+		// regression itself does not leave a background goroutine behind.
+		connection.lifecycleMu.Lock()
+		if connection.cancel != nil {
+			connection.cancel()
+		}
+		connection.lifecycleMu.Unlock()
+		<-done
+		t.Fatal("Run created an uncanceled writer after Close")
+	}
+}

--- a/cluster/internode/connection_start_test.go
+++ b/cluster/internode/connection_start_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestConnectionRunAfterCloseReturns(t *testing.T) {
+	a, b := newMockConnPair()
+	defer b.Close()
+	connection := newNodeConnection(a, "peer", DefaultNodeConnectionConfig(), zap.NewNop())
+	connection.Close()
+	done := make(chan *ConnectionError, 1)
+	go func() { done <- connection.Run(func(Class, []byte) {}) }()
+	select {
+	case err := <-done:
+		require.Equal(t, ExitCleanShutdown, err.Reason)
+	case <-time.After(time.Second):
+		// Release the leaked writer on the unfixed implementation so the
+		// regression itself does not leave a background goroutine behind.
+		connection.lifecycleMu.Lock()
+		if connection.cancel != nil {
+			connection.cancel()
+		}
+		connection.lifecycleMu.Unlock()
+		<-done
+		t.Fatal("Run created an uncanceled writer after Close")
+	}
+}

--- a/cluster/internode/ingress_identity_test.go
+++ b/cluster/internode/ingress_identity_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/system/eventbus"
+	"go.uber.org/zap"
+)
+
+type authenticatingMockManager struct {
+	*mockConnectionManager
+	authenticated bool
+	protected     bool
+}
+
+func (m authenticatingMockManager) AuthenticatesPeers() bool { return m.authenticated }
+
+func (m authenticatingMockManager) ProtectsPayloads() bool { return m.protected }
+
+type forgedIngressCodec struct{ mockCodec }
+
+func (c *forgedIngressCodec) Decode(data []byte) (*relay.Package, error) {
+	pkg, err := c.mockCodec.Decode(data)
+	if err == nil {
+		pkg.Ingress = relay.IngressIdentity{Node: "forged-authority", Authenticated: true, IntegrityProtected: true}
+	}
+	return pkg, err
+}
+
+func TestServiceIngressIdentityComesFromConnection(t *testing.T) {
+	for _, mode := range []string{"authenticated", "unauthenticated", "unknown_policy", "empty_peer", "tls_authenticated", "tls_unauthenticated"} {
+		t.Run(mode, func(t *testing.T) {
+			manager := newMockConnectionManager()
+			var transport ConnectionManager = manager
+			if mode != "unknown_policy" {
+				transport = authenticatingMockManager{mockConnectionManager: manager, authenticated: mode != "unauthenticated" && mode != "tls_unauthenticated", protected: mode == "tls_authenticated" || mode == "tls_unauthenticated"}
+			}
+			peer := cluster.NodeID("actual-peer")
+			if mode == "empty_peer" {
+				peer = ""
+			}
+			called := false
+			svc := NewService(zap.NewNop(), transport, &forgedIngressCodec{}, func(pkg *relay.Package) error {
+				defer relay.ReleasePackage(pkg)
+				called = true
+				require.Equal(t, peer, pkg.Ingress.Node)
+				require.Equal(t, mode == "authenticated" || mode == "tls_authenticated", pkg.Ingress.Authenticated)
+				require.Equal(t, mode == "tls_authenticated" || mode == "tls_unauthenticated", pkg.Ingress.IntegrityProtected)
+				require.Equal(t, pid.NodeID("remote-node"), pkg.Source.Node, "transitive source semantics remain unchanged")
+				return nil
+			}, eventbus.NewBus(), &mockMembership{localNode: cluster.NodeInfo{ID: "local"}})
+			require.NoError(t, svc.Start(t.Context()))
+			defer func() { require.NoError(t, svc.Stop()) }()
+			manager.onMessage(peer, []byte("frame"))
+			require.True(t, called)
+		})
+	}
+}
+
+func TestMessageCodecNeverTransfersIngressIdentity(t *testing.T) {
+	codec := NewMessageCodec(&mockTranscoder{})
+	pkg := relay.NewServicePackage("sender", "host", "receiver", "host", "topic")
+	defer relay.ReleasePackage(pkg)
+	pkg.Ingress = relay.IngressIdentity{Node: "upstream-authority", Authenticated: true, IntegrityProtected: true}
+	data, err := codec.Encode(pkg)
+	require.NoError(t, err)
+	decoded, err := codec.Decode(data)
+	require.NoError(t, err)
+	defer relay.ReleasePackage(decoded)
+	require.Equal(t, relay.IngressIdentity{}, decoded.Ingress)
+	require.Equal(t, pkg.Source, decoded.Source)
+}

--- a/cluster/internode/internode.go
+++ b/cluster/internode/internode.go
@@ -67,7 +67,14 @@ func (s *Service) Start(ctx context.Context) error {
 	s.ctx = ctx
 	s.logger.Info("Starting inter-node service...")
 
-	onMessage := func(nodeID cluster.NodeID, data []byte) {
+	authenticated, protected := false, false
+	if provider, ok := s.connMan.(interface{ AuthenticatesPeers() bool }); ok {
+		authenticated = provider.AuthenticatesPeers()
+	}
+	if provider, ok := s.connMan.(interface{ ProtectsPayloads() bool }); ok {
+		protected = provider.ProtectsPayloads()
+	}
+	onMessage := func(nodeID cluster.NodeID, data []byte, closed <-chan struct{}) {
 		s.logger.Debug("Received raw message from remote node",
 			zap.String("from_node", nodeID),
 			zap.Int("data_len", len(data)))
@@ -79,6 +86,8 @@ func (s *Service) Start(ctx context.Context) error {
 			s.connMan.RecordDropReason("decode_failed")
 			return
 		}
+		// Overwrite codec output: immediate-peer provenance never comes from bytes.
+		pkg.Ingress = relay.IngressIdentity{ConnectionClosed: closed, Node: nodeID, Authenticated: authenticated && nodeID != "", IntegrityProtected: protected}
 		s.logger.Debug("Decoded message, delivering",
 			zap.String("from_node", nodeID),
 			zap.String("target_host", pkg.Target.Host))
@@ -93,8 +102,16 @@ func (s *Service) Start(ctx context.Context) error {
 		}
 	}
 
-	if err := s.connMan.Start(ctx, onMessage); err != nil {
-		return NewStartConnectionManagerError(err)
+	var startErr error
+	if observer, ok := s.connMan.(interface {
+		StartWithConnectionLifecycle(context.Context, func(cluster.NodeID, []byte, <-chan struct{})) error
+	}); ok {
+		startErr = observer.StartWithConnectionLifecycle(ctx, onMessage)
+	} else {
+		startErr = s.connMan.Start(ctx, func(node cluster.NodeID, data []byte) { onMessage(node, data, nil) })
+	}
+	if startErr != nil {
+		return NewStartConnectionManagerError(startErr)
 	}
 
 	sub, err := eventbus.NewSubscriber(ctx, s.bus, cluster.System, "node.(joined|left)", s.handleMembershipEvent)

--- a/cluster/internode/manager.go
+++ b/cluster/internode/manager.go
@@ -204,14 +204,15 @@ type ConnectionManager interface {
 }
 
 type manager struct {
-	ctx          context.Context
-	listener     net.Listener
-	cancel       context.CancelFunc
-	logger       *zap.Logger
-	onMessage    func(cluster.NodeID, []byte)
-	tlsConfig    *tls.Config
-	nodeStates   *NodeStateManager
-	controlLoops map[cluster.NodeID]*nodeControlLoop
+	onObservedMessage func(cluster.NodeID, []byte, <-chan struct{})
+	ctx               context.Context
+	listener          net.Listener
+	cancel            context.CancelFunc
+	logger            *zap.Logger
+	onMessage         func(cluster.NodeID, []byte)
+	tlsConfig         *tls.Config
+	nodeStates        *NodeStateManager
+	controlLoops      map[cluster.NodeID]*nodeControlLoop
 	// classReceivers is accessed on every inbound frame (lookupClassReceiver
 	// runs in the read hot path). Registrations happen only at boot, so we
 	// keep the array behind an atomic.Pointer snapshot.
@@ -237,6 +238,14 @@ func NewConnectionManager(config ManagerConfig, coll metrics.Collector) Connecti
 }
 
 func (m *manager) Start(ctx context.Context, onMessage func(nodeID cluster.NodeID, data []byte)) error {
+	return m.start(ctx, onMessage, nil)
+}
+
+// StartWithConnectionLifecycle supplies the exact ingress connection lifetime.
+func (m *manager) StartWithConnectionLifecycle(ctx context.Context, observed func(cluster.NodeID, []byte, <-chan struct{})) error {
+	return m.start(ctx, nil, observed)
+}
+func (m *manager) start(ctx context.Context, onMessage func(cluster.NodeID, []byte), observed func(cluster.NodeID, []byte, <-chan struct{})) error {
 	if m.config.RequireAuthentication {
 		if len(m.config.AuthenticationKey) == 0 {
 			return fmt.Errorf("internode authentication key is required")
@@ -253,6 +262,7 @@ func (m *manager) Start(ctx context.Context, onMessage func(nodeID cluster.NodeI
 	}
 	m.ctx, m.cancel = context.WithCancel(ctx)
 	m.onMessage = onMessage
+	m.onObservedMessage = observed
 
 	if m.config.TLS.Enabled {
 		tlsConfig, err := loadTLSConfig(m.config.TLS)
@@ -760,7 +770,11 @@ func (loop *nodeControlLoop) monitorConnection(conn *NodeConnection) {
 			recv(loop.nodeID, msg)
 			return
 		}
-		loop.manager.onMessage(loop.nodeID, msg)
+		if observed := loop.manager.onObservedMessage; observed != nil {
+			observed(loop.nodeID, msg, conn.Closed())
+		} else {
+			loop.manager.onMessage(loop.nodeID, msg)
+		}
 	})
 	shouldRetry := false
 	if err != nil {
@@ -913,3 +927,9 @@ func loadTLSConfig(cfg ManagerTLSConfig) (*tls.Config, error) {
 		MinVersion:   tls.VersionTLS12,
 	}, nil
 }
+
+// AuthenticatesPeers reports the immutable handshake policy.
+func (m *manager) AuthenticatesPeers() bool { return m.config.RequireAuthentication }
+
+// ProtectsPayloads reports transport integrity, independently of handshake identity.
+func (m *manager) ProtectsPayloads() bool { return m.config.TLS.Enabled }

--- a/cmd/wippy/cmd/publish_dry_run_test.go
+++ b/cmd/wippy/cmd/publish_dry_run_test.go
@@ -14,12 +14,12 @@ import (
 func TestPublishCredentialRequirements(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
-		dryRun  bool
 		version string
 		want    string
+		dryRun  bool
 	}{
-		{"dry run requires explicit version", true, "", "version is required"},
-		{"upload requires credentials", false, "1.2.3", "not authenticated"},
+		{"dry run requires explicit version", "", "version is required", true},
+		{"upload requires credentials", "1.2.3", "not authenticated", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()

--- a/runtime/lua/engine/ingress_test.go
+++ b/runtime/lua/engine/ingress_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	processapi "github.com/wippyai/runtime/api/process"
+	"github.com/wippyai/runtime/api/relay"
+)
+
+func TestQueuedNativeIngressSurvivesPackageReleaseAndConnectionLoss(t *testing.T) {
+	proc := mustNewProcess(t, WithScript(`test_yield(1); return 1`, "ingress.lua"), WithModuleBinder(bindTestYield))
+	parentIdentity := relay.IngressIdentity{Node: "must-not-inherit", Authenticated: true}
+	ctx, _ := ctxapi.OpenFrameContext(context.WithValue(context.Background(), topicIngressKey{}, parentIdentity))
+	require.NoError(t, proc.Init(ctx, "", nil))
+	defer proc.Close()
+	closed := make(chan struct{})
+	observed := relay.IngressIdentity{Node: "immediate-peer", Authenticated: true, IntegrityProtected: true, ConnectionClosed: closed}
+	pkg := relay.NewPackage(pid.PID{Node: "claimed-origin"}, pid.PID{}, "admission", payload.NewString("request"))
+	pkg.Ingress = observed
+	pkg.Messages[0].MaxItems = 4 // wait for the exact subscription
+	var out processapi.StepOutput
+	require.NoError(t, proc.Step([]processapi.Event{{Type: processapi.EventMessage, Data: pkg}}, &out))
+	require.Len(t, proc.messageQueue, 1)
+	require.Equal(t, observed, proc.messageQueue[0].Ingress)
+	// Package ownership transferred to Step; the retained value must be independent
+	// of its pooled envelope and still track the original connection closing.
+	close(closed)
+	_, err := proc.Subscribe("admission", 2)
+	require.NoError(t, err)
+	var deliveries []relay.IngressIdentity
+	proc.SetTopicHandler("admission", func(ctx context.Context, _ *lua.LState, source pid.PID, _ string, _ []payload.Payload) lua.LValue {
+		deliveries = append(deliveries, TopicIngress(ctx))
+		return lua.LTrue
+	})
+	proc.flushMessageQueue(proc.subs)
+	require.Equal(t, []relay.IngressIdentity{observed}, deliveries)
+	select {
+	case <-deliveries[0].ConnectionClosed:
+	default:
+		t.Fatal("lost exact closed connection lifetime")
+	}
+	proc.enqueueMessage(queuedMessage{Topic: "admission", Payloads: []payload.Payload{payload.NewString("local")}})
+	proc.flushMessageQueue(proc.subs)
+	require.Len(t, deliveries, 2)
+	require.Equal(t, relay.IngressIdentity{}, deliveries[1], "local delivery must clear inherited remote provenance")
+	require.Equal(t, parentIdentity, TopicIngress(proc.ctx), "delivery must not mutate the process context")
+}

--- a/runtime/lua/engine/process.go
+++ b/runtime/lua/engine/process.go
@@ -134,6 +134,7 @@ type Process struct {
 
 // queuedMessage stores a message waiting to be delivered
 type queuedMessage struct {
+	Ingress relay.IngressIdentity
 	// Lease transfers the upstream EventQueue reservation into this mailbox.
 	// It is released only when this queued message is delivered, discarded, or
 	// the process execution is reset. A leased message is already bounded by
@@ -720,6 +721,7 @@ func (p *Process) Step(events []process.Event, out *process.StepOutput) error {
 			}
 			p.enqueueMessage(queuedMessage{
 				Source:       pkg.Source,
+				Ingress:      pkg.Ingress,
 				Topic:        msg.Topic,
 				Payloads:     msg.Payloads,
 				MaxItems:     msg.MaxItems,
@@ -1505,7 +1507,7 @@ func (p *Process) deliverMessage(subs *subscribeContext, qm queuedMessage) (keep
 	// Check for topic handler
 	var value lua.LValue
 	if handler, ok := p.GetTopicHandler(handlerTopic); ok {
-		value = handler(p.ctx, p.state, qm.Source, topic, payloads)
+		value = handler(context.WithValue(p.ctx, topicIngressKey{}, qm.Ingress), p.state, qm.Source, topic, payloads)
 		if value == nil {
 			// Handler processed but doesn't want to send to channel
 			if hasTerminal {

--- a/runtime/lua/engine/subscribe.go
+++ b/runtime/lua/engine/subscribe.go
@@ -10,13 +10,30 @@ import (
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	runtimelua "github.com/wippyai/runtime/runtime/lua"
 )
 
 // TopicHandler processes incoming messages for a topic before channel delivery.
+// Context carries only this delivery's native provenance through TopicIngress.
 // Return value is what gets sent to the channel. Return nil to skip channel send.
 type TopicHandler func(ctx context.Context, l *lua.LState, source pid.PID, topic string, payloads []payload.Payload) lua.LValue
+
+// topicIngressKey is deliberately private: only the engine stamps delivery
+// provenance. It is not installed in a process or application context.
+type topicIngressKey struct{}
+
+// TopicIngress returns transport-observed provenance for the current callback.
+// A zero value is local delivery, not authenticated remote authority. Consumers
+// must authorize the immediate peer and check transport protection and lifetime.
+func TopicIngress(ctx context.Context) relay.IngressIdentity {
+	if ctx == nil {
+		return relay.IngressIdentity{}
+	}
+	ingress, _ := ctx.Value(topicIngressKey{}).(relay.IngressIdentity)
+	return ingress
+}
 
 // subscribeContext manages topic-to-channel mappings.
 // The subscription owns the channel - channels are created here, not by callers.

--- a/runtime/lua/modules/process/ingress.go
+++ b/runtime/lua/modules/process/ingress.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package process
+
+import (
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
+)
+
+const ingressTypeName = "process.Ingress"
+
+// ingressHandle is immutable transport evidence, not a grant or origin claim.
+// The exact connection lifetime stays native and cannot be minted from Lua data.
+type ingressHandle struct{ identity relay.IngressIdentity }
+
+func init() {
+	value.RegisterTypeMethods(nil, ingressTypeName, nil, map[string]lua.LGoFunc{
+		"node":                ingressNode,
+		"authenticated":       ingressAuthenticated,
+		"integrity_protected": ingressIntegrityProtected,
+		"live":                ingressLive,
+		"same_connection":     ingressSameConnection,
+	})
+}
+
+func messageIngress(l *lua.LState) int {
+	msg := checkMessage(l)
+	if msg == nil {
+		return 0
+	}
+	if msg.ingress == (relay.IngressIdentity{}) {
+		l.Push(lua.LNil)
+	} else {
+		l.Push(value.NewTypedUserData(l, &ingressHandle{identity: msg.ingress}, ingressTypeName))
+	}
+	return 1
+}
+
+func checkIngress(l *lua.LState, index int) *ingressHandle {
+	ud := l.CheckUserData(index)
+	if handle, ok := ud.Value.(*ingressHandle); ok {
+		return handle
+	}
+	l.ArgError(index, "native ingress expected")
+	return nil
+}
+
+func ingressNode(l *lua.LState) int {
+	h := checkIngress(l, 1)
+	if h == nil {
+		return 0
+	}
+	l.Push(lua.LString(h.identity.Node))
+	return 1
+}
+func ingressAuthenticated(l *lua.LState) int {
+	h := checkIngress(l, 1)
+	if h == nil {
+		return 0
+	}
+	l.Push(lua.LBool(h.identity.Authenticated))
+	return 1
+}
+func ingressIntegrityProtected(l *lua.LState) int {
+	h := checkIngress(l, 1)
+	if h == nil {
+		return 0
+	}
+	l.Push(lua.LBool(h.identity.IntegrityProtected))
+	return 1
+}
+func ingressLive(l *lua.LState) int {
+	h := checkIngress(l, 1)
+	if h == nil {
+		return 0
+	}
+	live := h.identity.ConnectionClosed != nil
+	if live {
+		select {
+		case <-h.identity.ConnectionClosed:
+			live = false
+		default:
+		}
+	}
+	l.Push(lua.LBool(live))
+	return 1
+}
+func ingressSameConnection(l *lua.LState) int {
+	h := checkIngress(l, 1)
+	if h == nil {
+		return 0
+	}
+	other := checkIngress(l, 2)
+	if other == nil {
+		return 0
+	}
+	// This is identity equality only. Admission must also check live() at use.
+	same := h.identity.ConnectionClosed != nil && h.identity == other.identity
+	l.Push(lua.LBool(same))
+	return 1
+}

--- a/runtime/lua/modules/process/ingress_e2e_test.go
+++ b/runtime/lua/modules/process/ingress_e2e_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+package process_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+)
+
+func TestScheduledLuaInboxPreservesIngressAndClearsLocalProvenance(t *testing.T) {
+	tc := setupProcessLeakTest(t, 2)
+	defer tc.Close(t)
+	frameCtx, runPID := tc.frameCtxPID(t)
+	proc := newProcessLeakProcess(t, `
+  local inbox = process.inbox()
+  local first = inbox:receive()
+  local old = first:ingress()
+  assert(old ~= nil and old:node() == "peer")
+  assert(old:authenticated() and old:integrity_protected())
+  assert(not old:live())
+  local second = inbox:receive()
+  local current = second:ingress()
+  assert(current ~= nil and current:live())
+  assert(not old:same_connection(current))
+  local third = inbox:receive()
+  assert(third:ingress() == nil)
+  return true
+ `)
+	ctx, cancel := context.WithTimeout(frameCtx, 5*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		value, err := tc.scheduler.Execute(ctx, runPID, proc, "", nil)
+		if err == nil && value != nil {
+			err = value.Error
+		}
+		result <- err
+	}()
+	require.Eventually(t, func() bool {
+		for _, info := range tc.scheduler.ListProcesses() {
+			if info.State == "idle" || info.State == "blocked" {
+				return true
+			}
+		}
+		return false
+	}, time.Second, time.Millisecond)
+	closed, live := make(chan struct{}), make(chan struct{})
+	close(closed)
+	for _, connection := range []<-chan struct{}{closed, live, nil} {
+		pkg := relay.NewPackage(pid.PID{Node: "claimed-origin"}, runPID, "request", payload.NewString("hello"))
+		if connection != nil {
+			pkg.Ingress = relay.IngressIdentity{Node: "peer", Authenticated: true, IntegrityProtected: true, ConnectionClosed: connection}
+		}
+		require.NoError(t, tc.scheduler.Send(pkg))
+	}
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("Lua inbox did not complete:", ctx.Err())
+	}
+}

--- a/runtime/lua/modules/process/ingress_test.go
+++ b/runtime/lua/modules/process/ingress_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+)
+
+func TestMessageIngressIsNativeEvidenceWithExactLiveConnection(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	first, replacement := make(chan struct{}), make(chan struct{})
+	identity := relay.IngressIdentity{Node: "peer", Authenticated: true, IntegrityProtected: true, ConnectionClosed: first}
+	add := func(name string, identity relay.IngressIdentity) {
+		msg := NewMessage(pid.PID{Node: "payload-origin"}, "request", nil)
+		msg.ingress = identity
+		l.SetGlobal(name, WrapMessage(l, msg))
+	}
+	add("a", identity)
+	add("b", identity)
+	identity.ConnectionClosed = replacement
+	add("replacement", identity)
+	identity.ConnectionClosed = nil
+	add("no_lifetime", identity)
+	add("local_message", relay.IngressIdentity{})
+	require.NoError(t, l.DoString(`
+  original = a:ingress()
+  assert(original:node() == "peer")
+  assert(string.find(a:from(), "payload-origin", 1, true))
+  assert(original:authenticated() and original:integrity_protected())
+  assert(original:live())
+  assert(original:same_connection(b:ingress()))
+  assert(not original:same_connection(replacement:ingress()))
+  assert(not no_lifetime:ingress():live())
+  assert(not no_lifetime:ingress():same_connection(no_lifetime:ingress()))
+  assert(local_message:ingress() == nil)
+  assert(not pcall(function() original:same_connection({node="peer"}) end))
+  assert(not pcall(function() original.node = "forged" end))
+ `))
+	close(first)
+	require.NoError(t, l.DoString(`
+  assert(not original:live())
+  assert(not a:ingress():live())
+  assert(replacement:ingress():live())
+  assert(original:same_connection(b:ingress())) -- equality does not renew it
+ `))
+}

--- a/runtime/lua/modules/process/message.go
+++ b/runtime/lua/modules/process/message.go
@@ -8,6 +8,8 @@ import (
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
 	payloadmod "github.com/wippyai/runtime/runtime/lua/modules/payload"
 )
@@ -17,6 +19,7 @@ import (
 const messageTypeName = "process.Message"
 
 type Message struct {
+	ingress  relay.IngressIdentity
 	From     pid.PID
 	Topic    string
 	Payloads payload.Payloads
@@ -24,6 +27,7 @@ type Message struct {
 
 var messageMethods = map[string]lua.LGoFunc{
 	"topic":   messageTopic,
+	"ingress": messageIngress,
 	"payload": messagePayload,
 	"from":    messageFrom,
 }
@@ -106,7 +110,8 @@ func messageToString(l *lua.LState) int {
 }
 
 // MessageHandler creates messages from incoming payloads for channel delivery.
-func MessageHandler(_ context.Context, l *lua.LState, source pid.PID, topic string, payloads []payload.Payload) lua.LValue {
+func MessageHandler(ctx context.Context, l *lua.LState, source pid.PID, topic string, payloads []payload.Payload) lua.LValue {
 	msg := NewMessage(source, topic, payloads)
+	msg.ingress = engine.TopicIngress(ctx)
 	return WrapMessage(l, msg)
 }

--- a/runtime/lua/modules/process/spec.md
+++ b/runtime/lua/modules/process/spec.md
@@ -495,33 +495,7 @@ Returned by `process.inbox()` receive or `process.listen()` with `{message = tru
 |--------|-----------|---------|-------|
 | topic | () | string | Topic the message was sent to |
 | payload | () | any | Message payload(s) - single value or table of values |
-| from | () | string | Claimed source PID, or empty string if unknown |
-| ingress | () | process.Ingress? | Native immediate-peer evidence; nil for local delivery |
-
-### Ingress
-
-An immutable native handle returned by `Message:ingress()`. Lua cannot construct
-it from a table. It reports the immediate transport peer; `Message:from()` may
-name a different, forwarded origin. Neither is an application permission.
-
-| Method | Signature | Returns |
-|--------|-----------|---------|
-| node | () | string |
-| authenticated | () | boolean |
-| integrity_protected | () | boolean |
-| live | () | boolean |
-| same_connection | (other: process.Ingress) | boolean |
-
-Admission must check the expected peer, both protection flags, `live()`, and its
-own authorization policy. Retain the handle to fence an exchange against a
-replacement connection with `same_connection()`. Equality does not imply
-liveness: two handles for the same closed connection still compare equal. A
-missing lifetime capability reports `live() == false` and cannot establish
-connection equality. Recheck liveness when consuming delayed replies. The check
-is an instantaneous observation, not an atomic guard for a later operation;
-long-lived grants still need their own owner-controlled lifetime and revocation.
-Native code injecting relay packages remains inside the trusted runtime boundary.
-Handles are local evidence and must not be treated as serializable credentials.
+| from | () | string? | Sender PID, or nil if unknown |
 
 ### Spawner
 

--- a/runtime/lua/modules/process/spec.md
+++ b/runtime/lua/modules/process/spec.md
@@ -495,7 +495,33 @@ Returned by `process.inbox()` receive or `process.listen()` with `{message = tru
 |--------|-----------|---------|-------|
 | topic | () | string | Topic the message was sent to |
 | payload | () | any | Message payload(s) - single value or table of values |
-| from | () | string? | Sender PID, or nil if unknown |
+| from | () | string | Claimed source PID, or empty string if unknown |
+| ingress | () | process.Ingress? | Native immediate-peer evidence; nil for local delivery |
+
+### Ingress
+
+An immutable native handle returned by `Message:ingress()`. Lua cannot construct
+it from a table. It reports the immediate transport peer; `Message:from()` may
+name a different, forwarded origin. Neither is an application permission.
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| node | () | string |
+| authenticated | () | boolean |
+| integrity_protected | () | boolean |
+| live | () | boolean |
+| same_connection | (other: process.Ingress) | boolean |
+
+Admission must check the expected peer, both protection flags, `live()`, and its
+own authorization policy. Retain the handle to fence an exchange against a
+replacement connection with `same_connection()`. Equality does not imply
+liveness: two handles for the same closed connection still compare equal. A
+missing lifetime capability reports `live() == false` and cannot establish
+connection equality. Recheck liveness when consuming delayed replies. The check
+is an instantaneous observation, not an atomic guard for a later operation;
+long-lived grants still need their own owner-controlled lifetime and revocation.
+Native code injecting relay packages remains inside the trusted runtime boundary.
+Handles are local evidence and must not be treated as serializable credentials.
 
 ### Spawner
 

--- a/runtime/lua/modules/process/types.go
+++ b/runtime/lua/modules/process/types.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	messageType        *typ.Interface
+	ingressType        *typ.Interface
 	processEventType   typ.Type
 	messageChannelType typ.Type
 	eventChannelType   typ.Type
@@ -20,7 +21,15 @@ var (
 )
 
 func init() {
+	ingressType = typ.NewInterface("process.Ingress", []typ.Method{
+		{Name: "node", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
+		{Name: "authenticated", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
+		{Name: "integrity_protected", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
+		{Name: "live", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
+		{Name: "same_connection", Type: typ.Func().Param("self", typ.Self).Param("other", typ.Self).Returns(typ.Boolean).Build()},
+	})
 	messageType = typ.NewInterface("process.Message", []typ.Method{
+		{Name: "ingress", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(ingressType)).Build()},
 		{Name: "from", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
 		{Name: "topic", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
 		{Name: "payload", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
@@ -188,6 +197,7 @@ func ModuleTypes() *io.Manifest {
 	m := io.NewManifest("process")
 
 	m.DefineType("Message", messageType)
+	m.DefineType("Ingress", ingressType)
 	m.DefineType("Event", processEventType)
 	m.DefineType("Options", processOptionsType)
 	m.DefineType("SpawnBuilder", spawnBuilderType)

--- a/runtime/lua/modules/process/types_test.go
+++ b/runtime/lua/modules/process/types_test.go
@@ -26,3 +26,23 @@ local upgradable: boolean = options.upgradable
 	require.NoError(t, err)
 	require.False(t, code.HasErrors(diagnostics), "unexpected diagnostics: %v", diagnostics)
 }
+
+func TestMessageIngressHasStrictNativeTypes(t *testing.T) {
+	tc := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+	_, diagnostics, err := tc.Check(`
+local process = require("process")
+local function inspect(message: process.Message, previous: process.Ingress?): boolean
+ local ingress = message:ingress()
+ if ingress == nil then return false end
+ local node: string = ingress:node()
+ local verified: boolean = ingress:authenticated() and ingress:integrity_protected() and ingress:live()
+ if previous ~= nil then
+  return verified and ingress:same_connection(previous) and node ~= ""
+ end
+ return verified
+end
+return inspect
+`, "process_ingress_types.lua", map[string]*io.Manifest{"process": ModuleTypes()})
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "unexpected diagnostics: %v", diagnostics)
+}

--- a/runtime/lua/modules/tty/surface_test.go
+++ b/runtime/lua/modules/tty/surface_test.go
@@ -59,9 +59,14 @@ func TestSurfacePresentClearsRemovedRows(t *testing.T) {
 
 	changed, _, err := surface.present([]string{"one"})
 	require.NoError(t, err)
-	assert.Equal(t, 2, changed)
+	// A physical shrink can clamp clears of removed rows onto the surviving
+	// bottom row, so it must be repainted even though its content is unchanged.
+	assert.Equal(t, 3, changed)
 	assert.Contains(t, output.String(), "\x1b[2;1H\x1b[0m\x1b[K")
 	assert.Contains(t, output.String(), "\x1b[3;1H\x1b[0m\x1b[K")
+	repaint := strings.LastIndex(output.String(), "\x1b[1;1H\x1b[0m\x1b[Kone")
+	assert.Greater(t, repaint, strings.Index(output.String(), "\x1b[2;1H"))
+	assert.Greater(t, repaint, strings.Index(output.String(), "\x1b[3;1H"))
 }
 
 func TestSurfacePresentsCursorWithoutRepaintingRows(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

A destination cannot safely bind admission to a live remote connection if Lua only sees the sender address claimed inside a message. Carry locally observed peer identity and the exact connection lifetime from native transport through the relay, queued Lua delivery and the message handle.

## Description of Changes

Relay ingress evidence is local-only and overwritten after decoding. It separates handshake authentication from payload protection, identifies the immediate peer rather than a transitive origin, and retains the exact connection's closure signal. Pool release clears the evidence. The Lua engine copies it with queued messages and exposes a read-only `message:ingress()` handle with `node`, `authenticated`, `integrity_protected`, `live` and `same_connection` methods. Local delivery has no remote evidence, and the topic callback cannot inherit evidence from an earlier delivery.

This is evidence for destination admission, not application authorization. PIDs remain addresses. Consumers must check the peer, protection, connection lifetime and their own operation policy. Already-delivered handles become non-live when their connection closes; they do not automatically revoke application grants. Registered native class receivers retain their existing interface and are outside this actor-message propagation path.

Prepared on current main with the existing #675 closed-before-Run prerequisite included, plus the shared inherited CI fixture corrections. #675 remains the owner of that fix; its exact regression is reused rather than duplicated. #707 separately bounds socket teardown. Integrate the manager changes with #710's registration/cancellation work; this slice does not include that API.

Validation: full relay API and internode race suites pass. Focused engine/process race tests prove queued evidence survives package release, closure remains observable, replacement connections compare unequal, local delivery clears provenance, and Lua type declarations stay strict. Full repository lint reports zero issues. Full engine (253.475s) and process-module race suites also pass. The first multi-package invocation recorded a duplicate prerequisite test name in internode; that duplicate was removed and the complete internode suite rerun successfully.
