### PR TITLE
test(http): give listener probe requests a context

### DIFF
--- a/service/http/server.go
+++ b/service/http/server.go
@@ -255,6 +255,7 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 	} else {
 		baseHandler = s.routeMgr
 	}
+	listenAddr := ""
 
 	// Wrap handler with per-request FrameContext creation
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -264,7 +265,7 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 
 		// Set all HTTP-specific metadata in FrameContext in one place
 		_ = config.SetServerID(ctx, s.id.String())
-		_ = config.SetServerHost(ctx, s.config.Addr)
+		_ = config.SetServerHost(ctx, listenAddr)
 		_ = fc.Set(config.ServerKey(), s)
 
 		baseHandler.ServeHTTP(w, r.WithContext(ctx))
@@ -287,6 +288,7 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 		s.mu.Unlock()
 		return nil, err
 	}
+	listenAddr = reportedListenAddr(s.config.Addr, ln)
 	s.server = srv
 	s.started.Store(true)
 
@@ -306,7 +308,7 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 		s.started.Store(false)
 	}()
 
-	if err := s.ensureRunning(ctx, probe); err != nil {
+	if err := s.ensureRunning(ctx, probe, listenAddr); err != nil {
 		_ = ln.Close()
 		_ = srv.Close()
 		s.mu.Lock()
@@ -336,7 +338,7 @@ func (s *ServerService) Start(ctx context.Context) (<-chan any, error) {
 	})
 
 	select {
-	case s.statusChan <- fmt.Sprintf("service listening on %s", s.config.Addr):
+	case s.statusChan <- fmt.Sprintf("service listening on %s", listenAddr):
 	default:
 	}
 
@@ -367,9 +369,17 @@ func (s *ServerService) Stop(ctx context.Context) error {
 // services, and the overlay driver when cfg.Network is set.
 type probeFunc func(ctx context.Context, addr string) (net.Conn, error)
 
+func reportedListenAddr(configured string, ln net.Listener) string {
+	_, port, err := net.SplitHostPort(configured)
+	if err == nil && port == "0" {
+		return ln.Addr().String()
+	}
+	return configured
+}
+
 // ensureRunning verifies that the server is listening by dialing itself on
 // the same fabric it bound on.
-func (s *ServerService) ensureRunning(ctx context.Context, probe probeFunc) error {
+func (s *ServerService) ensureRunning(ctx context.Context, probe probeFunc, listenAddr string) error {
 	timeout := time.After(BootTimeout)
 	ticker := time.NewTicker(CheckInterval)
 	defer ticker.Stop()
@@ -382,7 +392,7 @@ func (s *ServerService) ensureRunning(ctx context.Context, probe probeFunc) erro
 			return NewStartupCanceledError(ctx.Err())
 		case <-ticker.C:
 			dialCtx, cancel := context.WithTimeout(ctx, time.Second)
-			conn, err := probe(dialCtx, s.config.Addr)
+			conn, err := probe(dialCtx, listenAddr)
 			cancel()
 			if err == nil {
 				_ = conn.Close()

--- a/service/http/server_startup_test.go
+++ b/service/http/server_startup_test.go
@@ -24,6 +24,15 @@ type failingProbeService struct {
 	listened chan struct{}
 }
 
+func requestServer(t *testing.T, client *http.Client, address string) (*http.Response, error) {
+	t.Helper()
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+address, nil)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(request)
+}
+
 func serverHostHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fc := contextapi.FrameFromContext(r.Context())
@@ -60,7 +69,7 @@ func TestServerService_PortZeroPublishesBoundAddress(t *testing.T) {
 		require.True(t, strings.HasPrefix(address, "service listening on 127.0.0.1:"))
 		require.NotContains(t, address, ":0")
 		bound := strings.TrimPrefix(address, "service listening on ")
-		response, requestErr := client.Get("http://" + bound)
+		response, requestErr := requestServer(t, client, bound)
 		require.NoError(t, requestErr)
 		body, readErr := io.ReadAll(response.Body)
 		require.NoError(t, response.Body.Close())
@@ -131,7 +140,7 @@ func TestServerService_NonZeroNamedHostPreserved(t *testing.T) {
 	select {
 	case details := <-statusCh:
 		require.Equal(t, "service listening on "+configured, details)
-		response, requestErr := client.Get("http://" + configured)
+		response, requestErr := requestServer(t, client, configured)
 		require.NoError(t, requestErr)
 		body, readErr := io.ReadAll(response.Body)
 		require.NoError(t, response.Body.Close())
@@ -168,7 +177,7 @@ func TestServerService_PortZeroRestartReportsCurrentAddress(t *testing.T) {
 	}
 	ctx1, cancel1 := context.WithCancel(overlayCtx())
 	address1 := start(ctx1)
-	response, err := client.Get("http://" + address1)
+	response, err := requestServer(t, client, address1)
 	require.NoError(t, err)
 	body, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
@@ -185,7 +194,7 @@ func TestServerService_PortZeroRestartReportsCurrentAddress(t *testing.T) {
 	defer cancel2()
 	address2 := start(ctx2)
 	require.NotEqual(t, address1, address2)
-	response, err = client.Get("http://" + address2)
+	response, err = requestServer(t, client, address2)
 	require.NoError(t, err)
 	body, err = io.ReadAll(response.Body)
 	require.NoError(t, err)

--- a/service/http/server_startup_test.go
+++ b/service/http/server_startup_test.go
@@ -5,11 +5,15 @@ package http
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	contextapi "github.com/wippyai/runtime/api/context"
 	netapi "github.com/wippyai/runtime/api/net"
 	"github.com/wippyai/runtime/api/registry"
 	config "github.com/wippyai/runtime/api/service/http"
@@ -18,6 +22,176 @@ import (
 
 type failingProbeService struct {
 	listened chan struct{}
+}
+
+func serverHostHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fc := contextapi.FrameFromContext(r.Context())
+		host := ""
+		if fc != nil {
+			fc.Iterate(func(key any, value any) {
+				if contextKey, ok := key.(*contextapi.Key); ok && contextKey.Name == "http.server.host" {
+					host, _ = value.(string)
+				}
+			})
+		}
+		_, _ = w.Write([]byte(host))
+	})
+}
+
+func TestServerService_PortZeroPublishesBoundAddress(t *testing.T) {
+	server, err := NewServerService(
+		registry.NewID("test", "port-zero"),
+		&config.ServerConfig{Addr: "127.0.0.1:0"},
+		NewMiddlewareRegistry(zap.NewNop()),
+	)
+	require.NoError(t, err)
+	server.SetHandlerFunc(serverHostHandler())
+	client := &http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithCancel(overlayCtx())
+	defer cancel()
+	statusCh, err := server.Start(ctx)
+	require.NoError(t, err)
+
+	select {
+	case details := <-statusCh:
+		address, ok := details.(string)
+		require.True(t, ok)
+		require.True(t, strings.HasPrefix(address, "service listening on 127.0.0.1:"))
+		require.NotContains(t, address, ":0")
+		bound := strings.TrimPrefix(address, "service listening on ")
+		response, requestErr := client.Get("http://" + bound)
+		require.NoError(t, requestErr)
+		body, readErr := io.ReadAll(response.Body)
+		require.NoError(t, response.Body.Close())
+		require.NoError(t, readErr)
+		require.Equal(t, bound, string(body))
+	case <-time.After(time.Second):
+		t.Fatal("server did not report readiness")
+	}
+	cancel()
+	deadline := time.After(time.Second)
+	for server.started.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("server did not stop after context cancellation")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	require.NoError(t, server.Stop(context.Background()))
+}
+
+func TestServerService_WildcardPortZeroPreservesConfiguredAddress(t *testing.T) {
+	server, err := NewServerService(
+		registry.NewID("test", "wildcard-port-zero"),
+		&config.ServerConfig{Addr: ":0"},
+		NewMiddlewareRegistry(zap.NewNop()),
+	)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(overlayCtx())
+	defer cancel()
+	statusCh, err := server.Start(ctx)
+	require.NoError(t, err)
+
+	select {
+	case details := <-statusCh:
+		address, ok := details.(string)
+		require.True(t, ok)
+		bound := strings.TrimPrefix(address, "service listening on ")
+		_, port, splitErr := net.SplitHostPort(bound)
+		require.NoError(t, splitErr)
+		require.NotEqual(t, "0", port)
+	case <-time.After(time.Second):
+		t.Fatal("server did not report readiness")
+	}
+	require.Equal(t, ":0", server.config.Addr)
+	require.NoError(t, server.Stop(context.Background()))
+}
+
+func TestServerService_NonZeroNamedHostPreserved(t *testing.T) {
+	reserved, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(reserved.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, reserved.Close())
+	configured := "localhost:" + port
+	server, err := NewServerService(
+		registry.NewID("test", "named-host"),
+		&config.ServerConfig{Addr: configured},
+		NewMiddlewareRegistry(zap.NewNop()),
+	)
+	require.NoError(t, err)
+	server.SetHandlerFunc(serverHostHandler())
+	client := &http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithCancel(overlayCtx())
+	defer cancel()
+	statusCh, err := server.Start(ctx)
+	require.NoError(t, err)
+	select {
+	case details := <-statusCh:
+		require.Equal(t, "service listening on "+configured, details)
+		response, requestErr := client.Get("http://" + configured)
+		require.NoError(t, requestErr)
+		body, readErr := io.ReadAll(response.Body)
+		require.NoError(t, response.Body.Close())
+		require.NoError(t, readErr)
+		require.Equal(t, configured, string(body))
+	case <-time.After(time.Second):
+		t.Fatal("server did not report readiness")
+	}
+	require.NoError(t, server.Stop(context.Background()))
+}
+
+func TestServerService_PortZeroRestartReportsCurrentAddress(t *testing.T) {
+	server, err := NewServerService(
+		registry.NewID("test", "port-zero-restart"),
+		&config.ServerConfig{Addr: "127.0.0.1:0"},
+		NewMiddlewareRegistry(zap.NewNop()),
+	)
+	require.NoError(t, err)
+	server.SetHandlerFunc(serverHostHandler())
+	client := &http.Client{Timeout: time.Second}
+
+	start := func(ctx context.Context) string {
+		statusCh, startErr := server.Start(ctx)
+		require.NoError(t, startErr)
+		select {
+		case details := <-statusCh:
+			address, ok := details.(string)
+			require.True(t, ok)
+			return strings.TrimPrefix(address, "service listening on ")
+		case <-time.After(time.Second):
+			t.Fatal("server did not report readiness")
+			return ""
+		}
+	}
+	ctx1, cancel1 := context.WithCancel(overlayCtx())
+	address1 := start(ctx1)
+	response, err := client.Get("http://" + address1)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, address1, string(body))
+	require.NoError(t, server.Stop(context.Background()))
+	cancel1()
+	require.Eventually(t, func() bool { return !server.started.Load() }, time.Second, 10*time.Millisecond)
+	reserved, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", address1)
+	require.NoError(t, err)
+	defer reserved.Close()
+
+	ctx2, cancel2 := context.WithCancel(overlayCtx())
+	defer cancel2()
+	address2 := start(ctx2)
+	require.NotEqual(t, address1, address2)
+	response, err = client.Get("http://" + address2)
+	require.NoError(t, err)
+	body, err = io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, address2, string(body))
+	require.NoError(t, server.Stop(context.Background()))
 }
 
 func (s *failingProbeService) DialContext(context.Context, string, string) (net.Conn, error) {

--- a/service/http/server_test.go
+++ b/service/http/server_test.go
@@ -683,7 +683,7 @@ func TestEnsureRunning(t *testing.T) {
 	ctx, cancel := context.WithTimeout(contextapi.NewRootContext(), 2*time.Second)
 	defer cancel()
 
-	err = server.ensureRunning(ctx, probe)
+	err = server.ensureRunning(ctx, probe, cfg.Addr)
 	assert.NoError(t, err)
 
 	// Now stop the server and the check should fail
@@ -701,7 +701,7 @@ func TestEnsureRunning(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(contextapi.NewRootContext(), 500*time.Millisecond) // Short timeout
 	defer cancel2()
 
-	err = server.ensureRunning(ctx2, probe)
+	err = server.ensureRunning(ctx2, probe, cfg.Addr)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
The port-zero listener tests added in #737 call `http.Client.Get`, which fails the repository's `noctx` lint rule. Build requests with the test context and send them through the existing bounded client.

Production behavior is unchanged. Focused port-zero, named-host and probe-failure tests pass.
