### PR TITLE
fix(internode): release rejected incoming packages

### DIFF
--- a/cluster/internode/delivery_ownership_test.go
+++ b/cluster/internode/delivery_ownership_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package internode
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/cluster"
+	"github.com/wippyai/runtime/api/relay"
+	"github.com/wippyai/runtime/system/eventbus"
+	"go.uber.org/zap"
+)
+
+type deliveryReleaseProbe struct{ releases int }
+
+func (p *deliveryReleaseProbe) Release() { p.releases++ }
+
+type deliveryLeaseCodec struct {
+	lease *deliveryReleaseProbe
+	mockCodec
+}
+
+func (c *deliveryLeaseCodec) Decode(data []byte) (*relay.Package, error) {
+	pkg, err := c.mockCodec.Decode(data)
+	if err != nil {
+		return nil, err
+	}
+	message := relay.AcquireMessage()
+	message.SetRetentionLease(c.lease)
+	pkg.Messages = append(pkg.Messages, message)
+	return pkg, nil
+}
+
+func TestServiceIncomingPackageOwnership(t *testing.T) {
+	for _, reject := range []bool{true, false} {
+		name := "accepted"
+		if reject {
+			name = "rejected"
+		}
+		t.Run(name, func(t *testing.T) {
+			probe := &deliveryReleaseProbe{}
+			codec := &deliveryLeaseCodec{lease: probe}
+			manager := newMockConnectionManager()
+			var accepted *relay.Package
+			service := NewService(zap.NewNop(), manager, codec, func(pkg *relay.Package) error {
+				if reject {
+					return errors.New("destination refused admission")
+				}
+				accepted = pkg
+				return nil
+			}, eventbus.NewBus(), &mockMembership{localNode: cluster.NodeInfo{ID: "local"}})
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, service.Start(ctx))
+			defer func() { require.NoError(t, service.Stop()) }()
+			manager.onMessage("remote-node", []byte("data"))
+			if reject {
+				require.Equal(t, 1, probe.releases, "rejected delivery must release its retained payload")
+			} else {
+				require.Zero(t, probe.releases, "accepted delivery belongs to the receiver")
+				require.NotNil(t, accepted)
+				relay.ReleasePackage(accepted)
+				require.Equal(t, 1, probe.releases)
+			}
+		})
+	}
+}

--- a/cluster/internode/internode.go
+++ b/cluster/internode/internode.go
@@ -32,6 +32,8 @@ const (
 	MetadataPublicKey     = "internode_public_key"
 )
 
+// PackageCallback takes ownership only when it returns nil. On error it must
+// leave the package owned by Service, which releases it after rejection.
 type PackageCallback func(*relay.Package) error
 
 type Service struct {
@@ -83,6 +85,7 @@ func (s *Service) Start(ctx context.Context) error {
 			zap.String("from_node", nodeID),
 			zap.String("target_host", pkg.Target.Host))
 		if err := s.deliveryCallback(pkg); err != nil {
+			relay.ReleasePackage(pkg)
 			// Hot path under partition: the local PG host may have torn down
 			// while a peer is still sending to it. Counted as a drop with
 			// no per-message log to avoid the chaos-time spam we observed.


### PR DESCRIPTION
A decoded internode package remained owned by the service when local delivery rejected it, but the error path did not release it. Packages carrying bounded-retention leases could therefore leak their payload reservations. Successful delivery already transfers ownership to the receiver and remains unchanged.\n\nThe service now releases a decoded package exactly when the delivery callback returns an error, and the existing callback type documents that transactional ownership rule.\n\nRegression coverage uses an observable retention lease to prove both sides:\n- rejection releases the package and lease exactly once;\n- acceptance does not release early and transfers ownership to the receiver.\n\nValidation:\n- focused ownership regression passes 100 times under race;\n- full cluster/internode race suite passes;\n- pinned golangci-lint v2.13.2 reports 0 issues.\n\nThe rebased PR contains only the internode ownership fix and its regression test. Unrelated publish and terminal test adjustments were removed. It adds no new exported API or signature, runtime/Lua/native binding, config or protocol field, wire change, lifecycle state, documentation, worker, or timer.