### PR TITLE
Expose native cluster TLS configuration and execution-bound admission

### DIFF
--- a/boot/components/system/cluster.go
+++ b/boot/components/system/cluster.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wippyai/runtime/api/boot"
@@ -113,8 +114,15 @@ func Cluster() boot.Component {
 	var logger *zap.Logger
 	var advertiseConfig boot.Config
 	var internodeActive, membershipActive bool
-	// Boot lifecycle calls are serialized. Clear each ownership flag before
-	// cleanup so failed Start followed by Loader.Shutdown cannot stop it twice.
+	var lifecycle sync.Mutex
+	type execution struct {
+		cancelWatch func() bool
+		done        chan struct{}
+	}
+	var current *execution
+	// The lifecycle lock also serializes context cancellation with boot calls.
+	// Clear ownership before cleanup so a failed Start followed by shutdown
+	// cannot stop a service twice.
 	stopServices := func() {
 		if internodeActive {
 			internodeActive = false
@@ -134,6 +142,11 @@ func Cluster() boot.Component {
 		Name:      ClusterName,
 		DependsOn: []boot.Name{metricsboot.Name},
 		Load: func(ctx context.Context) (context.Context, error) {
+			lifecycle.Lock()
+			defer lifecycle.Unlock()
+			if current != nil || internodeActive || membershipActive {
+				return ctx, fmt.Errorf("cluster component already started")
+			}
 			logger = logapi.GetLogger(ctx).Named("cluster")
 			cfg := boot.GetConfig(ctx)
 
@@ -395,7 +408,12 @@ func Cluster() boot.Component {
 			return ctx, nil
 		},
 		Start: func(ctx context.Context) error {
-			if internodeActive || membershipActive {
+			lifecycle.Lock()
+			defer lifecycle.Unlock()
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if current != nil || internodeActive || membershipActive {
 				return fmt.Errorf("cluster component already started")
 			}
 			if internodeSvc != nil {
@@ -459,10 +477,32 @@ func Cluster() boot.Component {
 				})
 			}
 
+			// Network admission ends with this execution, independently of reverse
+			// loader shutdown order (a supervisor may still be draining actors).
+			run := &execution{done: make(chan struct{})}
+			current = run
+			run.cancelWatch = context.AfterFunc(ctx, func() {
+				defer close(run.done)
+				lifecycle.Lock()
+				defer lifecycle.Unlock()
+				if current == run {
+					stopServices()
+				}
+			})
 			return nil
 		},
 		Stop: func(_ context.Context) error {
+			lifecycle.Lock()
+			run := current
+			join := run != nil && !run.cancelWatch()
 			stopServices()
+			current = nil
+			lifecycle.Unlock()
+			// An already scheduled callback may be waiting for the lock. Join it
+			// without holding the lock; its identity cannot stop a later Start.
+			if join {
+				<-run.done
+			}
 			return nil
 		},
 	})

--- a/boot/components/system/cluster.go
+++ b/boot/components/system/cluster.go
@@ -225,6 +225,10 @@ func Cluster() boot.Component {
 
 			// Create connection manager config
 			connManagerCfg := internode.DefaultManagerConfig()
+			connManagerCfg.TLS, err = clusterTLSConfig(clusterCfg)
+			if err != nil {
+				return ctx, err
+			}
 			connManagerCfg.LocalNodeID = nodeName
 			connManagerCfg.BindAddr = clusterCfg.GetString(ClusterInternodeBindAddr, "0.0.0.0")
 			connManagerCfg.BindPort = clusterCfg.GetInt(ClusterInternodeBindPort, 0)

--- a/boot/components/system/cluster_tls.go
+++ b/boot/components/system/cluster_tls.go
@@ -13,6 +13,9 @@ import (
 // clusterTLSConfig selects the same TLS implementation used by native stacks.
 // Invalid explicit configuration never silently selects plaintext.
 func clusterTLSConfig(cluster boot.Config) (internode.ManagerTLSConfig, error) {
+	if _, present := cluster.Get("internode.tls"); present {
+		return internode.ManagerTLSConfig{}, fmt.Errorf("cluster.internode.tls requires named settings such as enabled and cert_file, not a root value")
+	}
 	cfg := cluster.Sub("internode.tls")
 	var result internode.ManagerTLSConfig
 	for _, key := range cfg.Keys() {

--- a/boot/components/system/cluster_tls.go
+++ b/boot/components/system/cluster_tls.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package system
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/cluster/internode"
+)
+
+// clusterTLSConfig selects the same TLS implementation used by native stacks.
+// Invalid explicit configuration never silently selects plaintext.
+func clusterTLSConfig(cluster boot.Config) (internode.ManagerTLSConfig, error) {
+	cfg := cluster.Sub("internode.tls")
+	var result internode.ManagerTLSConfig
+	for _, key := range cfg.Keys() {
+		raw, _ := cfg.Get(key)
+		switch key {
+		case "enabled":
+			enabled, ok := raw.(bool)
+			if !ok {
+				return result, fmt.Errorf("cluster.internode.tls.enabled must be a boolean")
+			}
+			result.Enabled = enabled
+		case "cert_file", "key_file", "ca_file":
+			path, ok := raw.(string)
+			if !ok || strings.TrimSpace(path) == "" {
+				return result, fmt.Errorf("cluster.internode.tls.%s must be a nonempty path", key)
+			}
+			switch key {
+			case "cert_file":
+				result.CertFile = path
+			case "key_file":
+				result.KeyFile = path
+			case "ca_file":
+				result.CAFile = path
+			}
+		default:
+			return result, fmt.Errorf("unknown cluster.internode.tls setting %q", key)
+		}
+	}
+	if result.Enabled && (result.CertFile == "" || result.KeyFile == "" || result.CAFile == "") {
+		return result, fmt.Errorf("cluster.internode.tls requires cert_file, key_file and ca_file when enabled")
+	}
+	if !result.Enabled && (result.CertFile != "" || result.KeyFile != "" || result.CAFile != "") {
+		return result, fmt.Errorf("cluster.internode.tls credential paths require enabled=true")
+	}
+	return result, nil
+}

--- a/boot/components/system/cluster_tls_test.go
+++ b/boot/components/system/cluster_tls_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MPL-2.0
+package system
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/boot"
+	clusterapi "github.com/wippyai/runtime/api/cluster"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/event"
+	logsapi "github.com/wippyai/runtime/api/logs"
+	metricsapi "github.com/wippyai/runtime/api/metrics"
+	payloadapi "github.com/wippyai/runtime/api/payload"
+	relayapi "github.com/wippyai/runtime/api/relay"
+	metricscfg "github.com/wippyai/runtime/api/service/metrics"
+	"github.com/wippyai/runtime/cluster/internode"
+	"github.com/wippyai/runtime/service/metrics"
+	"github.com/wippyai/runtime/system/eventbus"
+	"github.com/wippyai/runtime/system/payload"
+	"github.com/wippyai/runtime/system/relay"
+	"go.uber.org/zap"
+)
+
+func TestClusterBootTLSConfigurationFailsClosed(t *testing.T) {
+	for name, values := range map[string]map[string]any{
+		"string-enabled":   {"enabled": "true"},
+		"unknown":          {"verify": false},
+		"missing-paths":    {"enabled": true},
+		"disabled-paths":   {"enabled": false, "cert_file": "cert"},
+		"implicit-enabled": {"cert_file": "cert"},
+		"empty-path":       {"enabled": true, "cert_file": ""},
+		"nonstring-path":   {"enabled": true, "key_file": 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			settings := make(map[string]any)
+			for key, value := range values {
+				settings["internode.tls."+key] = value
+			}
+			_, err := clusterTLSConfig(boot.NewConfig(boot.WithSection("cluster", settings)).Sub("cluster"))
+			require.Error(t, err)
+		})
+	}
+	config, err := clusterTLSConfig(boot.NewConfig().Sub("cluster"))
+	require.NoError(t, err)
+	require.False(t, config.Enabled)
+}
+
+func TestClusterBootTLSUsesNativeManager(t *testing.T) {
+	for _, invalid := range []bool{false, true} {
+		name := "mutual-tls"
+		if invalid {
+			name = "invalid-certificates"
+		}
+		t.Run(name, func(t *testing.T) {
+			pub, key, err := ed25519.GenerateKey(rand.Reader)
+			require.NoError(t, err)
+			template := &x509.Certificate{SerialNumber: big.NewInt(1), NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(time.Hour), KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}, IPAddresses: []net.IP{net.ParseIP("127.0.0.1")}}
+			der, err := x509.CreateCertificate(rand.Reader, template, template, pub, key)
+			require.NoError(t, err)
+			cert, err := x509.ParseCertificate(der)
+			require.NoError(t, err)
+			encodedKey, err := x509.MarshalPKCS8PrivateKey(key)
+			require.NoError(t, err)
+			bundle := append(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: encodedKey})...)
+			path := filepath.Join(t.TempDir(), "tls.pem")
+			require.NoError(t, os.WriteFile(path, bundle, 0600))
+			if invalid {
+				path += ".missing"
+			}
+			secret := make([]byte, 32)
+			_, err = rand.Read(secret)
+			require.NoError(t, err)
+			nodeName := "boot-tls-proof"
+			cfg := boot.NewConfig(boot.WithSection("cluster", map[string]any{
+				"enabled": true, ClusterNodeName: nodeName, "raft.enabled": false,
+				"membership.bind_addr": "127.0.0.1", "membership.bind_port": 0,
+				ClusterMembershipSecret: base64.StdEncoding.EncodeToString(secret),
+				"internode.bind_addr":   "127.0.0.1", "internode.auto_port": true,
+				"internode.identity_key":                  base64.RawStdEncoding.EncodeToString(key),
+				"internode.trusted_peer_keys." + nodeName: base64.RawStdEncoding.EncodeToString(pub),
+				"internode.tls.enabled":                   true, "internode.tls.cert_file": path,
+				"internode.tls.key_file": path, "internode.tls.ca_file": path,
+			}))
+			base, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			ctx := ctxapi.WithAppContext(base, ctxapi.NewAppContext())
+			ctx = boot.WithConfig(ctx, cfg)
+			ctx = logsapi.WithLogger(ctx, zap.NewNop())
+			ctx = event.WithBus(ctx, eventbus.NewBus())
+			ctx = payloadapi.WithTranscoder(ctx, payload.NewTranscoder())
+			node := relay.NewNode(nodeName)
+			ctx = relayapi.WithNode(ctx, node)
+			ctx = relayapi.WithRouter(ctx, relay.NewRouter(node, nil))
+			collector := metrics.NewCollector(metricscfg.Config{})
+			defer collector.Close()
+			ctx = metricsapi.WithCollector(ctx, collector)
+			component := Cluster()
+			ctx, err = component.Load(ctx)
+			require.NoError(t, err)
+			defer component.(boot.Stopper).Stop(ctx)
+			err = component.(boot.Starter).Start(ctx)
+			if invalid {
+				require.Error(t, err)
+				require.Empty(t, clusterapi.GetMembership(ctx).LocalNode().Meta[internode.MetadataPort])
+				return
+			}
+			require.NoError(t, err)
+			info := clusterapi.GetMembership(ctx).LocalNode()
+			endpoint := net.JoinHostPort("127.0.0.1", info.Meta[internode.MetadataPort])
+			pair, err := tls.X509KeyPair(bundle, bundle)
+			require.NoError(t, err)
+			roots := x509.NewCertPool()
+			roots.AddCert(cert)
+			dialer := &net.Dialer{Timeout: time.Second}
+			connection, err := tls.DialWithDialer(dialer, "tcp", endpoint, &tls.Config{RootCAs: roots, Certificates: []tls.Certificate{pair}, MinVersion: tls.VersionTLS12})
+			require.NoError(t, err)
+			require.True(t, connection.ConnectionState().HandshakeComplete)
+			require.NotEmpty(t, connection.ConnectionState().VerifiedChains)
+			require.NoError(t, connection.NetConn().Close())
+			require.NoError(t, component.(boot.Stopper).Stop(ctx))
+			listener, err := net.Listen("tcp", endpoint)
+			require.NoError(t, err)
+			require.NoError(t, listener.Close())
+		})
+	}
+}

--- a/boot/components/system/cluster_tls_test.go
+++ b/boot/components/system/cluster_tls_test.go
@@ -54,6 +54,10 @@ func TestClusterBootTLSConfigurationFailsClosed(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+	for _, raw := range []any{true, "enabled", nil, map[string]any{"enabled": true}} {
+		_, err := clusterTLSConfig(boot.NewConfig(boot.WithSection("cluster", map[string]any{"internode.tls": raw})).Sub("cluster"))
+		require.Error(t, err, "an explicit TLS root value must not silently become plaintext")
+	}
 	config, err := clusterTLSConfig(boot.NewConfig().Sub("cluster"))
 	require.NoError(t, err)
 	require.False(t, config.Enabled)
@@ -126,16 +130,16 @@ func TestClusterBootTLSUsesNativeManager(t *testing.T) {
 			roots := x509.NewCertPool()
 			roots.AddCert(cert)
 			dialer := &net.Dialer{Timeout: time.Second}
-			connection, err := tls.DialWithDialer(dialer, "tcp", endpoint, &tls.Config{RootCAs: roots, Certificates: []tls.Certificate{pair}, MinVersion: tls.VersionTLS12})
+			connection, err := (&tls.Dialer{NetDialer: dialer, Config: &tls.Config{RootCAs: roots, Certificates: []tls.Certificate{pair}, MinVersion: tls.VersionTLS12}}).DialContext(ctx, "tcp", endpoint)
 			require.NoError(t, err)
-			require.True(t, connection.ConnectionState().HandshakeComplete)
-			require.NotEmpty(t, connection.ConnectionState().VerifiedChains)
-			require.NoError(t, connection.NetConn().Close())
+			require.True(t, connection.(*tls.Conn).ConnectionState().HandshakeComplete)
+			require.NotEmpty(t, connection.(*tls.Conn).ConnectionState().VerifiedChains)
+			require.NoError(t, connection.(*tls.Conn).NetConn().Close())
 			// Cancellation must release admission before Loader reaches Stop;
 			// other components may still be draining user processes.
 			cancel()
 			require.Eventually(t, func() bool {
-				probe, err := net.DialTimeout("tcp", endpoint, 50*time.Millisecond)
+				probe, err := (&net.Dialer{Timeout: 50 * time.Millisecond}).DialContext(t.Context(), "tcp", endpoint)
 				if err != nil {
 					return true
 				}
@@ -148,7 +152,7 @@ func TestClusterBootTLSUsesNativeManager(t *testing.T) {
 			}
 			stops.Wait()
 			require.NoError(t, component.(boot.Stopper).Stop(ctx))
-			listener, err := net.Listen("tcp", endpoint)
+			listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", endpoint)
 			require.NoError(t, err)
 			require.NoError(t, listener.Close())
 		})

--- a/boot/components/system/cluster_tls_test.go
+++ b/boot/components/system/cluster_tls_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -130,6 +131,22 @@ func TestClusterBootTLSUsesNativeManager(t *testing.T) {
 			require.True(t, connection.ConnectionState().HandshakeComplete)
 			require.NotEmpty(t, connection.ConnectionState().VerifiedChains)
 			require.NoError(t, connection.NetConn().Close())
+			// Cancellation must release admission before Loader reaches Stop;
+			// other components may still be draining user processes.
+			cancel()
+			require.Eventually(t, func() bool {
+				probe, err := net.DialTimeout("tcp", endpoint, 50*time.Millisecond)
+				if err != nil {
+					return true
+				}
+				_ = probe.Close()
+				return false
+			}, time.Second, 5*time.Millisecond)
+			var stops sync.WaitGroup
+			for range 8 {
+				stops.Go(func() { _ = component.(boot.Stopper).Stop(ctx) })
+			}
+			stops.Wait()
 			require.NoError(t, component.(boot.Stopper).Stop(ctx))
 			listener, err := net.Listen("tcp", endpoint)
 			require.NoError(t, err)

--- a/cluster/stack.go
+++ b/cluster/stack.go
@@ -90,6 +90,9 @@ type StackConfig struct {
 	InternodeBindPort             int // zero asks the OS for an internode TCP port
 	MembershipSuspicionMult       int
 	InternodeAutoPort             bool
+	// InternodeTLS selects the existing native mutual-TLS transport. Certificate
+	// loading happens during Start. The zero value preserves plaintext transport.
+	InternodeTLS internode.ManagerTLSConfig
 }
 
 // AssembleStack constructs the relay node, router, membership service,
@@ -149,6 +152,7 @@ func AssembleStack(cfg StackConfig) (*Stack, error) {
 	mgrCfg.AuthenticationKey = secretKey
 	mgrCfg.SigningKey = signingKey
 	mgrCfg.RequireAuthentication = true
+	mgrCfg.TLS = cfg.InternodeTLS
 	var memSvc *membership.Service
 	mgrCfg.ResolvePeerKey = func(id clusterapi.NodeID) (ed25519.PublicKey, bool) {
 		return internode.ResolveMemberKey(cfg.NodeName, id, trustedPeerKeys, cfg.InternodePeerKeySource, memSvc)

--- a/cluster/stack.go
+++ b/cluster/stack.go
@@ -69,16 +69,19 @@ type StackConfig struct {
 	// the harness to avoid disturbing the runtime's raft quorum.
 	Meta clusterapi.NodeMeta
 
-	NodeName                      string
-	MembershipBindAddr            string
-	MembershipAdvertise           string
-	SecretKey                     string
-	SecretFile                    string
-	InternodeIdentityKey          string
-	InternodeIdentityKeyFile      string
-	InternodeTrustedPeerKeys      map[string]string
-	InternodePeerKeySource        clusterapi.PeerKeySource
-	InternodeBindAddr             string
+	NodeName                 string
+	MembershipBindAddr       string
+	MembershipAdvertise      string
+	SecretKey                string
+	SecretFile               string
+	InternodeIdentityKey     string
+	InternodeIdentityKeyFile string
+	InternodeTrustedPeerKeys map[string]string
+	InternodePeerKeySource   clusterapi.PeerKeySource
+	InternodeBindAddr        string
+	// InternodeTLS selects the existing native mutual-TLS transport. Certificate
+	// loading happens during Start. The zero value preserves plaintext transport.
+	InternodeTLS                  internode.ManagerTLSConfig
 	JoinAddrs                     []string
 	MembershipGossipInterval      time.Duration
 	MembershipPushPullInterval    time.Duration
@@ -90,9 +93,6 @@ type StackConfig struct {
 	InternodeBindPort             int // zero asks the OS for an internode TCP port
 	MembershipSuspicionMult       int
 	InternodeAutoPort             bool
-	// InternodeTLS selects the existing native mutual-TLS transport. Certificate
-	// loading happens during Start. The zero value preserves plaintext transport.
-	InternodeTLS internode.ManagerTLSConfig
 }
 
 // AssembleStack constructs the relay node, router, membership service,

--- a/cluster/stack_tls_test.go
+++ b/cluster/stack_tls_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -235,6 +236,15 @@ func TestTwoStackTLSCommunication(t *testing.T) {
 
 	cfgA := env.config("node-a", env.privA)
 	cfgA.InternodeTLS = tlsA
+	cfgA.InternodeTrustedPeerKeys = map[string]string{"node-a": env.trusted["node-a"]}
+	var keyLookups atomic.Int64
+	cfgA.InternodePeerKeySource = func(node string) (ed25519.PublicKey, bool) {
+		if node != "node-b" {
+			return nil, false
+		}
+		keyLookups.Add(1)
+		return append(ed25519.PublicKey(nil), env.pubB...), true
+	}
 
 	stackA, err := AssembleStack(cfgA)
 	require.NoError(t, err)
@@ -259,6 +269,7 @@ func TestTwoStackTLSCommunication(t *testing.T) {
 
 	require.Equal(t, []clusterapi.NodeID{"node-b"}, stackA.ConnMgr.ConnectedNodes())
 	require.Equal(t, []clusterapi.NodeID{"node-a"}, stackB.ConnMgr.ConnectedNodes())
+	require.Positive(t, keyLookups.Load(), "TLS admission must use the host-approved peer key")
 
 	// Inspect an actual decoded relay message, not a copied configuration flag.
 	received := make(chan tlsMessage, 1)

--- a/cluster/stack_tls_test.go
+++ b/cluster/stack_tls_test.go
@@ -94,12 +94,12 @@ func generateTestTLSCerts(t *testing.T, nameA, nameB string) (internode.ManagerT
 
 type twoStackEnv struct {
 	collector apimetrics.Collector
+	trusted   map[string]string
 	secret    []byte
 	privA     ed25519.PrivateKey
 	privB     ed25519.PrivateKey
 	pubA      ed25519.PublicKey
 	pubB      ed25519.PublicKey
-	trusted   map[string]string
 }
 
 func setupTwoStackEnv(t *testing.T) *twoStackEnv {
@@ -265,25 +265,20 @@ func TestTwoStackTLSCommunication(t *testing.T) {
 	require.NoError(t, stackB.Node.RegisterHost("tls-proof", tlsInbox{received}))
 	testPayload := []byte("hello-over-native-tls")
 	pkg := relay.NewServicePackage("node-a", "fixture", "node-b", "tls-proof", "proof", apipayload.NewPayload(testPayload, apipayload.Bytes))
-	if err := stackA.Router.SendContext(ctx, pkg); err != nil {
+	if err := stackA.Router.Send(pkg); err != nil {
 		relay.ReleasePackage(pkg)
 		t.Fatal(err)
 	}
 	select {
 	case message := <-received:
 		require.Equal(t, testPayload, message.body)
-		require.Equal(t, clusterapi.NodeID("node-a"), message.ingress.Node)
-		require.True(t, message.ingress.Authenticated)
-		require.True(t, message.ingress.IntegrityProtected)
-		require.NotNil(t, message.ingress.ConnectionClosed)
 	case <-ctx.Done():
 		t.Fatal("TLS relay message not received", ctx.Err())
 	}
 }
 
 type tlsMessage struct {
-	body    []byte
-	ingress relay.IngressIdentity
+	body []byte
 }
 type tlsInbox struct{ received chan tlsMessage }
 
@@ -298,7 +293,7 @@ func (r tlsInbox) Send(pkg *relay.Package) error {
 			return errors.New("unexpected TLS payload type")
 		}
 		select {
-		case r.received <- tlsMessage{body: append([]byte(nil), body...), ingress: pkg.Ingress}:
+		case r.received <- tlsMessage{body: append([]byte(nil), body...)}:
 		default:
 			return errors.New("unexpected TLS duplicate")
 		}

--- a/cluster/stack_tls_test.go
+++ b/cluster/stack_tls_test.go
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package cluster
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	clusterapi "github.com/wippyai/runtime/api/cluster"
+	apimetrics "github.com/wippyai/runtime/api/metrics"
+	apipayload "github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/relay"
+	metricscfg "github.com/wippyai/runtime/api/service/metrics"
+	"github.com/wippyai/runtime/cluster/internode"
+	"github.com/wippyai/runtime/service/metrics"
+	"github.com/wippyai/runtime/system/eventbus"
+	"github.com/wippyai/runtime/system/payload"
+	"go.uber.org/zap"
+)
+
+// generateTestTLSCerts creates a temporary CA and two leaf certificates signed by that CA.
+// All certificate fixtures are created in t.TempDir() and are temporary only.
+func generateTestTLSCerts(t *testing.T, nameA, nameB string) (internode.ManagerTLSConfig, internode.ManagerTLSConfig) {
+	t.Helper()
+
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	now := time.Now()
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	rootDer, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, rootPub, rootPriv)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDer}), 0600))
+
+	issueLeaf := func(name string, serial int64) internode.ManagerTLSConfig {
+		leafPub, leafPriv, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		leafTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(serial),
+			NotBefore:    now.Add(-time.Minute),
+			NotAfter:     now.Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+			IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+			DNSNames:     []string{"localhost"},
+		}
+
+		leafDer, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootTemplate, leafPub, rootPriv)
+		require.NoError(t, err)
+
+		keyBytes, err := x509.MarshalPKCS8PrivateKey(leafPriv)
+		require.NoError(t, err)
+
+		certPath := filepath.Join(dir, name+".pem")
+		keyPath := filepath.Join(dir, name+".key")
+
+		require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDer}), 0600))
+		require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}), 0600))
+
+		return internode.ManagerTLSConfig{
+			Enabled:  true,
+			CAFile:   caPath,
+			CertFile: certPath,
+			KeyFile:  keyPath,
+		}
+	}
+
+	return issueLeaf(nameA, 2), issueLeaf(nameB, 3)
+}
+
+type twoStackEnv struct {
+	collector apimetrics.Collector
+	secret    []byte
+	privA     ed25519.PrivateKey
+	privB     ed25519.PrivateKey
+	pubA      ed25519.PublicKey
+	pubB      ed25519.PublicKey
+	trusted   map[string]string
+}
+
+func setupTwoStackEnv(t *testing.T) *twoStackEnv {
+	t.Helper()
+
+	pubA, privA, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pubB, privB, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	secret := make([]byte, 32)
+	_, err = rand.Read(secret)
+	require.NoError(t, err)
+
+	collector := metrics.NewCollector(metricscfg.Config{})
+	t.Cleanup(func() { collector.Close() })
+
+	trusted := map[string]string{
+		"node-a": base64.RawStdEncoding.EncodeToString(pubA),
+		"node-b": base64.RawStdEncoding.EncodeToString(pubB),
+	}
+
+	return &twoStackEnv{
+		collector: collector,
+		secret:    secret,
+		privA:     privA,
+		privB:     privB,
+		pubA:      pubA,
+		pubB:      pubB,
+		trusted:   trusted,
+	}
+}
+
+func (env *twoStackEnv) config(name string, key ed25519.PrivateKey) StackConfig {
+	return StackConfig{
+		NodeName:                 name,
+		Logger:                   zap.NewNop(),
+		Bus:                      eventbus.NewBus(),
+		Transcoder:               payload.NewTranscoder(),
+		Collector:                env.collector,
+		MembershipBindAddr:       "127.0.0.1",
+		InternodeBindAddr:        "127.0.0.1",
+		MembershipBindPort:       0,
+		InternodeBindPort:        0,
+		InternodeAutoPort:        true,
+		SecretKey:                base64.StdEncoding.EncodeToString(env.secret),
+		InternodeIdentityKey:     base64.RawStdEncoding.EncodeToString(key),
+		InternodeTrustedPeerKeys: env.trusted,
+	}
+}
+
+func TestStackTLSInvalidConfigurationFails(t *testing.T) {
+	env := setupTwoStackEnv(t)
+	tempDir := t.TempDir()
+
+	testCases := []struct {
+		name      string
+		tlsConfig internode.ManagerTLSConfig
+	}{
+		{
+			name: "missing cert file",
+			tlsConfig: internode.ManagerTLSConfig{
+				Enabled:  true,
+				CertFile: filepath.Join(tempDir, "nonexistent-cert.pem"),
+				KeyFile:  filepath.Join(tempDir, "nonexistent-key.pem"),
+				CAFile:   filepath.Join(tempDir, "nonexistent-ca.pem"),
+			},
+		},
+		{
+			name: "missing key file",
+			tlsConfig: func() internode.ManagerTLSConfig {
+				c, _ := generateTestTLSCerts(t, "node-a", "node-b")
+				c.KeyFile = filepath.Join(tempDir, "nonexistent-key.pem")
+				return c
+			}(),
+		},
+		{
+			name: "missing ca file",
+			tlsConfig: func() internode.ManagerTLSConfig {
+				c, _ := generateTestTLSCerts(t, "node-a", "node-b")
+				c.CAFile = filepath.Join(tempDir, "nonexistent-ca.pem")
+				return c
+			}(),
+		},
+		{
+			name: "corrupted ca file",
+			tlsConfig: func() internode.ManagerTLSConfig {
+				c, _ := generateTestTLSCerts(t, "node-a", "node-b")
+				badCA := filepath.Join(tempDir, "corrupt-ca.pem")
+				require.NoError(t, os.WriteFile(badCA, []byte("NOT A VALID CERTIFICATE"), 0600))
+				c.CAFile = badCA
+				return c
+			}(),
+		},
+		{
+			name: "corrupted cert file",
+			tlsConfig: func() internode.ManagerTLSConfig {
+				c, _ := generateTestTLSCerts(t, "node-a", "node-b")
+				badCert := filepath.Join(tempDir, "corrupt-cert.pem")
+				require.NoError(t, os.WriteFile(badCert, []byte("NOT A VALID CERTIFICATE"), 0600))
+				c.CertFile = badCert
+				return c
+			}(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := env.config("node-a", env.privA)
+			cfg.InternodeTLS = tc.tlsConfig
+
+			// Construction succeeds because construction must not load TLS or bind ports
+			stack, err := AssembleStack(cfg)
+			require.NoError(t, err)
+
+			// Startup must fail because TLS configuration cannot be loaded
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			err = stack.Start(ctx)
+			require.Error(t, err, "Start must fail when TLS configuration is invalid")
+			_ = stack.Stop()
+		})
+	}
+}
+
+func TestTwoStackTLSCommunication(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+
+	env := setupTwoStackEnv(t)
+	tlsA, tlsB := generateTestTLSCerts(t, "node-a", "node-b")
+
+	cfgA := env.config("node-a", env.privA)
+	cfgA.InternodeTLS = tlsA
+
+	stackA, err := AssembleStack(cfgA)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stackA.Stop() })
+
+	require.NoError(t, stackA.Start(ctx))
+
+	cfgB := env.config("node-b", env.privB)
+	cfgB.InternodeTLS = tlsB
+	cfgB.JoinAddrs = []string{stackA.Membership.LocalNode().Addr}
+
+	stackB, err := AssembleStack(cfgB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stackB.Stop() })
+
+	require.NoError(t, stackB.Start(ctx))
+
+	// Verify both nodes form an authenticated TLS mesh connection
+	require.Eventually(t, func() bool {
+		return len(stackA.ConnMgr.ConnectedNodes()) == 1 && len(stackB.ConnMgr.ConnectedNodes()) == 1
+	}, 15*time.Second, 50*time.Millisecond, "mutual TLS mesh connection must form between two stacks")
+
+	require.Equal(t, []clusterapi.NodeID{"node-b"}, stackA.ConnMgr.ConnectedNodes())
+	require.Equal(t, []clusterapi.NodeID{"node-a"}, stackB.ConnMgr.ConnectedNodes())
+
+	// Inspect an actual decoded relay message, not a copied configuration flag.
+	received := make(chan tlsMessage, 1)
+	require.NoError(t, stackB.Node.RegisterHost("tls-proof", tlsInbox{received}))
+	testPayload := []byte("hello-over-native-tls")
+	pkg := relay.NewServicePackage("node-a", "fixture", "node-b", "tls-proof", "proof", apipayload.NewPayload(testPayload, apipayload.Bytes))
+	if err := stackA.Router.SendContext(ctx, pkg); err != nil {
+		relay.ReleasePackage(pkg)
+		t.Fatal(err)
+	}
+	select {
+	case message := <-received:
+		require.Equal(t, testPayload, message.body)
+		require.Equal(t, clusterapi.NodeID("node-a"), message.ingress.Node)
+		require.True(t, message.ingress.Authenticated)
+		require.True(t, message.ingress.IntegrityProtected)
+		require.NotNil(t, message.ingress.ConnectionClosed)
+	case <-ctx.Done():
+		t.Fatal("TLS relay message not received", ctx.Err())
+	}
+}
+
+type tlsMessage struct {
+	body    []byte
+	ingress relay.IngressIdentity
+}
+type tlsInbox struct{ received chan tlsMessage }
+
+func (r tlsInbox) Send(pkg *relay.Package) error {
+	defer relay.ReleasePackage(pkg)
+	for _, msg := range pkg.Messages {
+		if len(msg.Payloads) != 1 {
+			return errors.New("unexpected TLS payload count")
+		}
+		body, ok := msg.Payloads[0].Data().([]byte)
+		if !ok {
+			return errors.New("unexpected TLS payload type")
+		}
+		select {
+		case r.received <- tlsMessage{body: append([]byte(nil), body...), ingress: pkg.Ingress}:
+		default:
+			return errors.New("unexpected TLS duplicate")
+		}
+	}
+	return nil
+}
+
+func TestTwoStackTLSWithPlaintextIncompatible(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	env := setupTwoStackEnv(t)
+	tlsA, _ := generateTestTLSCerts(t, "node-a", "node-b")
+
+	// Stack A has native TLS enabled
+	cfgA := env.config("node-a", env.privA)
+	cfgA.InternodeTLS = tlsA
+
+	stackA, err := AssembleStack(cfgA)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stackA.Stop() })
+	require.NoError(t, stackA.Start(ctx))
+
+	// Stack B has native TLS disabled (plaintext)
+	cfgB := env.config("node-b", env.privB)
+	cfgB.InternodeTLS = internode.ManagerTLSConfig{Enabled: false}
+	cfgB.JoinAddrs = []string{stackA.Membership.LocalNode().Addr}
+
+	stackB, err := AssembleStack(cfgB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stackB.Stop() })
+	require.NoError(t, stackB.Start(ctx))
+
+	// Stacks will discover each other over gossip, but TLS handshake will fail
+	// because Stack B dials with plaintext TCP while Stack A expects TLS.
+	// Therefore, mesh connection must never form.
+	require.Never(t, func() bool {
+		return len(stackA.ConnMgr.ConnectedNodes()) > 0 || len(stackB.ConnMgr.ConnectedNodes()) > 0
+	}, 3*time.Second, 100*time.Millisecond, "plaintext stack must not form internode connection with TLS stack")
+}
+
+func TestTwoStackTLSWithUntrustedCAFails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	env := setupTwoStackEnv(t)
+
+	// Generate two separate, independent CAs
+	tlsA1, _ := generateTestTLSCerts(t, "node-a", "node-b")
+	_, tlsB2 := generateTestTLSCerts(t, "node-a", "node-b")
+
+	// Stack A trusts CA 1
+	cfgA := env.config("node-a", env.privA)
+	cfgA.InternodeTLS = tlsA1
+
+	stackA, err := AssembleStack(cfgA)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stackA.Stop() })
+	require.NoError(t, stackA.Start(ctx))
+
+	// Stack B trusts CA 2 (different root CA)
+	cfgB := env.config("node-b", env.privB)
+	cfgB.InternodeTLS = tlsB2
+	cfgB.JoinAddrs = []string{stackA.Membership.LocalNode().Addr}
+
+	stackB, err := AssembleStack(cfgB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stackB.Stop() })
+	require.NoError(t, stackB.Start(ctx))
+
+	// Due to mutual TLS verification failure, connection must never form
+	require.Never(t, func() bool {
+		return len(stackA.ConnMgr.ConnectedNodes()) > 0 || len(stackB.ConnMgr.ConnectedNodes()) > 0
+	}, 3*time.Second, 100*time.Millisecond, "stacks with untrusted CAs must not form connection")
+}


### PR DESCRIPTION
## Summary

Expose the existing native mutual-TLS transport through `StackConfig.InternodeTLS` and standard `cluster.internode.tls` boot settings. End boot network admission when its execution context is cancelled, independently of later loader shutdown order.

- Boot TLS decoding rejects unknown settings, wrong types, malformed root values, missing required paths, and credential paths without explicit enablement. Certificate loading and handshake verification remain the connection manager's responsibility.
- Omitted TLS settings preserve existing transport selection.
- Serialize boot lifecycle ownership. Concurrent cleanup and an old cancellation callback cannot retire a newer execution.
- Preserve retained listeners, socket-first TLS teardown, native peer-key lookup, and cancellable relay admission from the preceding PRs.

No certificate provisioning, enrollment service, Lua ingress API, or separate listener is added.

## Validation

- Three repeated race runs of TLS-focused cluster/boot tests pass.
- Ten race repetitions of real TLS relay delivery using the native host-approved key source pass.
- Full combined cluster/boot/relay race suites pass with #709's peer-key source retained.
- Pinned golangci-lint on affected packages: 0 issues.
- Coverage includes actual mutual-TLS relay payload delivery, plaintext incompatibility, untrusted CAs, missing/corrupt certificates, malformed boot settings, cancellation before loader Stop, concurrent Stop calls, and released listener ports.

Depends on #708's retained-listener lifecycle and preserves #709's overlapping configuration fields.
