### PR TITLE
build(deps): bump go-lua to v1.5.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/tree-sitter/tree-sitter-php v0.24.2
 	github.com/tree-sitter/tree-sitter-python v0.25.0
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
-	github.com/wippyai/go-lua v1.5.20
+	github.com/wippyai/go-lua v1.5.21
 	github.com/wippyai/module-registry-proto-go v0.0.2-0.20260908140534-f6e2910c835f
 	github.com/wippyai/tree-sitter-markdown v0.0.3
 	github.com/wippyai/tree-sitter-sql v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -542,8 +542,8 @@ github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-github.com/wippyai/go-lua v1.5.20 h1:6QFSZisNjzE9Kup/Q2OArkIXIb2Sj//0tPZPM70/Fjs=
-github.com/wippyai/go-lua v1.5.20/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
+github.com/wippyai/go-lua v1.5.21 h1:7KybKJYQh8mCST4nD404EBmsY8bUeEcanpuXBzB+PZo=
+github.com/wippyai/go-lua v1.5.21/go.mod h1:cwD+390gJgx9cs+Zamby/lch5csqPV9RN1aDEfx/27M=
 github.com/wippyai/module-registry-proto-go v0.0.2-0.20260908140534-f6e2910c835f h1:AoKS058roqnsHXaJ8Gww7ODz14qJqOK5QBeoALvcq6I=
 github.com/wippyai/module-registry-proto-go v0.0.2-0.20260908140534-f6e2910c835f/go.mod h1:p4ihYQKRQuqRVLxaH1YL0IEnkz4zKdyfVADOwvA5Tno=
 github.com/wippyai/tree-sitter-markdown v0.0.3 h1:u6e53+hzPSS848Xhm+I48SwtvWQHrC21wDrogdwCwuc=


### PR DESCRIPTION
## Summary

- update `github.com/wippyai/go-lua` from `v1.5.20` to `v1.5.21`
- consume generic metatype overload inference and assert-return narrowing fixes
- keep the dependency update limited to `go.mod` and `go.sum`

## Verification

- release tag resolves to go-lua merge commit `0525373712e159c6268790ad8864d8638789c020`
- `proxy.golang.org` resolves `v1.5.21` to that same commit
- `sum.golang.org` checksum matches `go.sum`
- `go mod tidy`
- `go test ./...`
- `go vet ./...`

The full test suite was run against the published module artifact without a local replacement.