### PR TITLE
fix: close release-validation lifecycle and diagnostic gaps

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -1641,7 +1641,10 @@ func (h *DependencyHandler) refreshReplacementModuleIdentities(modules []Resolve
 		}
 		digest, size, err := digestReplacementTree(replacement)
 		if err != nil {
-			return NewDependencyIntegrityError(modKey(*mod), err, mod.Digest, mod.SizeBytes)
+			return apierror.New(apierror.Invalid, fmt.Sprintf("load local replacement %s from %q", modKey(*mod), replacement)).
+				WithDetails(attrs.NewBagFrom(map[string]any{"module": modKey(*mod), "path": replacement})).
+				WithCause(err).
+				WithRetryable(apierror.False)
 		}
 		mod.Digest = digest
 		mod.Source = moduleSourceReplacementTreeV1

--- a/boot/deps/hub/replacement_diagnostic_test.go
+++ b/boot/deps/hub/replacement_diagnostic_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierror "github.com/wippyai/runtime/api/error"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+func TestMissingReplacementDiagnosticIdentifiesLocalModuleAndPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing")
+	h := &DependencyHandler{replacements: map[string]lock.Replacement{
+		"example/local": {From: "example/local", To: path},
+	}}
+	err := h.refreshReplacementModuleIdentities([]ResolvedModule{{Org: "example", Name: "local", Version: "1.0.0"}})
+	require.ErrorIs(t, err, fs.ErrNotExist)
+	require.Contains(t, err.Error(), "local replacement")
+	require.Contains(t, err.Error(), "example/local")
+	require.Contains(t, filepath.ToSlash(err.Error()), filepath.ToSlash(path))
+	require.False(t, strings.Contains(err.Error(), "downloaded"))
+	var detailed apierror.Error
+	require.ErrorAs(t, err, &detailed)
+	require.Equal(t, apierror.Invalid, detailed.Kind())
+	require.Contains(t, detailed.Details().GetString("module", ""), "example/local")
+	require.Equal(t, path, detailed.Details().GetString("path", ""))
+}

--- a/service/websocket/registry_test.go
+++ b/service/websocket/registry_test.go
@@ -179,6 +179,7 @@ func TestRegistryResourceCleanup(t *testing.T) {
 
 func TestRegistryReadLoop(t *testing.T) {
 	const numMessages = 3
+	ready := make(chan struct{})
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
@@ -186,6 +187,13 @@ func TestRegistryReadLoop(t *testing.T) {
 		}
 		defer func() { _ = conn.CloseNow() }()
 
+		select {
+		case <-ready:
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			return
+		}
 		for i := 0; i < numMessages; i++ {
 			_ = conn.Write(r.Context(), websocket.MessageText, []byte("msg"))
 		}
@@ -208,10 +216,26 @@ func TestRegistryReadLoop(t *testing.T) {
 	r := NewRegistry(store.Table(), nil)
 	id := r.Register(ctx, conn, 16, 0)
 
-	msgCh, _ := r.GetMessageChan(id)
-
+	msgCh, err := r.GetMessageChan(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(ready)
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
 	var received int
-	for msg := range msgCh {
+readMessages:
+	for {
+		var msg wsapi.Message
+		var ok bool
+		select {
+		case msg, ok = <-msgCh:
+			if !ok {
+				break readMessages
+			}
+		case <-deadline.C:
+			t.Fatal("timed out receiving websocket messages")
+		}
 		if msg.EOF {
 			break
 		}
@@ -224,6 +248,7 @@ func TestRegistryReadLoop(t *testing.T) {
 }
 
 func TestRegistryReadLoopBinary(t *testing.T) {
+	ready := make(chan struct{})
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
@@ -231,6 +256,13 @@ func TestRegistryReadLoopBinary(t *testing.T) {
 		}
 		defer func() { _ = conn.CloseNow() }()
 
+		select {
+		case <-ready:
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			return
+		}
 		_ = conn.Write(r.Context(), websocket.MessageBinary, []byte{0x01, 0x02})
 		_ = conn.Close(websocket.StatusNormalClosure, "done")
 	}))
@@ -251,8 +283,17 @@ func TestRegistryReadLoopBinary(t *testing.T) {
 	r := NewRegistry(store.Table(), nil)
 	id := r.Register(ctx, conn, 16, 0)
 
-	msgCh, _ := r.GetMessageChan(id)
-	msg := <-msgCh
+	msgCh, err := r.GetMessageChan(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(ready)
+	var msg wsapi.Message
+	select {
+	case msg = <-msgCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out receiving binary websocket message")
+	}
 
 	if msg.MessageType != wsapi.MessageBinary {
 		t.Errorf("expected binary, got %d", msg.MessageType)

--- a/system/supervisor/canceled_start_cleanup_test.go
+++ b/system/supervisor/canceled_start_cleanup_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/supervisor"
+)
+
+func TestCanceledStartStillRequiresBoundedCleanup(t *testing.T) {
+	started := make(chan struct{})
+	stopped := make(chan error, 1)
+	startCtx, cancelStart := context.WithCancel(t.Context())
+	defer cancelStart()
+	controller := NewController(t.Context(), &mockService{
+		startFunc: func(ctx context.Context) (<-chan any, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		stopFunc: func(ctx context.Context) error {
+			stopped <- ctx.Err()
+			return nil
+		},
+	}, supervisor.LifecycleConfig{StartTimeout: time.Second, StopTimeout: time.Second}, nil)
+	defer controller.close()
+	done := make(chan error, 1)
+	go func() { done <- controller.startContext(startCtx) }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("start did not begin")
+	}
+	cancelStart()
+	require.ErrorIs(t, <-done, context.Canceled)
+	stopCtx, cancelStop := context.WithTimeout(t.Context(), time.Second)
+	defer cancelStop()
+	require.NoError(t, controller.StopContext(stopCtx))
+	select {
+	case err := <-stopped:
+		require.NoError(t, err, "cleanup inherited the canceled start context")
+	case <-time.After(time.Second):
+		t.Fatal("canceled start skipped service cleanup")
+	}
+}

--- a/system/supervisor/controller.go
+++ b/system/supervisor/controller.go
@@ -329,7 +329,7 @@ func (c *Controller) supervise() {
 						// for an independent bounded Stop.
 						c.state.setDesiredStatus(supervisor.StatusStopped)
 						err = op.ctx.Err()
-						c.updateState(supervisor.StatusStopped, err)
+						c.updateState(supervisor.StatusFailed, err)
 						respondAndCancel(err)
 						break
 					}
@@ -451,6 +451,8 @@ func (e *controllerStopBoundError) Error() string { return e.cause.Error() }
 func (e *controllerStopBoundError) Unwrap() error { return e.cause }
 
 func boundControllerStopContext(parent, bound context.Context) (context.Context, context.CancelFunc) {
+	// Cleanup retains service values but is bounded independently of its run.
+	parent = context.WithoutCancel(parent)
 	deadlineCtx := parent
 	cancelDeadline := func() {}
 	if deadline, ok := bound.Deadline(); ok {

--- a/system/supervisor/controller_test.go
+++ b/system/supervisor/controller_test.go
@@ -1256,10 +1256,9 @@ func TestController_StartTimeout(t *testing.T) {
 		t.Errorf("Expected final status Failed, got: %v", state.Status)
 	}
 
-	// Cleanup
-	if err := ctr.Stop(); err == nil {
-		t.Fatal("Expected error from stop, got nil")
-	}
+	// Startup timeout does not cancel the independent cleanup budget.
+	require.NoError(t, ctr.Stop())
+	require.Equal(t, supervisor.StatusStopped, ctr.State().Status)
 }
 
 func TestController_ServiceExitError(t *testing.T) {


### PR DESCRIPTION
## Summary

Three independently reproduced release-validation failures:

- A canceled controller start could mark the service stopped without calling its cleanup. Keep failed-start state until Stop, and give cleanup a separate bounded context while retaining service context values. No new API is added.
- WebSocket read-loop fixtures could let the server finish and remove its registry entry before retrieving the message channel. The ignored lookup error then caused an unbounded receive from nil. Synchronize receiver registration, check errors and bound receives; production WebSocket behavior is unchanged.
- Missing local replacements failed safely but were logged as downloaded-artifact integrity errors without the module name in the visible message. Name the local module and path while preserving structured details, error kind and filesystem cause.

The supervisor issue reproduced during v0.3.41a validation. The WebSocket hang occurred in #703's Ubuntu CI (run 34542992668), unrelated to its application changes.

## Validation

- New deterministic canceled-start cleanup test fails before the fix and passes after it.
- New test plus existing failed-autostart shutdown regression: 50 race repetitions pass.
- Both WebSocket read-loop fixtures: 100 race repetitions pass.
- Full supervisor and WebSocket packages: three race repetitions pass.
- Pinned lint on both packages: zero issues.
- Replacement diagnostics and restore tests pass ten race repetitions; the new diagnostic test requires the module/path in the visible error, not only structured details.
- The v0.3.41a candidate with the supervisor correction passes its core race gate and 392 native application fixtures; broader release acceptance remains separate.
