### PR TITLE
feat(app): select embedded baseline through executable options

### DIFF
--- a/cmd/app/baseline.go
+++ b/cmd/app/baseline.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// embeddedDeployment returns the immutable, digest-scoped deployment for a
+// bundled application. Ordinary embedded startup and explicit base recovery
+// share these files, but Run gives them different registry history paths.
+func embeddedDeployment(state string, bundle Bundle) string {
+	return filepath.Join(state, "base", bundleID(bundle))
+}
+
+// selectLaunchDeployment applies the host-selected deployment policy. Embedded
+// startup intentionally does not inspect active.json: that record belongs to
+// the separately updateable deployment. The returned history path stays in the
+// state directory except for explicit base recovery.
+func selectLaunchDeployment(state string, bundle Bundle, embedded, base bool, mode string) (string, string, error) {
+	if base {
+		if mode != "base" {
+			return "", "", fmt.Errorf("bootstrap applications do not expose a base deployment")
+		}
+		deployment := embeddedDeployment(state, bundle)
+		return deployment, filepath.Join(deployment, "registry.db"), nil
+	}
+	history := filepath.Join(state, "registry.db")
+	if embedded {
+		return embeddedDeployment(state, bundle), history, nil
+	}
+	deployment, err := selectedDeployment(state)
+	if err != nil {
+		return "", "", err
+	}
+	return deployment, history, nil
+}

--- a/cmd/app/baseline_test.go
+++ b/cmd/app/baseline_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/wapp"
+)
+
+func testBundleVersion(t *testing.T, version string) Bundle {
+	t.Helper()
+	var data bytes.Buffer
+	err := wapp.NewWriter().PackEntries(wapp.Metadata{"namespace": "acme.app", "name": "app", "version": version}, nil, &data)
+	require.NoError(t, err)
+	digest := sha256.Sum256(data.Bytes())
+	return Bundle{Root: "acme/app", Packs: []Pack{{Module: "acme/app", Version: version, Digest: fmt.Sprintf("sha256:%x", digest), Data: data.Bytes()}}}
+}
+
+func TestSelectLaunchDeploymentKeepsEmbeddedBaselineHistoryInState(t *testing.T) {
+	state := t.TempDir()
+	bundle := testBundleVersion(t, "1.0.0")
+	ordinary, history, err := selectLaunchDeployment(state, bundle, false, false, "base")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(state, "deployment"), ordinary)
+	require.Equal(t, filepath.Join(state, "registry.db"), history)
+
+	embedded, history, err := selectLaunchDeployment(state, bundle, true, false, "base")
+	require.NoError(t, err)
+	require.Equal(t, embeddedDeployment(state, bundle), embedded)
+	require.Equal(t, filepath.Join(state, "registry.db"), history)
+
+	recovery, history, err := selectLaunchDeployment(state, bundle, false, true, "base")
+	require.NoError(t, err)
+	require.Equal(t, embedded, recovery)
+	require.Equal(t, filepath.Join(recovery, "registry.db"), history)
+}
+
+func TestEmbeddedBaselineVersionChangeUsesNewDigestAndSharedHistory(t *testing.T) {
+	state := t.TempDir()
+	first := testBundleVersion(t, "1.0.0")
+	second := testBundleVersion(t, "2.0.0")
+	oldDeployment := filepath.Join(state, "deployment")
+	_, err := first.Seed(oldDeployment)
+	require.NoError(t, err)
+	before, err := os.ReadFile(filepath.Join(oldDeployment, "wippy.lock"))
+	require.NoError(t, err)
+
+	deployment, history, err := selectLaunchDeployment(state, second, true, false, "base")
+	require.NoError(t, err)
+	require.NotEqual(t, oldDeployment, deployment)
+	require.Equal(t, filepath.Join(state, "registry.db"), history)
+	_, err = second.Seed(deployment)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(deployment, "wippy.lock"))
+	require.FileExists(t, filepath.Join(oldDeployment, "wippy.lock"))
+	after, err := os.ReadFile(filepath.Join(oldDeployment, "wippy.lock"))
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	selected, err := selectedDeployment(state)
+	require.NoError(t, err)
+	require.Equal(t, oldDeployment, selected)
+}
+
+func TestEmbeddedBaselineFailureLeavesPriorDeploymentRecoverable(t *testing.T) {
+	state := t.TempDir()
+	first := testBundleVersion(t, "1.0.0")
+	oldDeployment := filepath.Join(state, "deployment")
+	oldLock, err := first.Seed(oldDeployment)
+	require.NoError(t, err)
+	before, err := os.ReadFile(oldLock)
+	require.NoError(t, err)
+
+	second := testBundleVersion(t, "2.0.0")
+	second.Packs[0].Digest = "sha256:invalid"
+	deployment, history, err := selectLaunchDeployment(state, second, true, false, "base")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(state, "registry.db"), history)
+	_, err = second.Seed(deployment)
+	require.Error(t, err)
+	after, err := os.ReadFile(oldLock)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	require.NoDirExists(t, deployment)
+	selected, err := selectedDeployment(state)
+	require.NoError(t, err)
+	require.Equal(t, oldDeployment, selected)
+}
+
+func TestEmbeddedBaselineSelectionIgnoresStaleActivation(t *testing.T) {
+	state := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(state, "active.json"), []byte("invalid"), 0o600))
+	deployment, history, err := selectLaunchDeployment(state, testBundleVersion(t, "1.0.0"), true, false, "base")
+	require.NoError(t, err)
+	require.NotEmpty(t, deployment)
+	require.Equal(t, filepath.Join(state, "registry.db"), history)
+}
+
+func TestBaseSelectionRejectsBootstrapMode(t *testing.T) {
+	_, _, err := selectLaunchDeployment(t.TempDir(), testBundleVersion(t, "1.0.0"), false, true, "bootstrap")
+	require.ErrorContains(t, err, "bootstrap applications do not expose a base deployment")
+}

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -20,7 +20,10 @@ import (
 // DataEnv maps application-owned environment variables to paths within StateDir.
 // Existing environment values remain explicit user overrides.
 type Options struct {
-	Launch     Launch
+	Launch Launch
+	// Baseline selects ordinary startup code: "activated" (also the default)
+	// or "embedded". Both retain the selected state's registry history.
+	Baseline   string
 	DataEnv    map[string]string
 	Components []boot.Component
 	Name       string
@@ -50,6 +53,9 @@ func Run(ctx context.Context, options Options, args []string) error {
 	}
 	if options.Command == "" {
 		return fmt.Errorf("application command is required")
+	}
+	if options.Baseline != "" && options.Baseline != "activated" && options.Baseline != "embedded" {
+		return fmt.Errorf("application baseline must be activated or embedded")
 	}
 	flags := flag.NewFlagSet(options.Name, flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
@@ -137,19 +143,10 @@ func runApplication(ctx context.Context, options Options, stateDir string, base 
 	if err := configureDataEnvironment(stateDir, options.DataEnv); err != nil {
 		return err
 	}
-	deployment, err := selectedDeployment(stateDir)
+	ordinary := len(remaining) == 0 || (remaining[0] != "runtime" && remaining[0] != "update")
+	deployment, historyPath, err := selectLaunchDeployment(stateDir, options.Bundle, ordinary && options.Baseline == "embedded", base, options.Mode)
 	if err != nil {
 		return err
-	}
-	historyPath := filepath.Join(stateDir, "registry.db")
-	if base {
-		if options.Mode != "base" {
-			return fmt.Errorf("bootstrap applications do not expose a base deployment")
-		}
-		// Each executable's embedded content selects an independent baseline.
-		// Application databases are intentionally not rolled back or removed.
-		deployment = filepath.Join(stateDir, "base", bundleID(options.Bundle))
-		historyPath = filepath.Join(deployment, "registry.db")
 	}
 	lockPath, err := options.Bundle.Seed(deployment)
 	if err != nil {


### PR DESCRIPTION
## Purpose

Let Builder-produced applications explicitly choose whether ordinary startup follows the activated deployment or the executable's embedded bundle, without changing ordinary Wippy runtime semantics.

## Design

- `cmd/app.Options.Baseline` selects `activated` (also the empty/default value) or `embedded`; invalid values fail before launch.
- Embedded ordinary startup uses the digest-qualified bundle and retains the selected state's registry history.
- Explicit base recovery retains separate registry history. Update and runtime tooling continue selecting the activated deployment and bypass the application launch callback.
- The policy is executable configuration, independent of #703's launch callback. No `LaunchPlan` flag, core API package, README or public locking package is added.
- Stacked on the revised #703. All changes are under `cmd/app`.

## Validation

- Ten race runs of `./cmd/app` pass.
- Tests cover digest changes, unchanged activated deployment, shared ordinary history paths, isolated recovery history, stale activation, and non-destructive seed failures.
- Builder-generated old/new binary upgrade and authored-history/replacement acceptance remain required before merge; path-selection tests alone do not establish those guarantees.

This work is separate from the focused v0.3.41a release candidate.
