### PR TITLE
feat(stream): add host-authorized pipe allocation

### DIFF
--- a/api/stream/command.go
+++ b/api/stream/command.go
@@ -11,7 +11,7 @@ func init() {
 	dispatcher.MustRegisterCommands("stream",
 		Read, Close, Write,
 		Seek, Flush, Stat,
-		ScannerCreate, ScannerScan,
+		ScannerCreate, ScannerScan, Pipe,
 	)
 }
 
@@ -26,6 +26,7 @@ const (
 	Stat          dispatcher.CommandID = 55 // Get stream info (size, etc)
 	ScannerCreate dispatcher.CommandID = 56 // Create scanner from stream
 	ScannerScan   dispatcher.CommandID = 57 // Scan next token
+	Pipe          dispatcher.CommandID = 58 // Allocate an admitted receive pipe
 )
 
 // Seek whence constants (matching io.Seek*)

--- a/api/stream/errors.go
+++ b/api/stream/errors.go
@@ -13,4 +13,6 @@ var (
 	ErrNotSeekable     = errors.New("stream is not seekable")
 	ErrNoTable         = errors.New("resource table not available")
 	ErrScannerNotFound = errors.New("scanner not found")
+	ErrBusy            = errors.New("stream dispatcher queue full")
+	ErrUnavailable     = errors.New("stream dispatcher not running")
 )

--- a/api/stream/io.go
+++ b/api/stream/io.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package stream
+
+import "context"
+
+// ContextReader is an optional extension implemented by interruptible streams.
+// ReadContext must return when ctx ends without retaining p after return.
+// Implementations also provide io.Reader for ordinary native consumers.
+type ContextReader interface {
+	ReadContext(ctx context.Context, p []byte) (int, error)
+}
+
+// ContextWriter is an optional extension implemented by interruptible streams.
+// WriteContext must return when ctx ends without retaining p after return.
+// Cancellation does not undo bytes already written and must not trigger replay.
+// Implementations also provide io.Writer for ordinary native producers.
+type ContextWriter interface {
+	WriteContext(ctx context.Context, p []byte) (int, error)
+}

--- a/api/stream/pipe.go
+++ b/api/stream/pipe.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+package stream
+
+import (
+	"context"
+	"io"
+
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/dispatcher"
+)
+
+// PipeAllocator is supplied by trusted host composition in the caller's frame.
+// Implementations authorize the actual caller and peer, bind transport identity,
+// and tie the returned endpoint to lifetime. Offers are routing metadata,
+// never authority to read a producer's files or other resources.
+// Allocate must observe ctx cancellation. It runs off the Lua scheduler.
+type PipeAllocator interface {
+	Allocate(ctx, lifetime context.Context, peer string, limit uint64) (io.ReadCloser, string, error)
+}
+
+var pipeAllocatorKey = &ctxapi.Key{Name: "stream.pipe_allocator", Inherit: false}
+
+func SetPipeAllocator(ctx context.Context, a PipeAllocator) error {
+	frame := ctxapi.FrameFromContext(ctx)
+	if frame == nil {
+		return ctxapi.ErrNoFrameContext
+	}
+	return frame.Set(pipeAllocatorKey, a)
+}
+func GetPipeAllocator(ctx context.Context) PipeAllocator {
+	frame := ctxapi.FrameFromContext(ctx)
+	if frame == nil {
+		return nil
+	}
+	v, ok := frame.Get(pipeAllocatorKey)
+	if !ok {
+		return nil
+	}
+	a, _ := v.(PipeAllocator)
+	return a
+}
+
+type PipeCmd struct {
+	Peer  string
+	Limit uint64
+}
+
+func (PipeCmd) CmdID() dispatcher.CommandID { return Pipe }
+
+type PipeResult struct {
+	Offer    string
+	StreamID uint64
+}

--- a/runtime/lua/modules/stream/module.go
+++ b/runtime/lua/modules/stream/module.go
@@ -21,10 +21,12 @@ func buildModule() (*lua.LTable, []luaapi.YieldType) {
 	registerStreamMetatable()
 	registerScannerMetatable()
 
-	mod := lua.CreateTable(0, 0)
+	mod := lua.CreateTable(0, 1)
+	mod.RawSetString("pipe", lua.LGoFunc(allocatePipe))
 	mod.Immutable = true
 
 	yields := []luaapi.YieldType{
+		{Sample: &pipeYield{}, CmdID: streamapi.Pipe},
 		{Sample: &ReadYield{}, CmdID: streamapi.Read},
 		{Sample: &WriteYield{}, CmdID: streamapi.Write},
 		{Sample: &SeekYield{}, CmdID: streamapi.Seek},

--- a/runtime/lua/modules/stream/pipe.go
+++ b/runtime/lua/modules/stream/pipe.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+package stream
+
+import (
+	"errors"
+	"math"
+	"unicode/utf8"
+
+	lua "github.com/wippyai/go-lua"
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	streamapi "github.com/wippyai/runtime/api/stream"
+	streamsys "github.com/wippyai/runtime/system/stream"
+)
+
+func allocatePipe(l *lua.LState) int {
+	peer := l.CheckString(1)
+	limit := float64(l.CheckNumber(2))
+	if len(peer) == 0 || len(peer) > 512 || !utf8.ValidString(peer) || math.IsNaN(limit) || limit < 1 || limit > 1<<40 || limit != math.Trunc(limit) {
+		l.Push(lua.LNil)
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "invalid pipe peer or byte limit").WithKind(lua.Invalid))
+		return 3
+	}
+	l.Push(&pipeYield{peer: peer, limit: uint64(limit)})
+	return -1
+}
+
+type pipeYield struct {
+	peer  string
+	limit uint64
+}
+
+func (*pipeYield) String() string              { return "<stream.pipe>" }
+func (*pipeYield) Type() lua.LValueType        { return lua.LTUserData }
+func (*pipeYield) CmdID() dispatcher.CommandID { return streamapi.Pipe }
+func (y *pipeYield) ToCommand() dispatcher.Command {
+	return streamapi.PipeCmd{Peer: y.peer, Limit: y.limit}
+}
+func (*pipeYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
+	fail := func(err error) []lua.LValue {
+		return []lua.LValue{lua.LNil, lua.LNil, lua.WrapErrorWithLua(l, err, "allocate pipe")}
+	}
+	if err != nil {
+		return fail(err)
+	}
+	r, ok := data.(streamapi.PipeResult)
+	if !ok {
+		return fail(errors.New("invalid pipe result"))
+	}
+	table := resource.GetTable(l.Context())
+	if table == nil {
+		return fail(streamapi.ErrNoTable)
+	}
+	if _, err := streamsys.Get(table, r.StreamID); err != nil {
+		return fail(err)
+	}
+	return []lua.LValue{NewStream(l, r.StreamID), lua.LString(r.Offer), lua.LNil}
+}

--- a/runtime/lua/modules/stream/pipe_integration_test.go
+++ b/runtime/lua/modules/stream/pipe_integration_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MPL-2.0
+package stream_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	lua "github.com/wippyai/go-lua"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	"github.com/wippyai/runtime/api/pid"
+	"github.com/wippyai/runtime/api/process"
+	runtimeapi "github.com/wippyai/runtime/api/runtime"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	streamapi "github.com/wippyai/runtime/api/stream"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+	streammod "github.com/wippyai/runtime/runtime/lua/modules/stream"
+	"github.com/wippyai/runtime/system/scheduler"
+	actor "github.com/wippyai/runtime/system/scheduler/actor"
+	streamsys "github.com/wippyai/runtime/system/stream"
+)
+
+type pipeFixture struct {
+	calls  atomic.Int32
+	closed atomic.Bool
+}
+type fixtureReader struct {
+	io.Reader
+	owner *pipeFixture
+}
+
+func (r *fixtureReader) Close() error { r.owner.closed.Store(true); return nil }
+func (f *pipeFixture) Allocate(ctx, lifetime context.Context, peer string, limit uint64) (io.ReadCloser, string, error) {
+	f.calls.Add(1)
+	p, ok := runtimeapi.GetFramePID(ctx)
+	if !ok || p.UniqID != "pipe-agent" || peer != "approved-peer" || limit != 64 || ctx.Err() != nil || lifetime.Err() != nil {
+		return nil, "", errors.New("fixture admission denied")
+	}
+	return &fixtureReader{Reader: strings.NewReader("pipe bytes"), owner: f}, "opaque-offer", nil
+}
+
+type pipeCompletion chan *runtimeapi.Result
+
+func (pipeCompletion) OnStart(context.Context, pid.PID, process.Process) error         { return nil }
+func (c pipeCompletion) OnComplete(_ context.Context, _ pid.PID, r *runtimeapi.Result) { c <- r }
+
+func TestLuaAllocatesCanonicalPipeThroughScheduler(t *testing.T) {
+	for _, mode := range []string{"allowed", "missing_allocator", "wrong_peer", "invalid_limit"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, frame := ctxapi.OpenFrameContext(ctxapi.NewRootContext())
+			defer frame.Close()
+			caller := pid.PID{Node: "local", Host: "lua", UniqID: "pipe-agent"}
+			if err := runtimeapi.SetFramePID(ctx, caller); err != nil {
+				t.Fatal(err)
+			}
+			store := resource.NewStore()
+			defer store.Close()
+			if err := resource.SetStore(ctx, store); err != nil {
+				t.Fatal(err)
+			}
+			fixture := &pipeFixture{}
+			if mode != "missing_allocator" {
+				if err := streamapi.SetPipeAllocator(ctx, fixture); err != nil {
+					t.Fatal(err)
+				}
+			}
+			dispatcher := streamsys.NewDispatcher()
+			if err := dispatcher.Start(ctx); err != nil {
+				t.Fatal(err)
+			}
+			defer dispatcher.Stop(context.Background())
+			registry := scheduler.NewRegistry()
+			dispatcher.RegisterAll(registry.Register)
+			registry.Freeze()
+			done := make(pipeCompletion, 1)
+			sched := actor.NewScheduler(registry, actor.WithWorkers(2), actor.WithLifecycle(done))
+			sched.Start()
+			defer func() {
+				stop, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				sched.Stop(stop)
+			}()
+			script := `local s,offer,e=stream.pipe("approved-peer",64); assert(s and offer=="opaque-offer" and not e); local text,e=s:read(64); assert(text=="pipe bytes" and not e); local text,e=s:read(64); assert(text==nil and e==nil); assert(s:close()); return "done"`
+			if mode != "allowed" {
+				peer := "approved-peer"
+				limit := "64"
+				if mode == "wrong_peer" {
+					peer = "other"
+				}
+				if mode == "invalid_limit" {
+					limit = "-1"
+				}
+				script = `local s,o,e=stream.pipe("` + peer + `",` + limit + `); assert(s==nil and o==nil and e~=nil); return "denied"`
+			}
+			proc, err := engine.NewProcess(engine.WithScript(script, "pipe.lua"), engine.WithModuleBinder(func(l *lua.LState) error { engine.LoadModuleDef(l, streammod.Module); return nil }))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := sched.Submit(ctx, caller, proc, "", nil); err != nil {
+				proc.Close()
+				t.Fatal(err)
+			}
+			select {
+			case result := <-done:
+				if result.Error != nil {
+					t.Fatal(result.Error)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("Lua pipe timed out")
+			}
+			expected := int32(1)
+			if mode == "missing_allocator" || mode == "invalid_limit" {
+				expected = 0
+			}
+			if fixture.calls.Load() != expected {
+				t.Fatalf("allocator calls=%d", fixture.calls.Load())
+			}
+			if mode == "allowed" && !fixture.closed.Load() {
+				t.Fatal("stream close did not close endpoint")
+			}
+		})
+	}
+}

--- a/runtime/lua/modules/stream/spec.md
+++ b/runtime/lua/modules/stream/spec.md
@@ -6,7 +6,28 @@ Stream read/write operations. IO, nondeterministic.
 
 ## Types
 
-Stream module does not export module-level functions. Stream objects are obtained from other modules (e.g., `http.request():stream()`, `fs.open()`).
+Stream objects are obtained from other modules (e.g., `http.request():stream()`,
+`fs.open()`) or from the host-configured pipe allocator below.
+
+### stream.pipe(peer, limit) → Stream?, offer?, error?
+
+Allocates a receive endpoint through an allocator installed by the host in the
+actual caller's frame. `peer` is a nonempty UTF-8 string of at most 512 bytes;
+`limit` is an integer total-byte budget from 1 through 2^40. The host can impose
+stricter limits, lifetime bounds and exact-peer permissions.
+
+Returns an ordinary Stream, a bounded UTF-8 offer string for the producer, and
+nil error. On failure both values are nil and a structured error is returned.
+An offer is routing metadata, not authorization to read or send producer data.
+No allocator is installed by default. The method yields through the existing
+Stream dispatcher; it does not create a second transport or image API.
+
+Native host composition supplies `api/stream.PipeAllocator` through a
+non-inherited FrameContext key before sealing the frame. The allocator receives
+an operation context and the caller lifetime separately, so completion of the
+allocation command does not cancel the returned endpoint. The endpoint belongs
+to the caller's existing Stream resource table and is closed on resource cleanup.
+The initial API exposes receive pipes; producer admission remains host-specific.
 
 ### Stream
 
@@ -54,7 +75,9 @@ Writes data to stream.
 
 **Returns:**
 - Success: `integer, nil` - number of bytes written
-- Error: `0, error` - structured error
+- Error: `integer, error` - bytes written before failure and a structured error.
+  A nonzero count does not prove remote consumption or file persistence. Do not
+  automatically replay a failed write.
 
 **Yields:** until write completes
 

--- a/runtime/lua/modules/stream/stream_test.go
+++ b/runtime/lua/modules/stream/stream_test.go
@@ -539,8 +539,8 @@ func TestModuleBuild(t *testing.T) {
 		t.Error("module table should be immutable")
 	}
 
-	if len(yields) != 8 {
-		t.Errorf("expected 8 yield types, got %d", len(yields))
+	if len(yields) != 9 {
+		t.Errorf("expected 9 yield types, got %d", len(yields))
 	}
 }
 
@@ -730,5 +730,16 @@ func TestScannerSplitWords(t *testing.T) {
 		if w != expected[i] {
 			t.Errorf("word[%d]: expected '%s', got '%s'", i, expected[i], w)
 		}
+	}
+}
+
+func TestWriteYieldPreservesPartialErrorCount(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	y := AcquireWriteYield(1, []byte("payload"))
+	defer ReleaseWriteYield(y)
+	result := y.HandleResult(l, int64(3), errors.New("connection ended after partial write"))
+	if len(result) != 2 || result[0] != lua.LNumber(3) || result[1] == lua.LNil {
+		t.Fatalf("partial result lost: %v", result)
 	}
 }

--- a/runtime/lua/modules/stream/types.go
+++ b/runtime/lua/modules/stream/types.go
@@ -32,7 +32,7 @@ func ModuleTypes() *io.Manifest {
 	m.DefineType("Stream", StreamType)
 	m.DefineType("Scanner", scannerType)
 
-	moduleType := typ.NewInterface("stream", []typ.Method{})
+	moduleType := typ.NewInterface("stream", []typ.Method{{Name: "pipe", Type: typ.Func().Param("peer", typ.String).Param("limit", typ.Integer).Returns(typ.NewOptional(StreamType), typ.NewOptional(typ.String), typ.NewOptional(typ.LuaError)).Build()}})
 
 	m.SetExport(moduleType)
 	return m

--- a/runtime/lua/modules/stream/yields.go
+++ b/runtime/lua/modules/stream/yields.go
@@ -157,10 +157,11 @@ func (y *WriteYield) Release() { ReleaseWriteYield(y) }
 
 func (y *WriteYield) HandleResult(l *lua.LState, data any, err error) []lua.LValue {
 	if err != nil {
+		n, _ := data.(int64)
 		luaErr := lua.WrapErrorWithLua(l, err, "stream write").
 			WithKind(lua.Internal).
 			WithRetryable(false)
-		return []lua.LValue{lua.LNumber(0), luaErr}
+		return []lua.LValue{lua.LNumber(n), luaErr}
 	}
 	if n, ok := data.(int64); ok {
 		return []lua.LValue{lua.LNumber(n), lua.LNil}

--- a/system/stream/context_io_test.go
+++ b/system/stream/context_io_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MPL-2.0
+package stream
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/dispatcher"
+	"github.com/wippyai/runtime/api/runtime/resource"
+	streamapi "github.com/wippyai/runtime/api/stream"
+)
+
+type interruptibleStream struct {
+	entered chan struct{}
+	calls   atomic.Int32
+}
+
+func (*interruptibleStream) Read([]byte) (int, error) { return 0, errors.New("non-context read used") }
+func (*interruptibleStream) Write([]byte) (int, error) {
+	return 0, errors.New("non-context write used")
+}
+func (*interruptibleStream) Close() error { return nil }
+func (s *interruptibleStream) ReadContext(ctx context.Context, _ []byte) (int, error) {
+	s.calls.Add(1)
+	close(s.entered)
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+func (s *interruptibleStream) WriteContext(ctx context.Context, _ []byte) (int, error) {
+	s.calls.Add(1)
+	close(s.entered)
+	<-ctx.Done()
+	return 1, ctx.Err()
+}
+
+func TestDispatcherInterruptsContextIO(t *testing.T) {
+	for _, op := range []string{"read", "write"} {
+		for _, end := range []string{"caller", "shutdown"} {
+			t.Run(op+"/"+end, func(t *testing.T) {
+				ctx, store := setupTestContext()
+				defer store.Close()
+				callCtx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				d := NewDispatcher(WithWorkers(1))
+				if err := d.Start(ctx); err != nil {
+					t.Fatal(err)
+				}
+				stopped := false
+				defer func() {
+					cancel()
+					if !stopped {
+						d.Stop(context.Background())
+					}
+				}()
+				s := &interruptibleStream{entered: make(chan struct{})}
+				id := Insert(resource.GetTable(ctx), s)
+				var cmd dispatcher.Command = streamapi.ReadCmd{StreamID: id, Size: 8}
+				if op == "write" {
+					cmd = streamapi.WriteCmd{StreamID: id, Data: []byte("payload")}
+				}
+				recv := newSyncReceiver()
+				d.submit(callCtx, cmd, 1, recv)
+				select {
+				case <-s.entered:
+				case <-time.After(time.Second):
+					t.Fatal("context IO did not start")
+				}
+				if end == "caller" {
+					cancel()
+				} else {
+					done := make(chan struct{})
+					go func() { d.Stop(context.Background()); close(done) }()
+					select {
+					case <-done:
+						stopped = true
+					case <-time.After(time.Second):
+						t.Fatal("shutdown did not interrupt IO")
+					}
+				}
+				recv.wait(t)
+				if !errors.Is(recv.err, context.Canceled) {
+					t.Fatalf("operation error: %v", recv.err)
+				}
+				if op == "write" && recv.data != int64(1) {
+					t.Fatalf("partial count lost: %v", recv.data)
+				}
+				if s.calls.Load() != 1 {
+					t.Fatalf("operation retried: %d calls", s.calls.Load())
+				}
+			})
+		}
+	}
+}
+
+func TestWriteContextPreservesPartialCount(t *testing.T) {
+	table := resource.NewTable()
+	defer table.Close()
+	s := &interruptibleStream{entered: make(chan struct{})}
+	id := Insert(table, s)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { <-s.entered; cancel() }()
+	n, err := WriteContext(ctx, table, id, []byte("payload"))
+	if n != 1 || !errors.Is(err, context.Canceled) {
+		t.Fatalf("partial result: n=%d err=%v", n, err)
+	}
+	if s.calls.Load() != 1 {
+		t.Fatal("partial write retried")
+	}
+}

--- a/system/stream/dispatch_backpressure_test.go
+++ b/system/stream/dispatch_backpressure_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MPL-2.0
+package stream
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wippyai/runtime/api/runtime/resource"
+	streamapi "github.com/wippyai/runtime/api/stream"
+)
+
+type gatedReader struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *gatedReader) Read([]byte) (int, error) {
+	r.once.Do(func() { close(r.entered) })
+	<-r.release
+	return 0, io.EOF
+}
+func (*gatedReader) Close() error { return nil }
+
+func TestDispatcherSaturationDoesNotExecuteOnCaller(t *testing.T) {
+	ctx, store := setupTestContext()
+	defer store.Close()
+	d := NewDispatcher(WithWorkers(1))
+	if err := d.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	r := &gatedReader{entered: make(chan struct{}), release: make(chan struct{})}
+	defer func() { close(r.release); d.Stop(context.Background()) }()
+	id := Insert(resource.GetTable(ctx), r)
+	first := newSyncReceiver()
+	d.submit(ctx, streamapi.ReadCmd{StreamID: id}, 1, first)
+	select {
+	case <-r.entered:
+	case <-time.After(time.Second):
+		t.Fatal("read not running")
+	}
+	for i := 0; i < 2; i++ {
+		d.submit(ctx, streamapi.StatCmd{StreamID: id}, uint64(i+2), newSyncReceiver())
+	}
+	rejected := newSyncReceiver()
+	returned := make(chan struct{})
+	go func() { d.submit(ctx, streamapi.ReadCmd{StreamID: id}, 4, rejected); close(returned) }()
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("saturated dispatcher blocked caller on IO")
+	}
+	rejected.wait(t)
+	if !errors.Is(rejected.err, streamapi.ErrBusy) {
+		t.Fatalf("rejection = %v", rejected.err)
+	}
+}
+
+func TestDispatcherRejectsUnavailableAndCancelled(t *testing.T) {
+	d := NewDispatcher()
+	recv := newSyncReceiver()
+	d.submit(context.Background(), streamapi.ReadCmd{}, 1, recv)
+	recv.wait(t)
+	if !errors.Is(recv.err, streamapi.ErrUnavailable) {
+		t.Fatalf("unstarted dispatcher: %v", recv.err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recv = newSyncReceiver()
+	d.submit(ctx, streamapi.ReadCmd{}, 2, recv)
+	recv.wait(t)
+	if !errors.Is(recv.err, context.Canceled) {
+		t.Fatalf("cancelled command: %v", recv.err)
+	}
+}

--- a/system/stream/dispatcher.go
+++ b/system/stream/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"sync"
 	"sync/atomic"
+	"unicode/utf8"
 
 	"github.com/wippyai/runtime/api/dispatcher"
 	"github.com/wippyai/runtime/api/runtime/resource"
@@ -165,6 +166,15 @@ func Read(table *resource.Table, id uint64, size int64) ([]byte, error) {
 // The caller MUST call buf.Release() when done with the data.
 // Returns nil buffer on EOF with no data.
 func ReadBuffered(table *resource.Table, id uint64, size int64) (*streamapi.Buffer, error) {
+	return ReadBufferedContext(context.Background(), table, id, size)
+}
+
+// ReadBufferedContext supplies cancellation to streams implementing ContextReader.
+// Ordinary io.Reader implementations retain their existing blocking behavior.
+func ReadBufferedContext(ctx context.Context, table *resource.Table, id uint64, size int64) (*streamapi.Buffer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	entry, err := Get(table, id)
 	if err != nil {
 		return nil, err
@@ -183,7 +193,12 @@ func ReadBuffered(table *resource.Table, id uint64, size int64) (*streamapi.Buff
 	if readSize > int64(len(buf.Data)) {
 		readSize = int64(len(buf.Data))
 	}
-	n, err := entry.reader.Read(buf.Data[:readSize])
+	var n int
+	if reader, ok := entry.reader.(streamapi.ContextReader); ok {
+		n, err = reader.ReadContext(ctx, buf.Data[:readSize])
+	} else {
+		n, err = entry.reader.Read(buf.Data[:readSize])
+	}
 	buf.N = n
 
 	if errors.Is(err, io.EOF) {
@@ -204,6 +219,15 @@ func ReadBuffered(table *resource.Table, id uint64, size int64) (*streamapi.Buff
 
 // Write writes data to stream with given ID.
 func Write(table *resource.Table, id uint64, data []byte) (int, error) {
+	return WriteContext(context.Background(), table, id, data)
+}
+
+// WriteContext supplies cancellation to streams implementing ContextWriter.
+// It never retries a write, including after partial delivery or cancellation.
+func WriteContext(ctx context.Context, table *resource.Table, id uint64, data []byte) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	entry, err := Get(table, id)
 	if err != nil {
 		return 0, err
@@ -212,6 +236,9 @@ func Write(table *resource.Table, id uint64, data []byte) (int, error) {
 		return 0, streamapi.ErrNotWritable
 	}
 
+	if writer, ok := entry.writer.(streamapi.ContextWriter); ok {
+		return writer.WriteContext(ctx, data)
+	}
 	return entry.writer.Write(data)
 }
 
@@ -431,29 +458,78 @@ func (d *Dispatcher) worker() {
 
 func (d *Dispatcher) submit(ctx context.Context, cmd dispatcher.Command, tag uint64, receiver dispatcher.ResultReceiver) {
 	j := job{ctx: ctx, cmd: cmd, tag: tag, receiver: receiver}
+	if err := ctx.Err(); err != nil {
+		receiver.CompleteYield(tag, nil, err)
+		return
+	}
 	if d.jobs == nil {
-		d.execute(j)
+		receiver.CompleteYield(tag, nil, streamapi.ErrUnavailable)
 		return
 	}
 
 	select {
 	case d.jobs <- j:
 	case <-d.ctx.Done():
+		receiver.CompleteYield(tag, nil, d.ctx.Err())
 	default:
-		d.execute(j)
+		receiver.CompleteYield(tag, nil, streamapi.ErrBusy)
 	}
 }
 
 func (d *Dispatcher) execute(j job) {
+	if err := j.ctx.Err(); err != nil {
+		j.receiver.CompleteYield(j.tag, nil, err)
+		return
+	}
+	if err := d.ctx.Err(); err != nil {
+		j.receiver.CompleteYield(j.tag, nil, err)
+		return
+	}
 	table := resource.GetTable(j.ctx)
 	if table == nil {
 		j.receiver.CompleteYield(j.tag, nil, streamapi.ErrNoTable)
 		return
 	}
+	ioCtx, cancel := context.WithCancel(j.ctx)
+	stop := context.AfterFunc(d.ctx, cancel)
+	defer func() { stop(); cancel() }()
 
 	switch c := j.cmd.(type) {
+	case streamapi.PipeCmd:
+		allocator := streamapi.GetPipeAllocator(j.ctx)
+		if allocator == nil {
+			j.receiver.CompleteYield(j.tag, nil, streamapi.ErrUnavailable)
+			return
+		}
+		if len(c.Peer) == 0 || len(c.Peer) > 512 || !utf8.ValidString(c.Peer) || c.Limit == 0 || c.Limit > 1<<40 {
+			j.receiver.CompleteYield(j.tag, nil, errors.New("invalid pipe request"))
+			return
+		}
+		endpoint, offer, err := allocator.Allocate(ioCtx, j.ctx, c.Peer, c.Limit)
+		if err != nil {
+			if endpoint != nil {
+				endpoint.Close()
+			}
+			j.receiver.CompleteYield(j.tag, nil, err)
+			return
+		}
+		if endpoint == nil || len(offer) == 0 || len(offer) > 16*1024 || !utf8.ValidString(offer) || ioCtx.Err() != nil {
+			if endpoint != nil {
+				endpoint.Close()
+			}
+			j.receiver.CompleteYield(j.tag, nil, errors.New("invalid or retired pipe allocation"))
+			return
+		}
+		handle := Insert(table, endpoint)
+		if handle == 0 {
+			endpoint.Close()
+			j.receiver.CompleteYield(j.tag, nil, streamapi.ErrClosed)
+			return
+		}
+		j.receiver.CompleteYield(j.tag, streamapi.PipeResult{StreamID: handle, Offer: offer}, nil)
+
 	case streamapi.ReadCmd:
-		buf, err := ReadBuffered(table, c.StreamID, c.Size)
+		buf, err := ReadBufferedContext(ioCtx, table, c.StreamID, c.Size)
 		if errors.Is(err, io.EOF) {
 			j.receiver.CompleteYield(j.tag, nil, nil)
 			return
@@ -465,9 +541,9 @@ func (d *Dispatcher) execute(j job) {
 		j.receiver.CompleteYield(j.tag, buf, nil)
 
 	case streamapi.WriteCmd:
-		n, err := Write(table, c.StreamID, c.Data)
+		n, err := WriteContext(ioCtx, table, c.StreamID, c.Data)
 		if err != nil {
-			j.receiver.CompleteYield(j.tag, nil, err)
+			j.receiver.CompleteYield(j.tag, int64(n), err)
 			return
 		}
 		j.receiver.CompleteYield(j.tag, int64(n), nil)
@@ -537,6 +613,7 @@ func (d *Dispatcher) handle(ctx context.Context, cmd dispatcher.Command, tag uin
 // RegisterAll registers all stream handlers.
 func (d *Dispatcher) RegisterAll(register func(id dispatcher.CommandID, h dispatcher.Handler)) {
 	h := dispatcher.HandlerFunc(d.handle)
+	register(streamapi.Pipe, h)
 	register(streamapi.Read, h)
 	register(streamapi.Write, h)
 	register(streamapi.Close, h)

--- a/system/stream/dispatcher_test.go
+++ b/system/stream/dispatcher_test.go
@@ -316,8 +316,8 @@ func TestDispatcher_RegisterAll(t *testing.T) {
 	d.RegisterAll(func(_ dispatcher.CommandID, _ dispatcher.Handler) {
 		count++
 	})
-	if count != 8 {
-		t.Errorf("expected 8 handlers registered, got %d", count)
+	if count != 9 {
+		t.Errorf("expected 9 handlers registered, got %d", count)
 	}
 }
 


### PR DESCRIPTION
Lua actors currently cannot ask a host to allocate a transport-backed Stream, so native mesh endpoints either need a parallel API or have to expose host routing and authorization details to Lua. This adds `stream.pipe(peer, limit)`: the host receives the real caller context through a non-inherited `PipeAllocator`, authorizes and creates the endpoint, and Lua receives an ordinary Stream plus opaque offer metadata.

The Stream dispatcher now rejects unavailable or saturated admission instead of running blocking I/O on the submitting scheduler. Optional context-aware readers and writers receive caller and dispatcher-shutdown cancellation, while partial write counts remain visible when a write fails. Pipe endpoints use the caller's existing resource table and close through its normal lifecycle.

The offer and peer arguments are routing inputs, not authorization. Native hosts remain responsible for binding the requested peer to authenticated connection provenance, enforcing byte and lifetime limits, and authorizing the producer independently.

Validation:

- `GOWORK=off GOCACHE=/tmp/canonical-stream-go-cache go test -race ./api/stream ./system/stream ./runtime/lua/modules/stream`
- `GOWORK=off GOCACHE=/tmp/canonical-stream-vet-cache go vet ./api/stream ./system/stream ./runtime/lua/modules/stream`
- `GOWORK=off GOCACHE=/tmp/canonical-stream-lint-cache make lint`
- Bee staging exercised the allocator with authenticated local mesh transfers and a live Windows-to-Linux PNG transfer; that native integration is outside this runtime PR.
