### PR TITLE
fix(terminal): keep shutdown progressing during blocked input

### DIFF
--- a/service/terminal/proxy/docker_input_cancellation_integration_test.go
+++ b/service/terminal/proxy/docker_input_cancellation_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+// SPDX-License-Identifier: MPL-2.0
+
+package proxy
+
+import (
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+	execapi "github.com/wippyai/runtime/api/service/exec"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+	dockerexec "github.com/wippyai/runtime/service/exec/docker"
+	"go.uber.org/zap"
+)
+
+const dockerAttachProofTimeout = 10 * time.Second
+
+// observedDockerPTY instruments only writes; all execution behavior is native.
+type observedDockerPTY struct {
+	execapi.PTYProcess
+	entered  chan struct{}
+	returned chan struct{}
+}
+
+func (p *observedDockerPTY) WriteStdin(data []byte) error {
+	close(p.entered)
+	defer close(p.returned)
+	return p.PTYProcess.WriteStdin(data)
+}
+func TestNativeDockerInputCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cli, err := client.New(client.FromEnv)
+	require.NoError(t, err)
+	defer cli.Close()
+	setupCtx, setupCancel := context.WithTimeout(ctx, dockerAttachProofTimeout)
+	defer setupCancel()
+	image, err := cli.ImageInspect(setupCtx, "alpine:latest")
+	require.NoError(t, err, "fixture requires local image; no downloads")
+	executor, err := dockerexec.NewDockerExecutor(zap.NewNop(), &execapi.DockerExecutorConfig{Image: image.ID, AutoRemove: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = executor.Close() })
+	child, err := executor.NewProcess("sh -c 'stty -echo -icanon; echo ready; sleep 60'", execapi.ProcessOptions{PTY: &execapi.PTYOptions{Width: 20, Height: 4}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = child.Signal(int(syscall.SIGKILL))
+		if c, ok := child.(execapi.WaitCanceler); ok {
+			c.CancelWait()
+		}
+	})
+	process := &observedDockerPTY{PTYProcess: child.(execapi.PTYProcess), entered: make(chan struct{}), returned: make(chan struct{})}
+	surface := &testSurface{}
+	bridge, err := New(process, surface, 20, 4)
+	require.NoError(t, err)
+	events := make(chan ttyapi.Event, 1)
+	done := make(chan error, 1)
+	go func() { done <- bridge.Run(ctx, events) }()
+	require.Eventually(t, func() bool {
+		surface.mu.Lock()
+		defer surface.mu.Unlock()
+		return strings.Contains(strings.Join(surface.rows, "\n"), "ready")
+	}, dockerAttachProofTimeout, 20*time.Millisecond)
+	events <- ttyapi.Event{Type: "paste", Paste: strings.Repeat("x", 16*1024*1024)}
+	select {
+	case <-process.entered:
+	case <-time.After(time.Second):
+		t.Fatal("input not dispatched")
+	}
+	select {
+	case <-process.returned:
+		t.Fatal("fixture did not block input")
+	case <-time.After(200 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(8 * time.Second):
+		_ = child.Signal(int(syscall.SIGKILL))
+		select {
+		case <-done:
+		case <-time.After(dockerAttachProofTimeout):
+		}
+		t.Fatal("native Docker input blocked terminal cancellation")
+	}
+}

--- a/service/terminal/proxy/input_cancellation_test.go
+++ b/service/terminal/proxy/input_cancellation_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ttyapi "github.com/wippyai/runtime/api/tty"
+)
+
+// The process ignores TERM and stops consuming input. Only KILL releases the
+// pending write, so shutdown escalation must run independently of terminal I/O.
+type stubbornInputProcess struct {
+	killError error
+	*shutdownProcess
+	entered     chan struct{}
+	released    chan struct{}
+	releaseOnce sync.Once
+}
+
+func (p *stubbornInputProcess) WriteStdin([]byte) error {
+	close(p.entered)
+	<-p.released
+	return io.ErrClosedPipe
+}
+func (p *stubbornInputProcess) Signal(sig int) error {
+	p.signals <- sig
+	if sig == int(syscall.SIGKILL) {
+		p.releaseOnce.Do(func() { close(p.released) })
+		return p.killError
+	}
+	return nil
+}
+func TestProxyCancellationEscalatesDuringBlockedInput(t *testing.T) {
+	signalError := errors.New("kill response failed")
+	for _, tc := range []struct {
+		killError error
+		name      string
+		direct    bool
+	}{
+		{name: "context"}, {name: "request-close", direct: true}, {name: "kill-error", direct: true, killError: signalError},
+	} {
+		direct := tc.direct
+		name := tc.name
+		t.Run(name, func(t *testing.T) {
+			reader, writer := io.Pipe()
+			defer writer.Close()
+			process := &stubbornInputProcess{
+				shutdownProcess: &shutdownProcess{testProcess: &testProcess{stdout: reader}, wait: make(chan error, 1), signals: make(chan int, 4)},
+				entered:         make(chan struct{}), released: make(chan struct{}), killError: tc.killError,
+			}
+			bridge, err := New(process, &testSurface{}, 10, 2)
+			require.NoError(t, err)
+			bridge.shutdownGrace = 20 * time.Millisecond
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			events := make(chan ttyapi.Event, 1)
+			done := make(chan error, 1)
+			completed := false
+			go func() { done <- bridge.Run(ctx, events) }()
+			defer func() {
+				if completed {
+					return
+				}
+				process.releaseOnce.Do(func() { close(process.released) })
+				process.wait <- errors.New("killed")
+				_ = writer.Close()
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+				}
+			}()
+			events <- ttyapi.Event{Type: "paste", Paste: "blocked"}
+			select {
+			case <-process.entered:
+			case <-time.After(time.Second):
+				t.Fatal("write not entered")
+			}
+			if direct {
+				bridge.RequestClose()
+			} else {
+				cancel()
+			}
+			for _, want := range []int{int(syscall.SIGTERM), int(syscall.SIGKILL)} {
+				select {
+				case got := <-process.signals:
+					require.Equal(t, want, got)
+				case <-time.After(time.Second):
+					t.Fatalf("shutdown did not deliver signal %d during blocked input", want)
+				}
+			}
+			process.wait <- errors.New("killed")
+			require.NoError(t, writer.Close())
+			select {
+			case err := <-done:
+				completed = true
+				if tc.killError != nil {
+					require.ErrorIs(t, err, tc.killError)
+				} else if direct {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, context.Canceled)
+				}
+				require.NotErrorIs(t, err, ErrShutdownTimeout)
+			case <-time.After(time.Second):
+				t.Fatal("proxy did not reap the child after escalation")
+			}
+		})
+	}
+}

--- a/service/terminal/proxy/run.go
+++ b/service/terminal/proxy/run.go
@@ -24,7 +24,12 @@ const (
 
 // Run starts the external terminal and owns its I/O until completion,
 // cancellation, or a close event. The caller owns the events channel.
-func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) error {
+func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) (result error) {
+	defer func() {
+		if ctx.Err() != nil {
+			result = errors.Join(ctx.Err(), result)
+		}
+	}()
 	if err := p.start(); err != nil {
 		return err
 	}
@@ -36,6 +41,25 @@ func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) error {
 		return stopStartedProcess(p.process, execapi.ErrPTYUnavailable, p.shutdownTimeout())
 	}
 	defer func() { _ = output.Close() }()
+	finished := make(chan struct{})
+	watcherDone := make(chan struct{})
+	shutdownErrors := make(chan error, 2)
+	defer func() {
+		close(finished)
+		<-watcherDone
+		for {
+			select {
+			case err := <-shutdownErrors:
+				result = errors.Join(result, err)
+			default:
+				return
+			}
+		}
+	}()
+	go func() {
+		defer close(watcherDone)
+		p.watchShutdown(ctx, output, finished, shutdownErrors)
+	}()
 	defer func() {
 		// Closing the response pipe wakes copyResponses without racing x/vt's
 		// output parser through Emulator.Close's unsynchronized closed flag.
@@ -61,8 +85,6 @@ func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) error {
 	closing := false
 	var frameTimer *time.Timer
 	var frameReady <-chan time.Time
-	var shutdownTimer <-chan time.Time
-	var forcedShutdownTimer <-chan time.Time
 	stopFrameTimer := func() {
 		if frameTimer != nil {
 			if !frameTimer.Stop() {
@@ -97,7 +119,6 @@ func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) error {
 		if err := p.closeSignalError(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 			shutdownCause = errors.Join(shutdownCause, err)
 		}
-		shutdownTimer = time.After(p.shutdownTimeout())
 	}
 	if p.closeRequested.Load() {
 		beginShutdown(nil, true)
@@ -110,15 +131,11 @@ func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) error {
 			beginShutdown(nil, true)
 		case <-ctxDone:
 			beginShutdown(ctx.Err(), p.closeRequested.Load())
-		case <-shutdownTimer:
-			shutdownTimer = nil
-			if err := p.process.Signal(int(syscall.SIGKILL)); err != nil && !errors.Is(err, os.ErrProcessDone) {
-				shutdownCause = errors.Join(shutdownCause, err)
+		case err := <-shutdownErrors:
+			shutdownCause = errors.Join(shutdownCause, err)
+			if errors.Is(err, ErrShutdownTimeout) {
+				return shutdownCause
 			}
-			forcedShutdownTimer = time.After(p.shutdownTimeout())
-		case <-forcedShutdownTimer:
-			cancelProcessWait(p.process)
-			return errors.Join(shutdownCause, ErrShutdownTimeout)
 		case err := <-waitDone:
 			waitErr, processDone, waitDone = err, true, nil
 			if outputClosed {
@@ -184,6 +201,50 @@ func (p *Proxy) Run(ctx context.Context, events <-chan ttyapi.Event) error {
 			}
 		}
 	}
+}
+
+// watchShutdown owns escalation independently of synchronous terminal writes.
+// A child may ignore TERM while leaving its PTY input blocked. Run still owns
+// normal completion and reaping; finished retires the watcher on every return.
+func (p *Proxy) watchShutdown(ctx context.Context, output io.Closer, finished <-chan struct{}, shutdownErrors chan<- error) {
+	select {
+	case <-finished:
+		return
+	case <-ctx.Done():
+	case <-p.closeNotify:
+	}
+	select {
+	case <-finished:
+		return
+	default:
+	}
+	p.RequestClose()
+	timer := time.NewTimer(p.shutdownTimeout())
+	defer timer.Stop()
+	select {
+	case <-finished:
+		return
+	case <-timer.C:
+	}
+	err := p.process.Signal(int(syscall.SIGKILL))
+	if err != nil && !errors.Is(err, os.ErrProcessDone) {
+		shutdownErrors <- err
+	}
+	timer.Reset(p.shutdownTimeout())
+	select {
+	case <-finished:
+		return
+	case <-timer.C:
+	}
+	// Stop owned I/O as well as waiting. Docker can half-close its attached
+	// socket; native PTYs share their output descriptor with input and cannot
+	// be half-closed. Closing output releases that descriptor on abandonment.
+	shutdownErrors <- ErrShutdownTimeout
+	if closer, ok := p.process.(execapi.StdinCloser); ok {
+		_ = closer.CloseStdin()
+	}
+	_ = output.Close()
+	cancelProcessWait(p.process)
 }
 
 // stopStartedProcess closes the ownership gap between Start and the proxy event


### PR DESCRIPTION
A PTY child that stops reading stdin can block the terminal event loop inside `WriteStdin`. Context cancellation then cannot send SIGTERM; even direct `RequestClose` cannot escalate if the child ignores SIGTERM.

Move the existing shutdown escalation into one joined watcher per running proxy. It observes cancellation and close intent independently of terminal input, preserves the existing grace periods, and closes owned I/O and cancels abandoned waits on timeout. Run retains normal process/output completion; cancellation, signal failures and forced-shutdown errors remain observable. Public exec and terminal APIs are unchanged.

Validation:
- Deterministic regressions fail on current main for missing TERM on cancellation and missing KILL after direct close; fixed tests also cover reaping and signal-error preservation.
- Race suites pass for terminal, native/Docker executors and Lua exec. Final proxy/Lua exec race run includes the opt-in real Docker regression.
- The real Docker test uses an already-local immutable Alpine image, a non-reading container, and a 16 MiB paste; it performs no pull and cleans up only its own process. Run with `go test -race -tags integration ./service/terminal/proxy -run TestNativeDockerInputCancellation`.
- Scoped lint passes with the Makefile's golangci-lint version, including the integration test.

This fixes cancellation and direct close while input is blocked. It does not add Docker container attachment APIs or complete Bee's managed Docker integration. An event-channel close still follows earlier input; callers needing asynchronous shutdown use the existing `RequestClose` method.
