### PR TITLE
fix(lua): preserve native channel select value types

### DIFF
--- a/runtime/lua/engine/channel_types.go
+++ b/runtime/lua/engine/channel_types.go
@@ -63,6 +63,14 @@ var channelType = typ.NewInterface("channel.Channel", []typ.Method{
 
 var channelGeneric = typ.NewGeneric("channel.Channel", []*typ.TypeParam{channelElem}, channelType)
 
+// ChannelSelectCaseType returns the canonical SelectCase<C, T> type used by
+// channel.select. Native channel wrappers use this helper so their
+// case_receive methods participate in the same select result inference as
+// channels created by channel.new.
+func ChannelSelectCaseType(channel, value typ.Type) typ.Type {
+	return typ.Instantiate(selectCaseGeneric, channel, value)
+}
+
 // SelectResult type returned by channel.select
 var selectResultType = typ.NewRecord().
 	Field("channel", typ.Any).

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -155,7 +155,9 @@ local child = assert(executor:exec("bash", {
 local session = assert(child:attach_terminal())
 ```
 
-The session exposes `send(event)`, `done()`, `status()`, and `close()`.
+The session exposes `send(event)`, `done()`, `status()`, and `close()`. The
+completion channel's `receive()` and `case_receive()` values are booleans, so a
+`channel.select` result from `done():case_receive()` carries a boolean value.
 Resize, keyboard, mouse, focus, and paste events use the canonical `tty`
 event records.
 

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -5,6 +5,7 @@ package exec
 import (
 	"github.com/wippyai/go-lua/types/io"
 	"github.com/wippyai/go-lua/types/typ"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 	luatty "github.com/wippyai/runtime/runtime/lua/modules/tty"
 )
 
@@ -30,7 +31,7 @@ func init() {
 		{Name: "receive", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.Boolean, typ.Boolean).Build()},
 		{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).
-			Returns(typ.Any).Build()},
+			Returns(engine.ChannelSelectCaseType(typ.Self, typ.Boolean)).Build()},
 	})
 	terminalSessionType = typ.NewInterface("exec.TerminalSession", []typ.Method{
 		{Name: "send", Type: typ.Func().Param("self", typ.Self).

--- a/runtime/lua/modules/exec/types_test.go
+++ b/runtime/lua/modules/exec/types_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	luaapi "github.com/wippyai/runtime/api/runtime/lua"
+	"github.com/wippyai/runtime/runtime/lua/code"
+	"github.com/wippyai/runtime/runtime/lua/engine"
+)
+
+func TestTerminalCompletionPreservesSelectValueType(t *testing.T) {
+	config := code.DefaultTypeCheckConfig()
+	config.Enabled = true
+	config.SkipUntyped = false
+	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{engine.ChannelModule, Module})
+	_, diagnostics, err := checker.Check(`
+local channel = require("channel")
+local exec = require("exec")
+
+local function completion_value(session: exec.TerminalSession): boolean
+    local done = session:done()
+    local selected = channel.select({done:case_receive()})
+    if selected.channel == done then
+        local completed: boolean = selected.value
+        return completed
+    end
+    return false
+end
+
+return completion_value
+`, "terminal_completion_select_types.lua", nil)
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "terminal completion select type was lost: %v", diagnostics)
+}

--- a/runtime/lua/modules/tty/spec.md
+++ b/runtime/lua/modules/tty/spec.md
@@ -222,7 +222,9 @@ See the [agent workflow guide](../../../../tests/tty-mesh/LUA_GUIDE.md) for
 node/host identity, controller discovery, simulated input, and restart handling.
 `tty.MountRights` names the grant options; `tty.InputEvent` describes synthetic
 input (modifier flags default to false), while `tty.TTYEvent` describes received
-events. Input channels support both `receive()` and `case_receive()`.
+events. Input channels support both `receive()` and `case_receive()`; a
+`channel.select` result from `case_receive()` carries the corresponding event
+type. Viewport update channels likewise carry an integer revision in select.
 
 A viewport owner can delegate independent observation, input, and resize rights
 using a mount reference. The reference is bound to an exact process PID,

--- a/runtime/lua/modules/tty/types.go
+++ b/runtime/lua/modules/tty/types.go
@@ -5,6 +5,7 @@ package tty
 import (
 	typio "github.com/wippyai/go-lua/types/io"
 	"github.com/wippyai/go-lua/types/typ"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 )
 
 // Style interface returned by tty.style()
@@ -157,13 +158,15 @@ func EventType() typ.Type { return ttyEventType }
 // Channel type for tty.events()
 var eventChannelType = typ.NewInterface("tty.EventChannel", []typ.Method{
 	{Name: "receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.NewOptional(ttyEventType), typ.Boolean).Build()},
-	{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
+	{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).
+		Returns(engine.ChannelSelectCaseType(typ.Self, ttyEventType)).Build()},
 	{Name: "close", Type: typ.Func().Param("self", typ.Self).Build()},
 })
 
 var viewportUpdateChannelType = typ.NewInterface("tty.ViewportUpdateChannel", []typ.Method{
 	{Name: "receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.Integer, typ.Boolean).Build()},
-	{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).Returns(typ.Any).Build()},
+	{Name: "case_receive", Type: typ.Func().Param("self", typ.Self).
+		Returns(engine.ChannelSelectCaseType(typ.Self, typ.Integer)).Build()},
 })
 
 var surfaceOptionsType = typ.NewRecord().

--- a/runtime/lua/modules/tty/types_test.go
+++ b/runtime/lua/modules/tty/types_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	luaapi "github.com/wippyai/runtime/api/runtime/lua"
 	"github.com/wippyai/runtime/runtime/lua/code"
+	"github.com/wippyai/runtime/runtime/lua/engine"
 )
 
 func TestAgentSurfaceSDKTypes(t *testing.T) {
@@ -52,4 +53,32 @@ func TestAgentSurfaceSDKRejectsInvalidInput(t *testing.T) {
  `, "invalid_surface_input.lua", nil)
 	require.NoError(t, err)
 	require.True(t, code.HasErrors(diagnostics), "invalid input must be rejected by SDK types")
+}
+
+func TestNativeChannelsPreserveSelectValueTypes(t *testing.T) {
+	config := code.DefaultTypeCheckConfig()
+	config.Enabled = true
+	config.SkipUntyped = false
+	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{engine.ChannelModule, Module})
+	_, diagnostics, err := checker.Check(`
+local channel = require("channel")
+local tty = require("tty")
+
+local events = tty.events()
+local view = tty.viewport()
+local updates = view:updates()
+local selected = channel.select({
+    events:case_receive(),
+    updates:case_receive(),
+})
+
+if selected.channel == events then
+    local event: tty.TTYEvent = selected.value
+    local event_type: string = event.type
+else
+    local revision: integer = selected.value
+end
+`, "native_channel_select_types.lua", nil)
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "native select types lost their value contract: %v", diagnostics)
 }


### PR DESCRIPTION
Native TTY event, viewport update and terminal completion channels declared `case_receive()` as `any`, so `channel.select` lost their value types. Bee's console consequently could not pass a selected event back to the typed terminal input API under strict checking.

Use the engine's canonical `SelectCase<Self, T>` instantiation for these wrappers. Event delivery, channel behavior and runtime authorization are unchanged. Add regressions using the actual module declarations for event/update correlation and terminal completion values.

Validation: reverting only the channel declarations makes both new regressions fail; focused race tests and scoped lint pass. A combined candidate with the separate assertion-return compiler fix passes the preserved 430-entry Bee fixture. The full engine/TTY/exec race suite passes on this main base. The combined Bee candidate also passes all 481 Wippy tests.

