### PR TITLE
fix(terminal): add bounded native scrollback

### DIFF
--- a/service/terminal/proxy/input.go
+++ b/service/terminal/proxy/input.go
@@ -45,6 +45,8 @@ func (p *Proxy) handle(event ttyapi.Event) error {
 		p.screenMu.Lock()
 		p.height.Store(int64(event.Height))
 		p.screen.Resize(event.Width, event.Height)
+		p.resizeScrollbackLocked(event.Width)
+		p.viewOffset = min(p.viewOffset, p.screen.ScrollbackLen())
 		p.screenMu.Unlock()
 		if err := p.process.Resize(event.Width, event.Height); err != nil {
 			return err
@@ -55,7 +57,7 @@ func (p *Proxy) handle(event ttyapi.Event) error {
 		if p.input.bracketedPaste.Load() {
 			text = ansi.BracketedPasteStart + text + ansi.BracketedPasteEnd
 		}
-		return p.write(text)
+		return p.writeLive(text)
 	case "focus":
 		if p.input.focusEvents.Load() {
 			if event.Focused {
@@ -64,11 +66,65 @@ func (p *Proxy) handle(event ttyapi.Event) error {
 			return p.write("\x1b[O")
 		}
 	case "key":
-		return p.write(p.input.key(event))
+		return p.writeLive(p.input.key(event))
 	case "mouse":
-		return p.write(p.input.mouse(event))
+		if p.input.mouseEnabled.Load() {
+			return p.writeLive(p.input.mouse(event))
+		}
+		if p.input.altScreen.Load() {
+			return p.write(p.input.alternateScroll(event))
+		}
+		return p.scroll(event)
 	}
 	return nil
+}
+
+// writeLive returns a history viewport to the live screen before delivering
+// user input. Output keeps a history viewport stable while x/vt's retained
+// history is still growing; after eviction x/vt exposes no line identity with
+// which to anchor a viewport. A resize keeps it where possible (clamped to
+// retained history).
+func (p *Proxy) writeLive(sequence string) error {
+	if sequence == "" {
+		return nil
+	}
+	p.screenMu.Lock()
+	changed := p.viewOffset != 0
+	p.viewOffset = 0
+	p.screenMu.Unlock()
+	if changed {
+		if err := p.present(); err != nil {
+			return err
+		}
+	}
+	return p.write(sequence)
+}
+
+// scroll consumes a primary-screen wheel event for the proxy's native history.
+// Mouse-tracking children and alternate-screen applications are handled before
+// this function is called.
+func (p *Proxy) scroll(event ttyapi.Event) error {
+	if event.Action != "wheel" {
+		return nil
+	}
+	var delta int
+	switch event.Button {
+	case "wheel_up":
+		delta = scrollLinesPerWheel
+	case "wheel_down":
+		delta = -scrollLinesPerWheel
+	default:
+		return nil
+	}
+	p.screenMu.Lock()
+	old := p.viewOffset
+	p.viewOffset = min(max(p.viewOffset+delta, 0), p.screen.ScrollbackLen())
+	changed := p.viewOffset != old
+	p.screenMu.Unlock()
+	if !changed {
+		return nil
+	}
+	return p.present()
 }
 
 func (p *Proxy) write(sequence string) error {

--- a/service/terminal/proxy/proxy.go
+++ b/service/terminal/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	vt "github.com/charmbracelet/x/vt"
 	execapi "github.com/wippyai/runtime/api/service/exec"
 	ttyapi "github.com/wippyai/runtime/api/tty"
@@ -22,7 +23,16 @@ var (
 	ErrShutdownTimeout = errors.New("PTY process did not exit after forced shutdown")
 )
 
-const retainedScrollbackLines = 1
+const (
+	// scrollbackCellBudget keeps history bounded even for a very wide PTY.
+	// Keeping the cap small also bounds x/vt's line-slice eviction work, which
+	// otherwise shifts its default 10,000 entries for every later output line.
+	scrollbackCellBudget = 20_480
+	maxScrollbackLines   = 256
+
+	// scrollLinesPerWheel matches the usual terminal wheel notch behavior.
+	scrollLinesPerWheel = 3
+)
 
 // Proxy owns the process/VT/surface pipeline. A native Wippy process, plugin,
 // or standalone adapter can supply events without exposing its scheduler here.
@@ -35,6 +45,7 @@ type Proxy struct {
 	input           inputState
 	shutdownGrace   time.Duration
 	height          atomic.Int64
+	viewOffset      int
 	closeNotifyOnce sync.Once
 	closeSignalOnce sync.Once
 	screenMu        sync.Mutex
@@ -94,11 +105,10 @@ func New(process execapi.PTYProcess, surface ttyapi.Surface, width, height int) 
 		process: process, surface: surface, screen: vt.NewSafeEmulator(width, height),
 		shutdownGrace: defaultShutdownGrace, closeNotify: make(chan struct{}),
 	}
-	// Proxy presents only the current terminal frame; its public contract has
-	// no scrollback viewport. x/vt otherwise retains 10,000 cloned lines and
-	// shifts that history for every line after it fills. Keep the one line its
-	// scroll machinery requires without retaining inaccessible history.
-	p.screen.SetScrollbackSize(retainedScrollbackLines)
+	// Retain a bounded primary-screen history for nested surfaces. Physical
+	// terminals normally provide their own scrollback, but a virtual surface
+	// cannot. The cap avoids x/vt's costly default 10,000-line retention.
+	p.resizeScrollbackLocked(width)
 	p.height.Store(int64(height))
 	p.cursorVisible.Store(true)
 	p.input.init()
@@ -113,17 +123,11 @@ func New(process execapi.PTYProcess, surface ttyapi.Surface, width, height int) 
 
 func (p *Proxy) present() error {
 	p.screenMu.Lock()
-	rows := strings.Split(p.screen.Render(), "\n")
 	height := int(p.height.Load())
-	if len(rows) > height {
-		rows = rows[:height]
-	}
-	for len(rows) < height {
-		rows = append(rows, "")
-	}
+	rows, scrolled := p.rowsLocked(height)
 	position := p.screen.CursorPosition()
 	width := p.screen.Width()
-	visible := p.cursorVisible.Load()
+	visible := p.cursorVisible.Load() && !scrolled
 	p.screenMu.Unlock()
 	frame := ttyapi.Frame{Rows: rows, Cursor: &ttyapi.Cursor{
 		Column:  min(max(position.X, 0), width-1),
@@ -132,4 +136,92 @@ func (p *Proxy) present() error {
 	}}
 	_, err := p.surface.Present(frame)
 	return err
+}
+
+// rowsLocked renders the live screen unless the primary-screen viewport has
+// been moved into scrollback. screenMu must be held by the caller.
+func (p *Proxy) rowsLocked(height int) ([]string, bool) {
+	if p.input.altScreen.Load() {
+		p.viewOffset = 0
+		return paddedRows(p.screen.Render(), height), false
+	}
+
+	history := p.screen.ScrollbackLen()
+	p.viewOffset = min(p.viewOffset, history)
+	if p.viewOffset == 0 {
+		return paddedRows(p.screen.Render(), height), false
+	}
+
+	width := p.screen.Width()
+	start := history - p.viewOffset
+	rows := make([]string, height)
+	for y := range rows {
+		line := uv.NewLine(width)
+		lineIndex := start + y
+		for x := range width {
+			var cell *uv.Cell
+			if lineIndex < history {
+				cell = p.screen.ScrollbackCellAt(x, lineIndex)
+			} else {
+				cell = p.screen.CellAt(x, lineIndex-history)
+			}
+			if cell != nil {
+				line[x] = *cell.Clone()
+			}
+		}
+		rows[y] = line.Render()
+	}
+	return rows, true
+}
+
+func paddedRows(rendered string, height int) []string {
+	rows := strings.Split(rendered, "\n")
+	if len(rows) > height {
+		rows = rows[:height]
+	}
+	for len(rows) < height {
+		rows = append(rows, "")
+	}
+	return rows
+}
+
+func scrollbackSize(width int) int {
+	return min(maxScrollbackLines, max(scrollbackCellBudget/max(width, 1), 1))
+}
+
+// resizeScrollbackLocked retains as much recent history as fits both the
+// current line cap and cell budget. x/vt stores old lines at their original
+// widths, so changing from a very wide terminal to a narrow one needs more
+// than simply recomputing the number of retained lines. Once the proxy is
+// live, callers hold screenMu while changing this state.
+func (p *Proxy) resizeScrollbackLocked(width int) {
+	target := scrollbackSize(width)
+	p.screen.SetScrollbackSize(target)
+
+	lines := p.screen.Scrollback().Lines()
+	used, retained := 0, 0
+	for index := len(lines) - 1; index >= 0; index-- {
+		cells := len(lines[index])
+		if cells > scrollbackCellBudget-used {
+			break
+		}
+		used += cells
+		retained++
+	}
+	if len(lines) == 0 {
+		return
+	}
+	if retained == 0 {
+		p.screen.ClearScrollback()
+		return
+	}
+	// Existing wide rows consume part of the budget. Bound the number of new
+	// rows at the current width, without paying to rescan history on output.
+	// SetMaxLines only removes old entries, so trim first if necessary and then
+	// install the conservative cap for subsequent output at this geometry.
+	capacity := min(target, retained+(scrollbackCellBudget-used)/max(width, 1))
+	if retained < len(lines) {
+		p.screen.SetScrollbackSize(retained)
+	}
+	p.screen.SetScrollbackSize(capacity)
 }

--- a/service/terminal/proxy/proxy_test.go
+++ b/service/terminal/proxy/proxy_test.go
@@ -5,6 +5,7 @@ package proxy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"runtime"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 	execapi "github.com/wippyai/runtime/api/service/exec"
 	ttyapi "github.com/wippyai/runtime/api/tty"
@@ -79,7 +81,7 @@ func (s *testSurface) Present(frame ttyapi.Frame) (ttyapi.PresentStats, error) {
 	return ttyapi.PresentStats{Rows: len(frame.Rows), ChangedRows: len(frame.Rows)}, nil
 }
 
-func TestProxyDoesNotRetainInaccessibleScrollback(t *testing.T) {
+func TestProxyBoundsRetainedScrollbackByViewportWidth(t *testing.T) {
 	proxy, err := New(
 		&testProcess{input: make(chan []byte, 1)},
 		&testSurface{},
@@ -87,7 +89,205 @@ func TestProxyDoesNotRetainInaccessibleScrollback(t *testing.T) {
 		24,
 	)
 	require.NoError(t, err)
-	require.Equal(t, retainedScrollbackLines, proxy.screen.Scrollback().MaxLines())
+	require.Equal(t, 256, proxy.screen.Scrollback().MaxLines())
+
+	wide, err := New(&testProcess{input: make(chan []byte, 1)}, &testSurface{}, execapi.MaxPTYDimension, 4)
+	require.NoError(t, err)
+	require.Equal(t, 1, wide.screen.Scrollback().MaxLines())
+}
+
+func TestProxyPrimaryScreenWheelPresentsBoundedHistory(t *testing.T) {
+	process := &testProcess{stdout: io.NopCloser(strings.NewReader("")), input: make(chan []byte, 1)}
+	surface := &testSurface{}
+	proxy, err := New(process, surface, 12, 2)
+	require.NoError(t, err)
+	_, err = proxy.writeOutput([]byte("one\r\ntwo\r\nthree\r\nfour\r\nfive"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, proxy.screen.ScrollbackLen(), 3)
+
+	require.NoError(t, proxy.handle(wheel("wheel_up")))
+	surface.mu.Lock()
+	rows, cursor := append([]string(nil), surface.rows...), *surface.cursor
+	surface.mu.Unlock()
+	require.Equal(t, []string{"one", "two"}, rows)
+	require.False(t, cursor.Visible)
+	select {
+	case unexpected := <-process.input:
+		t.Fatalf("primary-screen wheel reached child: %q", unexpected)
+	default:
+	}
+
+	// Growing history keeps the reader on the same lines.
+	_, err = proxy.writeOutput([]byte("\r\nsix"))
+	require.NoError(t, err)
+	require.NoError(t, proxy.present())
+	surface.mu.Lock()
+	rows = append([]string(nil), surface.rows...)
+	surface.mu.Unlock()
+	require.Equal(t, []string{"one", "two"}, rows)
+
+	// Actual input returns the viewport to the live screen before forwarding.
+	require.NoError(t, proxy.handle(ttyapi.Event{Type: "key", Key: "x", Action: "press"}))
+	require.Equal(t, "x", string(<-process.input))
+	surface.mu.Lock()
+	cursor = *surface.cursor
+	surface.mu.Unlock()
+	require.True(t, cursor.Visible)
+}
+
+func TestProxyPrimaryTrackpadTicksScrollHistory(t *testing.T) {
+	process := &testProcess{stdout: io.NopCloser(strings.NewReader("")), input: make(chan []byte, 1)}
+	proxy, err := New(process, &testSurface{}, 12, 2)
+	require.NoError(t, err)
+	_, err = proxy.writeOutput([]byte("one\r\ntwo\r\nthree\r\nfour\r\nfive\r\nsix\r\nseven\r\neight\r\nnine\r\nten\r\neleven\r\ntwelve"))
+	require.NoError(t, err)
+
+	// Physical ports normalize wheel and trackpad movement into the same
+	// discrete wheel event; a trackpad gesture therefore delivers many ticks.
+	for range 3 {
+		require.NoError(t, proxy.handle(wheel("wheel_up")))
+	}
+	require.Equal(t, 9, proxy.viewOffset)
+	select {
+	case unexpected := <-process.input:
+		t.Fatalf("primary-screen trackpad tick reached child: %q", unexpected)
+	default:
+	}
+}
+
+func TestProxyIgnoresNonWheelMouseActionsOnPrimaryScreen(t *testing.T) {
+	proxy, err := New(&testProcess{input: make(chan []byte, 1)}, &testSurface{}, 12, 2)
+	require.NoError(t, err)
+	_, err = proxy.writeOutput([]byte("one\r\ntwo\r\nthree\r\nfour\r\nfive"))
+	require.NoError(t, err)
+
+	for _, action := range []string{"press", "release"} {
+		require.NoError(t, proxy.handle(ttyapi.Event{Type: "mouse", Action: action, Button: "wheel_up"}))
+	}
+	require.Zero(t, proxy.viewOffset)
+}
+
+func TestProxyResizeClampsHistoryAndReboundsItsCellBudget(t *testing.T) {
+	process := &testProcess{stdout: io.NopCloser(strings.NewReader("")), input: make(chan []byte, 1)}
+	proxy, err := New(process, &testSurface{}, 80, 2)
+	require.NoError(t, err)
+	_, err = proxy.writeOutput([]byte("one\r\ntwo\r\nthree\r\nfour"))
+	require.NoError(t, err)
+	require.NoError(t, proxy.handle(wheel("wheel_up")))
+	require.Positive(t, proxy.screen.ScrollbackLen())
+
+	require.NoError(t, proxy.handle(ttyapi.Event{Type: "resize", Width: execapi.MaxPTYDimension, Height: 4}))
+	require.Equal(t, 1, proxy.screen.Scrollback().MaxLines())
+	require.LessOrEqual(t, proxy.screen.ScrollbackLen(), proxy.screen.Scrollback().MaxLines())
+
+	require.NoError(t, proxy.handle(ttyapi.Event{Type: "resize", Width: 80, Height: 4}))
+	require.Equal(t, 256, proxy.screen.Scrollback().MaxLines())
+}
+
+func TestProxyNarrowResizeDropsOverwideHistory(t *testing.T) {
+	proxy, err := New(&testProcess{input: make(chan []byte, 1)}, &testSurface{}, execapi.MaxPTYDimension, 1)
+	require.NoError(t, err)
+	_, err = proxy.writeOutput([]byte("\x1b[1;65535HX\r\n"))
+	require.NoError(t, err)
+	require.Equal(t, 1, proxy.screen.ScrollbackLen())
+	require.Greater(t, len(proxy.screen.Scrollback().Line(0)), scrollbackCellBudget)
+
+	require.NoError(t, proxy.handle(ttyapi.Event{Type: "resize", Width: 80, Height: 1}))
+	require.Zero(t, proxy.screen.ScrollbackLen())
+	require.Equal(t, maxScrollbackLines, proxy.screen.Scrollback().MaxLines())
+}
+
+func TestProxyNarrowResizeCapsLaterOutputAroundRetainedWideRows(t *testing.T) {
+	proxy, err := New(&testProcess{input: make(chan []byte, 1)}, &testSurface{}, 5_000, 1)
+	require.NoError(t, err)
+	for i := range 4 {
+		_, err = proxy.writeOutput([]byte(fmt.Sprintf("\x1b[1;4000H%d\r\n", i)))
+		require.NoError(t, err)
+	}
+	require.Equal(t, 4, proxy.screen.ScrollbackLen())
+
+	require.NoError(t, proxy.handle(ttyapi.Event{Type: "resize", Width: 80, Height: 1}))
+	// Four 4,000-cell rows leave space for only 56 current-width rows.
+	require.Equal(t, 60, proxy.screen.Scrollback().MaxLines())
+	narrowRow := []byte(strings.Repeat("n", 80) + "\r\n")
+	for range maxScrollbackLines {
+		_, err = proxy.writeOutput(narrowRow)
+		require.NoError(t, err)
+	}
+	lines := proxy.screen.Scrollback().Lines()
+	used := 0
+	for _, line := range lines {
+		used += len(line)
+	}
+	require.LessOrEqual(t, used, scrollbackCellBudget)
+}
+
+func TestProxyForwardsPrimaryWheelWhenChildTracksMouse(t *testing.T) {
+	process := &testProcess{stdout: io.NopCloser(strings.NewReader("")), input: make(chan []byte, 1)}
+	proxy, err := New(process, &testSurface{}, 12, 2)
+	require.NoError(t, err)
+	_, err = proxy.writeOutput([]byte("one\r\ntwo\r\nthree\r\nfour"))
+	require.NoError(t, err)
+	_, err = proxy.screen.Write([]byte(ansi.SetModeMouseNormal))
+	require.NoError(t, err)
+
+	require.NoError(t, proxy.handle(wheel("wheel_up")))
+	require.Equal(t, ansi.MouseX10(ansi.EncodeMouseButton(ansi.MouseWheelUp, false, false, false, false), 2, 3), string(<-process.input))
+}
+
+func TestProxyScrolledViewportMovesAfterHistoryEviction(t *testing.T) {
+	process := &testProcess{stdout: io.NopCloser(strings.NewReader("")), input: make(chan []byte, 1)}
+	surface := &testSurface{}
+	proxy, err := New(process, surface, 8, 1)
+	require.NoError(t, err)
+	for i := range maxScrollbackLines + 1 {
+		_, err = proxy.writeOutput([]byte(fmt.Sprintf("%03d\r\n", i)))
+		require.NoError(t, err)
+	}
+	require.Equal(t, maxScrollbackLines, proxy.screen.ScrollbackLen())
+	require.NoError(t, proxy.handle(wheel("wheel_up")))
+	surface.mu.Lock()
+	before := surface.rows[0]
+	surface.mu.Unlock()
+
+	_, err = proxy.writeOutput([]byte("999\r\n"))
+	require.NoError(t, err)
+	require.NoError(t, proxy.present())
+	surface.mu.Lock()
+	after := surface.rows[0]
+	surface.mu.Unlock()
+	require.NotEqual(t, before, after, "x/vt does not expose an eviction generation to anchor a full history viewport")
+}
+
+func BenchmarkProxyOutputScrollback(b *testing.B) {
+	for _, limit := range []struct {
+		name   string
+		lines  int
+		legacy bool
+	}{
+		{name: "previous_retain_1", lines: 1, legacy: true},
+		{name: "bounded_256", lines: maxScrollbackLines},
+	} {
+		b.Run(limit.name, func(b *testing.B) {
+			proxy, err := New(&testProcess{input: make(chan []byte, 1)}, &testSurface{}, 80, 24)
+			require.NoError(b, err)
+			proxy.screen.SetScrollbackSize(limit.lines)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if limit.legacy {
+					proxy.screenMu.Lock()
+					_, err = proxy.screen.Write([]byte("benchmark output\r\n"))
+					proxy.screenMu.Unlock()
+				} else {
+					_, err = proxy.writeOutput([]byte("benchmark output\r\n"))
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }
 
 func TestProxyCoalescesTransportChunksIntoOneCursorFrame(t *testing.T) {

--- a/service/terminal/proxy/run.go
+++ b/service/terminal/proxy/run.go
@@ -246,9 +246,7 @@ func (p *Proxy) copyOutput(reader io.Reader, dirty chan<- struct{}, done chan<- 
 	for {
 		n, err := reader.Read(buf)
 		if n > 0 {
-			p.screenMu.Lock()
-			_, writeErr := p.screen.Write(buf[:n])
-			p.screenMu.Unlock()
+			_, writeErr := p.writeOutput(buf[:n])
 			if writeErr != nil {
 				done <- writeErr
 				return
@@ -263,6 +261,21 @@ func (p *Proxy) copyOutput(reader io.Reader, dirty chan<- struct{}, done chan<- 
 			return
 		}
 	}
+}
+
+// writeOutput updates the emulator and keeps a scrolled primary viewport on
+// the same lines while history grows. Once the fixed-size x/vt buffer evicts
+// an old line its length no longer changes, and its public API has no stable
+// line identity to retain that anchor without a second terminal parser.
+func (p *Proxy) writeOutput(data []byte) (int, error) {
+	p.screenMu.Lock()
+	defer p.screenMu.Unlock()
+	before := p.screen.ScrollbackLen()
+	n, err := p.screen.Write(data)
+	if added := p.screen.ScrollbackLen() - before; added > 0 && p.viewOffset > 0 && !p.input.altScreen.Load() {
+		p.viewOffset = min(p.viewOffset+added, p.screen.ScrollbackLen())
+	}
+	return n, err
 }
 
 func terminalEOF(err error) bool {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MPL-2.0 -->

# Reason for This PR

Nested terminal surfaces could not scroll through previous primary-screen output: the proxy retained one inaccessible history line and dropped wheel events when the child did not track mouse input.

## Description of Changes

Retain bounded primary-screen history and render its viewport when the child has not requested mouse tracking. Mouse-aware children keep their wheel input; alternate-screen applications retain DECSET 1007 cursor-key behavior. Keyboard, paste and forwarded child mouse input return to the live frame.

History is capped at 256 lines and 20,480 cells for normal terminal widths. Resize accounts for actual retained line widths and sets a conservative limit for subsequent output. The viewport stays anchored while history grows. Once the capped buffer evicts a line, the emulator exposes no stable line identity and the viewport can advance; a regression records this limitation.

Validation: proxy and service race suites, internal/API race suites, repository lint and hosted CI pass. Combined with Unix input framing in PR #705, Bee source/pack acceptance passes physical wheel notch, trackpad-style burst, scroll down and subsequent keyboard input. All 161 keyboard-navigation cases and existing Terminal source/pack acceptance pass as well. These synthetic input checks do not establish real-device trackpad behavior or a full Codex conversation acceptance.
