### PR TITLE
fix(lua): type Future response channels

### DIFF
--- a/runtime/lua/modules/funcs/manifest_consistency_test.go
+++ b/runtime/lua/modules/funcs/manifest_consistency_test.go
@@ -5,7 +5,11 @@ package funcs_test
 import (
 	"testing"
 
+	"github.com/wippyai/go-lua/types/diag"
 	"github.com/wippyai/go-lua/types/typ"
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/runtime/lua/code"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 	"github.com/wippyai/runtime/runtime/lua/modules/funcs"
 	"github.com/wippyai/runtime/runtime/lua/modules/future"
 )
@@ -41,6 +45,81 @@ func TestFutureManifestMatchesRegisteredMethods(t *testing.T) {
 	for name := range registered {
 		if !manifest[name] {
 			t.Errorf("future package registers %q but the funcs.Future manifest omits it (undocumented method)", name)
+		}
+	}
+}
+
+func TestFutureManifestChannelsAreOptionalUnknownChannels(t *testing.T) {
+	target, ok := funcs.ModuleTypes().LookupType("Future")
+	if !ok {
+		t.Fatal("Future type not found in funcs manifest")
+	}
+
+	iface := target.(*typ.Interface)
+	for _, name := range []string{"response", "channel"} {
+		t.Run(name, func(t *testing.T) {
+			var method *typ.Method
+			for i := range iface.Methods {
+				if iface.Methods[i].Name == name {
+					method = &iface.Methods[i]
+					break
+				}
+			}
+			if method == nil {
+				t.Fatalf("Future.%s method missing", name)
+			}
+
+			fn := method.Type
+			if len(fn.Returns) != 1 {
+				t.Fatalf("Future.%s type = %v, want one return", name, method.Type)
+			}
+			optional, ok := fn.Returns[0].(*typ.Optional)
+			if !ok {
+				t.Fatalf("Future.%s return = %v, want optional channel", name, fn.Returns[0])
+			}
+			channel, ok := optional.Inner.(*typ.Instantiated)
+			if !ok || channel.Generic.Name != "channel.Channel" {
+				t.Fatalf("Future.%s return = %v, want channel.Channel<unknown>?", name, fn.Returns[0])
+			}
+			if len(channel.TypeArgs) != 1 || !channel.TypeArgs[0].Equals(typ.Unknown) {
+				t.Fatalf("Future.%s return = %v, want channel.Channel<unknown>?", name, fn.Returns[0])
+			}
+		})
+	}
+}
+
+func TestFutureResponseCanBeRetainedAndSelectedInStrictLua(t *testing.T) {
+	source := `
+local funcs = require("funcs")
+local channel = require("channel")
+type Channel = channel.Channel
+type ResponseChannel = Channel<unknown>
+
+local function select_response(future: funcs.Future): ResponseChannel?
+    local response: ResponseChannel? = future:response()
+    if not response then return nil end
+
+    local selected = channel.select { response:case_receive() }
+    if selected.channel == response then
+        return response
+    end
+    return nil
+end
+
+return select_response
+`
+
+	tc := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, []*luaapi.ModuleDef{
+		engine.ChannelModule,
+		funcs.Module,
+	})
+	_, diagnostics, err := tc.Check(source, "future_response.lua", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity == diag.SeverityError {
+			t.Fatalf("unexpected strict type error at %d:%d: %s", diagnostic.Position.Line, diagnostic.Position.Column, diagnostic.Message)
 		}
 	}
 }

--- a/runtime/lua/modules/funcs/manifest_consistency_test.go
+++ b/runtime/lua/modules/funcs/manifest_consistency_test.go
@@ -49,7 +49,7 @@ func TestFutureManifestMatchesRegisteredMethods(t *testing.T) {
 	}
 }
 
-func TestFutureManifestChannelsAreOptionalUnknownChannels(t *testing.T) {
+func TestFutureManifestChannelsAreUnknownChannels(t *testing.T) {
 	target, ok := funcs.ModuleTypes().LookupType("Future")
 	if !ok {
 		t.Fatal("Future type not found in funcs manifest")
@@ -73,16 +73,12 @@ func TestFutureManifestChannelsAreOptionalUnknownChannels(t *testing.T) {
 			if len(fn.Returns) != 1 {
 				t.Fatalf("Future.%s type = %v, want one return", name, method.Type)
 			}
-			optional, ok := fn.Returns[0].(*typ.Optional)
-			if !ok {
-				t.Fatalf("Future.%s return = %v, want optional channel", name, fn.Returns[0])
-			}
-			channel, ok := optional.Inner.(*typ.Instantiated)
+			channel, ok := fn.Returns[0].(*typ.Instantiated)
 			if !ok || channel.Generic.Name != "channel.Channel" {
-				t.Fatalf("Future.%s return = %v, want channel.Channel<unknown>?", name, fn.Returns[0])
+				t.Fatalf("Future.%s return = %v, want channel.Channel<unknown>", name, fn.Returns[0])
 			}
 			if len(channel.TypeArgs) != 1 || !channel.TypeArgs[0].Equals(typ.Unknown) {
-				t.Fatalf("Future.%s return = %v, want channel.Channel<unknown>?", name, fn.Returns[0])
+				t.Fatalf("Future.%s return = %v, want channel.Channel<unknown>", name, fn.Returns[0])
 			}
 		})
 	}

--- a/runtime/lua/modules/funcs/types.go
+++ b/runtime/lua/modules/funcs/types.go
@@ -10,16 +10,16 @@ import (
 
 // Future response values are the native completion channels created by the
 // async adapter. They carry an opaque payload, since the invoked function's
-// result is only known at runtime, and may be absent for an invalid future.
+// result is only known at runtime.
 var futureResponseChannelType = futureChannelType()
 
 func futureChannelType() typ.Type {
 	if manifest := engine.ChannelModuleTypes(); manifest != nil {
 		if channel, ok := manifest.LookupType("Channel"); ok {
 			if generic, ok := channel.(*typ.Generic); ok {
-				return typ.NewOptional(typ.Instantiate(generic, typ.Unknown))
+				return typ.Instantiate(generic, typ.Unknown)
 			}
-			return typ.NewOptional(channel)
+			return channel
 		}
 	}
 	return typ.Any

--- a/runtime/lua/modules/funcs/types.go
+++ b/runtime/lua/modules/funcs/types.go
@@ -5,12 +5,30 @@ package funcs
 import (
 	"github.com/wippyai/go-lua/types/io"
 	"github.com/wippyai/go-lua/types/typ"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 )
+
+// Future response values are the native completion channels created by the
+// async adapter. They carry an opaque payload, since the invoked function's
+// result is only known at runtime, and may be absent for an invalid future.
+var futureResponseChannelType = futureChannelType()
+
+func futureChannelType() typ.Type {
+	if manifest := engine.ChannelModuleTypes(); manifest != nil {
+		if channel, ok := manifest.LookupType("Channel"); ok {
+			if generic, ok := channel.(*typ.Generic); ok {
+				return typ.NewOptional(typ.Instantiate(generic, typ.Unknown))
+			}
+			return typ.NewOptional(channel)
+		}
+	}
+	return typ.Any
+}
 
 // Future type
 var futureType = typ.NewInterface("funcs.Future", []typ.Method{
-	{Name: "response", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
-	{Name: "channel", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
+	{Name: "response", Type: typ.Func().Param("self", typ.Self).Returns(futureResponseChannelType).Build()},
+	{Name: "channel", Type: typ.Func().Param("self", typ.Self).Returns(futureResponseChannelType).Build()},
 	{Name: "is_complete", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
 	{Name: "is_canceled", Type: typ.Func().Param("self", typ.Self).Returns(typ.Boolean).Build()},
 	{Name: "result", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any, typ.NewOptional(typ.LuaError)).Build()},


### PR DESCRIPTION
## Problem

`funcs.Future:response()` and `funcs.Future:channel()` were declared as `any`, so strict Lua could not retain the completion channel in a typed value or pass it to channel selection.

## Change

- Resolve the native `channel.Channel` generic from the engine manifest.
- Declare both Future channel methods as `channel.Channel<unknown>`, preserving their single channel return used by existing direct receive callers.
- Add manifest shape coverage and a strict type checker regression that retains the response, narrows an optional local, and uses `channel.select` with `case_receive`.

## Validation

- `GOWORK=off go test -race -short ./runtime/lua/modules/funcs ./runtime/lua/modules/future`
- `GOWORK=off go test -tags 'fts5 sqlite_vec treesitter sqlite_preupdate_hook' ./runtime/lua/...`
- `GOWORK=off make lint`
- `GOWORK=off bash tests/app/test.sh`
