### PR TITLE
feat(relay): add owned native host registration

### DIFF
--- a/api/relay/relay.go
+++ b/api/relay/relay.go
@@ -143,6 +143,15 @@ type (
 		Detach(pid.PID)
 	}
 
+	// OwnedHostRegistrar is an optional native composition capability. Its release
+	// removes only the registration it created, never a later replacement, and
+	// is safe to call repeatedly. Failure returns no release authority.
+	// Release does not cancel or drain calls already dispatched to the receiver.
+	// Registration is routing configuration, not remote operation authorization.
+	OwnedHostRegistrar interface {
+		RegisterOwnedHost(pid.HostID, Receiver) (context.CancelFunc, error)
+	}
+
 	// Node represents a messaging node that hosts and routes messages.
 	Node interface {
 		Receiver

--- a/system/relay/node.go
+++ b/system/relay/node.go
@@ -18,7 +18,7 @@ import (
 // must be targeted to a host registered within this Node instance.
 type Node struct {
 	nodeID pid.NodeID
-	hosts  sync.Map // stores mapping: HostID -> api.Receiver
+	hosts  sync.Map // stores mapping: HostID -> *hostRegistration
 }
 
 // NewNode creates a new, isolated messaging node with the specified ID.
@@ -33,32 +33,54 @@ func (n *Node) ID() pid.NodeID {
 	return n.nodeID
 }
 
-// RegisterHost adds a new host to the node with the specified host ID.
-// Returns an error if a host with the same ID is already registered.
-func (n *Node) RegisterHost(hostID pid.HostID, host api.Receiver) error {
-	_, loaded := n.hosts.LoadOrStore(hostID, host)
-	if loaded {
-		return NewHostExistsError(hostID, n.nodeID)
-	}
-	return nil
+// hostRegistration distinguishes successive registrations even when they reuse
+// the same receiver. Optional receiver capabilities are never wrapped or hidden.
+type hostRegistration struct {
+	receiver api.Receiver
 }
 
-// UnregisterHost removes a host from the node by its host ID.
+var _ api.OwnedHostRegistrar = (*Node)(nil)
+
+// RegisterHost adds a host until explicit UnregisterHost by its owning composition.
+func (n *Node) RegisterHost(hostID pid.HostID, host api.Receiver) error {
+	_, err := n.RegisterOwnedHost(hostID, host)
+	return err
+}
+
+// RegisterOwnedHost returns an idempotent release for this registration only.
+// Release stops new lookups; a receiver already obtained by Send, GetHost or
+// Attach may still be in use. The receiver owns admission fencing and draining.
+func (n *Node) RegisterOwnedHost(hostID pid.HostID, host api.Receiver) (context.CancelFunc, error) {
+	registration := &hostRegistration{receiver: host}
+	if _, loaded := n.hosts.LoadOrStore(hostID, registration); loaded {
+		return nil, NewHostExistsError(hostID, n.nodeID)
+	}
+	return func() { n.hosts.CompareAndDelete(hostID, registration) }, nil
+}
+
+// UnregisterHost unconditionally removes the current host. It remains available
+// to the owning composition; replaceable components should use RegisterOwnedHost.
 func (n *Node) UnregisterHost(hostID pid.HostID) {
 	n.hosts.Delete(hostID)
 }
 
-// GetHost returns a host by ID if it exists.
+// lookupHost keeps missing registrations distinct from invalid stored values.
+func (n *Node) lookupHost(hostID pid.HostID) (api.Receiver, bool) {
+	value, found := n.hosts.Load(hostID)
+	if !found {
+		return nil, false
+	}
+	registration, ok := value.(*hostRegistration)
+	if !ok {
+		return nil, true
+	}
+	return registration.receiver, true
+}
+
+// GetHost returns the original receiver with all its optional capabilities.
 func (n *Node) GetHost(hostID pid.HostID) (api.Receiver, bool) {
-	h, ok := n.hosts.Load(hostID)
-	if !ok {
-		return nil, false
-	}
-	receiver, ok := h.(api.Receiver)
-	if !ok {
-		return nil, false
-	}
-	return receiver, true
+	receiver, found := n.lookupHost(hostID)
+	return receiver, found && receiver != nil
 }
 
 // Send delivers a package to its destination. The destination must be a host
@@ -89,13 +111,13 @@ func (n *Node) send(ctx context.Context, pkg *api.Package) error {
 		return NewExternalNodeError(pkg.Target.Node)
 	}
 
-	h, ok := n.hosts.Load(pkg.Target.Host)
+	h, ok := n.lookupHost(pkg.Target.Host)
 	if !ok {
 		return NewHostNotFoundError(pkg.Target.Host, n.nodeID)
 	}
 
-	receiver, ok := h.(api.Receiver)
-	if !ok {
+	receiver := h
+	if receiver == nil {
 		return NewInvalidHostTypeError(pkg.Target.Host, n.nodeID)
 	}
 
@@ -115,7 +137,7 @@ func (n *Node) Attach(p pid.PID, ch chan *api.Package) (context.CancelFunc, erro
 		return nil, NewExternalNodeError(p.Node)
 	}
 
-	h, ok := n.hosts.Load(p.Host)
+	h, ok := n.lookupHost(p.Host)
 	if !ok {
 		return nil, NewHostNotFoundError(p.Host, n.nodeID)
 	}
@@ -134,7 +156,7 @@ func (n *Node) Detach(p pid.PID) {
 		return
 	}
 
-	h, ok := n.hosts.Load(p.Host)
+	h, ok := n.lookupHost(p.Host)
 	if !ok {
 		return
 	}

--- a/system/relay/owned_host_test.go
+++ b/system/relay/owned_host_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package relay
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/pid"
+	api "github.com/wippyai/runtime/api/relay"
+)
+
+func TestOwnedHostReleasePreservesReplacement(t *testing.T) {
+	node := NewNode("local")
+	host := &dummyHost{}
+	release, err := node.RegisterOwnedHost("control", host)
+	require.NoError(t, err)
+	duplicate, err := node.RegisterOwnedHost("control", &dummyHost{})
+	require.Error(t, err)
+	require.Nil(t, duplicate, "failed registration grants no cleanup authority")
+	current, found := node.GetHost("control")
+	require.True(t, found)
+	require.Same(t, host, current)
+
+	node.UnregisterHost("control")
+	// Reusing the exact receiver must still create a new registration identity.
+	replacementRelease, err := node.RegisterOwnedHost("control", host)
+	require.NoError(t, err)
+	defer replacementRelease()
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() { release() })
+	}
+	wg.Wait()
+	current, found = node.GetHost("control")
+	require.True(t, found)
+	require.Same(t, host, current)
+	replacementRelease()
+	replacementRelease()
+	_, found = node.GetHost("control")
+	require.False(t, found)
+}
+
+func TestOwnedHostReleasePreservesLegacyRegistration(t *testing.T) {
+	node := NewNode("local")
+	host := &dummyHost{}
+	release, err := node.RegisterOwnedHost("control", host)
+	require.NoError(t, err)
+	release()
+	require.NoError(t, node.RegisterHost("control", host))
+	release()
+	current, found := node.GetHost("control")
+	require.True(t, found)
+	require.Same(t, host, current)
+}
+
+func TestOwnedHostRetainsReceiverCapabilities(t *testing.T) {
+	node := NewNode("local")
+	host := &dummyHost{}
+	release, err := node.RegisterOwnedHost("control", host)
+	require.NoError(t, err)
+	defer release()
+	target := pid.PID{Node: "local", Host: "control", UniqID: "actor"}
+	detach, err := node.Attach(target, make(chan *api.Package))
+	require.NoError(t, err)
+	detach()
+	require.EqualValues(t, 1, host.attachCalled)
+	require.NoError(t, node.Send(&api.Package{Target: target}))
+	require.EqualValues(t, 1, host.sendCalled)
+}
+
+func TestOwnedHostReleaseDoesNotDrainDispatchedCall(t *testing.T) {
+	node := NewNode("local")
+	host := &blockingHost{entered: make(chan struct{}), release: make(chan struct{})}
+	release, err := node.RegisterOwnedHost("control", host)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	target := pid.PID{Node: "local", Host: "control"}
+	go func() { done <- node.Send(&api.Package{Target: target}) }()
+	<-host.entered
+	release()
+	require.Error(t, node.SendContext(context.Background(), &api.Package{Target: target}))
+	select {
+	case <-done:
+		t.Fatal("registration release must not complete a call already in the receiver")
+	default:
+	}
+	close(host.release)
+	require.NoError(t, <-done)
+}
+
+type ownedContextHost struct {
+	dummyHost
+	calls int
+}
+
+func (h *ownedContextHost) SendContext(context.Context, *api.Package) error {
+	h.calls++
+	return nil
+}
+
+func TestOwnedHostPreservesContextDelivery(t *testing.T) {
+	node := NewNode("local")
+	host := &ownedContextHost{}
+	release, err := node.RegisterOwnedHost("control", host)
+	require.NoError(t, err)
+	defer release()
+	receiver, found := node.GetHost("control")
+	require.True(t, found)
+	_, capable := receiver.(api.ContextSender)
+	require.True(t, capable)
+	require.NoError(t, node.SendContext(context.Background(), &api.Package{Target: pid.PID{Node: "local", Host: "control"}}))
+	require.Equal(t, 1, host.calls)
+	require.Zero(t, host.sendCalled, "must not fall back to legacy Send")
+}


### PR DESCRIPTION
Replaceable native receivers can now release their own relay-host registration without removing a newer receiver at the same address. OwnedHostRegistrar is optional; existing Node implementations and RegisterHost or UnregisterHost callers remain compatible.

Each registration has an internal identity separate from the receiver object. Its idempotent release removes only that identity. GetHost, delivery, and attachment retain the original receiver and its optional capabilities. Release removes routing availability but does not drain calls already dispatched to that receiver.

This is the ownership leaf required by the native topology-control work. It does not add remote monitoring or peer authorization.

Validation on the current-main replay: focused race tests, full vet, repository-pinned scoped lint, module verification, Windows CGO build, and diff checks pass.