### PR TITLE
Fix local dependency removal on restart and authenticated module search

### DIFF
--- a/boot/deps/hub/dependency_handler.go
+++ b/boot/deps/hub/dependency_handler.go
@@ -169,9 +169,11 @@ func NewDependencyHandler(opts DependencyHandlerOptions) (*DependencyHandler, er
 	}, nil
 }
 
-// PrepareRestore materializes the exact module artifacts recorded for the
-// current registry version. Version selection remains the stored resolution;
-// the Hub is used only when a verified artifact is absent locally.
+// PrepareRestore loads the deployment baseline and prefetches immutable artifacts
+// recorded for the current registry version. Historical local replacements are
+// validated during reconciliation against the final declarations. Version
+// selection remains the stored resolution; the Hub is used only when a verified
+// artifact is absent locally.
 func (h *DependencyHandler) PrepareRestore(ctx context.Context, history regapi.History) error {
 	resolutions, ok := history.(regapi.ResolutionHistory)
 	if h == nil || !ok {
@@ -206,14 +208,6 @@ func (h *DependencyHandler) PrepareRestore(ctx context.Context, history regapi.H
 	if err != nil {
 		return err
 	}
-	// A configured workspace replacement is a mutable development source: its
-	// recorded digest is the checkpoint of the run that wrote it, not a durable
-	// artifact identity. Restore re-snapshots every replacement from its current
-	// tree exactly as reconciliation does, so materialization verifies the
-	// generation it is about to load. Hub artifacts keep their recorded digest.
-	if err := h.refreshReplacementModuleIdentities(effective); err != nil {
-		return err
-	}
 	if deployment == nil {
 		// A source checkout has an unrooted lock: its ordinary lock loader has
 		// already published the deployment sources. History may add modules, but
@@ -221,7 +215,7 @@ func (h *DependencyHandler) PrepareRestore(ctx context.Context, history regapi.H
 		if h.lock != nil {
 			h.deployment = nil
 			ctx = regapi.WithDependencyAccess(ctx, regapi.DependencyAccessOnline)
-			return h.materializeRestoreModules(ctx, effective)
+			return h.prepareRecordedArtifacts(ctx, effective)
 		}
 		return fmt.Errorf("persisted deployment baseline is unavailable; start once with its lock file")
 	}
@@ -237,7 +231,7 @@ func (h *DependencyHandler) PrepareRestore(ctx context.Context, history regapi.H
 	if err := h.prepareRestoreSources(ctx, baseline); err != nil {
 		return err
 	}
-	return h.materializeRestoreModules(ctx, effective)
+	return h.prepareRecordedArtifacts(ctx, effective)
 }
 
 func (h *DependencyHandler) deploymentFromLock() (*regapi.Deployment, error) {

--- a/boot/deps/hub/restore_removed_replacement_test.go
+++ b/boot/deps/hub/restore_removed_replacement_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package hub
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wippyai/runtime/api/payload"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/internal/version"
+	registryimpl "github.com/wippyai/runtime/system/registry"
+	"github.com/wippyai/runtime/system/registry/expansion"
+	historysqlite "github.com/wippyai/runtime/system/registry/history/sqlite"
+	"github.com/wippyai/runtime/system/registry/topology"
+	"go.uber.org/zap"
+)
+
+func TestColdRestartReconcilesRemovedReplacementBeforeLoadingArtifacts(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		removed      bool
+		historyOwned bool
+	}{
+		{name: "still-required"},
+		{name: "removed-from-source", removed: true},
+		{name: "history-owned-still-required", historyOwned: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := regapi.WithDependencyAccess(newTestContext(), regapi.DependencyAccessUnspecified)
+			f := newTestFixture(t)
+			f.writeLock(t, "", "")
+			digest, size, err := digestReplacementTree(f.replacementPath)
+			require.NoError(t, err)
+			_, recorded := f.newHistoryWithModule(t, moduleSourceReplacementTreeV1, digest, size)
+			recorded.Deployment = nil
+			oldBaseline := regapi.State{hardeningRoot("app:mod", "local/mod", "1.0.0")}
+			oldBaseline[0].Registry.Root = !tc.historyOwned
+			oldHandler := f.newHandler(t, f.replacements)
+			recorded.BaselineDigest, err = oldHandler.deploymentBaselineDigest(ctx, oldBaseline, payload.GetTranscoder(ctx))
+			require.NoError(t, err)
+			recorded = *recorded.Canonical()
+
+			dbPath := filepath.Join(f.root, "history.db")
+			history, err := historysqlite.NewSQLite(dbPath, zap.NewNop())
+			require.NoError(t, err)
+			root, err := history.GetVersion(regapi.RootVersion)
+			require.NoError(t, err)
+			head := version.FromParent(root, 1)
+			var authored regapi.ChangeSet
+			if tc.historyOwned {
+				authored = regapi.ChangeSet{{Kind: regapi.EntryCreate, Entry: oldBaseline[0]}}
+			}
+			require.NoError(t, history.SaveWithDependencyResolution(head, authored, &recorded, true))
+			require.NoError(t, history.Close())
+
+			// Cold start after removing workspace.replacements; only the positive case
+			// also removes ns.dependency from the current source baseline.
+			reopened, err := historysqlite.NewSQLite(dbPath, zap.NewNop())
+			require.NoError(t, err)
+			defer reopened.Close()
+			h := f.newHandler(t, nil)
+			require.NoError(t, h.PrepareRestore(ctx, reopened))
+			resolver := topology.NewResolver()
+			h.resolver = resolver
+			runner := &bootRecordingRunner{}
+			reg := registryimpl.NewRegistry(reopened, runner, topology.NewStateBuilder(zap.NewNop(), resolver), resolver, zap.NewNop(),
+				registryimpl.WithKindDirective(regapi.NamespaceDependency, expansion.NewDependencyDirective(h.Expand).
+					WithResolutionTransition(h.ReconcileResolution).WithChangesExpansion(h.ExpandChanges)))
+			baseline := oldBaseline
+			if tc.removed || tc.historyOwned {
+				baseline = nil
+			}
+			err = reg.LoadState(regapi.WithRegistry(ctx, reg), baseline, head)
+			if !tc.removed {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "stored local replacement is not configured")
+				require.Empty(t, runner.transitions, "no registry activation before a required source is verified")
+				stored, getErr := reopened.GetDependencyResolution(head)
+				require.NoError(t, getErr)
+				require.Equal(t, recorded.Digest, stored.Digest, "failed boot must preserve its checkpoint")
+				return
+			}
+			require.NoError(t, err)
+			stored, err := reopened.GetDependencyResolution(head)
+			require.NoError(t, err)
+			require.Empty(t, stored.Modules)
+			require.Empty(t, stored.Roots)
+			// A second restart must work from the reconciled checkpoint too.
+			require.NoError(t, f.newHandler(t, nil).PrepareRestore(ctx, reopened))
+		})
+	}
+}

--- a/boot/deps/hub/restore_sources.go
+++ b/boot/deps/hub/restore_sources.go
@@ -46,8 +46,17 @@ func (h *DependencyHandler) prepareRestoreSources(ctx context.Context, modules [
 	return nil
 }
 
-func (h *DependencyHandler) materializeRestoreModules(ctx context.Context, modules []ResolvedModule) error {
+// prepareRecordedArtifacts prefetches immutable history artifacts while online
+// access is available. Local trees cannot be recovered from the Hub: the final
+// declaration graph must select them before reconciliation snapshots and loads
+// them. Deployment baseline sources are loaded separately by prepareRestoreSources
+// (or the source checkout loader), including the application root.
+func (h *DependencyHandler) prepareRecordedArtifacts(ctx context.Context, modules []ResolvedModule) error {
 	for _, module := range modules {
+		_, replaced := h.replacementPath(module.Org + "/" + module.Name)
+		if module.Source == moduleSourceReplacementTreeV1 || replaced {
+			continue
+		}
 		if _, err := h.ensureModuleAvailable(ctx, module); err != nil {
 			return fmt.Errorf("materialize recorded module %s: %w", modKey(module), err)
 		}

--- a/cmd/wippy/cmd/search.go
+++ b/cmd/wippy/cmd/search.go
@@ -50,9 +50,15 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	if registryURL == "" {
 		registryURL = store.DefaultRegistry()
 	}
+	cred, _ := store.Get(registryURL)
+	var token string
+	if cred != nil {
+		token = cred.Token
+	}
 
 	client, err := hub.NewClient(hub.Options{
 		BaseURL: registryURL,
+		Token:   token,
 	})
 	if err != nil {
 		return NewSearchClientError(registryURL, err)

--- a/cmd/wippy/cmd/search_auth_test.go
+++ b/cmd/wippy/cmd/search_auth_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	modulev1 "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1"
+	moduleconnect "github.com/wippyai/runtime/api/hub/wippy/api/hub/module/v1/modulev1connect"
+)
+
+type searchAuthService struct {
+	moduleconnect.UnimplementedModuleServiceHandler
+	authorization string
+	query         string
+}
+
+func (s *searchAuthService) SearchModules(_ context.Context, req *connect.Request[modulev1.SearchModulesRequest]) (*connect.Response[modulev1.SearchModulesResponse], error) {
+	s.authorization = req.Header().Get("Authorization")
+	s.query = req.Msg.Query
+	return connect.NewResponse(&modulev1.SearchModulesResponse{}), nil
+}
+func TestSearchUsesConfiguredCredentials(t *testing.T) {
+	previousContext := searchCmd.Context()
+	t.Cleanup(func() { searchCmd.SetContext(previousContext) })
+	searchCmd.SetContext(context.Background())
+	for _, token := range []string{"test-private-org-token", ""} {
+		t.Run(token, func(t *testing.T) {
+			t.Setenv("WIPPY_TOKEN", token)
+			service := &searchAuthService{}
+			mux := http.NewServeMux()
+			path, handler := moduleconnect.NewModuleServiceHandler(service)
+			mux.Handle(path, handler)
+			server := httptest.NewServer(mux)
+			defer server.Close()
+			old := searchCmd.Flags().Lookup("registry").Value.String()
+			require.NoError(t, searchCmd.Flags().Set("registry", server.URL))
+			defer func() { _ = searchCmd.Flags().Set("registry", old) }()
+			captureStdout(t, func() { require.NoError(t, runSearch(searchCmd, []string{"private-org"})) })
+			want := ""
+			if token != "" {
+				want = "Bearer " + token
+			}
+			require.Equal(t, want, service.authorization)
+			require.Equal(t, "private-org", service.query)
+		})
+	}
+}


### PR DESCRIPTION
Removing a source-owned dependency, its workspace replacement, and its lock entry currently prevents restart: preparation tries to load the historical local tree before the registry reconciles the changed declarations. Prefetch only immutable historical artifacts in that phase. Deployment sources, including the application root, still load during preparation; the final source-plus-history graph selects and verifies local replacements during reconciliation.

The intentional semantic change is the failure phase for historical local replacements: missing or invalid trees fail during reconciliation if still required, before registry activation. An absent replacement is never treated as proof that the dependency was removed. Source-owned removals can reconcile away; history-owned dependencies remain required. Exact Hub artifact retrieval and early integrity checks stay in preparation, and offline replay policy is unchanged.

Also pass the configured registry credential to CLI module search, matching the other Hub read commands, so private modules can appear in search results.

Validation:

- Dependency handler, CLI, registry/history, and source-loader Go suites pass on current main.
- SQLite close/reopen regressions cover source-owned removal, retained source-owned dependency, and retained history-owned dependency, including no activation/checkpoint mutation on failure.
- Actual CLI fixture: `.41` reproduces `materialize recorded module ... stored local replacement is not configured` after removal. Candidate boots after removal and on a second restart; a still-required missing source refuses startup.
- Existing cold-cache artifact, corruption, deployment-root, replacement rebuild, and history replay tests pass unchanged.
- Authenticated and anonymous search requests tested against a local Connect service.

Runtime changes are submitted for review; the experimental binary has not been deployed to production. CI was skipped on the push to conserve the requested GitHub quota; local test logs are available.
