### PR TITLE
feat(exec): expose optional process identity on terminal sessions

### DIFF
--- a/runtime/lua/modules/exec/module_test.go
+++ b/runtime/lua/modules/exec/module_test.go
@@ -627,6 +627,13 @@ type mockPTYProcess struct{ mockProcess }
 
 func (*mockPTYProcess) Resize(int, int) error { return nil }
 
+type mockPTYIdentityProcess struct {
+	*mockPTYProcess
+	pid int
+}
+
+func (p *mockPTYIdentityProcess) Pid() (int, error) { return p.pid, nil }
+
 func TestTakePTYProcessTransfersExclusiveOwnership(t *testing.T) {
 	l := lua.NewState()
 	defer l.Close()
@@ -643,6 +650,27 @@ func TestTakePTYProcessTransfersExclusiveOwnership(t *testing.T) {
 	}
 	if _, err := takePTYProcess(ud); !errors.Is(err, errPTYOwnership) {
 		t.Fatalf("second transfer error = %v, want %v", err, errPTYOwnership)
+	}
+}
+
+func TestTakePTYProcessRetainsOptionalIdentity(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	handle := &mockPTYIdentityProcess{mockPTYProcess: &mockPTYProcess{}, pid: 42}
+	p := NewProcess(context.Background(), handle)
+	ud := value.PushTypedUserData(l, p, processTypeName)
+
+	got, err := takePTYProcess(ud)
+	if err != nil {
+		t.Fatalf("take PTY process: %v", err)
+	}
+	identity, ok := got.(execapi.ProcessIdentity)
+	if !ok {
+		t.Fatal("transferred PTY process lost its optional process identity")
+	}
+	pid, err := identity.Pid()
+	if err != nil || pid != 42 {
+		t.Fatalf("transferred process identity = (%d, %v), want (42, nil)", pid, err)
 	}
 }
 

--- a/runtime/lua/modules/exec/spec.md
+++ b/runtime/lua/modules/exec/spec.md
@@ -158,7 +158,11 @@ local child = assert(executor:exec("bash", {
 local session = assert(child:attach_terminal())
 ```
 
-The session exposes `send(event)`, `done()`, `status()`, and `close()`. The
+The session exposes `send(event)`, `done()`, `pid()`, `status()`, and `close()`.
+`pid()` returns the host process identifier when the attached process exposes
+that capability. The call may return a not-started error while the asynchronous
+attachment is starting; once the session has completed with a startup error,
+it returns that terminal error instead of a retryable pending result.
 completion channel's `receive()` and `case_receive()` values are booleans, so a
 `channel.select` result from `done():case_receive()` carries a boolean value.
 Resize, keyboard, mouse, focus, and paste events use the canonical `tty`

--- a/runtime/lua/modules/exec/terminal.go
+++ b/runtime/lua/modules/exec/terminal.go
@@ -8,6 +8,7 @@ import (
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/relay"
 	"github.com/wippyai/runtime/api/runtime"
+	execapi "github.com/wippyai/runtime/api/service/exec"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 	"github.com/wippyai/runtime/runtime/lua/engine"
 	"github.com/wippyai/runtime/runtime/lua/engine/value"
@@ -63,6 +64,7 @@ func procAttachTerminal(l *lua.LState) int {
 		pushTerminalError(l, err, "acquire PTY process")
 		return 2
 	}
+	identity, _ := process.(execapi.ProcessIdentity)
 	bridge, err := proxy.New(process, surface, width, height)
 	if err != nil {
 		completion.close()
@@ -70,7 +72,7 @@ func procAttachTerminal(l *lua.LState) int {
 		pushTerminalError(l, err, "create terminal proxy")
 		return 2
 	}
-	session := newTerminalSession(bridge, completion)
+	session := newTerminalSession(bridge, completion, identity)
 	go func() {
 		err := bridge.Run(ctx, session.events)
 		_ = surface.Close()

--- a/runtime/lua/modules/exec/terminal_session.go
+++ b/runtime/lua/modules/exec/terminal_session.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	lua "github.com/wippyai/go-lua"
+	execapi "github.com/wippyai/runtime/api/service/exec"
 	ttyapi "github.com/wippyai/runtime/api/tty"
 	luatty "github.com/wippyai/runtime/runtime/lua/modules/tty"
 	"github.com/wippyai/runtime/service/terminal/proxy"
@@ -18,6 +19,7 @@ var terminalSessionMethods = map[string]lua.LGoFunc{
 	"send":   terminalSessionSend,
 	"close":  terminalSessionClose,
 	"done":   terminalSessionDone,
+	"pid":    terminalSessionPID,
 	"status": terminalSessionStatus,
 }
 
@@ -26,14 +28,16 @@ type terminalSession struct {
 	events     chan ttyapi.Event
 	completion *terminalCompletion
 	bridge     *proxy.Proxy
+	identity   execapi.ProcessIdentity
 	errMu      sync.RWMutex
 	once       sync.Once
 	done       atomic.Bool
 }
 
-func newTerminalSession(bridge *proxy.Proxy, completion *terminalCompletion) *terminalSession {
+func newTerminalSession(bridge *proxy.Proxy, completion *terminalCompletion, identity execapi.ProcessIdentity) *terminalSession {
 	return &terminalSession{
 		events: make(chan ttyapi.Event, 256), bridge: bridge, completion: completion,
+		identity: identity,
 	}
 }
 
@@ -92,6 +96,40 @@ func terminalSessionClose(l *lua.LState) int {
 func terminalSessionDone(l *lua.LState) int {
 	l.Push(checkTerminalSession(l).completion.value)
 	return 1
+}
+
+func terminalSessionPID(l *lua.LState) int {
+	session := checkTerminalSession(l)
+	if session.identity == nil {
+		l.Push(lua.LNil)
+		l.Push(lua.NewLuaError(l, "process has no host process id").WithKind(lua.Unavailable).WithRetryable(false))
+		return 2
+	}
+	if session.bridge != nil && !session.bridge.Started() {
+		l.Push(lua.LNil)
+		if session.done.Load() {
+			session.errMu.RLock()
+			err := session.err
+			session.errMu.RUnlock()
+			if err != nil {
+				l.Push(wrapExecError(l, err, "PTY process", lua.Internal))
+				return 2
+			}
+			l.Push(lua.NewLuaError(l, "terminal process has not started").WithKind(lua.Unavailable).WithRetryable(false))
+			return 2
+		}
+		l.Push(lua.NewLuaError(l, "terminal process has not started").WithKind(lua.Unavailable).WithRetryable(true))
+		return 2
+	}
+	pid, err := session.identity.Pid()
+	if err != nil {
+		l.Push(lua.LNil)
+		l.Push(wrapExecError(l, err, "read process id", lua.Internal))
+		return 2
+	}
+	l.Push(lua.LInteger(pid))
+	l.Push(lua.LNil)
+	return 2
 }
 
 func terminalSessionStatus(l *lua.LState) int {

--- a/runtime/lua/modules/exec/terminal_test.go
+++ b/runtime/lua/modules/exec/terminal_test.go
@@ -5,15 +5,21 @@ package exec
 import (
 	"context"
 	"errors"
+	"io"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	lua "github.com/wippyai/go-lua"
 	"github.com/wippyai/runtime/api/payload"
 	"github.com/wippyai/runtime/api/pid"
 	"github.com/wippyai/runtime/api/relay"
 	ttyapi "github.com/wippyai/runtime/api/tty"
+	"github.com/wippyai/runtime/runtime/lua/engine/value"
 	luatty "github.com/wippyai/runtime/runtime/lua/modules/tty"
+	"github.com/wippyai/runtime/service/exec/native"
+	"github.com/wippyai/runtime/service/terminal/proxy"
 )
 
 type terminalCompletionReceiver struct {
@@ -87,6 +93,187 @@ func TestEnqueueTerminalEventBackpressure(t *testing.T) {
 func TestProcessExportsTerminalAttachment(t *testing.T) {
 	if processMethods["attach_terminal"] == nil {
 		t.Fatal("exec.Process attach_terminal method is missing")
+	}
+}
+
+func TestTerminalSessionExportsPID(t *testing.T) {
+	if terminalSessionMethods["pid"] == nil {
+		t.Fatal("exec.TerminalSession pid method is missing")
+	}
+}
+
+type terminalSessionIdentity struct {
+	err error
+	pid int
+}
+
+func (i terminalSessionIdentity) Pid() (int, error) { return i.pid, i.err }
+
+func callTerminalSessionPID(t *testing.T, identity interface{ Pid() (int, error) }) (lua.LValue, lua.LValue) {
+	t.Helper()
+	l := lua.NewState()
+	defer l.Close()
+	value.PushTypedUserData(l, newTerminalSession(nil, nil, identity), terminalSessionTypeName)
+	if returns := terminalSessionPID(l); returns != 2 {
+		t.Fatalf("terminalSessionPID returned %d values, want 2", returns)
+	}
+	return l.Get(-2), l.Get(-1)
+}
+
+func TestTerminalSessionPID(t *testing.T) {
+	pid, err := callTerminalSessionPID(t, terminalSessionIdentity{pid: 42})
+	if got, ok := pid.(lua.LInteger); !ok || int(got) != 42 {
+		t.Fatalf("pid = %v, want 42", pid)
+	}
+	if err != lua.LNil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+}
+
+func TestTerminalSessionPIDUnavailable(t *testing.T) {
+	l := lua.NewState()
+	defer l.Close()
+	value.PushTypedUserData(l, newTerminalSession(nil, nil, nil), terminalSessionTypeName)
+
+	if returns := terminalSessionPID(l); returns != 2 {
+		t.Fatalf("terminalSessionPID returned %d values, want 2", returns)
+	}
+	if l.Get(-2) != lua.LNil {
+		t.Fatalf("pid = %v, want nil", l.Get(-2))
+	}
+	err, ok := l.Get(-1).(*lua.Error)
+	if !ok {
+		t.Fatalf("error = %v, want Lua error", l.Get(-1))
+	}
+	if err.Kind() != lua.Unavailable || err.Error() != "process has no host process id" {
+		t.Fatalf("error = %v (kind %v), want unavailable host process id", err, err.Kind())
+	}
+}
+
+func TestTerminalSessionPIDPreservesIdentityErrors(t *testing.T) {
+	failure := errors.New("pid lookup failed")
+	pid, err := callTerminalSessionPID(t, terminalSessionIdentity{err: failure})
+	if pid != lua.LNil {
+		t.Fatalf("pid = %v, want nil", pid)
+	}
+	luaErr, ok := err.(*lua.Error)
+	if !ok {
+		t.Fatalf("error = %v, want Lua error", err)
+	}
+	if !errors.Is(luaErr, failure) || !strings.Contains(luaErr.Error(), "read process id") {
+		t.Fatalf("error = %v, want wrapped PID failure", luaErr)
+	}
+}
+
+func TestTerminalSessionPIDBeforeStart(t *testing.T) {
+	pid, err := callTerminalSessionPID(t, terminalSessionIdentity{err: native.ErrProcessNotStarted})
+	if pid != lua.LNil {
+		t.Fatalf("pid = %v, want nil", pid)
+	}
+	luaErr, ok := err.(*lua.Error)
+	if !ok {
+		t.Fatalf("error = %v, want Lua error", err)
+	}
+	if luaErr.Kind() != lua.Internal || !strings.Contains(luaErr.Error(), "process not started") {
+		t.Fatalf("error = %v (kind %v), want wrapped not-started error", luaErr, luaErr.Kind())
+	}
+}
+
+type delayedTerminalProcess struct {
+	startEntered chan struct{}
+	startRelease chan struct{}
+}
+
+func (p *delayedTerminalProcess) Start() error {
+	close(p.startEntered)
+	<-p.startRelease
+	return nil
+}
+func (*delayedTerminalProcess) Signal(int) error        { return nil }
+func (*delayedTerminalProcess) WriteStdin([]byte) error { return nil }
+func (*delayedTerminalProcess) Stdout() io.ReadCloser   { return io.NopCloser(strings.NewReader("")) }
+func (*delayedTerminalProcess) Stderr() io.ReadCloser   { return nil }
+func (*delayedTerminalProcess) Wait() error             { return nil }
+func (*delayedTerminalProcess) Resize(int, int) error   { return nil }
+func (*delayedTerminalProcess) Pid() (int, error)       { return 42, nil }
+
+type terminalSessionSurface struct{}
+
+func (*terminalSessionSurface) Present(ttyapi.Frame) (ttyapi.PresentStats, error) {
+	return ttyapi.PresentStats{}, nil
+}
+func (*terminalSessionSurface) Invalidate()  {}
+func (*terminalSessionSurface) Close() error { return nil }
+
+func TestTerminalSessionPIDDoesNotBlockDuringAsyncStart(t *testing.T) {
+	process := &delayedTerminalProcess{
+		startEntered: make(chan struct{}),
+		startRelease: make(chan struct{}),
+	}
+	bridge, err := proxy.New(process, &terminalSessionSurface{}, 1, 1)
+	if err != nil {
+		t.Fatalf("create terminal proxy: %v", err)
+	}
+	runDone := make(chan error, 1)
+	go func() { runDone <- bridge.Run(context.Background(), make(chan ttyapi.Event)) }()
+	<-process.startEntered
+
+	l := lua.NewState()
+	defer l.Close()
+	value.PushTypedUserData(l, newTerminalSession(bridge, nil, process), terminalSessionTypeName)
+	result := make(chan struct{})
+	go func() {
+		if returns := terminalSessionPID(l); returns != 2 {
+			t.Errorf("terminalSessionPID returned %d values, want 2", returns)
+		}
+		close(result)
+	}()
+	select {
+	case <-result:
+	case <-time.After(time.Second):
+		t.Fatal("pid blocked while asynchronous process startup was in progress")
+	}
+	if l.Get(-2) != lua.LNil {
+		t.Fatalf("pid = %v, want nil before startup completes", l.Get(-2))
+	}
+	if got, ok := l.Get(-1).(*lua.Error); !ok || got.Kind() != lua.Unavailable || got.Retryable() != lua.TernaryTrue {
+		t.Fatalf("error = %v, want retryable unavailable not-started error", l.Get(-1))
+	}
+
+	close(process.startRelease)
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not finish after startup release")
+	}
+}
+
+func TestTerminalSessionPIDReportsCompletedStartupFailure(t *testing.T) {
+	process := &delayedTerminalProcess{
+		startEntered: make(chan struct{}),
+		startRelease: make(chan struct{}),
+	}
+	bridge, err := proxy.New(process, &terminalSessionSurface{}, 1, 1)
+	if err != nil {
+		t.Fatalf("create terminal proxy: %v", err)
+	}
+	failure := errors.New("terminal startup failed")
+	session := newTerminalSession(bridge, nil, process)
+	session.err = failure
+	session.done.Store(true)
+
+	l := lua.NewState()
+	defer l.Close()
+	value.PushTypedUserData(l, session, terminalSessionTypeName)
+	if returns := terminalSessionPID(l); returns != 2 {
+		t.Fatalf("terminalSessionPID returned %d values, want 2", returns)
+	}
+	if l.Get(-2) != lua.LNil {
+		t.Fatalf("pid = %v, want nil after startup failure", l.Get(-2))
+	}
+	luaErr, ok := l.Get(-1).(*lua.Error)
+	if !ok || !errors.Is(luaErr, failure) || luaErr.Retryable() != lua.TernaryFalse {
+		t.Fatalf("error = %v, want non-retryable startup failure", l.Get(-1))
 	}
 }
 

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -55,6 +55,8 @@ func init() {
 			Returns(typ.Boolean, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "done", Type: typ.Func().Param("self", typ.Self).
 			Returns(terminalCompletionType).Build()},
+		{Name: "pid", Type: typ.Func().Param("self", typ.Self).
+			Returns(typ.Integer, typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "status", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.NewUnion(typ.LiteralString("running"), typ.LiteralString("done")), typ.NewOptional(typ.LuaError)).Build()},
 	})

--- a/runtime/lua/modules/exec/types.go
+++ b/runtime/lua/modules/exec/types.go
@@ -56,7 +56,7 @@ func init() {
 		{Name: "done", Type: typ.Func().Param("self", typ.Self).
 			Returns(terminalCompletionType).Build()},
 		{Name: "pid", Type: typ.Func().Param("self", typ.Self).
-			Returns(typ.Integer, typ.NewOptional(typ.LuaError)).Build()},
+			Returns(typ.NewOptional(typ.Integer), typ.NewOptional(typ.LuaError)).Build()},
 		{Name: "status", Type: typ.Func().Param("self", typ.Self).
 			Returns(typ.NewUnion(typ.LiteralString("running"), typ.LiteralString("done")), typ.NewOptional(typ.LuaError)).Build()},
 	})

--- a/runtime/lua/modules/exec/types_test.go
+++ b/runtime/lua/modules/exec/types_test.go
@@ -35,3 +35,28 @@ return completion_value
 	require.NoError(t, err)
 	require.False(t, code.HasErrors(diagnostics), "terminal completion select type was lost: %v", diagnostics)
 }
+
+func TestTerminalSessionPIDType(t *testing.T) {
+	config := code.DefaultTypeCheckConfig()
+	config.Enabled = true
+	config.SkipUntyped = false
+	checker := code.NewTypeChecker(config, []*luaapi.ModuleDef{Module})
+	_, diagnostics, err := checker.Check(`
+local exec = require("exec")
+
+local function session_pid(session: exec.TerminalSession): integer
+    local pid, err = session:pid()
+    if err ~= nil then
+        return 0
+    end
+    if pid == nil then
+        return 0
+    end
+    return pid
+end
+
+return session_pid
+`, "terminal_session_pid_types.lua", nil)
+	require.NoError(t, err)
+	require.False(t, code.HasErrors(diagnostics), "terminal session pid type was not exposed: %v", diagnostics)
+}

--- a/service/terminal/proxy/proxy.go
+++ b/service/terminal/proxy/proxy.go
@@ -53,7 +53,7 @@ type Proxy struct {
 	lifecycleMu     sync.Mutex
 	closeRequested  atomic.Bool
 	cursorVisible   atomic.Bool
-	started         bool
+	started         atomic.Bool
 }
 
 // RequestClose accepts asynchronous shutdown intent. Run owns termination and
@@ -63,9 +63,15 @@ func (p *Proxy) RequestClose() {
 	p.closeNotifyOnce.Do(func() { close(p.closeNotify) })
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
-	if p.started {
+	if p.started.Load() {
 		_ = p.signalCloseLocked()
 	}
+}
+
+// Started reports whether the process startup phase has completed. It does not
+// inspect the process or acquire its startup lock.
+func (p *Proxy) Started() bool {
+	return p.started.Load()
 }
 
 // start serializes process startup with an early close request. Once Start
@@ -77,7 +83,7 @@ func (p *Proxy) start() error {
 	}
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
-	p.started = true
+	p.started.Store(true)
 	if p.closeRequested.Load() {
 		_ = p.signalCloseLocked()
 	}


### PR DESCRIPTION
Managed terminal callers lose access to the optional host process identity when `attach_terminal()` transfers ownership from `exec.Process`. Add `TerminalSession:pid()` so a caller can record that identity for later reconciliation.

Attachment remains asynchronous. PID reads return a retryable unavailable error until startup completes, without acquiring the process startup lock; unsupported identity and failed startup remain explicit errors. The Lua result is `integer?` plus an optional error. A PID or terminal completion does not prove that a process group is gone.

Stacked on #726 (`feat/embedded-default-deployment-pr`) to match the terminal attachment API used by Bee. No remote-monitor or mesh changes.

Validation: affected exec and terminal proxy race suites pass; Go vet passes; repository-pinned golangci-lint v2.13.2 reports 0 issues. Tests cover exclusive PTY ownership, optional identity, delayed startup, failure, unsupported identity and typed guarded PID use. Bee's pinned toolchain builds with the composed patch; native window integration acceptance is still in progress.
