### PR TITLE
fix(app): preserve dependency artifacts across embedded updates

### DIFF
--- a/cmd/app/artifact_cache.go
+++ b/cmd/app/artifact_cache.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/lock"
+)
+
+const artifactCacheDirectory = "artifact-cache"
+
+func dependencyVendorDirectory(state string) string {
+	return filepath.Join(state, artifactCacheDirectory, "vendor")
+}
+
+// seedDependencyCache stores embedded packs and imports verified immutable
+// artifacts from retained deployment vendors. Deployment locks and history are
+// left untouched; only exact content-addressed files enter the stable vendor.
+func seedDependencyCache(state, deployment string, bundle Bundle) error {
+	if err := bundle.validate(); err != nil {
+		return err
+	}
+	cache := dependencyVendorDirectory(state)
+	stateRoot, err := os.OpenRoot(state)
+	if err != nil {
+		return fmt.Errorf("open application state: %w", err)
+	}
+	if err := stateRoot.MkdirAll(filepath.ToSlash(filepath.Join(artifactCacheDirectory, "vendor")), 0o700); err != nil {
+		stateRoot.Close()
+		return fmt.Errorf("create dependency artifact cache: %w", err)
+	}
+	stateRoot.Close()
+	for _, pack := range bundle.Packs {
+		name, _ := graph.ParseName(pack.Module)
+		relative := immutableRelativePath(name, pack.Version, pack.Digest)
+		if relative == "" {
+			return fmt.Errorf("invalid embedded artifact digest for %s", pack.Module)
+		}
+		if err := publishBytes(cache, relative, pack.Data, pack.Digest, uint64(len(pack.Data))); err != nil {
+			return fmt.Errorf("cache embedded module %s@%s: %w", pack.Module, pack.Version, err)
+		}
+	}
+	roots, err := retainedDeploymentRoots(state, deployment, bundle)
+	if err != nil {
+		return err
+	}
+	for _, root := range roots {
+		if err := importDeploymentArtifacts(root, cache); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func retainedDeploymentRoots(state, selected string, bundle Bundle) ([]string, error) {
+	roots := make([]string, 0, 8)
+	seen := make(map[string]struct{})
+	add := func(root string) error {
+		if root == "" {
+			return nil
+		}
+		absolute, err := filepath.Abs(root)
+		if err != nil {
+			return err
+		}
+		absolute = filepath.Clean(absolute)
+		if _, exists := seen[absolute]; !exists {
+			seen[absolute] = struct{}{}
+			roots = append(roots, absolute)
+		}
+		return nil
+	}
+	if err := add(selected); err != nil {
+		return nil, err
+	}
+	if err := add(embeddedDeployment(state, bundle)); err != nil {
+		return nil, err
+	}
+	if active, err := selectedDeployment(state); err == nil {
+		if err := add(active); err != nil {
+			return nil, err
+		}
+	}
+	for _, parent := range []string{filepath.Join(state, "base"), filepath.Join(state, "revisions")} {
+		entries, err := os.ReadDir(parent)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read retained deployments: %w", err)
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			root := filepath.Join(parent, entry.Name())
+			if filepath.Base(parent) == "revisions" {
+				root = filepath.Join(root, "deployment")
+			}
+			if err := add(root); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return roots, nil
+}
+
+func importDeploymentArtifacts(deployment, cache string) error {
+	lockPath := filepath.Join(deployment, lock.DefaultFilename)
+	lockInfo, err := os.Lstat(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect retained deployment lock %s: %w", lockPath, err)
+	}
+	if lockInfo.Mode()&os.ModeSymlink != 0 || !lockInfo.Mode().IsRegular() {
+		return fmt.Errorf("retained deployment lock is not a regular file: %s", lockPath)
+	}
+	locked, err := lock.New(lockPath)
+	if err != nil {
+		return fmt.Errorf("read retained deployment lock %s: %w", lockPath, err)
+	}
+	vendor := lock.ResolveLockPath(filepath.Dir(lockPath), locked.GetVendorPath())
+	if !pathWithin(deployment, vendor) {
+		return fmt.Errorf("retained deployment vendor path escapes deployment: %s", vendor)
+	}
+	deploymentRoot, err := os.OpenRoot(deployment)
+	if err != nil {
+		return err
+	}
+	defer deploymentRoot.Close()
+	vendorRel, err := filepath.Rel(deployment, vendor)
+	if err != nil || filepath.IsAbs(vendorRel) || strings.HasPrefix(vendorRel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("retained deployment vendor path escapes deployment")
+	}
+	vendorRoot, err := deploymentRoot.OpenRoot(filepath.ToSlash(vendorRel))
+	if err != nil {
+		return fmt.Errorf("open retained deployment vendor: %w", err)
+	}
+	defer vendorRoot.Close()
+	if err := importImmutableArtifacts(vendorRoot, cache); err != nil {
+		return err
+	}
+	for _, module := range locked.GetModules() {
+		digest, err := sha256Digest(module.Hash)
+		if err != nil {
+			continue
+		}
+		name, err := graph.ParseName(module.Name)
+		if err != nil {
+			continue
+		}
+		relative := filepath.ToSlash(filepath.Join(name.Organization, name.Module+"-"+module.Version+".wapp"))
+		if _, err := vendorRoot.Lstat(relative); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("inspect retained legacy artifact: %w", err)
+		}
+		exact := immutableRelativePath(name, module.Version, digest)
+		if exact == "" {
+			continue
+		}
+		if err := copyArtifact(vendorRoot, relative, cache, exact, digest); err != nil {
+			return fmt.Errorf("cache retained module %s@%s: %w", module.Name, module.Version, err)
+		}
+	}
+	return nil
+}
+
+func importImmutableArtifacts(vendor *os.Root, cache string) error {
+	entries, err := readRootDir(vendor, ".")
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, org := range entries {
+		if org.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("retained artifact vendor contains symlink: %s", org.Name())
+		}
+		if !org.IsDir() {
+			continue
+		}
+		if _, err := graph.ParseName(org.Name() + "/module"); err != nil {
+			return fmt.Errorf("invalid retained artifact organization %s", org.Name())
+		}
+		orgRoot, err := vendor.OpenRoot(org.Name())
+		if err != nil {
+			return err
+		}
+		files, readErr := readRootDir(orgRoot, ".")
+		orgRoot.Close()
+		if readErr != nil {
+			return readErr
+		}
+		for _, file := range files {
+			if file.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("retained artifact organization contains symlink: %s", file.Name())
+			}
+			if file.IsDir() {
+				continue
+			}
+			digest, ok := immutableFilenameDigest(file.Name())
+			if !ok {
+				continue
+			}
+			source := filepath.ToSlash(filepath.Join(org.Name(), file.Name()))
+			if err := copyArtifact(vendor, source, cache, source, digest); err != nil {
+				return fmt.Errorf("cache retained artifact %s: %w", source, err)
+			}
+		}
+	}
+	return nil
+}
+
+func immutableFilenameDigest(filename string) (string, bool) {
+	const marker = ".sha256-"
+	if !strings.HasSuffix(filename, ".wapp") {
+		return "", false
+	}
+	base := strings.TrimSuffix(filename, ".wapp")
+	index := strings.LastIndex(base, marker)
+	if index <= 0 {
+		return "", false
+	}
+	digest, err := sha256Digest(base[index+len(marker):])
+	return digest, err == nil
+}
+
+func immutableRelativePath(name graph.Name, version, digest string) string {
+	digest, err := sha256Digest(digest)
+	if err != nil {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Join(name.Organization, name.Module+"-"+version+".sha256-"+digest+".wapp"))
+}
+
+func sha256Digest(raw string) (string, error) {
+	value := strings.TrimSpace(strings.TrimPrefix(strings.ToLower(raw), "sha256:"))
+	if len(value) != sha256.Size*2 {
+		return "", fmt.Errorf("invalid sha256 artifact digest")
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return "", fmt.Errorf("invalid sha256 artifact digest: %w", err)
+	}
+	return value, nil
+}
+
+func publishBytes(root, relative string, data []byte, digest string, size uint64) error {
+	destination, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+	if err := destination.MkdirAll(filepath.ToSlash(filepath.Dir(relative)), 0o700); err != nil {
+		return err
+	}
+	if err := verifyRootArtifact(destination, relative, digest, size); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return publishArtifact(destination, relative, bytes.NewReader(data), digest, size)
+}
+
+func publishArtifact(root *os.Root, relative string, input io.Reader, digest string, size uint64) error {
+	tmp, tmpRel, err := createRootTemp(root, filepath.Dir(relative), "artifact")
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	count, copyErr := io.Copy(io.MultiWriter(tmp, hash), input)
+	if copyErr != nil {
+		tmp.Close()
+		_ = root.Remove(tmpRel)
+		return copyErr
+	}
+	want, digestErr := sha256Digest(digest)
+	if digestErr != nil || hex.EncodeToString(hash.Sum(nil)) != want || (size > 0 && uint64(count) != size) {
+		tmp.Close()
+		_ = root.Remove(tmpRel)
+		return fmt.Errorf("artifact content does not match its immutable identity")
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		_ = root.Remove(tmpRel)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = root.Remove(tmpRel)
+		return err
+	}
+	if err := root.Link(tmpRel, relative); err != nil {
+		if verifyErr := verifyRootArtifact(root, relative, digest, size); verifyErr == nil {
+			_ = root.Remove(tmpRel)
+			return nil
+		}
+		_ = root.Remove(tmpRel)
+		return err
+	}
+	return root.Remove(tmpRel)
+}
+
+func copyArtifact(source *os.Root, sourceRel, destination, destinationRel, digest string) error {
+	destinationRoot, err := os.OpenRoot(destination)
+	if err != nil {
+		return err
+	}
+	defer destinationRoot.Close()
+	if err := destinationRoot.MkdirAll(filepath.ToSlash(filepath.Dir(destinationRel)), 0o700); err != nil {
+		return err
+	}
+	if err := verifyRootArtifact(destinationRoot, destinationRel, digest, 0); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if info, err := source.Lstat(sourceRel); err != nil {
+		return err
+	} else if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("retained artifact is not a regular file")
+	}
+	input, err := source.Open(sourceRel)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	return publishArtifact(destinationRoot, destinationRel, input, digest, 0)
+}
+
+func verifyRootArtifact(root *os.Root, relative, digest string, expectedSize uint64) error {
+	info, err := root.Lstat(relative)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("artifact is not a regular file")
+	}
+	file, err := root.Open(relative)
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if err := errors.Join(copyErr, closeErr); err != nil {
+		return err
+	}
+	want, err := sha256Digest(digest)
+	if err != nil || hex.EncodeToString(hash.Sum(nil)) != want {
+		return fmt.Errorf("artifact digest mismatch")
+	}
+	if expectedSize > 0 && uint64(info.Size()) != expectedSize {
+		return fmt.Errorf("artifact size mismatch")
+	}
+	return nil
+}
+
+func verifyCachedPath(root, relative, digest string, size uint64) error {
+	handle, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer handle.Close()
+	return verifyRootArtifact(handle, relative, digest, size)
+}
+
+func createRootTemp(handle *os.Root, directory, prefix string) (*os.File, string, error) {
+	for counter := 0; counter < 32; counter++ {
+		relative := filepath.ToSlash(filepath.Join(directory, fmt.Sprintf(".%s-%d", prefix, counter)))
+		file, err := handle.OpenFile(relative, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		return file, relative, nil
+	}
+	return nil, "", fmt.Errorf("create private artifact file: too many concurrent writers")
+}
+
+func readRootDir(root *os.Root, relative string) ([]os.DirEntry, error) {
+	file, err := root.Open(relative)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return file.ReadDir(-1)
+}
+
+func pathWithin(root, target string) bool {
+	relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(target))
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}

--- a/cmd/app/artifact_cache_test.go
+++ b/cmd/app/artifact_cache_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishArtifactConcurrentIdenticalArtifacts(t *testing.T) {
+	root := t.TempDir()
+	relative := filepath.Join("wippy", "agent-0.1.0-dev.sha256-"+digestFor([]byte("same"))+".wapp")
+	data := []byte("same")
+	digest := "sha256:" + digestFor(data)
+	handle, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	require.NoError(t, handle.MkdirAll(filepath.Dir(relative), 0o700))
+	handle.Close()
+
+	const writers = 12
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	var wait sync.WaitGroup
+	for range writers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			handle, err := os.OpenRoot(root)
+			if err == nil {
+				err = publishArtifact(handle, relative, bytes.NewReader(data), digest, uint64(len(data)))
+				handle.Close()
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.NoError(t, verifyCachedPath(root, relative, digest, uint64(len(data))))
+}
+
+func TestPublishArtifactReaderFailureLeavesNoFinalArtifact(t *testing.T) {
+	root := t.TempDir()
+	relative := filepath.Join("wippy", "agent-0.1.0-dev.sha256-"+digestFor([]byte("expected"))+".wapp")
+	handle, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	require.NoError(t, handle.MkdirAll(filepath.Dir(relative), 0o700))
+	err = publishArtifact(handle, relative, failingArtifactReader{}, "sha256:"+digestFor([]byte("expected")), uint64(len("expected")))
+	handle.Close()
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	_, err = os.Stat(filepath.Join(root, relative))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestPublishArtifactDigestMismatchLeavesNoFinalArtifact(t *testing.T) {
+	root := t.TempDir()
+	relative := filepath.Join("wippy", "agent-0.1.0-dev.sha256-"+digestFor([]byte("expected"))+".wapp")
+	handle, err := os.OpenRoot(root)
+	require.NoError(t, err)
+	require.NoError(t, handle.MkdirAll(filepath.Dir(relative), 0o700))
+	err = publishArtifact(handle, relative, bytes.NewReader([]byte("tampered")), "sha256:"+digestFor([]byte("expected")), uint64(len("tampered")))
+	handle.Close()
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(root, relative))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+type failingArtifactReader struct{}
+
+func (failingArtifactReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = 'x'
+	return 1, io.ErrUnexpectedEOF
+}
+
+func digestFor(data []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+var _ io.Reader = failingArtifactReader{}

--- a/cmd/app/bundle_test.go
+++ b/cmd/app/bundle_test.go
@@ -4,16 +4,26 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	ctxapi "github.com/wippyai/runtime/api/context"
+	moduleapi "github.com/wippyai/runtime/api/modules"
+	regapi "github.com/wippyai/runtime/api/registry"
+	"github.com/wippyai/runtime/boot/deps/graph"
+	"github.com/wippyai/runtime/boot/deps/hub"
 	"github.com/wippyai/runtime/boot/deps/lock"
+	"github.com/wippyai/runtime/internal/version"
+	historymem "github.com/wippyai/runtime/system/registry/history/memory"
 	"github.com/wippyai/wapp"
+	"go.uber.org/zap"
 )
 
 func testBundle(t *testing.T) Bundle {
@@ -89,4 +99,140 @@ func TestBundleConcurrentFirstLaunch(t *testing.T) {
 	for err := range failures {
 		require.NoError(t, err)
 	}
+}
+
+func bundleWithMarker(t *testing.T, marker string) Bundle {
+	t.Helper()
+	var data bytes.Buffer
+	err := wapp.NewWriter().PackEntries(
+		wapp.Metadata{"namespace": "acme.app", "name": "app", "version": "1.0.0"},
+		[]wapp.Entry{{ID: wapp.NewID("acme.app", "marker"), Kind: "ns.definition", Data: map[string]any{"marker": marker}}},
+		&data,
+	)
+	require.NoError(t, err)
+	digest := sha256.Sum256(data.Bytes())
+	return Bundle{Root: "acme/app", Packs: []Pack{{Module: "acme/app", Version: "1.0.0", Digest: fmt.Sprintf("sha256:%x", digest), Data: data.Bytes()}}}
+}
+
+func TestChangedBundleSeedsRetainedImmutableOverlayOffline(t *testing.T) {
+	state := t.TempDir()
+	oldBundle := bundleWithMarker(t, "old")
+	oldDeployment := embeddedDeployment(state, oldBundle)
+	_, err := oldBundle.Seed(oldDeployment)
+	require.NoError(t, err)
+	oldLockBefore, err := os.ReadFile(filepath.Join(oldDeployment, lock.DefaultFilename))
+	require.NoError(t, err)
+
+	// An installed overlay is not necessarily listed in the embedded bundle's
+	// lock. It is still a retained immutable artifact and must be carried over.
+	overlay := []byte("retained overlay artifact")
+	overlayDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(overlay))
+	overlayName, err := graph.ParseName("wippy/agent")
+	require.NoError(t, err)
+	overlayPath := filepath.Join(oldDeployment, ".wippy", "vendor", immutableRelativePath(overlayName, "0.1.0-dev", overlayDigest))
+	require.NotEmpty(t, overlayPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(overlayPath), 0o700))
+	require.NoError(t, os.WriteFile(overlayPath, overlay, 0o600))
+
+	newBundle := bundleWithMarker(t, "new")
+	newDeployment := embeddedDeployment(state, newBundle)
+	_, err = newBundle.Seed(newDeployment)
+	require.NoError(t, err)
+	require.NoError(t, seedDependencyCache(state, newDeployment, newBundle))
+
+	cache := dependencyVendorDirectory(state)
+	require.NoError(t, verifyCachedPath(cache, immutableRelativePath(graph.MustParseName("acme/app"), "1.0.0", newBundle.Packs[0].Digest), newBundle.Packs[0].Digest, uint64(len(newBundle.Packs[0].Data))))
+	retainedRelative := immutableRelativePath(overlayName, "0.1.0-dev", overlayDigest)
+	require.NoError(t, verifyCachedPath(cache, retainedRelative, overlayDigest, uint64(len(overlay))))
+
+	oldLock, err := os.ReadFile(filepath.Join(oldDeployment, lock.DefaultFilename))
+	require.NoError(t, err)
+	require.Equal(t, oldLockBefore, oldLock)
+}
+
+func TestDependencyCacheRejectsRetainedSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	state := t.TempDir()
+	bundle := bundleWithMarker(t, "stable")
+	deployment := embeddedDeployment(state, bundle)
+	_, err := bundle.Seed(deployment)
+	require.NoError(t, err)
+	outside := filepath.Join(t.TempDir(), "outside.wapp")
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o600))
+	symlink := filepath.Join(deployment, ".wippy", "vendor", "wippy", "agent-0.1.0-dev.sha256-"+fmt.Sprintf("%x", sha256.Sum256([]byte("outside")))+".wapp")
+	require.NoError(t, os.MkdirAll(filepath.Dir(symlink), 0o700))
+	require.NoError(t, os.Symlink(outside, symlink))
+	require.ErrorContains(t, seedDependencyCache(state, deployment, bundle), "symlink")
+}
+
+type cacheOfflineHub struct{ requests int }
+
+func (h *cacheOfflineHub) GetManifest(context.Context, string, string, string) (*hub.ModuleManifest, error) {
+	h.requests++
+	return nil, fmt.Errorf("Hub must not be contacted during restore")
+}
+
+func (h *cacheOfflineHub) ListAllVersions(context.Context, string, string) ([]hub.VersionInfo, error) {
+	h.requests++
+	return nil, fmt.Errorf("Hub must not be contacted during restore")
+}
+
+func (h *cacheOfflineHub) GetDownloadURL(context.Context, *hub.DownloadParams) (*hub.DownloadInfo, error) {
+	h.requests++
+	return nil, fmt.Errorf("Hub must not be contacted during restore")
+}
+
+func (h *cacheOfflineHub) DownloadToFile(context.Context, string, string) error {
+	h.requests++
+	return fmt.Errorf("Hub must not be contacted during restore")
+}
+
+func TestChangedBundleRestoresHistoricalOverlayOffline(t *testing.T) {
+	state := t.TempDir()
+	oldBundle := bundleWithMarker(t, "old")
+	oldDeployment := embeddedDeployment(state, oldBundle)
+	_, err := oldBundle.Seed(oldDeployment)
+	require.NoError(t, err)
+	newBundle := bundleWithMarker(t, "new")
+	newDeployment := embeddedDeployment(state, newBundle)
+	newLock, err := newBundle.Seed(newDeployment)
+	require.NoError(t, err)
+
+	overlay := []byte("retained overlay artifact")
+	overlayDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(overlay))
+	overlayRelative := immutableRelativePath(graph.MustParseName("wippy/agent"), "0.1.0-dev", overlayDigest)
+	overlayPath := filepath.Join(oldDeployment, ".wippy", "vendor", overlayRelative)
+	require.NoError(t, os.MkdirAll(filepath.Dir(overlayPath), 0o700))
+	require.NoError(t, os.WriteFile(overlayPath, overlay, 0o600))
+	require.NoError(t, seedDependencyCache(state, newDeployment, newBundle))
+
+	oldResolution := (&regapi.DependencyResolution{
+		Deployment: &regapi.Deployment{Root: "acme/app", Modules: []regapi.ResolvedModule{{
+			Name: "acme/app", Version: "1.0.0", Source: "hub", Digest: oldBundle.Packs[0].Digest,
+		}}},
+		Modules: []regapi.ResolvedModule{
+			{Name: "acme/app", Version: "1.0.0", Source: "hub", Digest: oldBundle.Packs[0].Digest},
+			{Name: "wippy/agent", Version: "0.1.0-dev", Source: "hub", Digest: overlayDigest},
+		},
+	}).Canonical()
+	history := historymem.New()
+	root, err := history.GetVersion(regapi.RootVersion)
+	require.NoError(t, err)
+	head := version.FromParent(root, 1)
+	require.NoError(t, history.SaveWithDependencyResolution(head, nil, oldResolution, true))
+
+	client := &cacheOfflineHub{}
+	depHandler, err := hub.NewDependencyHandler(hub.DependencyHandlerOptions{
+		Hub: client, Logger: zap.NewNop(), LockPath: newLock,
+		VendorDir: dependencyVendorDirectory(state),
+	})
+	require.NoError(t, err)
+	ctx := moduleapi.WithSourceRegistry(ctxapi.NewRootContext(), moduleapi.NewSourceRegistry())
+	ctx = regapi.WithDependencyAccess(ctx, regapi.DependencyAccessVerifiedOffline)
+	require.NoError(t, depHandler.PrepareRestore(ctx, history))
+	require.Zero(t, client.requests)
+	sources := moduleapi.GetSourceRegistry(ctx).Snapshot()
+	require.Equal(t, newBundle.Packs[0].Digest, sources["acme/app"].Digest)
 }

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/wippyai/runtime/api/boot"
+	"github.com/wippyai/runtime/cmd/internal/bootconfig"
 	"github.com/wippyai/runtime/cmd/wippy/cmd"
 )
 
@@ -154,6 +155,9 @@ func runApplication(ctx context.Context, options Options, stateDir string, base 
 	if err != nil {
 		return err
 	}
+	if err := seedDependencyCache(stateDir, deployment, options.Bundle); err != nil {
+		return err
+	}
 	if len(remaining) > 0 && remaining[0] == "update" {
 		if base {
 			return fmt.Errorf("base recovery cannot be updated")
@@ -179,12 +183,19 @@ func runApplication(ctx context.Context, options Options, stateDir string, base 
 	} else if !os.IsNotExist(err) {
 		return err
 	}
+	overrides = launchOverrides(overrides, historyPath)
+	// Keep dependency artifacts in application state so a new executable can
+	// restore an older registry graph without contacting the Hub. The lock and
+	// deployment source files remain selected independently above.
+	overrides = bootconfig.Merge(overrides, boot.NewConfig(boot.WithSection("registry", map[string]any{
+		"dependency_vendor_dir": dependencyVendorDirectory(stateDir),
+	})))
 	return cmd.ExecuteWithOptions(ctx, cmd.ExecuteOptions{
 		Args:        runtimeArgs,
 		LockFile:    lockPath,
 		ConfigFiles: configFiles,
 		Components:  options.Components,
-		Overrides:   launchOverrides(overrides, historyPath),
+		Overrides:   overrides,
 	})
 }
 


### PR DESCRIPTION
An embedded executable update selects a new deployment vendor directory while registry history still refers to previously installed module artifacts. Startup consequently attempts to download artifacts that already exist in older local deployments.

Keep dependency artifacts in an application-state cache using the existing `registry.dependency_vendor_dir` setting. Seed embedded packs and import retained exact immutable artifacts, including installed modules absent from deployment locks. Verify bytes while copying, publish atomically without replacing existing content, and preserve registry history, deployment locks and module digests.

This PR stacks on #726 because `cmd/app` is not on main. Offline-only registry restore is independently reviewed in #741; explicit command host selection is #740. None needs to be merged to review this change.

Validation: app suite and focused race tests pass, including changed bundles retaining installed artifacts, symlink rejection, concurrent identical publication, read failure and digest mismatch. Bee's combined executable offline acceptance is in progress and is not claimed here.
