### PR TITLE
feat(process): validate receiver-local typed listeners

### DIFF
--- a/runtime/lua/modules/process/listen.go
+++ b/runtime/lua/modules/process/listen.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package process
+
+import (
+	"context"
+	"fmt"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+)
+
+// listenHandler binds a receiver-local type. Neither the topic nor a type name
+// supplied by a sender is evidence that its payload satisfies this type.
+func listenHandler(options lua.LValue) (engine.TopicHandler, error) {
+	if options == lua.LNil {
+		return nil, nil
+	}
+	table, ok := options.(*lua.LTable)
+	if !ok {
+		return nil, fmt.Errorf("process.listen options must be a table")
+	}
+	var optionErr error
+	table.ForEach(func(key, _ lua.LValue) {
+		if key != lua.LString("message") && key != lua.LString("type") {
+			optionErr = fmt.Errorf("unsupported process.listen option %s", key.String())
+		}
+	})
+	if optionErr != nil {
+		return nil, optionErr
+	}
+	message := table.RawGetString("message")
+	if message != lua.LNil && message.Type() != lua.LTBool {
+		return nil, fmt.Errorf("process.listen message option must be a boolean")
+	}
+	requested := table.RawGetString("type")
+	if requested == lua.LNil {
+		if message == lua.LTrue {
+			return MessageHandler, nil
+		}
+		return nil, nil
+	}
+	expected, ok := requested.(*lua.LType)
+	if !ok {
+		return nil, fmt.Errorf("process.listen type option must be a type value")
+	}
+	return func(ctx context.Context, state *lua.LState, source pid.PID, topic string, inputs []payload.Payload) lua.LValue {
+		// Decode explicitly: a decoding failure must not masquerade as nil and pass
+		// a listener whose declared type is optional.
+		values := make([]payload.Payload, len(inputs))
+		for i, input := range inputs {
+			if input == nil {
+				return nil
+			}
+			if input.Format() != payload.Lua {
+				transcoder := payload.GetTranscoder(ctx)
+				if transcoder == nil {
+					return nil
+				}
+				var err error
+				input, err = transcoder.Transcode(input, payload.Lua)
+				if err != nil || input == nil {
+					return nil
+				}
+			}
+			if _, ok := input.Data().(lua.LValue); !ok {
+				return nil
+			}
+			values[i] = input
+		}
+		data := engine.PayloadsToLua(ctx, state, values)
+		if !expected.Validate(state, data) {
+			return nil
+		}
+		if message == lua.LTrue {
+			msg := NewMessage(source, topic, inputs)
+			msg.data = data
+			return WrapMessage(state, msg)
+		}
+		return data
+	}, nil
+}

--- a/runtime/lua/modules/process/listen_test.go
+++ b/runtime/lua/modules/process/listen_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package process
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/go-lua/types/typ"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/payload"
+	"github.com/wippyai/runtime/api/pid"
+	luapayload "github.com/wippyai/runtime/runtime/lua/engine/payload"
+	systempayload "github.com/wippyai/runtime/system/payload"
+)
+
+func TestTypedListenFiltersDecodedMapsAndRetainsSender(t *testing.T) {
+	for _, message := range []bool{false, true} {
+		t.Run(map[bool]string{false: "raw", true: "message"}[message], func(t *testing.T) {
+			l := lua.NewState()
+			defer l.Close()
+			tc := systempayload.NewTranscoder()
+			luapayload.Register(tc)
+			luapayload.RegisterAllBasicFormats(tc)
+			ctx := payload.WithTranscoder(ctxapi.NewRootContext(), tc)
+			options := l.NewTable()
+			options.RawSetString("message", lua.LBool(message))
+			options.RawSetString("type", lua.NewLType(typ.NewRecord().Field("count", typ.Integer).Build()))
+			handler, err := listenHandler(options)
+			require.NoError(t, err)
+			source := pid.PID{Node: "remote-node", Host: "supervisor", UniqID: "actor-17"}
+			for _, bad := range []payload.Payload{
+				payload.NewPayload(map[string]any{"count": "wrong"}, payload.Golang),
+				payload.NewPayload(map[string]any{"other": 17}, payload.Golang),
+				payload.NewPayload([]byte("{broken"), payload.JSON),
+			} {
+				require.Nil(t, handler(ctx, l, source, "request", []payload.Payload{bad}))
+			}
+			good := payload.NewPayload(map[string]any{"count": 17, "from": "forged-node:owner:actor"}, payload.Golang)
+			result := handler(ctx, l, source, "request", []payload.Payload{good})
+			require.NotNil(t, result)
+			if message {
+				msg := result.(*lua.LUserData).Value.(*Message)
+				require.Equal(t, source, msg.From)
+				require.Equal(t, "request", msg.Topic)
+				result = msg.data
+			}
+			require.Equal(t, lua.LInteger(17), result.(*lua.LTable).RawGetString("count"))
+		})
+	}
+}
+
+func TestTypedListenDecodeFailureDoesNotBecomeOptionalNil(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	options := l.NewTable()
+	options.RawSetString("type", lua.NewLType(typ.NewOptional(typ.String)))
+	handler, err := listenHandler(options)
+	require.NoError(t, err)
+	require.Nil(t, handler(context.Background(), l, pid.PID{}, "request",
+		[]payload.Payload{payload.NewPayload([]byte("{broken"), payload.JSON)}))
+	require.Equal(t, lua.LNil, handler(context.Background(), l, pid.PID{}, "request",
+		[]payload.Payload{payload.NewPayload(lua.LNil, payload.Lua)}))
+}
+
+func TestListenRejectsInvalidOptions(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	for _, test := range []struct {
+		value lua.LValue
+		key   string
+	}{
+		{lua.LString("Request"), "type"},
+		{lua.LInteger(1), "message"},
+		{lua.LTrue, "typo"},
+	} {
+		options := l.NewTable()
+		options.RawSetString(test.key, test.value)
+		_, err := listenHandler(options)
+		require.Error(t, err)
+	}
+	_, err := listenHandler(lua.LTrue)
+	require.Error(t, err)
+}

--- a/runtime/lua/modules/process/message.go
+++ b/runtime/lua/modules/process/message.go
@@ -8,6 +8,7 @@ import (
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
 	payloadmod "github.com/wippyai/runtime/runtime/lua/modules/payload"
 )
@@ -17,6 +18,7 @@ import (
 const messageTypeName = "process.Message"
 
 type Message struct {
+	data     lua.LValue
 	From     pid.PID
 	Topic    string
 	Payloads payload.Payloads
@@ -24,8 +26,23 @@ type Message struct {
 
 var messageMethods = map[string]lua.LGoFunc{
 	"topic":   messageTopic,
+	"data":    messageData,
 	"payload": messagePayload,
 	"from":    messageFrom,
+}
+
+// messageData returns the receiver-local decoded value. Typed listeners validate
+// this exact value before exposing the Message to the receiving process.
+func messageData(l *lua.LState) int {
+	msg := checkMessage(l)
+	if msg == nil {
+		return 0
+	}
+	if msg.data == nil {
+		msg.data = engine.PayloadsToLua(l.Context(), l, msg.Payloads)
+	}
+	l.Push(msg.data)
+	return 1
 }
 
 func messageTopic(l *lua.LState) int {

--- a/runtime/lua/modules/process/module.go
+++ b/runtime/lua/modules/process/module.go
@@ -935,14 +935,9 @@ func listen(l *lua.LState) int {
 		return pushProcessError(l, lua.LNil, newProcessError(l, lua.Invalid, "cannot listen to @ topics"))
 	}
 
-	// Check for options table (second argument)
-	// Options: { message = true } to receive Message objects instead of raw payloads
-	var handler engine.TopicHandler // default: nil = raw payloads (Lua tables/strings)
-	if l.GetTop() >= 2 && l.Get(2).Type() == lua.LTTable {
-		options := l.CheckTable(2)
-		if msgMode := options.RawGetString("message"); msgMode == lua.LTrue {
-			handler = MessageHandler // Message objects with :from(), :payload(), :topic()
-		}
+	handler, err := listenHandler(l.Get(2))
+	if err != nil {
+		return pushProcessError(l, lua.LNil, newProcessError(l, lua.Invalid, err.Error()))
 	}
 
 	req := &engine.SubscribeRequest{

--- a/runtime/lua/modules/process/typed_listen_delivery_test.go
+++ b/runtime/lua/modules/process/typed_listen_delivery_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package process_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/go-lua/compiler/parse"
+	"github.com/wippyai/go-lua/types/io"
+	"github.com/wippyai/runtime/runtime/lua/code"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	processmod "github.com/wippyai/runtime/runtime/lua/modules/process"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypedListenFiltersAtProcessDelivery(t *testing.T) {
+	tc := setupProcessLeakTest(t, 2)
+	defer tc.Close(t)
+	frame, receiver := tc.frameCtxPID(t)
+	script := `
+ local process = require("process")
+ type Request = {count: integer}
+ local stream, err = process.listen("request", {message = true, type = Request})
+ if not stream then return nil, tostring(err) end
+ local self = process.pid()
+ process.send(self, "request", {count = "invalid"})
+ process.send(self, "request", {count = 17})
+ local msg, ok = stream:receive()
+ if not ok then return nil, "listener closed" end
+ if msg:from() ~= tostring(self) then return nil, "sender changed" end
+ if msg:topic() ~= "request" then return nil, "topic changed" end
+ if msg:data().count ~= 17 then return nil, "unvalidated data delivered" end
+ process.unlisten(stream)
+ return 17
+ `
+	checker := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+	manifest, diagnostics, err := checker.Check(script, "typed_listener", map[string]*io.Manifest{"process": processmod.ModuleTypes()})
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "diagnostics: %v", diagnostics)
+	options, err := code.CompileOptionsForManifest(manifest)
+	require.NoError(t, err)
+	chunk, err := parse.Parse(strings.NewReader(script), "typed_listener")
+	require.NoError(t, err)
+	proto, err := lua.CompileWithOptions(chunk, "typed_listener", options)
+	require.NoError(t, err)
+	proc, err := engine.NewProcess(engine.WithProto(proto), engine.WithModuleBinder(func(l *lua.LState) error {
+		engine.LoadModuleDef(l, engine.ChannelModule)
+		mod, _ := processmod.Module.Build()
+		l.SetGlobal("process", mod)
+		return nil
+	}))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(frame, 5*time.Second)
+	defer cancel()
+	result, err := tc.scheduler.Execute(ctx, receiver, proc, "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Error, "script: %v", result.Error)
+	require.Equal(t, int64(17), extractProcessInt64(result.Value.Data()))
+}

--- a/runtime/lua/modules/process/types.go
+++ b/runtime/lua/modules/process/types.go
@@ -3,15 +3,13 @@
 package process
 
 import (
-	"github.com/wippyai/go-lua/types/constraint"
-	"github.com/wippyai/go-lua/types/contract"
 	"github.com/wippyai/go-lua/types/io"
 	"github.com/wippyai/go-lua/types/typ"
 	"github.com/wippyai/runtime/runtime/lua/engine"
 )
 
 var (
-	messageType        *typ.Interface
+	messageType        typ.Type
 	processEventType   typ.Type
 	messageChannelType typ.Type
 	eventChannelType   typ.Type
@@ -19,12 +17,43 @@ var (
 	channelGen         *typ.Generic
 )
 
-func init() {
-	messageType = typ.NewInterface("process.Message", []typ.Method{
+var messageElement = typ.NewTypeParam("T", nil)
+var messageGeneric = typ.NewGeneric("process.Message", []*typ.TypeParam{messageElement},
+	typ.NewInterface("process.Message", []typ.Method{
 		{Name: "from", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
 		{Name: "topic", Type: typ.Func().Param("self", typ.Self).Returns(typ.String).Build()},
 		{Name: "payload", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
-	})
+		{Name: "data", Type: typ.Func().Param("self", typ.Self).Returns(messageElement).Build()},
+	}))
+
+// The type argument belongs to the receiving process. Message mode changes the
+// envelope only; the same T is checked for both raw and message delivery.
+func listenType() typ.Type {
+	t := typ.NewTypeParam("T", nil)
+	rawOptions := typ.NewRecord().OptField("message", typ.False).Build()
+	messageOptions := typ.NewRecord().Field("message", typ.True).Build()
+	typedRawOptions := typ.NewRecord().OptField("message", typ.False).Field("type", typ.NewMeta(t)).Build()
+	typedMessageOptions := typ.NewRecord().Field("message", typ.True).Field("type", typ.NewMeta(t)).Build()
+	dynamicOptions := typ.NewRecord().OptField("message", typ.Boolean).Build()
+	typedDynamicOptions := typ.NewRecord().OptField("message", typ.Boolean).Field("type", typ.NewMeta(t)).Build()
+	return typ.NewUnion(
+		typ.Func().TypeParam("T", nil).Param("topic", typ.String).Param("options", typedDynamicOptions).
+			Returns(typ.NewUnion(typ.Instantiate(channelGen, t), typ.Instantiate(channelGen, typ.Instantiate(messageGeneric, t))), typ.NewOptional(typ.LuaError)).Build(),
+		typ.Func().Param("topic", typ.String).Param("options", dynamicOptions).
+			Returns(typ.NewUnion(rawChannelType, messageChannelType), typ.NewOptional(typ.LuaError)).Build(),
+		typ.Func().TypeParam("T", nil).Param("topic", typ.String).Param("options", typedMessageOptions).
+			Returns(typ.Instantiate(channelGen, typ.Instantiate(messageGeneric, t)), typ.NewOptional(typ.LuaError)).Build(),
+		typ.Func().TypeParam("T", nil).Param("topic", typ.String).Param("options", typedRawOptions).
+			Returns(typ.Instantiate(channelGen, t), typ.NewOptional(typ.LuaError)).Build(),
+		typ.Func().Param("topic", typ.String).Param("options", messageOptions).
+			Returns(messageChannelType, typ.NewOptional(typ.LuaError)).Build(),
+		typ.Func().Param("topic", typ.String).OptParam("options", rawOptions).
+			Returns(rawChannelType, typ.NewOptional(typ.LuaError)).Build(),
+	)
+}
+
+func init() {
+	messageType = typ.Instantiate(messageGeneric, typ.Any)
 
 	eventRecord := typ.NewRecord().
 		Field("kind", typ.String).
@@ -194,6 +223,7 @@ func ModuleTypes() *io.Manifest {
 
 	moduleFieldsType := typ.NewRecord().
 		Field("event", eventType).
+		Field("listen", listenType()).
 		Field("registry", registrySubType).
 		Build()
 
@@ -275,19 +305,6 @@ func ModuleTypes() *io.Manifest {
 			Build()},
 		{Name: "events", Type: typ.Func().
 			Returns(eventChannelType).
-			Build()},
-		{Name: "listen", Type: typ.Func().
-			Param("topic", typ.String).
-			OptParam("options", typ.Any).
-			Returns(rawChannelType, typ.NewOptional(typ.LuaError)).
-			Spec(contract.NewSpec().WithReturnCase(
-				constraint.FromConstraints(constraint.FieldEquals{
-					Target: constraint.ParamPath(1),
-					Field:  "message",
-					Value:  typ.True,
-				}),
-				messageChannelType,
-			)).
 			Build()},
 		{Name: "unlisten", Type: typ.Func().
 			Param("listener", typ.Any).

--- a/runtime/lua/modules/process/types_test.go
+++ b/runtime/lua/modules/process/types_test.go
@@ -26,3 +26,50 @@ local upgradable: boolean = options.upgradable
 	require.NoError(t, err)
 	require.False(t, code.HasErrors(diagnostics), "unexpected diagnostics: %v", diagnostics)
 }
+
+func TestTypedListenMessageData(t *testing.T) {
+	for _, test := range []struct {
+		name, options, expression, want string
+		invalid                         bool
+	}{
+		{"message", "{message = true, type = Request}", "item:data().count", "integer", false},
+		{"raw", "{type = Request}", "item.count", "integer", false},
+		{"wrong_message_field", "{message = true, type = Request}", "item:data().count", "string", true},
+		{"wrong_raw_field", "{type = Request}", "item.count", "string", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tc := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+			source := `
+local process = require("process")
+type Request = {count: integer}
+local stream, err = process.listen("request", ` + test.options + `)
+if not stream then error(tostring(err)) end
+local item, ok = stream:receive()
+if ok then
+ local count: ` + test.want + ` = ` + test.expression + `
+end
+`
+			_, diagnostics, err := tc.Check(source, test.name+".lua", map[string]*io.Manifest{"process": ModuleTypes()})
+			require.NoError(t, err)
+			require.Equal(t, test.invalid, code.HasErrors(diagnostics), "diagnostics: %v", diagnostics)
+		})
+	}
+}
+
+func TestUntypedListenMessageCompatibility(t *testing.T) {
+	tc := code.NewTypeChecker(code.TypeCheckConfig{Enabled: true, Strict: true}, nil)
+	_, diagnostics, err := tc.Check(`
+local process = require("process")
+local messages = process.listen("request", {message = true})
+local msg: process.Message = messages:receive()
+local sender: string = msg:from()
+local topic: string = msg:topic()
+local raw = process.listen("raw")
+local legacy = process.listen("legacy", {})
+local function dynamic(message: boolean)
+ return process.listen("dynamic", {message = message})
+end
+`, "listen_compatibility.lua", map[string]*io.Manifest{"process": ModuleTypes()})
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "diagnostics: %v", diagnostics)
+}


### PR DESCRIPTION
Process listeners previously ignored a type option, so receivers could not rely on the shape delivered to their channel.

This adds process.listen topic options with receiver-local runtime validation. Raw mode delivers the checked value directly; message mode preserves native sender and topic data while message data exposes the exact validated value. Decode or validation failures are discarded without closing the listener or falling through to the inbox.

No wire schema, transport evidence API, or topology surface is added. Existing untyped listeners remain supported; invalid option keys and values return clear registration errors.

The current-main replay uses released go-lua v1.5.21 and contains no dependency pin or standalone documentation file.

Validation: the full process package and repeated typed-listener matrix pass under race; repository-pinned scoped lint, vet, Windows compilation, and diff checks pass.