### PR TITLE
Add typed plain-text extraction for terminal rows

### DIFF
--- a/runtime/lua/modules/tty/module.go
+++ b/runtime/lua/modules/tty/module.go
@@ -65,6 +65,7 @@ func buildModule() (*lua.LTable, []luaapi.YieldType) {
 	text.RawSetString("width", lua.LGoFunc(textWidth))
 	text.RawSetString("truncate", lua.LGoFunc(textTruncate))
 	text.RawSetString("cut", lua.LGoFunc(textCut))
+	text.RawSetString("plain", lua.LGoFunc(textPlain))
 	text.RawSetString("height", lua.LGoFunc(textHeight))
 	text.RawSetString("size", lua.LGoFunc(textSize))
 	text.RawSetString("join_horizontal", lua.LGoFunc(textJoinHorizontal))

--- a/runtime/lua/modules/tty/text.go
+++ b/runtime/lua/modules/tty/text.go
@@ -3,10 +3,28 @@
 package tty
 
 import (
+	"strings"
+	"unicode"
+
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	lua "github.com/wippyai/go-lua"
 )
+
+// textPlain extracts display text without terminal instructions. Keep line
+// feeds and tabs; strip other control characters, including carriage returns.
+// Use textCut first when selecting a range of terminal cells.
+func textPlain(l *lua.LState) int {
+	plain := ansi.Strip(l.CheckString(1))
+	plain = strings.Map(func(r rune) rune {
+		if r != '\n' && r != '\t' && unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, plain)
+	l.Push(lua.LString(plain))
+	return 1
+}
 
 // textTruncate truncates styled text to a printable width without splitting
 // ANSI control sequences or multi-byte characters.

--- a/runtime/lua/modules/tty/text_plain_test.go
+++ b/runtime/lua/modules/tty/text_plain_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package tty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	lua "github.com/wippyai/go-lua"
+)
+
+func TestTextPlain(t *testing.T) {
+	for _, tc := range []struct{ name, input, want string }{
+		{"empty", "", ""},
+		{"unicode", "\x1b[31m界é🙂\x1b[0m", "界é🙂"},
+		{"lines", "first\n\tsecond\r\nthird", "first\n\tsecond\nthird"},
+		{"hyperlink", "\x1b]8;;https://example.com\x1b\\label\x1b]8;;\x1b\\", "label"},
+		{"clipboard", "before\x1b]52;c;c2VjcmV0\aafter", "beforeafter"},
+		{"dcs", "before\x1bPpayload\x1b\\after", "beforeafter"},
+		{"controls", "a\x00\a\b\x7fb", "ab"},
+		{"unterminated_osc", "before\x1b]52;c;hidden", "before"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := lua.NewState()
+			defer l.Close()
+			bindTTY(l)
+			l.SetGlobal("input", lua.LString(tc.input))
+			l.SetGlobal("expected", lua.LString(tc.want))
+			require.NoError(t, l.DoString(`assert(tty.text.plain(input) == expected)`))
+		})
+	}
+}
+
+func TestTextPlainRejectsNonString(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+	require.NoError(t, l.DoString(`assert(type(tty.text.plain) == "function"); assert(not pcall(tty.text.plain, {}))`))
+}
+
+func TestTextPlainAfterCellCut(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	bindTTY(l)
+	l.SetGlobal("styled", lua.LString("\x1b[31mA界éZ\x1b[0m"))
+	require.NoError(t, l.DoString(`assert(tty.text.plain(tty.text.cut(styled, 1, 4)) == "界é")`))
+}

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -278,6 +278,7 @@ func init() {
 		ReadonlyField("width", typ.Func().Param("s", typ.String).Returns(typ.Integer).Build()).
 		ReadonlyField("truncate", typ.Func().Param("s", typ.String).Param("width", typ.Integer).OptParam("tail", typ.String).Returns(typ.String).Build()).
 		ReadonlyField("cut", typ.Func().Param("s", typ.String).Param("left", typ.Integer).Param("right", typ.Integer).Returns(typ.String).Build()).
+		ReadonlyField("plain", typ.Func().Param("s", typ.String).Returns(typ.String).Build()).
 		ReadonlyField("height", typ.Func().Param("s", typ.String).Returns(typ.Integer).Build()).
 		ReadonlyField("size", typ.Func().Param("s", typ.String).Returns(typ.Integer, typ.Integer).Build()).
 		ReadonlyField("join_horizontal", typ.Func().Param("pos", typ.Number).Variadic(typ.String).Returns(typ.String).Build()).


### PR DESCRIPTION
Lua clients can slice styled terminal rows with `tty.text.cut`, but cannot extract plain text without implementing their own ANSI parser. Add the typed, non-yielding `tty.text.plain(string) -> string` helper using the existing native ANSI library; it removes escape sequences and control characters while preserving Unicode, line feeds and tabs.

This supplies text extraction for consumers such as window-local selection. It does not write to a clipboard or add a transport operation.

Validation: the new tests fail before the helper exists; the full TTY Lua module race suite and repository lint pass after the change, rebased onto current main. Coverage includes styled wide/combining text, cell slicing, multiline text, OSC hyperlinks/clipboard sequences, DCS, unterminated OSC and invalid argument types.
