### PR TITLE
feat(exec): authorize per-process Docker bind mounts

### DIFF
--- a/api/service/exec/api.go
+++ b/api/service/exec/api.go
@@ -4,7 +4,11 @@
 package exec
 
 import (
+	"fmt"
 	"io"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/wippyai/runtime/api/registry"
 )
@@ -27,6 +31,98 @@ type ProcessOptions struct {
 	// executor default.
 	ProcessGroup *bool
 	WorkDir      string
+	Mounts       []Mount
+}
+
+// Mount is a host path exposed at a path in a process. Mounts are bind mounts
+// for executors that support them; the executor does not infer additional
+// mounts from this value.
+type Mount struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	ReadOnly bool   `json:"read_only"`
+}
+
+// Validate checks a mount before it reaches an executor or security policy.
+func (m Mount) Validate() error {
+	if m.Source == "" {
+		return fmt.Errorf("%w: source is required", ErrInvalidMount)
+	}
+	if strings.IndexByte(m.Source, 0) >= 0 {
+		return fmt.Errorf("%w: source contains NUL", ErrInvalidMount)
+	}
+	if !filepath.IsAbs(m.Source) && !path.IsAbs(m.Source) {
+		return fmt.Errorf("%w: source must be absolute", ErrInvalidMount)
+	}
+	if filepath.Clean(m.Source) != m.Source {
+		return fmt.Errorf("%w: source must be a clean absolute path", ErrInvalidMount)
+	}
+	if m.Target == "" {
+		return fmt.Errorf("%w: target is required", ErrInvalidMount)
+	}
+	if strings.IndexByte(m.Target, 0) >= 0 {
+		return fmt.Errorf("%w: target contains NUL", ErrInvalidMount)
+	}
+	if !path.IsAbs(m.Target) {
+		return fmt.Errorf("%w: target must be absolute", ErrInvalidMount)
+	}
+	return nil
+}
+
+// ValidateMounts validates each mount and rejects duplicate container targets.
+func ValidateMounts(mounts []Mount) error {
+	seen := make(map[string]struct{}, len(mounts))
+	for _, mount := range mounts {
+		if err := mount.Validate(); err != nil {
+			return err
+		}
+		target := path.Clean(mount.Target)
+		if _, exists := seen[target]; exists {
+			return fmt.Errorf("%w: %q", ErrDuplicateMountTarget, target)
+		}
+		seen[target] = struct{}{}
+	}
+	return nil
+}
+
+// Clone validates and deep-copies process options. Executors retain the clone
+// so callers cannot mutate a process after NewProcess returns.
+func (o ProcessOptions) Clone() (ProcessOptions, error) {
+	if err := o.Validate(); err != nil {
+		return ProcessOptions{}, err
+	}
+	clone := o
+	if o.Env != nil {
+		clone.Env = make(map[string]string, len(o.Env))
+		for name, value := range o.Env {
+			clone.Env[name] = value
+		}
+	}
+	if o.PTY != nil {
+		pty := *o.PTY
+		clone.PTY = &pty
+	}
+	if o.ProcessGroup != nil {
+		group := *o.ProcessGroup
+		clone.ProcessGroup = &group
+	}
+	if o.Mounts != nil {
+		clone.Mounts = append([]Mount(nil), o.Mounts...)
+	}
+	return clone, nil
+}
+
+// Validate checks process options without retaining or mutating them.
+func (o ProcessOptions) Validate() error {
+	if err := ValidateMounts(o.Mounts); err != nil {
+		return err
+	}
+	if o.PTY != nil {
+		if _, _, err := o.PTY.Dimensions(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type PTYOptions struct {

--- a/api/service/exec/api.go
+++ b/api/service/exec/api.go
@@ -54,7 +54,13 @@ func (m Mount) Validate() error {
 	if !filepath.IsAbs(m.Source) && !path.IsAbs(m.Source) {
 		return fmt.Errorf("%w: source must be absolute", ErrInvalidMount)
 	}
-	if filepath.Clean(m.Source) != m.Source {
+	// The daemon may be on a Unix host even when the client runs on Windows.
+	// Clean Unix absolute paths as Unix paths, not as drive-relative Windows paths.
+	cleanSource := path.Clean(m.Source)
+	if filepath.IsAbs(m.Source) {
+		cleanSource = filepath.Clean(m.Source)
+	}
+	if cleanSource != m.Source {
 		return fmt.Errorf("%w: source must be a clean absolute path", ErrInvalidMount)
 	}
 	if m.Target == "" {

--- a/api/service/exec/api_test.go
+++ b/api/service/exec/api_test.go
@@ -33,8 +33,8 @@ func TestPTYDimensionsDefaultAndValidation(t *testing.T) {
 
 func TestProcessOptions_MarshalUnmarshal(t *testing.T) {
 	tests := []struct {
-		options ProcessOptions
 		name    string
+		options ProcessOptions
 		wantErr bool
 	}{
 		{
@@ -84,6 +84,45 @@ func TestProcessOptions_MarshalUnmarshal(t *testing.T) {
 			assert.Equal(t, tt.options, decoded)
 		})
 	}
+}
+
+func TestProcessOptionsCloneDeepCopiesAndValidatesMounts(t *testing.T) {
+	group := true
+	options := ProcessOptions{
+		Env:          map[string]string{"TOKEN": "secret"},
+		PTY:          &PTYOptions{Width: 100, Height: 30},
+		ProcessGroup: &group,
+		Mounts:       []Mount{{Source: "/host/project", Target: "/workspace", ReadOnly: true}},
+	}
+	clone, err := options.Clone()
+	require.NoError(t, err)
+	options.Env["TOKEN"] = "changed"
+	options.PTY.Width = 1
+	*options.ProcessGroup = false
+	options.Mounts[0].Source = "/other"
+	require.Equal(t, "secret", clone.Env["TOKEN"])
+	require.Equal(t, 100, clone.PTY.Width)
+	require.True(t, *clone.ProcessGroup)
+	require.Equal(t, "/host/project", clone.Mounts[0].Source)
+}
+
+func TestValidateMountsRejectsMalformedAndDuplicateTargets(t *testing.T) {
+	tests := []Mount{
+		{Target: "/workspace"},
+		{Source: "relative", Target: "/workspace"},
+		{Source: "/host", Target: "workspace"},
+		{Source: "/host\x00path", Target: "/workspace"},
+		{Source: "/allowed/../private", Target: "/workspace"},
+		{Source: "/allowed/./private", Target: "/workspace"},
+	}
+	for _, mount := range tests {
+		assert.ErrorIs(t, mount.Validate(), ErrInvalidMount)
+	}
+	err := ValidateMounts([]Mount{
+		{Source: "/one", Target: "/workspace"},
+		{Source: "/two", Target: "/workspace/"},
+	})
+	assert.ErrorIs(t, err, ErrDuplicateMountTarget)
 }
 
 func TestNativeExecutorConfig_MarshalUnmarshal(t *testing.T) {

--- a/api/service/exec/api_test.go
+++ b/api/service/exec/api_test.go
@@ -107,6 +107,9 @@ func TestProcessOptionsCloneDeepCopiesAndValidatesMounts(t *testing.T) {
 }
 
 func TestValidateMountsRejectsMalformedAndDuplicateTargets(t *testing.T) {
+	// A Windows client can submit Unix paths to a remote Linux Docker daemon.
+	require.NoError(t, (Mount{Source: "/host/project", Target: "/workspace"}).Validate())
+	require.NoError(t, (Mount{Source: t.TempDir(), Target: "/workspace"}).Validate())
 	tests := []Mount{
 		{Target: "/workspace"},
 		{Source: "relative", Target: "/workspace"},

--- a/api/service/exec/errors.go
+++ b/api/service/exec/errors.go
@@ -16,3 +16,9 @@ var ErrCommandRequired = apierror.New(apierror.Invalid, "command is required").W
 var ErrProcessGroupUnsupported = apierror.New(apierror.Unavailable, "process groups are not supported on this platform").WithRetryable(apierror.False)
 
 var ErrInvalidCommand = apierror.New(apierror.Invalid, "invalid command").WithRetryable(apierror.False)
+
+var ErrInvalidMount = apierror.New(apierror.Invalid, "invalid process mount").WithRetryable(apierror.False)
+
+var ErrDuplicateMountTarget = apierror.New(apierror.Invalid, "duplicate process mount target").WithRetryable(apierror.False)
+
+var ErrMountsUnsupported = apierror.New(apierror.Unavailable, "process mounts are not supported by this executor").WithRetryable(apierror.False)

--- a/runtime/lua/modules/exec/executor.go
+++ b/runtime/lua/modules/exec/executor.go
@@ -133,6 +133,16 @@ func executorExec(l *lua.LState) int {
 		l.Push(lua.NewLuaError(l, "permission denied: execute command").WithKind(lua.Invalid).WithRetryable(false))
 		return 2
 	}
+	for _, mount := range opts.Mounts {
+		if !security.IsAllowed(ctx, "exec.mount", mount.Source, attrs.Bag{
+			"target":    mount.Target,
+			"read_only": mount.ReadOnly,
+		}) {
+			l.Push(lua.LNil)
+			l.Push(lua.NewLuaError(l, "permission denied: mount host path").WithKind(lua.Invalid).WithRetryable(false))
+			return 2
+		}
+	}
 
 	proc, err := factory.NewProcess(cmd, opts)
 	if err != nil {

--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -17,7 +17,26 @@ import (
 	securityapi "github.com/wippyai/runtime/api/security"
 	execapi "github.com/wippyai/runtime/api/service/exec"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
+	secsystem "github.com/wippyai/runtime/system/security"
 )
+
+type mountPermissionPolicy struct {
+	metadata   attrs.Bag
+	allowMount bool
+}
+
+func (mountPermissionPolicy) ID() registry.ID { return registry.ParseID("test:exec-mount") }
+
+func (p *mountPermissionPolicy) Evaluate(_ securityapi.Actor, action, resource string, metadata attrs.Bag) securityapi.Result {
+	if action == "exec.run" {
+		return securityapi.Allow
+	}
+	if action == "exec.mount" && p.allowMount {
+		p.metadata = attrs.Bag{"resource": resource, "target": metadata["target"], "read_only": metadata["read_only"]}
+		return securityapi.Allow
+	}
+	return securityapi.Deny
+}
 
 func setupState() *lua.LState {
 	l := lua.NewState()
@@ -665,6 +684,13 @@ func TestExecutorExecParsesPTYOptions(t *testing.T) {
 	pty.RawSetString("height", lua.LInteger(30))
 	pty.RawSetString("term", lua.LString("xterm-256color"))
 	options.RawSetString("pty", pty)
+	mounts := l.NewTable()
+	mount := l.NewTable()
+	mount.RawSetString("source", lua.LString("/host/project"))
+	mount.RawSetString("target", lua.LString("/workspace"))
+	mount.RawSetString("read_only", lua.LTrue)
+	mounts.RawSetInt(1, mount)
+	options.RawSetString("mounts", mounts)
 	l.Push(options)
 
 	if returns := executorExec(l); returns != 2 {
@@ -684,6 +710,39 @@ func TestExecutorExecParsesPTYOptions(t *testing.T) {
 	}) {
 		t.Fatalf("PTY options = %+v", factory.lastOptions.PTY)
 	}
+	if len(factory.lastOptions.Mounts) != 1 || factory.lastOptions.Mounts[0] != (execapi.Mount{Source: "/host/project", Target: "/workspace", ReadOnly: true}) {
+		t.Fatalf("mount options = %+v", factory.lastOptions.Mounts)
+	}
+}
+
+func TestExecutorExecRequiresSeparateMountPermission(t *testing.T) {
+	l := setupState()
+	defer l.Close()
+	ctx := context.Background()
+	appCtx := ctxapi.NewAppContext()
+	ctx = ctxapi.WithAppContext(ctx, appCtx)
+	ctx, frame := ctxapi.OpenFrameContext(ctx)
+	defer frame.Close()
+	policy := &mountPermissionPolicy{}
+	require.NoError(t, securityapi.SetActor(ctx, securityapi.Actor{ID: "caller"}))
+	require.NoError(t, securityapi.SetScope(ctx, secsystem.NewScope([]securityapi.Policy{policy})))
+	l.SetContext(ctx)
+	factory := &mockProcessExecutor{}
+	value.PushTypedUserData(l, NewExecutor(ctx, nil, factory), executorTypeName)
+	l.Push(lua.LString("echo mounted"))
+	options := l.NewTable()
+	mounts := l.NewTable()
+	mount := l.NewTable()
+	mount.RawSetString("source", lua.LString("/host/project"))
+	mount.RawSetString("target", lua.LString("/workspace"))
+	mounts.RawSetInt(1, mount)
+	options.RawSetString("mounts", mounts)
+	l.Push(options)
+
+	require.Equal(t, 2, executorExec(l))
+	require.Equal(t, 0, factory.newProcessN, "mount denial must happen before NewProcess")
+	require.Equal(t, lua.LNil, l.Get(-2))
+	require.NotEqual(t, lua.LNil, l.Get(-1))
 }
 
 func TestProcessSecurityMetaExposesShapeWithoutEnvironmentValues(t *testing.T) {
@@ -764,6 +823,28 @@ func TestExecutorExecRejectsMalformedProcessOptions(t *testing.T) {
 			env := l.NewTable()
 			env.RawSetString("PORT", lua.LInteger(8080))
 			table.RawSetString("env", env)
+			return table
+		}},
+		{name: "mounts are not a table", build: func(l *lua.LState) lua.LValue {
+			table := l.NewTable()
+			table.RawSetString("mounts", lua.LString("/host:/workspace"))
+			return table
+		}},
+		{name: "mount entry is not a table", build: func(l *lua.LState) lua.LValue {
+			table := l.NewTable()
+			mounts := l.NewTable()
+			mounts.RawSetInt(1, lua.LString("/host:/workspace"))
+			table.RawSetString("mounts", mounts)
+			return table
+		}},
+		{name: "mount target is relative", build: func(l *lua.LState) lua.LValue {
+			table := l.NewTable()
+			mounts := l.NewTable()
+			mount := l.NewTable()
+			mount.RawSetString("source", lua.LString("/host"))
+			mount.RawSetString("target", lua.LString("workspace"))
+			mounts.RawSetInt(1, mount)
+			table.RawSetString("mounts", mounts)
 			return table
 		}},
 	}

--- a/runtime/lua/modules/exec/options.go
+++ b/runtime/lua/modules/exec/options.go
@@ -57,6 +57,53 @@ func parseProcessOptions(value lua.LValue) (apiexec.ProcessOptions, error) {
 		group := bool(enabled)
 		options.ProcessGroup = &group
 	}
+	if value := table.RawGetString("mounts"); value != lua.LNil {
+		mounts, ok := value.(*lua.LTable)
+		if !ok {
+			return options, fmt.Errorf("mounts must be a table")
+		}
+		options.Mounts = make([]apiexec.Mount, 0, mounts.Len())
+		var mountsErr error
+		var nextIndex int64 = 1
+		mounts.ForEach(func(key, value lua.LValue) {
+			if mountsErr != nil {
+				return
+			}
+			index, indexOK := mountIndex(key)
+			if !indexOK || index != nextIndex {
+				mountsErr = fmt.Errorf("mounts must be a contiguous array")
+				return
+			}
+			nextIndex++
+			mount, mountOK := value.(*lua.LTable)
+			if !mountOK {
+				mountsErr = fmt.Errorf("mounts entries must be tables")
+				return
+			}
+			source, sourceOK := mount.RawGetString("source").(lua.LString)
+			target, targetOK := mount.RawGetString("target").(lua.LString)
+			if !sourceOK || !targetOK {
+				mountsErr = fmt.Errorf("mount source and target must be strings")
+				return
+			}
+			readOnly := false
+			if value := mount.RawGetString("read_only"); value != lua.LNil {
+				readOnlyValue, readOnlyOK := value.(lua.LBool)
+				if !readOnlyOK {
+					mountsErr = fmt.Errorf("mount read_only must be a boolean")
+					return
+				}
+				readOnly = bool(readOnlyValue)
+			}
+			options.Mounts = append(options.Mounts, apiexec.Mount{Source: string(source), Target: string(target), ReadOnly: readOnly})
+		})
+		if mountsErr != nil {
+			return apiexec.ProcessOptions{}, mountsErr
+		}
+		if err := apiexec.ValidateMounts(options.Mounts); err != nil {
+			return apiexec.ProcessOptions{}, err
+		}
+	}
 	if value := table.RawGetString("pty"); value != lua.LNil {
 		pty, ok := value.(*lua.LTable)
 		if !ok {
@@ -69,6 +116,19 @@ func parseProcessOptions(value lua.LValue) (apiexec.ProcessOptions, error) {
 		}
 	}
 	return options, nil
+}
+
+func mountIndex(value lua.LValue) (int64, bool) {
+	switch value := value.(type) {
+	case lua.LInteger:
+		return int64(value), true
+	case lua.LNumber:
+		number := float64(value)
+		if math.Trunc(number) == number {
+			return int64(number), true
+		}
+	}
+	return 0, false
 }
 
 func parsePTYOptions(table *lua.LTable) (*apiexec.PTYOptions, error) {

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -82,6 +82,23 @@ Creates a new process with the specified command.
 | env | {[string]: string} | nil | Environment variables as key-value map |
 | pty | PTYOptions | nil | Allocate a pseudo-terminal for the child |
 | process_group | boolean | executor default | Start the child in its own process group so signals reach descendants; unsupported on Windows |
+| mounts | Mount[] | nil | Bind host paths into the process; each mount requires `exec.mount` permission |
+
+**Mount fields:**
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| source | string | required | Clean absolute host path checked by the separate mount permission |
+| target | string | required | Absolute path inside the process |
+| read_only | boolean | false | Mount the source read-only |
+
+Docker supports these per-process bind mounts; native execution rejects them.
+Each source is authorized with action `exec.mount`, resource equal to `source`,
+and `target` and `read_only` attributes before process creation. This permission
+checks the supplied path; it does not resolve symlinks or provide filesystem
+confinement. The source refers to the Docker daemon's host. Duplicate targets
+within the request or against configured Unix container bind targets are refused.
+Process options are copied at creation so later caller changes cannot alter them.
 
 **PTYOptions fields:**
 

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -16,6 +16,7 @@ var processExitChannelType typ.Type
 var terminalCompletionType typ.Type
 var terminalSessionType typ.Type
 var ptyOptionsType typ.Type
+var mountType typ.Type
 var processOptionsType typ.Type
 
 func init() {
@@ -24,11 +25,17 @@ func init() {
 		OptField("height", typ.Integer).
 		OptField("term", typ.String).
 		Build()
+	mountType = typ.NewRecord().
+		Field("source", typ.String).
+		Field("target", typ.String).
+		OptField("read_only", typ.Boolean).
+		Build()
 	processOptionsType = typ.NewRecord().
 		OptField("work_dir", typ.String).
 		OptField("env", typ.NewMap(typ.String, typ.String)).
 		OptField("pty", ptyOptionsType).
 		OptField("process_group", typ.Boolean).
+		OptField("mounts", typ.NewArray(mountType)).
 		Build()
 	processExitType = typ.NewRecord().
 		Field("code", typ.Integer).
@@ -93,6 +100,7 @@ func ModuleTypes() *io.Manifest {
 	m.DefineType("TerminalCompletionChannel", terminalCompletionType)
 	m.DefineType("TerminalSession", terminalSessionType)
 	m.DefineType("PTYOptions", ptyOptionsType)
+	m.DefineType("Mount", mountType)
 	m.DefineType("ProcessOptions", processOptionsType)
 
 	moduleType := typ.NewInterface("exec", []typ.Method{

--- a/runtime/lua/modules/exec/types_test.go
+++ b/runtime/lua/modules/exec/types_test.go
@@ -35,3 +35,19 @@ return completion_value
 	require.NoError(t, err)
 	require.False(t, code.HasErrors(diagnostics), "terminal completion select type was lost: %v", diagnostics)
 }
+
+func TestProcessMountOptionsAreTyped(t *testing.T) {
+	config := code.DefaultTypeCheckConfig()
+	config.Enabled = true
+	config.SkipUntyped = false
+	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{Module})
+	_, diagnostics, err := checker.Check(`
+local exec = require("exec")
+local function options() : exec.ProcessOptions
+    return {mounts = {{source = "/host", target = "/workspace", read_only = true}}}
+end
+return options
+`, "process_mount_options.lua", nil)
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "process mount options type was rejected: %v", diagnostics)
+}

--- a/service/exec/docker/docker.go
+++ b/service/exec/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	execapi "github.com/wippyai/runtime/api/service/exec"
@@ -61,6 +63,9 @@ func NewDockerExecutor(log *zap.Logger, config *execapi.DockerExecutorConfig) (*
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
+	if err := validateStaticMountTargets(config.Volumes); err != nil {
+		return nil, err
+	}
 
 	opts := []client.Opt{client.FromEnv}
 	if config.Host != "" {
@@ -96,18 +101,18 @@ func NewDockerExecutor(log *zap.Logger, config *execapi.DockerExecutorConfig) (*
 
 // NewProcess creates a new container process
 func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execapi.Process, error) {
+	options, err := options.Clone()
+	if err != nil {
+		return nil, err
+	}
+	if err := validateProcessMountTargets(e.volumes, options.Mounts); err != nil {
+		return nil, err
+	}
 	command, err := execapi.ParseCommand(cmd)
 	if err != nil {
 		return nil, err
 	}
 	ptyOptions := options.PTY
-	if ptyOptions != nil {
-		copy := *ptyOptions
-		ptyOptions = &copy
-		if _, _, err := ptyOptions.Dimensions(); err != nil {
-			return nil, err
-		}
-	}
 	if len(e.commandWhitelist) > 0 {
 		allowed := false
 		for _, whitelistedCmd := range e.commandWhitelist {
@@ -141,7 +146,8 @@ func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execa
 		env:             env,
 		workDir:         workDir,
 		networkMode:     e.networkMode,
-		volumes:         e.volumes,
+		volumes:         append([]string(nil), e.volumes...),
+		mounts:          append([]execapi.Mount(nil), options.Mounts...),
 		user:            e.user,
 		memoryLimit:     e.memoryLimit,
 		cpuQuota:        e.cpuQuota,
@@ -191,6 +197,7 @@ type Process struct {
 	user            string
 	capDrop         []string
 	volumes         []string
+	mounts          []execapi.Mount
 	cmd             []string
 	capAdd          []string
 	env             []string
@@ -223,10 +230,20 @@ func (p *Process) Start() error {
 	if err != nil {
 		return err
 	}
+	mounts := make([]mount.Mount, 0, len(p.mounts))
+	for _, processMount := range p.mounts {
+		mounts = append(mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   processMount.Source,
+			Target:   processMount.Target,
+			ReadOnly: processMount.ReadOnly,
+		})
+	}
 
 	hostConfig := &container.HostConfig{
 		AutoRemove:     p.autoRemove,
 		Binds:          binds,
+		Mounts:         mounts,
 		ReadonlyRootfs: p.readOnlyRootfs,
 		Tmpfs:          p.tmpfs,
 		CapDrop:        p.capDrop,
@@ -550,6 +567,55 @@ func buildBinds(volumes []string) ([]string, error) {
 		binds = append(binds, volume)
 	}
 	return binds, nil
+}
+
+func validateStaticMountTargets(volumes []string) error {
+	seen := make(map[string]struct{}, len(volumes))
+	for _, volume := range volumes {
+		target, ok := bindTarget(volume)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[target]; exists {
+			return fmt.Errorf("%w: %q", execapi.ErrDuplicateMountTarget, target)
+		}
+		seen[target] = struct{}{}
+	}
+	return nil
+}
+
+func validateProcessMountTargets(volumes []string, mounts []execapi.Mount) error {
+	if err := validateStaticMountTargets(volumes); err != nil {
+		return err
+	}
+	staticTargets := make(map[string]struct{}, len(volumes))
+	for _, volume := range volumes {
+		if target, ok := bindTarget(volume); ok {
+			staticTargets[target] = struct{}{}
+		}
+	}
+	for _, processMount := range mounts {
+		target := path.Clean(processMount.Target)
+		if _, exists := staticTargets[target]; exists {
+			return fmt.Errorf("%w: %q", execapi.ErrDuplicateMountTarget, target)
+		}
+	}
+	return nil
+}
+
+// bindTarget extracts a Unix container target, including binds whose host
+// source has a Windows drive prefix. Other syntax remains daemon-owned.
+func bindTarget(volume string) (string, bool) {
+	if len(volume) >= 3 && volume[1] == ':' &&
+		((volume[0] >= 'A' && volume[0] <= 'Z') || (volume[0] >= 'a' && volume[0] <= 'z')) &&
+		(volume[2] == '/' || volume[2] == '\\') {
+		volume = volume[2:]
+	}
+	parts := strings.SplitN(volume, ":", 3)
+	if len(parts) < 2 || !strings.HasPrefix(parts[1], "/") {
+		return "", false
+	}
+	return path.Clean(parts[1]), true
 }
 
 func isExplicitRelativePath(source string) bool {

--- a/service/exec/docker/docker_test.go
+++ b/service/exec/docker/docker_test.go
@@ -128,18 +128,44 @@ func TestDockerPTYProcessMountsUseSeparateHomes(t *testing.T) {
 		Image: "alpine:latest", AutoRemove: true,
 	})
 	require.NoError(t, err)
-	defer func() { _ = executor.Close() }()
+	t.Cleanup(func() { _ = executor.Close() })
+	processes := make([]execapi.PTYProcess, 0, len(homes))
+	outputs := make([]chan string, 0, len(homes))
 	for index, home := range homes {
-		process, processErr := executor.NewProcess(fmt.Sprintf("sh -c 'printf home-%d >/home/marker; sleep 1'", index), execapi.ProcessOptions{
+		process, processErr := executor.NewProcess(fmt.Sprintf("sh -c 'stty -echo; printf home-%d >/home/marker; echo ready; read value; stty size; cat /home/marker; echo'", index), execapi.ProcessOptions{
 			PTY:    &execapi.PTYOptions{Width: 80, Height: 24},
 			Mounts: []execapi.Mount{{Source: home, Target: "/home"}},
 		})
 		require.NoError(t, processErr)
-		_, hasPTY := process.(execapi.PTYProcess)
+		pty, hasPTY := process.(execapi.PTYProcess)
 		require.True(t, hasPTY)
 		require.NoError(t, process.Start())
+		t.Cleanup(func() { _ = process.Signal(9) })
+		output := process.Stdout()
+		t.Cleanup(func() { _ = output.Close() })
+		lines := make(chan string, 4)
+		go func() {
+			scanner := bufio.NewScanner(output)
+			for scanner.Scan() {
+				lines <- strings.TrimSpace(scanner.Text())
+			}
+			close(lines)
+		}()
+		require.Equal(t, "ready", awaitLine(t, lines, "ready"))
+		processes = append(processes, pty)
+		outputs = append(outputs, lines)
+	}
+	// Both containers are alive at the input barrier. Resize and release them
+	// independently, then verify both terminal output and retained host data.
+	for index, process := range processes {
+		require.NoError(t, process.Resize(100+index, 30+index))
+		require.NoError(t, process.WriteStdin([]byte("continue\n")))
+		size := fmt.Sprintf("%d %d", 30+index, 100+index)
+		require.Equal(t, size, awaitLine(t, outputs[index], size))
+		marker := fmt.Sprintf("home-%d", index)
+		require.Equal(t, marker, awaitLine(t, outputs[index], marker))
 		require.NoError(t, process.Wait())
-		content, readErr := os.ReadFile(filepath.Join(home, "marker"))
+		content, readErr := os.ReadFile(filepath.Join(homes[index], "marker"))
 		require.NoError(t, readErr)
 		require.Equal(t, fmt.Sprintf("home-%d", index), string(content))
 	}

--- a/service/exec/docker/docker_test.go
+++ b/service/exec/docker/docker_test.go
@@ -121,6 +121,30 @@ func TestDockerPTYResize(t *testing.T) {
 	require.NoError(t, process.Wait())
 }
 
+func TestDockerPTYProcessMountsUseSeparateHomes(t *testing.T) {
+	skipIfNoDocker(t)
+	homes := []string{t.TempDir(), t.TempDir()}
+	executor, err := NewDockerExecutor(zap.NewNop(), &execapi.DockerExecutorConfig{
+		Image: "alpine:latest", AutoRemove: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = executor.Close() }()
+	for index, home := range homes {
+		process, processErr := executor.NewProcess(fmt.Sprintf("sh -c 'printf home-%d >/home/marker; sleep 1'", index), execapi.ProcessOptions{
+			PTY:    &execapi.PTYOptions{Width: 80, Height: 24},
+			Mounts: []execapi.Mount{{Source: home, Target: "/home"}},
+		})
+		require.NoError(t, processErr)
+		_, hasPTY := process.(execapi.PTYProcess)
+		require.True(t, hasPTY)
+		require.NoError(t, process.Start())
+		require.NoError(t, process.Wait())
+		content, readErr := os.ReadFile(filepath.Join(home, "marker"))
+		require.NoError(t, readErr)
+		require.Equal(t, fmt.Sprintf("home-%d", index), string(content))
+	}
+}
+
 func TestDockerPTYResizeRejectsInvalidSizeBeforeDaemonCall(t *testing.T) {
 	process := &ptyProcess{Process: &Process{pty: &execapi.PTYOptions{}, started: true}}
 	require.ErrorIs(t, process.Resize(execapi.MaxPTYDimension+1, 1), execapi.ErrInvalidPTYSize)
@@ -199,6 +223,41 @@ func TestDockerExecutor_RequiresImage(t *testing.T) {
 
 	_, err := NewDockerExecutor(log, config)
 	assert.ErrorIs(t, err, execapi.ErrImageRequired)
+}
+
+func TestDockerExecutorRejectsStaticMountTargetCollision(t *testing.T) {
+	_, err := NewDockerExecutor(zap.NewNop(), &execapi.DockerExecutorConfig{
+		Image:   "alpine:latest",
+		Volumes: []string{"/one:/workspace", "/two:/workspace/"},
+	})
+	assert.ErrorIs(t, err, execapi.ErrDuplicateMountTarget)
+}
+
+func TestDockerExecutorRejectsProcessMountTargetCollision(t *testing.T) {
+	for _, volume := range []string{
+		"/one:/workspace", "named:/workspace/:ro", `C:\host\one:/workspace:ro`,
+		"c:/host/one:/workspace", `\\server\share:/workspace`,
+	} {
+		t.Run(volume, func(t *testing.T) {
+			executor := &Executor{volumes: []string{volume}}
+			_, err := executor.NewProcess("true", execapi.ProcessOptions{
+				Mounts: []execapi.Mount{{Source: "/two", Target: "/workspace"}},
+			})
+			assert.ErrorIs(t, err, execapi.ErrDuplicateMountTarget)
+		})
+	}
+}
+
+func TestDockerExecutorProcessMountsAreIsolated(t *testing.T) {
+	executor := &Executor{image: "alpine:latest"}
+	firstOptions := execapi.ProcessOptions{Mounts: []execapi.Mount{{Source: "/first", Target: "/workspace"}}}
+	first, err := executor.NewProcess("true", firstOptions)
+	require.NoError(t, err)
+	second, err := executor.NewProcess("true", execapi.ProcessOptions{Mounts: []execapi.Mount{{Source: "/second", Target: "/workspace"}}})
+	require.NoError(t, err)
+	firstOptions.Mounts[0].Source = "/mutated"
+	require.Equal(t, "/first", first.(*Process).mounts[0].Source)
+	require.Equal(t, "/second", second.(*Process).mounts[0].Source)
 }
 
 func TestDockerExecutorRejectsMissingAndMalformedCommands(t *testing.T) {

--- a/service/exec/native/native.go
+++ b/service/exec/native/native.go
@@ -56,17 +56,17 @@ func NewNativeExecutor(log *zap.Logger, config *execapi.NativeExecutorConfig) *E
 
 // NewProcess implements exec.ProcessExecutor interface
 func (e *Executor) NewProcess(cmd string, options execapi.ProcessOptions) (execapi.Process, error) {
+	options, err := options.Clone()
+	if err != nil {
+		return nil, err
+	}
+	if len(options.Mounts) > 0 {
+		return nil, execapi.ErrMountsUnsupported
+	}
 	if _, err := execapi.ParseCommand(cmd); err != nil {
 		return nil, err
 	}
 	ptyOptions := options.PTY
-	if ptyOptions != nil {
-		copy := *ptyOptions
-		ptyOptions = &copy
-		if _, _, err := ptyOptions.Dimensions(); err != nil {
-			return nil, err
-		}
-	}
 	processGroup := e.processGroup
 	if options.ProcessGroup != nil {
 		processGroup = *options.ProcessGroup

--- a/service/exec/native/native_test.go
+++ b/service/exec/native/native_test.go
@@ -90,6 +90,12 @@ func TestPTYCapabilityMatchesProcessConfiguration(t *testing.T) {
 	assert.True(t, hasPTYCapability)
 }
 
+func TestNativeExecutorRejectsProcessMounts(t *testing.T) {
+	executor := NewNativeExecutor(zap.NewNop(), &exec.NativeExecutorConfig{})
+	_, err := executor.NewProcess("true", exec.ProcessOptions{Mounts: []exec.Mount{{Source: "/host", Target: "/workspace"}}})
+	assert.ErrorIs(t, err, exec.ErrMountsUnsupported)
+}
+
 func TestPTYWaitReleasesMasterFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("PTY test requires Unix")


### PR DESCRIPTION
Processes using one Docker executor need distinct project and retained-home mounts. Add typed per-process bind mounts to Go `ProcessOptions` and Lua `executor:exec` options, with a separate `exec.mount` check on each source before process creation. Native execution rejects mount options.

Validate absolute sources and container targets, reject duplicate request/configured bind targets, and copy options before retaining them. Docker keeps its existing static volume syntax; collision checks include Windows host sources targeting Unix container paths. The source permission is a lexical path check, not symlink confinement, and refers to the Docker daemon's host.

Validation: race tests pass for `api/service/exec`, all `service/exec` packages and `runtime/lua/modules/exec`. Two live Alpine containers verify independent mounted homes, terminal input and resize. Lua tests cover typed options and denial before factory invocation, and native tests cover unsupported mounts. Scoped golangci-lint reports zero issues. The exec API suite also passes on actual Windows after fixing Unix daemon-path validation for Windows clients.

CI on the preceding revision passed Linux and native Lua. The Windows failure is corrected in the latest commit. Full CI lint currently reports three unchanged HTTP test `noctx` violations, addressed separately by #738.

This provides the runtime primitive. Managed harness Docker configuration and recovery remain Bee integration work.


## Follow-up commits
- Static mount targets are validated once, at executor construction; `NewProcess` checks only what varies per process. Redundant slice copies after `Clone` removed.
- Denials are `PERMISSION_DENIED` (were `INVALID`) for `exec.run`, `exec.mount` and executor access; a refused mount names `source`/`target`/`read_only` in details. Bee's `render_configuration.lua:48` asserts the old kind and changes to `"PermissionDenied"` when this lands.
- `Mount.Validate` reports through apierror constructors with `ErrInvalidMount`/`ErrDuplicateMountTarget` as the cause; every `ErrorIs` assertion still holds.
- Coverage: policy is evaluated for every mount with its target and mode (`TestExecutorExecMountPolicyScopesEachSource`, `…SeesAttributes`); one refused source refuses the whole process; a path that fails validation never reaches policy (`TestExecutorExecValidatesMountsBeforePolicy`).
- Spec has a `mounts` usage example. Native executors keep refusing mounts with `ErrMountsUnsupported`; a native confinement option is a separate, queued feature.
